### PR TITLE
Implement pretty printing for SelectOp, ClampOp, AfterAllOp types. Clean up type prints.

### DIFF
--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -5774,7 +5774,6 @@ void printSameOperandsAndResultTypeImpl(OpAsmPrinter& p, Operation* op,
                                         TypeRange operands, Type result) {
   // Handle zero operand types `() -> a` prints `a`
   if (operands.empty()) {
-    // call that has no operands and single output.
     p.printType(result);
     return;
   }

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -682,13 +682,16 @@ def StableHLO_ComplexOp: StableHLO_BinaryElementwiseOp<"complex", [NoSideEffect,
     Example:
 
     ```mlir
-    %0 = stablehlo.complex %arg0, %arg0 : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xcomplex<f32>>
+    %0 = stablehlo.complex %arg0, %arg0 : tensor<4xcomplex<f32>>
     ```
   }];
   let arguments = (ins HLO_Fp32Or64Tensor:$lhs, HLO_Fp32Or64Tensor:$rhs);
   let results = (outs HLO_ComplexTensor:$result);
 
-  let assemblyFormat = "operands attr-dict `:` functional-type(operands, results)";
+  let assemblyFormat = [{
+    operands attr-dict 
+      `:` custom<ComplexOpType>(type($lhs), type($rhs), type($result))
+  }];
 }
 
 def StableHLO_DivOp : StableHLO_BinaryElementwiseOp<"divide",

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -682,8 +682,7 @@ def StableHLO_ComplexOp: StableHLO_BinaryElementwiseOp<"complex", [NoSideEffect,
   let arguments = (ins HLO_Fp32Or64Tensor:$lhs, HLO_Fp32Or64Tensor:$rhs);
   let results = (outs HLO_ComplexTensor:$result);
 
-  // TODO(b/241767457): Remove parens when cleaning up BinaryOps.
-  let assemblyFormat = "`(`operands`)` attr-dict `:` `(`type(operands)`)` `->` type($result)";
+  let assemblyFormat = "operands attr-dict `:` functional-type(operands, results)";
 }
 
 def StableHLO_DivOp : StableHLO_BinaryElementwiseOp<"divide",
@@ -1068,14 +1067,17 @@ def StableHLO_AfterAllOp : StableHLO_Op<"after_all", [NoSideEffect]> {
     Example:
 
     ```mlir
-    %0 = stablehlo.after_all %arg0, %arg1 : (!stablehlo.token, !stablehlo.token) -> !stablehlo.token
+    %0 = stablehlo.after_all %arg0, %arg1 : !stablehlo.token
     ```
   }];
 
   let arguments = (ins Variadic<HLO_Token>:$operands);
-  let results = (outs HLO_Token);
+  let results = (outs HLO_Token:$result);
 
-  let assemblyFormat = "operands attr-dict `:` functional-type(operands, results)";
+  let assemblyFormat = [{
+    $operands attr-dict
+      `:` custom<VariadicSameOperandsAndResultType>(ref($operands), type($operands), type($result))
+  }];
 }
 
 // Xla Client API has two separate calls for indexed and predicated conditional,
@@ -1709,6 +1711,7 @@ def StableHLO_ClampOp : StableHLO_ShapedInterfaceOp<"clamp", [NoSideEffect,
 
     ```mlir
     %0 = stablehlo.clamp %arg0, %arg1, %arg2 : (tensor<f32>, tensor<4xf32>, tensor<f32>) -> tensor<4xf32>
+    %1 = stablehlo.clamp %arg1, %arg1, %arg1 : tensor<4xf32>
     ```
   }];
 
@@ -1717,7 +1720,7 @@ def StableHLO_ClampOp : StableHLO_ShapedInterfaceOp<"clamp", [NoSideEffect,
     HLO_Tensor:$operand,
     HLO_Tensor:$max
   );
-  let results = (outs HLO_Tensor);
+  let results = (outs HLO_Tensor:$result);
 
   let hasVerifier = 1;
 
