### PR TITLE
Allows StableHLO to be built as part of other CMake projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,33 +37,40 @@ endif()
 #-------------------------------------------------------------------------------
 # Project setup and globals
 #-------------------------------------------------------------------------------
-
-project(stablehlo LANGUAGES CXX C)
-set(CMAKE_C_STANDARD 11)
-set(CMAKE_CXX_STANDARD 17)
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+  set(STABLEHLO_STANDALONE_BUILD ON)
+  project(stablehlo LANGUAGES CXX C)
+  set(CMAKE_C_STANDARD 11)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
 
 #-------------------------------------------------------------------------------
 # MLIR/LLVM Configuration
 #-------------------------------------------------------------------------------
 
-find_package(MLIR REQUIRED CONFIG)
-message(STATUS "Using MLIRConfig.cmake in: ${MLIR_DIR}")
-message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
-set(LLVM_RUNTIME_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/bin)
-set(LLVM_LIBRARY_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/lib)
-list(APPEND CMAKE_MODULE_PATH "${MLIR_CMAKE_DIR}")
-list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
+if(STABLEHLO_STANDALONE_BUILD)
+  message(STATUS "Building StableHLO standalone")
+  find_package(MLIR REQUIRED CONFIG)
+  message(STATUS "Using MLIRConfig.cmake in: ${MLIR_DIR}")
+  message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+  set(LLVM_RUNTIME_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/bin)
+  set(LLVM_LIBRARY_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/lib)
+  list(APPEND CMAKE_MODULE_PATH "${MLIR_CMAKE_DIR}")
+  list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
 
-include(TableGen)
-include(AddLLVM)
-include(AddMLIR)
-include(HandleLLVMOptions)
-include_directories(${LLVM_INCLUDE_DIRS})
-include_directories(${MLIR_INCLUDE_DIRS})
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
-link_directories(${LLVM_BUILD_LIBRARY_DIR})
-add_definitions(${LLVM_DEFINITIONS})
+  include(TableGen)
+  include(AddLLVM)
+  include(AddMLIR)
+  include(HandleLLVMOptions)
+  include_directories(${LLVM_INCLUDE_DIRS})
+  include_directories(${MLIR_INCLUDE_DIRS})
+  include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+  include_directories(${CMAKE_CURRENT_BINARY_DIR})
+  link_directories(${LLVM_BUILD_LIBRARY_DIR})
+  add_definitions(${LLVM_DEFINITIONS})
+else()
+  message(STATUS "Building StableHLO as part of another project")
+endif()
 
 #-------------------------------------------------------------------------------
 # Directory setup

--- a/tests/lit.site.cfg.py.in
+++ b/tests/lit.site.cfg.py.in
@@ -43,7 +43,7 @@ config.llvm_use_sanitizer = "@LLVM_USE_SANITIZER@"
 config.llvm_host_triple = '@LLVM_HOST_TRIPLE@'
 config.host_arch = "@HOST_ARCH@"
 config.stablehlo_src_root = "@STABLEHLO_SOURCE_DIR@"
-config.stablehlo_obj_root = "@STABLEHLO_BINARY_DIR@"
+config.stablehlo_obj_root = "@CMAKE_BINARY_DIR@"
 config.mlir_runner_utils_dir = os.path.join(config.llvm_obj_root, "lib")
 
 # Support substitution of the tools_dir with user parameters. This is
@@ -61,4 +61,4 @@ import lit.llvm
 lit.llvm.initialize(lit_config, config)
 
 # Let the main config do the real work.
-lit_config.load_config(config, "@CMAKE_SOURCE_DIR@/tests/lit.cfg.py")
+lit_config.load_config(config, "@STABLEHLO_SOURCE_DIR@/tests/lit.cfg.py")


### PR DESCRIPTION
This is similar to how things are done in Clang: http://google3/third_party/llvm/llvm-project/clang/CMakeLists.txt;l=3-13;rcl=469417476.
Thank you, Mehdi, for the tip!

Backported from https://github.com/tensorflow/mlir-hlo/commit/32be07f12c82144965fd90671ca7c742e5c5f3f0