### PR TITLE
Add issue templates. Based on IREE templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,44 @@
+name: 🐞 Bug Report
+description: Report an issue
+labels: ["awaiting-triage", "bug 🐞"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        :star2: Thanks for taking the time to report this issue! :star2:
+
+        Please search through [other recent issues](https://github.com/openxla/stablehlo/issues) to see if your report overlaps with an existing issue.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: |
+        Also tell us, what did you expect to happen?
+
+        Include any MLIR output leading up to whatever error occurred where possible.
+      placeholder: Tell us what you see! Please also copy/paste or link to any relevant log output.
+    validations:
+      required: true
+  - type: textarea
+    id: reproducing
+    attributes:
+      label: Steps to reproduce your issue
+      description: |
+        Include any commands that you ran.
+      value: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
+  - type: textarea
+    id: version
+    attributes:
+      label: Version information
+      description: What version of our software are you using?
+      placeholder: This could be a git commit hash.
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem here.
+      placeholder: For example, did what you were trying work before?

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,5 @@
 name: 🐞 Bug Report
 description: Report an issue
-labels: ["awaiting-triage", "bug 🐞"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 📄 Blank Issue
+    url: https://github.com/openxla/stablehlo/issues/new
+    about: If you know what you're doing (especially collaborators)
+  - name: 🗣 Start a discussion on GitHub
+    url: https://github.com/openxla/stablehlo/discussions
+    about: An alternative platform for asynchronous discussion
+  - name: 💬 Join us on Discord
+    url: https://discord.gg/Wqr8vWZKKJ
+    about: For realtime communication with the team and collaborators

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,7 +5,7 @@ contact_links:
     about: If you know what you're doing (especially collaborators)
   - name: 🗣 Start a discussion on GitHub
     url: https://github.com/openxla/stablehlo/discussions
-    about: An alternative platform for asynchronous discussion
+    about: For early feedback on a design or other proposal
   - name: 💬 Join us on Discord
     url: https://discord.gg/Wqr8vWZKKJ
     about: For realtime communication with the team and collaborators

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,5 @@
 name: ➕ Feature Request
 description: Ask for a new feature to be added
-labels: ["awaiting-triage", "enhancement ➕"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,24 @@
+name: ➕ Feature Request
+description: Ask for a new feature to be added
+labels: ["awaiting-triage", "enhancement ➕"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        :star2: Thanks for taking the time to file this request! :star2:
+
+        We also work closely with upstream communities like the MLIR project, which uses the [MLIR Discourse forum](https://discourse.llvm.org/c/mlir/31) for coordination.
+  - type: textarea
+    id: overview
+    attributes:
+      label: Request description
+      description: |
+        What would you like added or changed?
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other context about your request here.
+      placeholder: For example, is a similar feature already implemented?


### PR DESCRIPTION
Adding some more community friendly issue templates. I believe much of the early work will be completed using blank templates for tasks, but as users begin to use this repo, a bug_report template will come in handy. Also a link to our discord for users encountering issues is helpful too.

Based on IREE templates:
https://github.com/iree-org/iree/issues/new/choose
https://github.com/iree-org/iree/tree/main/.github/ISSUE_TEMPLATE