@@ -1732,7 +1735,10 @@ def StableHLO_ClampOp : StableHLO_ShapedInterfaceOp<"clamp", [NoSideEffect,
     }
   }];
 
-  let assemblyFormat = "operands attr-dict `:` functional-type(operands, results)";
+  let assemblyFormat = [{
+    $min `,` $operand `,` $max attr-dict 
+      `:` custom<SameOperandsAndResultType>(type($min), type($operand), type($max), type($result))
+  }];
 }
 
 def StableHLO_ConcatenateOp : StableHLO_ShapedInterfaceOp<"concatenate",
@@ -2159,6 +2165,13 @@ def StableHLO_SelectOp: StableHLO_Op<"select", [NoSideEffect, HLO_BroadcastingEl
     broadcasted.
 
     See https://www.tensorflow.org/xla/operation_semantics#select.
+
+    Example:
+
+    ```mlir
+    %0 = stablehlo.select %arg0, %arg1, %arg1 : tensor<2x3xi1>, tensor<2x3xi32>
+    %1 = stablehlo.select %arg0, %arg2, %arg3 : (tensor<2x3xi1>, tensor<2x?xi32>, tensor<?x2xi32>) -> tensor<2x?xi32>
+    ```
   }];
   let arguments = (ins
     HLO_PredTensor:$pred,
@@ -2166,7 +2179,7 @@ def StableHLO_SelectOp: StableHLO_Op<"select", [NoSideEffect, HLO_BroadcastingEl
     HLO_Tensor:$on_false
   );
 
-  let results = (outs HLO_Tensor);
+  let results = (outs HLO_Tensor:$result);
 
   let hasVerifier = 1;
 
@@ -2174,6 +2187,11 @@ def StableHLO_SelectOp: StableHLO_Op<"select", [NoSideEffect, HLO_BroadcastingEl
     static bool isCompatibleReturnTypes(TypeRange l, TypeRange r) {
       return succeeded(mlir::verifyCompatibleShapes(l, r));
     }
+  }];
+
+  let assemblyFormat = [{
+    operands attr-dict `:`
+      custom<SelectOpType>(type($pred), type($on_true), type($on_false), type($result))
   }];
 }
 
@@ -2783,13 +2801,18 @@ def StableHLO_ComputeReshapeShapeOp :
     ```
     %0 = hlo.compute_reshape_shape 12, [2, -1] -> [2, 6]
     ```
+
+    Example:
+
+    ```mlir
+    %0 = stablehlo.compute_reshape_shape %arg0, %arg1 : (index, tensor<2xi32>) -> tensor<2xi32>
+    ```
   }];
 
   let arguments = (ins Index:$num_elements, 1DTensorOf<[AnyInteger, Index]>:$dynamic_shape);
   let results = (outs 1DTensorOf<[AnyInteger, Index]>:$result);
 
-  // TODO (b/241767462): Use functional-type for type printing for consistency.
-  let assemblyFormat = "$num_elements `,` $dynamic_shape attr-dict `:` type($num_elements) `,` type($dynamic_shape) `->` type($result)";
+  let assemblyFormat = "operands attr-dict `:` functional-type(operands, results)";
 }
 
 def StableHLO_CstrReshapableOp :
@@ -2804,13 +2827,18 @@ def StableHLO_CstrReshapableOp :
     %0 = stablehlo.cstr_reshapable 12, [2, -1] -> success
     %1 = stablehlo.cstr_reshapable 13, [2, -1] -> failure
     ```
+
+    Example:
+
+    ```mlir
+    %0 = stablehlo.cstr_reshapable %arg0, %arg1 : (index, tensor<3xi32>) -> !shape.witnes
+    ```
   }];
 
   let arguments = (ins Index:$num_elements, 1DTensorOf<[AnyInteger, Index]>:$dynamic_shape);
   let results = (outs Shape_WitnessType:$result);
 
-  // TODO (b/241767462): Use functional-type for type printing for consistency.
-  let assemblyFormat = "$num_elements `,` $dynamic_shape attr-dict `:` type($num_elements) `,` type($dynamic_shape)";
+  let assemblyFormat = "operands attr-dict `:` functional-type(operands, results)";
 }
 
 #endif // STABLEHLO_DIALECT_STABLEHLO_OPS

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -678,6 +678,12 @@ def StableHLO_ComplexOp: StableHLO_BinaryElementwiseOp<"complex", [NoSideEffect,
   let description = [{
     Performs element-wise conversion of a pair of real and imaginary values to
     a complex value.
+
+    Example:
+
+    ```mlir
+    %0 = stablehlo.complex %arg0, %arg0 : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xcomplex<f32>>
+    ```
   }];
   let arguments = (ins HLO_Fp32Or64Tensor:$lhs, HLO_Fp32Or64Tensor:$rhs);
   let results = (outs HLO_ComplexTensor:$result);
@@ -2831,7 +2837,7 @@ def StableHLO_CstrReshapableOp :
     Example:
 
     ```mlir
-    %0 = stablehlo.cstr_reshapable %arg0, %arg1 : (index, tensor<3xi32>) -> !shape.witnes
+    %0 = stablehlo.cstr_reshapable %arg0, %arg1 : (index, tensor<3xi32>) -> !shape.witness
     ```
   }];
 

--- a/stablehlo/tests/print_stablehlo.mlir
+++ b/stablehlo/tests/print_stablehlo.mlir
@@ -131,7 +131,7 @@ func.func @type_convert_ops(%arg0 : tensor<2xf32>) -> () {
 func.func @no_attr_ops(%arg0 : tensor<4xf32>, %arg1 : !stablehlo.token,
                        %arg2 : tensor<4xi32>, %arg3 : index) -> !stablehlo.token {
   // CHECK-NEXT: %0 = stablehlo.clamp %arg0, %arg0, %arg0 : tensor<4xf32>
-  // CHECK-NEXT: %1 = stablehlo.complex %arg0, %arg0 : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xcomplex<f32>>
+  // CHECK-NEXT: %1 = stablehlo.complex %arg0, %arg0 : tensor<4xcomplex<f32>>
   // CHECK-NEXT: %2 = stablehlo.compute_reshape_shape %arg3, %arg2 : (index, tensor<4xi32>) -> tensor<4xi32>
   // CHECK-NEXT: %3 = stablehlo.uniform_quantize %arg0 : (tensor<4xf32>) -> tensor<4x!quant.uniform<u8:f32, 3.400000e+01:16>>
   // CHECK-NEXT: %4 = stablehlo.uniform_dequantize %3 : (tensor<4x!quant.uniform<u8:f32, 3.400000e+01:16>>) -> tensor<4xf32>
@@ -226,11 +226,13 @@ func.func @encodings(%arg0: tensor<10x20xf32, #CSR>,
   // CHECK-NEXT: %1 = stablehlo.add %arg1, %arg1 : tensor<10x20xf32, #sparse_tensor.encoding<{ dimLevelType = [ "compressed", "compressed" ] }>>
   // CHECK-NEXT: %2 = stablehlo.abs %arg0 : (tensor<10x20xf32, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ] }>>) -> tensor<10x20xf32>
   // CHECK-NEXT: %3 = stablehlo.abs %arg0 : tensor<10x20xf32, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ] }>>
+  // CHECK-NEXT: %4 = stablehlo.complex %arg0, %arg0 : (tensor<10x20xf32, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ] }>>, tensor<10x20xf32, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ] }>>) -> tensor<10x20xcomplex<f32>>
   %0 = "stablehlo.add"(%arg0, %arg1) : (tensor<10x20xf32, #CSR>,
                                    tensor<10x20xf32, #DCSR>) -> tensor<10x20xf32>
   %1 = "stablehlo.add"(%arg1, %arg1) : (tensor<10x20xf32, #DCSR>,
                                    tensor<10x20xf32, #DCSR>) -> tensor<10x20xf32, #DCSR>
   %2 = "stablehlo.abs"(%arg0) : (tensor<10x20xf32, #CSR>) -> tensor<10x20xf32>
   %3 = "stablehlo.abs"(%arg0) : (tensor<10x20xf32, #CSR>) -> tensor<10x20xf32, #CSR>
+  %4 = "stablehlo.complex"(%arg0, %arg0) : (tensor<10x20xf32, #CSR>, tensor<10x20xf32, #CSR>) -> tensor<10x20xcomplex<f32>>
   func.return %0 : tensor<10x20xf32>
 }

--- a/stablehlo/tests/print_stablehlo.mlir
+++ b/stablehlo/tests/print_stablehlo.mlir
@@ -130,18 +130,24 @@ func.func @type_convert_ops(%arg0 : tensor<2xf32>) -> () {
 // CHECK-LABEL: func @no_attr_ops
 func.func @no_attr_ops(%arg0 : tensor<4xf32>, %arg1 : !stablehlo.token,
                        %arg2 : tensor<4xi32>, %arg3 : index) -> !stablehlo.token {
-  // CHECK:      %0 = stablehlo.clamp %arg0, %arg0, %arg0 : (tensor<4xf32>, tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
-  // CHECK-NEXT: %1 = stablehlo.complex(%arg0, %arg0) : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xcomplex<f32>>
-  // CHECK-NEXT: %2 = stablehlo.compute_reshape_shape %arg3, %arg2 : index, tensor<4xi32> -> tensor<4xi32>
+  // CHECK-NEXT: %0 = stablehlo.clamp %arg0, %arg0, %arg0 : tensor<4xf32>
+  // CHECK-NEXT: %1 = stablehlo.complex %arg0, %arg0 : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xcomplex<f32>>
+  // CHECK-NEXT: %2 = stablehlo.compute_reshape_shape %arg3, %arg2 : (index, tensor<4xi32>) -> tensor<4xi32>
   // CHECK-NEXT: %3 = stablehlo.uniform_quantize %arg0 : (tensor<4xf32>) -> tensor<4x!quant.uniform<u8:f32, 3.400000e+01:16>>
   // CHECK-NEXT: %4 = stablehlo.uniform_dequantize %3 : (tensor<4x!quant.uniform<u8:f32, 3.400000e+01:16>>) -> tensor<4xf32>
-  // CHECK-NEXT: %5 = stablehlo.after_all %arg1, %arg1 : (!stablehlo.token, !stablehlo.token) -> !stablehlo.token
+  // CHECK-NEXT: %5 = stablehlo.after_all %arg1, %arg1 : !stablehlo.token
+  // CHECK-NEXT: %6 = stablehlo.after_all : !stablehlo.token
+  // CHECK-NEXT: %7 = stablehlo.cstr_reshapable %arg3, %arg2 : (index, tensor<4xi32>) -> !shape.witness
+  // CHECK-NEXT: %8 = stablehlo.compute_reshape_shape %arg3, %arg2 : (index, tensor<4xi32>) -> tensor<4xi32>
   %0 = "stablehlo.clamp"(%arg0, %arg0, %arg0) : (tensor<4xf32>, tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
   %1 = "stablehlo.complex"(%arg0, %arg0) {} : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xcomplex<f32>>
   %2 = "stablehlo.compute_reshape_shape"(%arg3, %arg2) : (index, tensor<4xi32>) -> tensor<4xi32>
   %3 = "stablehlo.uniform_quantize"(%arg0) : (tensor<4xf32>) -> tensor<4x!quant.uniform<ui8:f32, 34.0:16>>
   %4 = "stablehlo.uniform_dequantize"(%3) : (tensor<4x!quant.uniform<ui8:f32, 34.0:16>>) -> tensor<4xf32>
   %5 = "stablehlo.after_all"(%arg1, %arg1) : (!stablehlo.token, !stablehlo.token) -> !stablehlo.token
+  %6 = "stablehlo.after_all"() : () -> !stablehlo.token
+  %7 = "stablehlo.cstr_reshapable"(%arg3, %arg2) : (index, tensor<4xi32>) -> !shape.witness
+  %8 = "stablehlo.compute_reshape_shape"(%arg3, %arg2) : (index, tensor<4xi32>) -> tensor<4xi32>
   "stablehlo.return"(%arg1) : (!stablehlo.token) -> ()
 }
 
@@ -151,6 +157,16 @@ func.func @multiple_attr_ops(%arg0 : tensor<3x4xf32>) -> () {
   // CHECK-NEXT: %1 = stablehlo.custom_call "foo"(%arg0, %arg0) {api_version = 1 : i32, backend_config = "bar", called_computations = [], has_side_effect = true} : (tensor<3x4xf32>, tensor<3x4xf32>) -> tensor<1x2x3xf32>
   %0 = "stablehlo.reduce_precision"(%arg0) {exponent_bits = 8 : i32, mantissa_bits = 10 : i32} : (tensor<3x4xf32>) -> tensor<3x4xf32>
   %1 = "stablehlo.custom_call"(%arg0, %arg0) {backend_config = "bar", call_target_name = "foo", has_side_effect = true} : (tensor<3x4xf32>, tensor<3x4xf32>) -> tensor<1x2x3xf32>
+  "stablehlo.return"() : () -> ()
+}
+
+// CHECK-LABEL: func @select_op
+func.func @select_op(%arg0: tensor<2x3xi1>, %arg1: tensor<2x3xi32>,
+                  %arg2: tensor<2x?xi32>, %arg3: tensor<?x2xi32>) -> () {
+  // CHECK      %0 = stablehlo.select %arg0, %arg1, %arg1 : tensor<2x3xi1>, tensor<2x3xi32>
+  // CHECK-NEXT %1 = stablehlo.select %arg0, %arg2, %arg3 : (tensor<2x3xi1>, tensor<2x?xi32>, tensor<?x2xi32>) -> tensor<2x?xi32>
+  %0 = "stablehlo.select"(%arg0, %arg1, %arg1) : (tensor<2x3xi1>, tensor<2x3xi32>, tensor<2x3xi32>) -> tensor<2x3xi32>
+  %1 = "stablehlo.select"(%arg0, %arg2, %arg3) : (tensor<2x3xi1>, tensor<2x?xi32>, tensor<?x2xi32>) -> tensor<2x?xi32>
   "stablehlo.return"() : () -> ()
 }
 

--- a/stablehlo/tests/print_types_invalid.mlir
+++ b/stablehlo/tests/print_types_invalid.mlir
@@ -39,6 +39,30 @@ func.func @binary_eltwise_multiple_out(%arg0: tensor<?x?xf64>,
 
 // -----
 
+func.func @complex_type_not_type(%arg0: tensor<1xf64>) -> tensor<1xf64> {
+  // expected-error @+1 {{expected non-function type}}
+  %0 = stablehlo.complex %arg0, %arg0 : %arg0
+  func.return %0 : tensor<1xf64>
+}
+
+// -----
+
+func.func @complex_type_not_tensor(%arg0: tensor<1xf64>) -> () {
+  // expected-error @+1 {{custom op 'stablehlo.complex' expected tensor with complex element type}}
+  %0 = stablehlo.complex %arg0, %arg0 : complex<f64>
+  func.return
+}
+
+// -----
+
+func.func @complex_type_not_complex(%arg0: tensor<1xf64>) -> () {
+  // expected-error @+1 {{custom op 'stablehlo.complex' expected tensor with complex element type}}
+  %0 = stablehlo.complex %arg0, %arg0 : tensor<1xf64>
+  func.return
+}
+
+// -----
+
 func.func @select_type_wrong_type(%arg0: tensor<2x3xi1>, %arg1: tensor<2x3xi32>) -> () {
   // expected-error @+1 {{custom op 'stablehlo.select' expected functional type or list of two types}}
   %0 = stablehlo.select %arg0, %arg1, %arg1 : tensor<2x3xi1>
@@ -88,7 +112,7 @@ func.func @pairwise_count_mismatch(%arg0: tensor<1xf64>) -> tensor<1xf64> {
 // -----
 
 func.func @pairwise_type_not_list(%arg0: tensor<1xf64>) -> tensor<1xf64> {
-  // expected-error @+2 {{xpected non-function type}}
+  // expected-error @+2 {{expected non-function type}}
   // expected-error @+1 {{custom op 'stablehlo.optimization_barrier' expected type list}}
   %0 = stablehlo.optimization_barrier %arg0, %arg0 : %arg0
   func.return %0 : tensor<1xf64>
@@ -97,7 +121,7 @@ func.func @pairwise_type_not_list(%arg0: tensor<1xf64>) -> tensor<1xf64> {
 // -----
 
 func.func @one_result_type(%arg0: tensor<1xf64>) -> tensor<1xf64> {
-  // expected-error @+1 {{xpected non-function type}}
+  // expected-error @+1 {{expected non-function type}}
   %0 = stablehlo.abs %arg0 : %arg0
   func.return %0 : tensor<1xf64>
 }

--- a/stablehlo/tests/print_types_invalid.mlir
+++ b/stablehlo/tests/print_types_invalid.mlir
@@ -39,6 +39,22 @@ func.func @binary_eltwise_multiple_out(%arg0: tensor<?x?xf64>,
 
 // -----
 
+func.func @select_type_wrong_type(%arg0: tensor<2x3xi1>, %arg1: tensor<2x3xi32>) -> () {
+  // expected-error @+1 {{custom op 'stablehlo.select' expected functional type or list of two types}}
+  %0 = stablehlo.select %arg0, %arg1, %arg1 : tensor<2x3xi1>
+  func.return %0
+}
+
+// -----
+
+func.func @select_type_too_many(%arg0: tensor<2x3xi1>, %arg1: tensor<2x3xi32>) -> () {
+  // expected-error @+1 {{custom op 'stablehlo.select' expected functional type or list of two types}}
+  %0 = stablehlo.select %arg0, %arg1, %arg1 : tensor<2x3xi1>, tensor<2x3xi32>, tensor<2x3xi32>
+  func.return
+}
+
+// -----
+
 func.func @tuple_type_mismatch(%arg0: tensor<1xf64>) -> tensor<1xf64> {
   // expected-error @+1 {{custom op 'stablehlo.tuple' expected tuple type}}
   %0 = stablehlo.tuple %arg0, %arg1 : tensor<1xf64>, tensor<1xf32>


### PR DESCRIPTION
Pretty print for SelectOp based on vector display of `arith.select`: https://mlir.llvm.org/docs/Dialects/ArithmeticOps/#arithselect-mlirarithselectop

```
// Element-wise vector selection in arith:
%vx = arith.select %vcond, %vtrue, %vfalse : vector<42xi1>, vector<42xf32>

// StableHLO display:
%0 = stablehlo.select %arg0, %arg1, %arg1 : tensor<2x3xi1>, tensor<2x3xi32>
```

Note that if branch types do not match exactly, `functional-type` is used:

```
%1 = stablehlo.select %arg0, %arg2, %arg3 : (tensor<2x3xi1>, tensor<2x?xi32>, tensor<?x2xi32>) -> tensor<2x?xi32>
```

Now that `SameOperandsAndResultType` is merged into main, we can use it in other ops that _may_ have the same operands and result types like ClampOp, or ops that _must_ have matching types like AfterAllOp:

```
%0 = stablehlo.clamp %arg0, %arg0, %arg0 : tensor<4xf32>
%5 = stablehlo.after_all %arg1, %arg1 : !stablehlo.token
%6 = stablehlo.after_all : !stablehlo.token
```

Added print tests and invalid MLIR tests.

Additionally this change cleans up some type prints, removing parentheses around operands / including parens around inputs in type printing for consistency with the rest of the dialect's assembly:

```
%0 = stablehlo.cstr_reshapable %arg0, %arg1 : (index, tensor<3xi32>) -> !shape.witness
%0 = stablehlo.compute_reshape_shape %arg0, %arg1 : (index, tensor<2xi32>) -> tensor<2xi32>
%0 = stablehlo.complex %arg0, %arg0 : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xcomplex<f32>>
```