### PR TITLE
Add Python bindings for CHLO/StableHLO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,11 @@ if(POLICY CMP0116)
 endif()
 
 #-------------------------------------------------------------------------------
+# Options and settings
+#-------------------------------------------------------------------------------
+option(STABLEHLO_ENABLE_BINDINGS_PYTHON "Enables StableHLO Python bindings" OFF)
+
+#-------------------------------------------------------------------------------
 # Project setup and globals
 #-------------------------------------------------------------------------------
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
@@ -70,6 +75,31 @@ if(STABLEHLO_STANDALONE_BUILD)
   add_definitions(${LLVM_DEFINITIONS})
 else()
   message(STATUS "Building StableHLO as part of another project")
+  set(MLIR_MAIN_SRC_DIR ${LLVM_MAIN_SRC_DIR}/../mlir ) # --src-root
+  set(MLIR_INCLUDE_DIR ${MLIR_MAIN_SRC_DIR}/include ) # --includedir
+  set(MLIR_GENERATED_INCLUDE_DIR ${LLVM_BINARY_DIR}/tools/mlir/include)
+
+  include_directories(SYSTEM ${MLIR_INCLUDE_DIR})
+  include_directories(SYSTEM ${MLIR_GENERATED_INCLUDE_DIR})
+  include_directories(SYSTEM ${MLIR_TABLEGEN_OUTPUT_DIR})
+  include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+  include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
+  set(BACKEND_PACKAGE_STRING "${PACKAGE_STRING}")
+  list(APPEND CMAKE_MODULE_PATH "${MLIR_MAIN_SRC_DIR}/cmake/modules")
+endif()
+
+#-------------------------------------------------------------------------------
+# Python configuration
+#-------------------------------------------------------------------------------
+
+if(STABLEHLO_ENABLE_BINDINGS_PYTHON)
+  if(STABLEHLO_STANDALONE_BUILD)
+    message(WARNING "StableHLO Python bindings are not supported in standalone mode. See build_tools/README.md for instructions.")
+  endif()
+
+  include(MLIRDetectPythonEnv)
+  mlir_configure_python_dev_packages()
 endif()
 
 #-------------------------------------------------------------------------------
@@ -82,5 +112,6 @@ set(STABLEHLO_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
 add_custom_target(check-stablehlo)
 
 add_subdirectory(dialect)
+add_subdirectory(integrations)
 add_subdirectory(tests)
 add_subdirectory(tools)

--- a/build_tools/README.md
+++ b/build_tools/README.md
@@ -27,3 +27,26 @@ $ cmake .. -GNinja \
    -DMLIR_DIR=${PWD}/../llvm-build/lib/cmake/mlir
 $ ninja check-stablehlo
 ```
+
+### Python API
+
+Note that the python package produced by this procedure includes the `mlir`
+package and is not suitable for deployment as-is (but it can be included into
+a larger aggregate).
+
+```
+$ mkdir build && cd build
+$ cmake -GNinja -B. ${PWD}/../llvm-project/llvm \
+   -DCMAKE_BUILD_TYPE=Release \
+   -DLLVM_ENABLE_PROJECTS=mlir \
+   -DLLVM_EXTERNAL_PROJECTS=stablehlo \
+   -DLLVM_EXTERNAL_STABLEHLO_SOURCE_DIR=${PWD}/.. \
+   -DLLVM_TARGETS_TO_BUILD=host \
+   -DPython3_EXECUTABLE=$(which python3) \
+   -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
+   -DSTABLEHLO_ENABLE_BINDINGS_PYTHON=ON
+
+ninja ChloPythonModules StablehloPythonModules
+export PYTHONPATH=$PWD/tools/stablehlo/python_packages/chlo:$PWD/tools/stablehlo/python_packages/stablehlo
+python -c "import mlir.dialects.chlo; import mlir.dialects.stablehlo"
+```

--- a/build_tools/README.md
+++ b/build_tools/README.md
@@ -45,8 +45,13 @@ $ cmake -GNinja -B. ${PWD}/../llvm-project/llvm \
    -DPython3_EXECUTABLE=$(which python3) \
    -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
    -DSTABLEHLO_ENABLE_BINDINGS_PYTHON=ON
+$ ninja check-stablehlo-python
+```
 
-ninja ChloPythonModules StablehloPythonModules
-export PYTHONPATH=$PWD/tools/stablehlo/python_packages/chlo:$PWD/tools/stablehlo/python_packages/stablehlo
-python -c "import mlir.dialects.chlo; import mlir.dialects.stablehlo"
+Here's how you can use the Python bindings:
+
+```
+$ ninja StablehloUnifiedPythonModules
+$ export PYTHONPATH=$PWD/tools/stablehlo/python_packages/stablehlo
+$ python -c "import mlir.dialects.chlo; import mlir.dialects.stablehlo"
 ```

--- a/integrations/CMakeLists.txt
+++ b/integrations/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2022 The StableHLO Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_subdirectory(c)
+
+if(STABLEHLO_ENABLE_BINDINGS_PYTHON)
+  add_subdirectory(python)
+endif()

--- a/integrations/c/CMakeLists.txt
+++ b/integrations/c/CMakeLists.txt
@@ -1,0 +1,33 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2022 The StableHLO Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_mlir_public_c_api_library(ChloCAPI
+  PARTIAL_SOURCES_INTENDED
+  ChloAttributes.cpp
+  ChloDialect.cpp
+
+  LINK_LIBS PUBLIC
+  ChloOps
+)
+
+add_mlir_public_c_api_library(StablehloCAPI
+  PARTIAL_SOURCES_INTENDED
+  StablehloAttributes.cpp
+  StablehloDialect.cpp
+  StablehloTypes.cpp
+
+  LINK_LIBS PUBLIC
+  StablehloOps
+)

--- a/integrations/c/ChloAttributes.cpp
+++ b/integrations/c/ChloAttributes.cpp
@@ -1,0 +1,62 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+   Copyright 2022 The StableHLO Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "integrations/c/ChloAttributes.h"
+
+#include "dialect/ChloOps.h"
+#include "mlir/CAPI/IR.h"
+#include "mlir/CAPI/Support.h"
+
+//===----------------------------------------------------------------------===//
+// ComparisonDirectionAttr
+//===----------------------------------------------------------------------===//
+
+MlirAttribute chloComparisonDirectionAttrGet(MlirContext ctx,
+                                             MlirStringRef direction) {
+  llvm::Optional<mlir::chlo::ComparisonDirection> compareDirection =
+      mlir::chlo::symbolizeComparisonDirection(unwrap(direction));
+  if (!compareDirection)
+    llvm_unreachable("Invalid comparison-direction specified.");
+  return wrap(mlir::chlo::ComparisonDirectionAttr::get(
+      unwrap(ctx), compareDirection.value()));
+}
+
+bool chloAttributeIsAComparisonDirectionAttr(MlirAttribute attr) {
+  return unwrap(attr).isa<mlir::chlo::ComparisonDirectionAttr>();
+}
+
+MlirStringRef chloComparisonDirectionAttrGetDirection(MlirAttribute attr) {
+  return wrap(mlir::chlo::stringifyComparisonDirection(
+      unwrap(attr).cast<mlir::chlo::ComparisonDirectionAttr>().getValue()));
+}
+
+//===----------------------------------------------------------------------===//
+// ComparisonTypeAttr
+//===----------------------------------------------------------------------===//
+
+MlirAttribute chloComparisonTypeAttrGet(MlirContext ctx, MlirStringRef type) {
+  llvm::Optional<mlir::chlo::ComparisonType> compareType =
+      mlir::chlo::symbolizeComparisonType(unwrap(type));
+  if (!compareType) llvm_unreachable("Invalid comparison-type specified.");
+  return wrap(
+      mlir::chlo::ComparisonTypeAttr::get(unwrap(ctx), compareType.value()));
+}
+
+bool chloAttributeIsAComparisonTypeAttr(MlirAttribute attr) {
+  return unwrap(attr).isa<mlir::chlo::ComparisonTypeAttr>();
+}
+
+MlirStringRef chloComparisonTypeAttrGetType(MlirAttribute attr) {
+  return wrap(mlir::chlo::stringifyComparisonType(
+      unwrap(attr).cast<mlir::chlo::ComparisonTypeAttr>().getValue()));
+}

--- a/integrations/c/ChloAttributes.h
+++ b/integrations/c/ChloAttributes.h
@@ -1,0 +1,54 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+   Copyright 2022 The StableHLO Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef STABLEHLO_INTEGRATIONS_C_CHLO_ATTRIBUTES_H
+#define STABLEHLO_INTEGRATIONS_C_CHLO_ATTRIBUTES_H
+
+#include <sys/types.h>
+
+#include "mlir-c/IR.h"
+#include "mlir-c/Support.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//===----------------------------------------------------------------------===//
+// ComparisonDirectionAttr
+//===----------------------------------------------------------------------===//
+
+MLIR_CAPI_EXPORTED MlirAttribute
+chloComparisonDirectionAttrGet(MlirContext ctx, MlirStringRef direction);
+
+MLIR_CAPI_EXPORTED bool chloAttributeIsAComparisonDirectionAttr(
+    MlirAttribute attr);
+
+MLIR_CAPI_EXPORTED MlirStringRef
+chloComparisonDirectionAttrGetDirection(MlirAttribute attr);
+
+//===----------------------------------------------------------------------===//
+// ComparisonTypeAttr
+//===----------------------------------------------------------------------===//
+
+MLIR_CAPI_EXPORTED MlirAttribute chloComparisonTypeAttrGet(MlirContext ctx,
+                                                           MlirStringRef type);
+
+MLIR_CAPI_EXPORTED bool chloAttributeIsAComparisonTypeAttr(MlirAttribute attr);
+
+MLIR_CAPI_EXPORTED MlirStringRef
+chloComparisonTypeAttrGetType(MlirAttribute attr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // STABLEHLO_INTEGRATIONS_C_CHLO_ATTRIBUTES_H

--- a/integrations/c/ChloDialect.cpp
+++ b/integrations/c/ChloDialect.cpp
@@ -1,0 +1,19 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+   Copyright 2022 The StableHLO Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "integrations/c/ChloDialect.h"
+
+#include "dialect/ChloOps.h"
+#include "mlir/CAPI/Registration.h"
+
+MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(Chlo, chlo, mlir::chlo::ChloDialect)

--- a/integrations/c/ChloDialect.h
+++ b/integrations/c/ChloDialect.h
@@ -1,0 +1,29 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+   Copyright 2022 The StableHLO Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef STABLEHLO_INTEGRATIONS_C_CHLO_DIALECT_H
+#define STABLEHLO_INTEGRATIONS_C_CHLO_DIALECT_H
+
+#include "mlir-c/RegisterEverything.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(Chlo, chlo);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // STABLEHLO_INTEGRATIONS_C_CHLO_DIALECT_H

--- a/integrations/c/StablehloAttributes.cpp
+++ b/integrations/c/StablehloAttributes.cpp
@@ -1,0 +1,556 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+   Copyright 2022 The StableHLO Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "integrations/c/StablehloAttributes.h"
+
+#include "dialect/StablehloOps.h"
+#include "mlir/CAPI/IR.h"
+#include "mlir/CAPI/Support.h"
+
+//===----------------------------------------------------------------------===//
+// ScatterDimensionNumbers
+//===----------------------------------------------------------------------===//
+
+MlirAttribute stablehloScatterDimensionNumbersGet(
+    MlirContext ctx, intptr_t nUpdateWindowDims,
+    const int64_t *updateWindowDims, intptr_t nInsertedWindowDims,
+    const int64_t *insertedWindowDims, intptr_t nScatteredDimsToOperandDims,
+    const int64_t *scatteredDimsToOperandDims, int64_t indexVectorDim) {
+  return wrap(mlir::stablehlo::ScatterDimensionNumbersAttr::get(
+      unwrap(ctx), llvm::makeArrayRef(updateWindowDims, nUpdateWindowDims),
+      llvm::makeArrayRef(insertedWindowDims, nInsertedWindowDims),
+      llvm::makeArrayRef(scatteredDimsToOperandDims,
+                         nScatteredDimsToOperandDims),
+      indexVectorDim));
+}
+
+bool stablehloAttributeIsAScatterDimensionNumbers(MlirAttribute attr) {
+  return unwrap(attr).isa<mlir::stablehlo::ScatterDimensionNumbersAttr>();
+}
+
+intptr_t stablehloScatterDimensionNumbersGetUpdateWindowDimsSize(
+    MlirAttribute attr) {
+  return unwrap(attr)
+      .cast<mlir::stablehlo::ScatterDimensionNumbersAttr>()
+      .getUpdateWindowDims()
+      .size();
+}
+
+int64_t stablehloScatterDimensionNumbersGetUpdateWindowDimsElem(
+    MlirAttribute attr, intptr_t pos) {
+  return unwrap(attr)
+      .cast<mlir::stablehlo::ScatterDimensionNumbersAttr>()
+      .getUpdateWindowDims()[pos];
+}
+
+intptr_t stablehloScatterDimensionNumbersGetInsertedWindowDimsSize(
+    MlirAttribute attr) {
+  return unwrap(attr)
+      .cast<mlir::stablehlo::ScatterDimensionNumbersAttr>()
+      .getInsertedWindowDims()
+      .size();
+}
+
+int64_t stablehloScatterDimensionNumbersGetInsertedWindowDimsElem(
+    MlirAttribute attr, intptr_t pos) {
+  return unwrap(attr)
+      .cast<mlir::stablehlo::ScatterDimensionNumbersAttr>()
+      .getInsertedWindowDims()[pos];
+}
+
+intptr_t stablehloScatterDimensionNumbersGetScatteredDimsToOperandDimsSize(
+    MlirAttribute attr) {
+  return unwrap(attr)
+      .cast<mlir::stablehlo::ScatterDimensionNumbersAttr>()
+      .getScatterDimsToOperandDims()
+      .size();
+}
+
+int64_t stablehloScatterDimensionNumbersGetScatteredDimsToOperandDimsElem(
+    MlirAttribute attr, intptr_t pos) {
+  return unwrap(attr)
+      .cast<mlir::stablehlo::ScatterDimensionNumbersAttr>()
+      .getScatterDimsToOperandDims()[pos];
+}
+
+int64_t stablehloDimensionNumbersGetIndexVectorDim(MlirAttribute attr) {
+  return unwrap(attr)
+      .cast<mlir::stablehlo::ScatterDimensionNumbersAttr>()
+      .getIndexVectorDim();
+}
+
+//===----------------------------------------------------------------------===//
+// GatherDimensionNumbers
+//===----------------------------------------------------------------------===//
+
+MlirAttribute stablehloGatherDimensionNumbersGet(
+    MlirContext ctx, intptr_t nOffsetDims, const int64_t *offsetDims,
+    intptr_t nCollapsedSliceDims, const int64_t *collapsedSliceDims,
+    intptr_t nStartIndexMap, const int64_t *startIndexMap,
+    int64_t indexVectorDim) {
+  return wrap(mlir::stablehlo::GatherDimensionNumbersAttr::get(
+      unwrap(ctx), llvm::makeArrayRef(offsetDims, nOffsetDims),
+      llvm::makeArrayRef(collapsedSliceDims, nCollapsedSliceDims),
+      llvm::makeArrayRef(startIndexMap, nStartIndexMap), indexVectorDim));
+}
+
+bool stablehloAttributeIsAGatherDimensionNumbers(MlirAttribute attr) {
+  return unwrap(attr).isa<mlir::stablehlo::GatherDimensionNumbersAttr>();
+}
+
+intptr_t stablehloGatherDimensionNumbersGetOffsetDimsSize(MlirAttribute attr) {
+  return unwrap(attr)
+      .cast<mlir::stablehlo::GatherDimensionNumbersAttr>()
+      .getOffsetDims()
+      .size();
+}
+
+int64_t stablehloGatherDimensionNumbersGetOffsetDimsElem(MlirAttribute attr,
+                                                         intptr_t pos) {
+  return unwrap(attr)
+      .cast<mlir::stablehlo::GatherDimensionNumbersAttr>()
+      .getOffsetDims()[pos];
+}
+
+intptr_t stablehloGatherDimensionNumbersGetCollapsedSliceDimsSize(
+    MlirAttribute attr) {
+  return unwrap(attr)
+      .cast<mlir::stablehlo::GatherDimensionNumbersAttr>()
+      .getCollapsedSliceDims()
+      .size();
+}
+
+int64_t stablehloGatherDimensionNumbersGetCollapsedSliceDimsElem(
+    MlirAttribute attr, intptr_t pos) {
+  return unwrap(attr)
+      .cast<mlir::stablehlo::GatherDimensionNumbersAttr>()
+      .getCollapsedSliceDims()[pos];
+}
+
+intptr_t stablehloGatherDimensionNumbersGetStartIndexMapSize(
+    MlirAttribute attr) {
+  return unwrap(attr)
+      .cast<mlir::stablehlo::GatherDimensionNumbersAttr>()
+      .getStartIndexMap()
+      .size();
+}
+
+int64_t stablehloGatherDimensionNumbersGetStartIndexMapElem(MlirAttribute attr,
+                                                            intptr_t pos) {
+  return unwrap(attr)
+      .cast<mlir::stablehlo::GatherDimensionNumbersAttr>()
+      .getStartIndexMap()[pos];
+}
+
+int64_t stablehloGatherDimensionNumbersGetIndexVectorDim(MlirAttribute attr) {
+  return unwrap(attr)
+      .cast<mlir::stablehlo::GatherDimensionNumbersAttr>()
+      .getIndexVectorDim();
+}
+
+//===----------------------------------------------------------------------===//
+// DotDimensionNumbers
+//===----------------------------------------------------------------------===//
+
+MlirAttribute stablehloDotDimensionNumbersGet(
+    MlirContext ctx, intptr_t nLhsBatchingDimensions,
+    const int64_t *lhsBatchingDimensions, intptr_t nRhsBatchingDimensions,
+    const int64_t *rhsBatchingDimensions, intptr_t nLhsContractingDimensions,
+    const int64_t *lhsContractingDimensions, intptr_t nRhsContractingDimensions,
+    const int64_t *rhsContractingDimensions) {
+  return wrap(mlir::stablehlo::DotDimensionNumbersAttr::get(
+      unwrap(ctx),
+      llvm::makeArrayRef(lhsBatchingDimensions, nLhsBatchingDimensions),
+      llvm::makeArrayRef(rhsBatchingDimensions, nRhsBatchingDimensions),
+      llvm::makeArrayRef(lhsContractingDimensions, nLhsContractingDimensions),
+      llvm::makeArrayRef(rhsContractingDimensions, nRhsContractingDimensions)));
+}
+
+bool stablehloAttributeIsADotDimensionNumbers(MlirAttribute attr) {
+  return unwrap(attr).isa<mlir::stablehlo::DotDimensionNumbersAttr>();
+}
+
+intptr_t stablehloDotDimensionNumbersGetLhsBatchingDimensionsSize(
+    MlirAttribute attr) {
+  return unwrap(attr)
+      .cast<mlir::stablehlo::DotDimensionNumbersAttr>()
+      .getLhsBatchingDimensions()
+      .size();
+}
+
+int64_t stablehloDotDimensionNumbersGetLhsBatchingDimensionsElem(
+    MlirAttribute attr, intptr_t pos) {
+  return unwrap(attr)
+      .cast<mlir::stablehlo::DotDimensionNumbersAttr>()
+      .getLhsBatchingDimensions()[pos];
+}
+
+intptr_t stablehloDotDimensionNumbersGetRhsBatchingDimensionsSize(
+    MlirAttribute attr) {
+  return unwrap(attr)
+      .cast<mlir::stablehlo::DotDimensionNumbersAttr>()
+      .getRhsBatchingDimensions()
+      .size();
+}
+
+int64_t stablehloDotDimensionNumbersGetRhsBatchingDimensionsElem(
+    MlirAttribute attr, intptr_t pos) {
+  return unwrap(attr)
+      .cast<mlir::stablehlo::DotDimensionNumbersAttr>()
+      .getRhsBatchingDimensions()[pos];
+}
+
+intptr_t stablehloDotDimensionNumbersGetLhsContractingDimensionsSize(
+    MlirAttribute attr) {
+  return unwrap(attr)
+      .cast<mlir::stablehlo::DotDimensionNumbersAttr>()
+      .getLhsContractingDimensions()
+      .size();
+}
+
+int64_t stablehloDotDimensionNumbersGetLhsContractingDimensionsElem(
+    MlirAttribute attr, intptr_t pos) {
+  return unwrap(attr)
+      .cast<mlir::stablehlo::DotDimensionNumbersAttr>()
+      .getLhsContractingDimensions()[pos];
+}
+
+intptr_t stablehloDotDimensionNumbersGetRhsContractingDimensionsSize(
+    MlirAttribute attr) {
+  return unwrap(attr)
+      .cast<mlir::stablehlo::DotDimensionNumbersAttr>()
+      .getRhsContractingDimensions()
+      .size();
+}
+
+int64_t stablehloDotDimensionNumbersGetRhsContractingDimensionsElem(
+    MlirAttribute attr, intptr_t pos) {
+  return unwrap(attr)
+      .cast<mlir::stablehlo::DotDimensionNumbersAttr>()
+      .getRhsContractingDimensions()[pos];
+}
+
+//===----------------------------------------------------------------------===//
+// ConvDimensionNumbers
+//===----------------------------------------------------------------------===//
+
+MlirAttribute stablehloConvDimensionNumbersGet(
+    MlirContext ctx, int64_t inputBatchDimension, int64_t inputFeatureDimension,
+    intptr_t nInputSpatialDimensions, const int64_t *inputSpatialDimensions,
+    int64_t kernelInputFeatureDimension, int64_t kernelOutputFeatureDimension,
+    intptr_t nKernelSpatialDimensions, const int64_t *kernelSpatialDimensions,
+    int64_t outputBatchDimension, int64_t outputFeatureDimension,
+    intptr_t nOutputSpatialDimensions, const int64_t *outputSpatialDimensions) {
+  return wrap(mlir::stablehlo::ConvDimensionNumbersAttr::get(
+      unwrap(ctx), inputBatchDimension, inputFeatureDimension,
+      llvm::makeArrayRef(inputSpatialDimensions, nInputSpatialDimensions),
+      kernelInputFeatureDimension, kernelOutputFeatureDimension,
+      llvm::makeArrayRef(kernelSpatialDimensions, nKernelSpatialDimensions),
+      outputBatchDimension, outputFeatureDimension,
+      llvm::makeArrayRef(outputSpatialDimensions, nOutputSpatialDimensions)));
+}
+
+bool stablehloAttributeIsAConvDimensionNumbers(MlirAttribute attr) {
+  return unwrap(attr).isa<mlir::stablehlo::ConvDimensionNumbersAttr>();
+}
+
+int64_t stablehloConvDimensionNumbersGetInputBatchDimension(
+    MlirAttribute attr) {
+  return unwrap(attr)
+      .cast<mlir::stablehlo::ConvDimensionNumbersAttr>()
+      .getInputBatchDimension();
+}
+
+int64_t stablehloConvDimensionNumbersGetInputFeatureDimension(
+    MlirAttribute attr) {
+  return unwrap(attr)
+      .cast<mlir::stablehlo::ConvDimensionNumbersAttr>()
+      .getInputFeatureDimension();
+}
+
+intptr_t stablehloConvDimensionNumbersGetInputSpatialDimensionsSize(
+    MlirAttribute attr) {
+  return unwrap(attr)
+      .cast<mlir::stablehlo::ConvDimensionNumbersAttr>()
+      .getInputSpatialDimensions()
+      .size();
+}
+
+int64_t stablehloConvDimensionNumbersGetInputSpatialDimensionsElem(
+    MlirAttribute attr, intptr_t pos) {
+  return unwrap(attr)
+      .cast<mlir::stablehlo::ConvDimensionNumbersAttr>()
+      .getInputSpatialDimensions()[pos];
+}
+
+int64_t stablehloConvDimensionNumbersGetKernelInputFeatureDimension(
+    MlirAttribute attr) {
+  return unwrap(attr)
+      .cast<mlir::stablehlo::ConvDimensionNumbersAttr>()
+      .getKernelInputFeatureDimension();
+}
+
+int64_t stablehloConvDimensionNumbersGetKernelOutputFeatureDimension(
+    MlirAttribute attr) {
+  return unwrap(attr)
+      .cast<mlir::stablehlo::ConvDimensionNumbersAttr>()
+      .getKernelOutputFeatureDimension();
+}
+
+intptr_t stablehloConvDimensionNumbersGetKernelSpatialDimensionsSize(
+    MlirAttribute attr) {
+  return unwrap(attr)
+      .cast<mlir::stablehlo::ConvDimensionNumbersAttr>()
+      .getKernelSpatialDimensions()
+      .size();
+}
+
+int64_t stablehloConvDimensionNumbersGetKernelSpatialDimensionsElem(
+    MlirAttribute attr, intptr_t pos) {
+  return unwrap(attr)
+      .cast<mlir::stablehlo::ConvDimensionNumbersAttr>()
+      .getKernelSpatialDimensions()[pos];
+}
+
+int64_t stablehloConvDimensionNumbersGetOutputBatchDimension(
+    MlirAttribute attr) {
+  return unwrap(attr)
+      .cast<mlir::stablehlo::ConvDimensionNumbersAttr>()
+      .getOutputBatchDimension();
+}
+
+int64_t stablehloConvDimensionNumbersGetOutputFeatureDimension(
+    MlirAttribute attr) {
+  return unwrap(attr)
+      .cast<mlir::stablehlo::ConvDimensionNumbersAttr>()
+      .getOutputFeatureDimension();
+}
+
+intptr_t stablehloConvDimensionNumbersGetOutputSpatialDimensionsSize(
+    MlirAttribute attr) {
+  return unwrap(attr)
+      .cast<mlir::stablehlo::ConvDimensionNumbersAttr>()
+      .getOutputSpatialDimensions()
+      .size();
+}
+
+int64_t stablehloConvDimensionNumbersGetOutputSpatialDimensionsElem(
+    MlirAttribute attr, intptr_t pos) {
+  return unwrap(attr)
+      .cast<mlir::stablehlo::ConvDimensionNumbersAttr>()
+      .getOutputSpatialDimensions()[pos];
+}
+
+//===----------------------------------------------------------------------===//
+// ComparisonDirectionAttr
+//===----------------------------------------------------------------------===//
+
+MlirAttribute stablehloComparisonDirectionAttrGet(MlirContext ctx,
+                                                  MlirStringRef direction) {
+  llvm::Optional<mlir::stablehlo::ComparisonDirection> compareDirection =
+      mlir::stablehlo::symbolizeComparisonDirection(unwrap(direction));
+  if (!compareDirection)
+    llvm_unreachable("Invalid comparison-direction specified.");
+  return wrap(mlir::stablehlo::ComparisonDirectionAttr::get(
+      unwrap(ctx), compareDirection.value()));
+}
+
+bool stablehloAttributeIsAComparisonDirectionAttr(MlirAttribute attr) {
+  return unwrap(attr).isa<mlir::stablehlo::ComparisonDirectionAttr>();
+}
+
+MlirStringRef stablehloComparisonDirectionAttrGetDirection(MlirAttribute attr) {
+  return wrap(mlir::stablehlo::stringifyComparisonDirection(
+      unwrap(attr)
+          .cast<mlir::stablehlo::ComparisonDirectionAttr>()
+          .getValue()));
+}
+
+//===----------------------------------------------------------------------===//
+// ComparisonTypeAttr
+//===----------------------------------------------------------------------===//
+
+MlirAttribute stablehloComparisonTypeAttrGet(MlirContext ctx,
+                                             MlirStringRef type) {
+  llvm::Optional<mlir::stablehlo::ComparisonType> compareType =
+      mlir::stablehlo::symbolizeComparisonType(unwrap(type));
+  if (!compareType) llvm_unreachable("Invalid comparison-type specified.");
+  return wrap(mlir::stablehlo::ComparisonTypeAttr::get(unwrap(ctx),
+                                                       compareType.value()));
+}
+
+bool stablehloAttributeIsAComparisonTypeAttr(MlirAttribute attr) {
+  return unwrap(attr).isa<mlir::stablehlo::ComparisonTypeAttr>();
+}
+
+MlirStringRef stablehloComparisonTypeAttrGetType(MlirAttribute attr) {
+  return wrap(mlir::stablehlo::stringifyComparisonType(
+      unwrap(attr).cast<mlir::stablehlo::ComparisonTypeAttr>().getValue()));
+}
+
+//===----------------------------------------------------------------------===//
+// PrecisionAttr
+//===----------------------------------------------------------------------===//
+
+MlirAttribute stablehloPrecisionAttrGet(MlirContext ctx, MlirStringRef type) {
+  llvm::Optional<mlir::stablehlo::Precision> precisionType =
+      mlir::stablehlo::symbolizePrecision(unwrap(type));
+  if (!precisionType) llvm_unreachable("Invalid precision-type specified.");
+  return wrap(mlir::stablehlo::PrecisionAttr::get(unwrap(ctx),
+                                                  precisionType.value()));
+}
+
+bool stablehloAttributeIsAPrecisionAttr(MlirAttribute attr) {
+  return unwrap(attr).isa<mlir::stablehlo::PrecisionAttr>();
+}
+
+MlirStringRef stablehloPrecisionAttrGetPrecision(MlirAttribute attr) {
+  return wrap(mlir::stablehlo::stringifyPrecision(
+      unwrap(attr).cast<mlir::stablehlo::PrecisionAttr>().getValue()));
+}
+
+//===----------------------------------------------------------------------===//
+// FftTypeAttr
+//===----------------------------------------------------------------------===//
+
+MlirAttribute stablehloFftTypeAttrGet(MlirContext ctx, MlirStringRef type) {
+  llvm::Optional<mlir::stablehlo::FftType> fftType =
+      mlir::stablehlo::symbolizeFftType(unwrap(type));
+  if (!fftType) llvm_unreachable("Invalid fft-type specified.");
+  return wrap(
+      mlir::stablehlo::FftTypeAttr::get(unwrap(ctx), fftType.value()));
+}
+
+bool stablehloAttributeIsAFftTypeAttr(MlirAttribute attr) {
+  return unwrap(attr).isa<mlir::stablehlo::FftTypeAttr>();
+}
+
+MlirStringRef stablehloFftTypeAttrGetFftType(MlirAttribute attr) {
+  return wrap(mlir::stablehlo::stringifyFftType(
+      unwrap(attr).cast<mlir::stablehlo::FftTypeAttr>().getValue()));
+}
+
+//===----------------------------------------------------------------------===//
+// TransposeAttr
+//===----------------------------------------------------------------------===//
+
+MlirAttribute stablehloTransposeAttrGet(MlirContext ctx, MlirStringRef type) {
+  llvm::Optional<mlir::stablehlo::Transpose> transposeType =
+      mlir::stablehlo::symbolizeTranspose(unwrap(type));
+  if (!transposeType) llvm_unreachable("Invalid transpose-type specified.");
+  return wrap(mlir::stablehlo::TransposeAttr::get(unwrap(ctx),
+                                                  transposeType.value()));
+}
+
+bool stablehloAttributeIsATransposeAttr(MlirAttribute attr) {
+  return unwrap(attr).isa<mlir::stablehlo::TransposeAttr>();
+}
+
+MlirStringRef stablehloTransposeAttrGetTranspose(MlirAttribute attr) {
+  return wrap(mlir::stablehlo::stringifyTranspose(
+      unwrap(attr).cast<mlir::stablehlo::TransposeAttr>().getValue()));
+}
+
+//===----------------------------------------------------------------------===//
+// RngDistributionAttr
+//===----------------------------------------------------------------------===//
+
+MlirAttribute stablehloRngDistributionAttrGet(MlirContext ctx,
+                                              MlirStringRef distribution) {
+  llvm::Optional<mlir::stablehlo::RngDistribution> rngDistribution =
+      mlir::stablehlo::symbolizeRngDistribution(unwrap(distribution));
+  if (!rngDistribution) llvm_unreachable("Invalid rng-distribution specified.");
+  return wrap(mlir::stablehlo::RngDistributionAttr::get(
+      unwrap(ctx), rngDistribution.value()));
+}
+
+bool stablehloAttributeIsARngDistributionAttr(MlirAttribute attr) {
+  return unwrap(attr).isa<mlir::stablehlo::RngDistributionAttr>();
+}
+
+MlirStringRef stablehloRngDistributionAttrGetRngDistribution(
+    MlirAttribute attr) {
+  return wrap(mlir::stablehlo::stringifyRngDistribution(
+      unwrap(attr).cast<mlir::stablehlo::RngDistributionAttr>().getValue()));
+}
+
+//===----------------------------------------------------------------------===//
+// RngAlgorithmAttr
+//===----------------------------------------------------------------------===//
+
+MlirAttribute stablehloRngAlgorithmAttrGet(MlirContext ctx,
+                                           MlirStringRef algorithm) {
+  llvm::Optional<mlir::stablehlo::RngAlgorithm> rngAlgorithm =
+      mlir::stablehlo::symbolizeRngAlgorithm(unwrap(algorithm));
+  if (!rngAlgorithm) llvm_unreachable("Invalid rng-algorithm specified.");
+  return wrap(mlir::stablehlo::RngAlgorithmAttr::get(unwrap(ctx),
+                                                     rngAlgorithm.value()));
+}
+
+bool stablehloAttributeIsARngAlgorithmAttr(MlirAttribute attr) {
+  return unwrap(attr).isa<mlir::stablehlo::RngAlgorithmAttr>();
+}
+
+MlirStringRef stablehloRngAlgorithmAttrGetRngAlgorithm(MlirAttribute attr) {
+  return wrap(mlir::stablehlo::stringifyRngAlgorithm(
+      unwrap(attr).cast<mlir::stablehlo::RngAlgorithmAttr>().getValue()));
+}
+
+//===----------------------------------------------------------------------===//
+// ChannelHandle
+//===----------------------------------------------------------------------===//
+
+MlirAttribute stablehloChannelHandleGet(MlirContext ctx, int64_t handle,
+                                        int64_t type) {
+  return wrap(
+      mlir::stablehlo::ChannelHandleAttr::get(unwrap(ctx), handle, type));
+}
+
+bool stablehloAttributeIsChannelHandle(MlirAttribute attr) {
+  return unwrap(attr).isa<mlir::stablehlo::ChannelHandleAttr>();
+}
+
+int64_t stablehloChannelHandleGetHandle(MlirAttribute attr) {
+  return unwrap(attr).cast<mlir::stablehlo::ChannelHandleAttr>().getHandle();
+}
+
+int64_t stablehloChannelHandleGetType(MlirAttribute attr) {
+  return unwrap(attr).cast<mlir::stablehlo::ChannelHandleAttr>().getType();
+}
+
+//===----------------------------------------------------------------------===//
+// TypeExtensions
+//===----------------------------------------------------------------------===//
+
+MlirAttribute stablehloTypeExtensionsGet(MlirContext ctx, intptr_t nBounds,
+                                         const int64_t *bounds) {
+  return wrap(mlir::stablehlo::TypeExtensionsAttr::get(
+      unwrap(ctx), llvm::makeArrayRef(bounds, nBounds)));
+}
+
+bool stablehloAttributeIsTypeExtensions(MlirAttribute attr) {
+  return unwrap(attr).isa<mlir::stablehlo::TypeExtensionsAttr>();
+}
+
+intptr_t stablehloTypeExtensionsGetBoundsSize(MlirAttribute attr) {
+  return unwrap(attr)
+      .cast<mlir::stablehlo::TypeExtensionsAttr>()
+      .getBounds()
+      .size();
+}
+
+int64_t stablehloTypeExtensionsGetBoundsElem(MlirAttribute attr, intptr_t pos) {
+  return unwrap(attr)
+      .cast<mlir::stablehlo::TypeExtensionsAttr>()
+      .getBounds()[pos];
+}

--- a/integrations/c/StablehloAttributes.cpp
+++ b/integrations/c/StablehloAttributes.cpp
@@ -406,8 +406,8 @@ MlirAttribute stablehloPrecisionAttrGet(MlirContext ctx, MlirStringRef type) {
   llvm::Optional<mlir::stablehlo::Precision> precisionType =
       mlir::stablehlo::symbolizePrecision(unwrap(type));
   if (!precisionType) llvm_unreachable("Invalid precision-type specified.");
-  return wrap(mlir::stablehlo::PrecisionAttr::get(unwrap(ctx),
-                                                  precisionType.value()));
+  return wrap(
+      mlir::stablehlo::PrecisionAttr::get(unwrap(ctx), precisionType.value()));
 }
 
 bool stablehloAttributeIsAPrecisionAttr(MlirAttribute attr) {
@@ -427,8 +427,7 @@ MlirAttribute stablehloFftTypeAttrGet(MlirContext ctx, MlirStringRef type) {
   llvm::Optional<mlir::stablehlo::FftType> fftType =
       mlir::stablehlo::symbolizeFftType(unwrap(type));
   if (!fftType) llvm_unreachable("Invalid fft-type specified.");
-  return wrap(
-      mlir::stablehlo::FftTypeAttr::get(unwrap(ctx), fftType.value()));
+  return wrap(mlir::stablehlo::FftTypeAttr::get(unwrap(ctx), fftType.value()));
 }
 
 bool stablehloAttributeIsAFftTypeAttr(MlirAttribute attr) {
@@ -448,8 +447,8 @@ MlirAttribute stablehloTransposeAttrGet(MlirContext ctx, MlirStringRef type) {
   llvm::Optional<mlir::stablehlo::Transpose> transposeType =
       mlir::stablehlo::symbolizeTranspose(unwrap(type));
   if (!transposeType) llvm_unreachable("Invalid transpose-type specified.");
-  return wrap(mlir::stablehlo::TransposeAttr::get(unwrap(ctx),
-                                                  transposeType.value()));
+  return wrap(
+      mlir::stablehlo::TransposeAttr::get(unwrap(ctx), transposeType.value()));
 }
 
 bool stablehloAttributeIsATransposeAttr(MlirAttribute attr) {

--- a/integrations/c/StablehloAttributes.h
+++ b/integrations/c/StablehloAttributes.h
@@ -1,0 +1,292 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+   Copyright 2022 The StableHLO Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef STABLEHLO_INTEGRATIONS_C_STABLEHLO_ATTRIBUTES_H
+#define STABLEHLO_INTEGRATIONS_C_STABLEHLO_ATTRIBUTES_H
+
+#include <sys/types.h>
+
+#include "mlir-c/IR.h"
+#include "mlir-c/Support.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//===----------------------------------------------------------------------===//
+// ScatterDimensionNumbers
+//===----------------------------------------------------------------------===//
+
+MLIR_CAPI_EXPORTED MlirAttribute stablehloScatterDimensionNumbersGet(
+    MlirContext ctx,                                                  //
+    intptr_t nUpdateWindowDims, const int64_t *updateWindowDims,      //
+    intptr_t nInsertedWindowDims, const int64_t *insertedWindowDims,  //
+    intptr_t nScatteredDimsToOperandDims,                             //
+    const int64_t *scatteredDimsToOperandDims,                        //
+    int64_t indexVectorDim);
+
+MLIR_CAPI_EXPORTED bool stablehloAttributeIsAScatterDimensionNumbers(
+    MlirAttribute attr);
+
+MLIR_CAPI_EXPORTED intptr_t
+stablehloScatterDimensionNumbersGetUpdateWindowDimsSize(MlirAttribute attr);
+MLIR_CAPI_EXPORTED int64_t
+stablehloScatterDimensionNumbersGetUpdateWindowDimsElem(MlirAttribute attr,
+                                                        intptr_t pos);
+MLIR_CAPI_EXPORTED intptr_t
+stablehloScatterDimensionNumbersGetInsertedWindowDimsSize(MlirAttribute attr);
+MLIR_CAPI_EXPORTED int64_t
+stablehloScatterDimensionNumbersGetInsertedWindowDimsElem(MlirAttribute attr,
+                                                          intptr_t pos);
+MLIR_CAPI_EXPORTED intptr_t
+stablehloScatterDimensionNumbersGetScatteredDimsToOperandDimsSize(
+    MlirAttribute attr);
+MLIR_CAPI_EXPORTED int64_t
+stablehloScatterDimensionNumbersGetScatteredDimsToOperandDimsElem(
+    MlirAttribute attr, intptr_t pos);
+MLIR_CAPI_EXPORTED int64_t
+stablehloDimensionNumbersGetIndexVectorDim(MlirAttribute attr);
+
+//===----------------------------------------------------------------------===//
+// GatherDimensionNumbers
+//===----------------------------------------------------------------------===//
+
+MLIR_CAPI_EXPORTED MlirAttribute stablehloGatherDimensionNumbersGet(
+    MlirContext ctx, intptr_t nOffsetDims, const int64_t *offsetDims,
+    intptr_t nCollapsedSliceDims, const int64_t *collapsedSliceDims,
+    intptr_t nStartIndexMap, const int64_t *startIndexMap,
+    int64_t indexVectorDim);
+
+MLIR_CAPI_EXPORTED bool stablehloAttributeIsAGatherDimensionNumbers(
+    MlirAttribute attr);
+
+MLIR_CAPI_EXPORTED intptr_t
+stablehloGatherDimensionNumbersGetOffsetDimsSize(MlirAttribute attr);
+MLIR_CAPI_EXPORTED int64_t stablehloGatherDimensionNumbersGetOffsetDimsElem(
+    MlirAttribute attr, intptr_t pos);
+MLIR_CAPI_EXPORTED intptr_t
+stablehloGatherDimensionNumbersGetCollapsedSliceDimsSize(MlirAttribute attr);
+MLIR_CAPI_EXPORTED int64_t
+stablehloGatherDimensionNumbersGetCollapsedSliceDimsElem(MlirAttribute attr,
+                                                         intptr_t pos);
+MLIR_CAPI_EXPORTED intptr_t
+stablehloGatherDimensionNumbersGetStartIndexMapSize(MlirAttribute attr);
+MLIR_CAPI_EXPORTED int64_t stablehloGatherDimensionNumbersGetStartIndexMapElem(
+    MlirAttribute attr, intptr_t pos);
+MLIR_CAPI_EXPORTED int64_t
+stablehloGatherDimensionNumbersGetIndexVectorDim(MlirAttribute attr);
+
+//===----------------------------------------------------------------------===//
+// DotDimensionNumbers
+//===----------------------------------------------------------------------===//
+
+MLIR_CAPI_EXPORTED MlirAttribute stablehloDotDimensionNumbersGet(
+    MlirContext ctx,                                                        //
+    intptr_t nLhsBatchingDimensions, const int64_t *lhsBatchingDimensions,  //
+    intptr_t nRhsBatchingDimensions, const int64_t *rhsBatchingDimensions,  //
+    intptr_t nLhsContractingDimensions,                                     //
+    const int64_t *lhsContractingDimensions,                                //
+    intptr_t nRhsContractingDimensions,                                     //
+    const int64_t *rhsContractingDimensions);
+
+MLIR_CAPI_EXPORTED bool stablehloAttributeIsADotDimensionNumbers(
+    MlirAttribute attr);
+
+MLIR_CAPI_EXPORTED intptr_t
+stablehloDotDimensionNumbersGetLhsBatchingDimensionsSize(MlirAttribute attr);
+MLIR_CAPI_EXPORTED int64_t
+stablehloDotDimensionNumbersGetLhsBatchingDimensionsElem(MlirAttribute attr,
+                                                         intptr_t pos);
+MLIR_CAPI_EXPORTED intptr_t
+stablehloDotDimensionNumbersGetRhsBatchingDimensionsSize(MlirAttribute attr);
+MLIR_CAPI_EXPORTED int64_t
+stablehloDotDimensionNumbersGetRhsBatchingDimensionsElem(MlirAttribute attr,
+                                                         intptr_t pos);
+MLIR_CAPI_EXPORTED intptr_t
+stablehloDotDimensionNumbersGetLhsContractingDimensionsSize(MlirAttribute attr);
+MLIR_CAPI_EXPORTED int64_t
+stablehloDotDimensionNumbersGetLhsContractingDimensionsElem(MlirAttribute attr,
+                                                            intptr_t pos);
+MLIR_CAPI_EXPORTED intptr_t
+stablehloDotDimensionNumbersGetRhsContractingDimensionsSize(MlirAttribute attr);
+MLIR_CAPI_EXPORTED int64_t
+stablehloDotDimensionNumbersGetRhsContractingDimensionsElem(MlirAttribute attr,
+                                                            intptr_t pos);
+
+//===----------------------------------------------------------------------===//
+// ConvDimensionNumbers
+//===----------------------------------------------------------------------===//
+
+MLIR_CAPI_EXPORTED MlirAttribute stablehloConvDimensionNumbersGet(
+    MlirContext ctx, int64_t inputBatchDimension, int64_t inputFeatureDimension,
+    intptr_t nInputSpatialDimensions, const int64_t *inputSpatialDimensions,
+    int64_t kernelInputFeatureDimension, int64_t kernelOutputFeatureDimension,
+    intptr_t nKernelSpatialDimensions, const int64_t *kernelSpatialDimensions,
+    int64_t outputBatchDimension, int64_t outputFeatureDimension,
+    intptr_t nOutputSpatialDimensions, const int64_t *outputSpatialDimensions);
+
+// Returns true of the given attribute is a ConvDimensionNumbers attribute.
+MLIR_CAPI_EXPORTED bool stablehloAttributeIsAConvDimensionNumbers(
+    MlirAttribute attr);
+
+// Returns the properties of ConvDimensionNumbers attributes.
+MLIR_CAPI_EXPORTED int64_t
+stablehloConvDimensionNumbersGetInputBatchDimension(MlirAttribute attr);
+MLIR_CAPI_EXPORTED int64_t
+stablehloConvDimensionNumbersGetInputFeatureDimension(MlirAttribute attr);
+
+MLIR_CAPI_EXPORTED intptr_t
+stablehloConvDimensionNumbersGetInputSpatialDimensionsSize(MlirAttribute attr);
+MLIR_CAPI_EXPORTED int64_t
+stablehloConvDimensionNumbersGetInputSpatialDimensionsElem(MlirAttribute attr,
+                                                           intptr_t pos);
+MLIR_CAPI_EXPORTED int64_t
+stablehloConvDimensionNumbersGetKernelInputFeatureDimension(MlirAttribute attr);
+MLIR_CAPI_EXPORTED int64_t
+stablehloConvDimensionNumbersGetKernelOutputFeatureDimension(
+    MlirAttribute attr);
+MLIR_CAPI_EXPORTED intptr_t
+stablehloConvDimensionNumbersGetKernelSpatialDimensionsSize(MlirAttribute attr);
+MLIR_CAPI_EXPORTED int64_t
+stablehloConvDimensionNumbersGetKernelSpatialDimensionsElem(MlirAttribute attr,
+                                                            intptr_t pos);
+MLIR_CAPI_EXPORTED int64_t
+stablehloConvDimensionNumbersGetOutputBatchDimension(MlirAttribute attr);
+MLIR_CAPI_EXPORTED int64_t
+stablehloConvDimensionNumbersGetOutputFeatureDimension(MlirAttribute attr);
+MLIR_CAPI_EXPORTED intptr_t
+stablehloConvDimensionNumbersGetOutputSpatialDimensionsSize(MlirAttribute attr);
+MLIR_CAPI_EXPORTED int64_t
+stablehloConvDimensionNumbersGetOutputSpatialDimensionsElem(MlirAttribute attr,
+                                                            intptr_t pos);
+
+//===----------------------------------------------------------------------===//
+// ComparisonDirectionAttr
+//===----------------------------------------------------------------------===//
+
+MLIR_CAPI_EXPORTED MlirAttribute
+stablehloComparisonDirectionAttrGet(MlirContext ctx, MlirStringRef direction);
+
+MLIR_CAPI_EXPORTED bool stablehloAttributeIsAComparisonDirectionAttr(
+    MlirAttribute attr);
+
+MLIR_CAPI_EXPORTED MlirStringRef
+stablehloComparisonDirectionAttrGetDirection(MlirAttribute attr);
+
+//===----------------------------------------------------------------------===//
+// ComparisonTypeAttr
+//===----------------------------------------------------------------------===//
+
+MLIR_CAPI_EXPORTED MlirAttribute
+stablehloComparisonTypeAttrGet(MlirContext ctx, MlirStringRef type);
+
+MLIR_CAPI_EXPORTED bool stablehloAttributeIsAComparisonTypeAttr(
+    MlirAttribute attr);
+
+MLIR_CAPI_EXPORTED MlirStringRef
+stablehloComparisonTypeAttrGetType(MlirAttribute attr);
+
+//===----------------------------------------------------------------------===//
+// PrecisionAttr
+//===----------------------------------------------------------------------===//
+
+MLIR_CAPI_EXPORTED MlirAttribute stablehloPrecisionAttrGet(MlirContext ctx,
+                                                           MlirStringRef type);
+
+MLIR_CAPI_EXPORTED bool stablehloAttributeIsAPrecisionAttr(MlirAttribute attr);
+
+MLIR_CAPI_EXPORTED MlirStringRef
+stablehloPrecisionAttrGetPrecision(MlirAttribute attr);
+
+//===----------------------------------------------------------------------===//
+// FftTypeAttr
+//===----------------------------------------------------------------------===//
+
+MLIR_CAPI_EXPORTED MlirAttribute stablehloFftTypeAttrGet(MlirContext ctx,
+                                                         MlirStringRef type);
+
+MLIR_CAPI_EXPORTED bool stablehloAttributeIsAFftTypeAttr(MlirAttribute attr);
+
+MLIR_CAPI_EXPORTED MlirStringRef
+stablehloFftTypeAttrGetFftType(MlirAttribute attr);
+
+//===----------------------------------------------------------------------===//
+// TransposeAttr
+//===----------------------------------------------------------------------===//
+
+MLIR_CAPI_EXPORTED MlirAttribute stablehloTransposeAttrGet(MlirContext ctx,
+                                                           MlirStringRef type);
+
+MLIR_CAPI_EXPORTED bool stablehloAttributeIsATransposeAttr(MlirAttribute attr);
+
+MLIR_CAPI_EXPORTED MlirStringRef
+stablehloTransposeAttrGetTranspose(MlirAttribute attr);
+
+//===----------------------------------------------------------------------===//
+// RngDistributionAttr
+//===----------------------------------------------------------------------===//
+
+MLIR_CAPI_EXPORTED MlirAttribute
+stablehloRngDistributionAttrGet(MlirContext ctx, MlirStringRef distribution);
+
+MLIR_CAPI_EXPORTED bool stablehloAttributeIsARngDistributionAttr(
+    MlirAttribute attr);
+
+MLIR_CAPI_EXPORTED MlirStringRef
+stablehloRngDistributionAttrGetRngDistribution(MlirAttribute attr);
+
+//===----------------------------------------------------------------------===//
+// RngAlgorithmAttr
+//===----------------------------------------------------------------------===//
+
+MLIR_CAPI_EXPORTED MlirAttribute
+stablehloRngAlgorithmAttrGet(MlirContext ctx, MlirStringRef algorithm);
+
+MLIR_CAPI_EXPORTED bool stablehloAttributeIsARngAlgorithmAttr(
+    MlirAttribute attr);
+
+MLIR_CAPI_EXPORTED MlirStringRef
+stablehloRngAlgorithmAttrGetRngAlgorithm(MlirAttribute attr);
+
+//===----------------------------------------------------------------------===//
+// ChannelHandle
+//===----------------------------------------------------------------------===//
+
+MLIR_CAPI_EXPORTED MlirAttribute stablehloChannelHandleGet(MlirContext ctx,
+                                                           int64_t handle,
+                                                           int64_t type);
+
+MLIR_CAPI_EXPORTED bool stablehloAttributeIsChannelHandle(MlirAttribute attr);
+
+MLIR_CAPI_EXPORTED int64_t stablehloChannelHandleGetHandle(MlirAttribute attr);
+
+MLIR_CAPI_EXPORTED int64_t stablehloChannelHandleGetType(MlirAttribute attr);
+
+//===----------------------------------------------------------------------===//
+// TypeExtensions
+//===----------------------------------------------------------------------===//
+
+MLIR_CAPI_EXPORTED MlirAttribute stablehloTypeExtensionsGet(
+    MlirContext ctx, intptr_t nBounds, const int64_t *bounds);
+
+MLIR_CAPI_EXPORTED bool stablehloAttributeIsTypeExtensions(MlirAttribute attr);
+
+MLIR_CAPI_EXPORTED intptr_t
+stablehloTypeExtensionsGetBoundsSize(MlirAttribute attr);
+MLIR_CAPI_EXPORTED int64_t
+stablehloTypeExtensionsGetBoundsElem(MlirAttribute attr, intptr_t pos);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // STABLEHLO_INTEGRATIONS_C_STABLEHLO_ATTRIBUTES_H

--- a/integrations/c/StablehloDialect.cpp
+++ b/integrations/c/StablehloDialect.cpp
@@ -1,0 +1,20 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+   Copyright 2022 The StableHLO Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "integrations/c/StablehloDialect.h"
+
+#include "dialect/StablehloOps.h"
+#include "mlir/CAPI/Registration.h"
+
+MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(Stablehlo, stablehlo,
+                                      mlir::stablehlo::StablehloDialect)

--- a/integrations/c/StablehloDialect.h
+++ b/integrations/c/StablehloDialect.h
@@ -1,0 +1,29 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+   Copyright 2022 The StableHLO Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef STABLEHLO_INTEGRATIONS_C_STABLEHLO_DIALECT_H
+#define STABLEHLO_INTEGRATIONS_C_STABLEHLO_DIALECT_H
+
+#include "mlir-c/RegisterEverything.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(Stablehlo, stablehlo);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // STABLEHLO_INTEGRATIONS_C_STABLEHLO_DIALECT_H

--- a/integrations/c/StablehloTypes.cpp
+++ b/integrations/c/StablehloTypes.cpp
@@ -1,0 +1,25 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+   Copyright 2022 The StableHLO Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "integrations/c/StablehloTypes.h"
+
+#include "dialect/StablehloOps.h"
+#include "mlir/CAPI/IR.h"
+
+MlirType stablehloTokenTypeGet(MlirContext ctx) {
+  return wrap(mlir::stablehlo::TokenType::get(unwrap(ctx)));
+}
+
+bool stablehloTypeIsAToken(MlirType type) {
+  return unwrap(type).isa<mlir::stablehlo::TokenType>();
+}

--- a/integrations/c/StablehloTypes.h
+++ b/integrations/c/StablehloTypes.h
@@ -1,0 +1,34 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+   Copyright 2022 The StableHLO Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef STABLEHLO_INTEGRATIONS_C_STABLEHLO_TYPES_H
+#define STABLEHLO_INTEGRATIONS_C_STABLEHLO_TYPES_H
+
+#include "mlir-c/IR.h"
+#include "mlir-c/Support.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Creates a token type in the given context.
+MLIR_CAPI_EXPORTED MlirType stablehloTokenTypeGet(MlirContext ctx);
+
+// Returns true if the type is a token type.
+MLIR_CAPI_EXPORTED bool stablehloTypeIsAToken(MlirType type);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // STABLEHLO_INTEGRATIONS_C_STABLEHLO_TYPES_H

--- a/integrations/python/CMakeLists.txt
+++ b/integrations/python/CMakeLists.txt
@@ -1,0 +1,123 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2022 The StableHLO Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+include(AddMLIRPython)
+
+################################################################################
+# Generate Python sources
+################################################################################
+
+declare_mlir_python_sources(ChloPythonSources)
+declare_mlir_python_sources(ChloPythonSources.Dialects
+  ADD_TO_PARENT ChloPythonSources
+)
+
+declare_mlir_dialect_python_bindings(
+  ADD_TO_PARENT ChloPythonSources.Dialects
+  ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/mlir"
+  TD_FILE dialects/ChloOps.td
+  SOURCES dialects/chlo.py
+  DIALECT_NAME chlo)
+
+declare_mlir_python_sources(StablehloPythonSources)
+declare_mlir_python_sources(StablehloPythonSources.Dialects
+  ADD_TO_PARENT StablehloPythonSources
+)
+
+declare_mlir_dialect_python_bindings(
+  ADD_TO_PARENT StablehloPythonSources.Dialects
+  ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/mlir"
+  TD_FILE dialects/StablehloOps.td
+  SOURCES dialects/stablehlo.py
+  DIALECT_NAME stablehlo)
+
+################################################################################
+# Generate Python extensions
+################################################################################
+
+declare_mlir_python_sources(ChloPythonExtensions)
+declare_mlir_python_extension(ChloPythonExtensions.Main
+  MODULE_NAME _chlo
+  ADD_TO_PARENT ChloPythonExtensions
+  SOURCES
+    ChloModule.cpp
+  EMBED_CAPI_LINK_LIBS
+    ChloCAPI
+  PRIVATE_LINK_LIBS
+    LLVMSupport
+)
+
+declare_mlir_python_sources(StablehloPythonExtensions)
+declare_mlir_python_extension(StablehloPythonExtensions.Main
+  MODULE_NAME _stablehlo
+  ADD_TO_PARENT StablehloPythonExtensions
+  SOURCES
+    StablehloModule.cpp
+  EMBED_CAPI_LINK_LIBS
+    StablehloCAPI
+  PRIVATE_LINK_LIBS
+    LLVMSupport
+)
+
+################################################################################
+# Generate packages and shared libraries
+################################################################################
+
+add_mlir_python_common_capi_library(ChloPythonCAPI
+  INSTALL_COMPONENT ChloPythonModules
+  INSTALL_DESTINATION python_packages/chlo/mlir/_mlir_libs
+  OUTPUT_DIRECTORY "${STABLEHLO_BINARY_DIR}/python_packages/chlo/mlir/_mlir_libs"
+  RELATIVE_INSTALL_ROOT "../../../.."
+  DECLARED_SOURCES
+    MLIRPythonSources
+    MLIRPythonExtension.RegisterEverything
+    ChloPythonSources
+    ChloPythonExtensions
+)
+
+add_mlir_python_modules(ChloPythonModules
+  ROOT_PREFIX "${STABLEHLO_BINARY_DIR}/python_packages/chlo/mlir"
+  INSTALL_PREFIX "python_packages/chlo/mlir"
+  DECLARED_SOURCES
+    MLIRPythonSources
+    MLIRPythonExtension.RegisterEverything
+    ChloPythonSources
+    ChloPythonExtensions
+  COMMON_CAPI_LINK_LIBS
+    ChloPythonCAPI
+  )
+
+add_mlir_python_common_capi_library(StablehloPythonCAPI
+  INSTALL_COMPONENT StablehloPythonModules
+  INSTALL_DESTINATION python_packages/stablehlo/mlir/_mlir_libs
+  OUTPUT_DIRECTORY "${STABLEHLO_BINARY_DIR}/python_packages/stablehlo/mlir/_mlir_libs"
+  RELATIVE_INSTALL_ROOT "../../../.."
+  DECLARED_SOURCES
+    MLIRPythonSources
+    MLIRPythonExtension.RegisterEverything
+    StablehloPythonSources
+    StablehloPythonExtensions
+)
+
+add_mlir_python_modules(StablehloPythonModules
+  ROOT_PREFIX "${STABLEHLO_BINARY_DIR}/python_packages/stablehlo/mlir"
+  INSTALL_PREFIX "python_packages/stablehlo/mlir"
+  DECLARED_SOURCES
+    MLIRPythonSources
+    MLIRPythonExtension.RegisterEverything
+    StablehloPythonSources
+    StablehloPythonExtensions
+  COMMON_CAPI_LINK_LIBS
+    StablehloPythonCAPI
+  )

--- a/integrations/python/CMakeLists.txt
+++ b/integrations/python/CMakeLists.txt
@@ -15,8 +15,12 @@
 include(AddMLIRPython)
 
 ################################################################################
-# Generate Python sources
+# Sources
 ################################################################################
+
+# Note that the directory structure for source files is meaningful. For example,
+# putting .td and .py files under . instead of mlir/python will break things,
+# even if the build rules below are adjusted accordingly.
 
 declare_mlir_python_sources(ChloPythonSources)
 declare_mlir_python_sources(ChloPythonSources.Dialects
@@ -43,7 +47,7 @@ declare_mlir_dialect_python_bindings(
   DIALECT_NAME stablehlo)
 
 ################################################################################
-# Generate Python extensions
+# Extensions
 ################################################################################
 
 declare_mlir_python_sources(ChloPythonExtensions)
@@ -74,50 +78,41 @@ declare_mlir_python_extension(StablehloPythonExtensions.Main
 # Generate packages and shared libraries
 ################################################################################
 
-add_mlir_python_common_capi_library(ChloPythonCAPI
-  INSTALL_COMPONENT ChloPythonModules
-  INSTALL_DESTINATION python_packages/chlo/mlir/_mlir_libs
-  OUTPUT_DIRECTORY "${STABLEHLO_BINARY_DIR}/python_packages/chlo/mlir/_mlir_libs"
-  RELATIVE_INSTALL_ROOT "../../../.."
-  DECLARED_SOURCES
-    MLIRPythonSources
-    MLIRPythonExtension.RegisterEverything
-    ChloPythonSources
-    ChloPythonExtensions
-)
+# Note that we are deliberately putting CHLO and StableHLO dialects together
+# into a single package, even though they are independent from each other.
+# That's because the initialization code generated for these packages modifies
+# global state, so importing multiple packages like that will mess things up.
 
-add_mlir_python_modules(ChloPythonModules
-  ROOT_PREFIX "${STABLEHLO_BINARY_DIR}/python_packages/chlo/mlir"
-  INSTALL_PREFIX "python_packages/chlo/mlir"
-  DECLARED_SOURCES
-    MLIRPythonSources
-    MLIRPythonExtension.RegisterEverything
-    ChloPythonSources
-    ChloPythonExtensions
-  COMMON_CAPI_LINK_LIBS
-    ChloPythonCAPI
-  )
-
-add_mlir_python_common_capi_library(StablehloPythonCAPI
-  INSTALL_COMPONENT StablehloPythonModules
+add_mlir_python_common_capi_library(StablehloUnifiedPythonCAPI
+  INSTALL_COMPONENT StablehloUnifiedPythonModules
   INSTALL_DESTINATION python_packages/stablehlo/mlir/_mlir_libs
   OUTPUT_DIRECTORY "${STABLEHLO_BINARY_DIR}/python_packages/stablehlo/mlir/_mlir_libs"
   RELATIVE_INSTALL_ROOT "../../../.."
   DECLARED_SOURCES
     MLIRPythonSources
     MLIRPythonExtension.RegisterEverything
+    ChloPythonSources
+    ChloPythonExtensions
     StablehloPythonSources
     StablehloPythonExtensions
 )
 
-add_mlir_python_modules(StablehloPythonModules
+add_mlir_python_modules(StablehloUnifiedPythonModules
   ROOT_PREFIX "${STABLEHLO_BINARY_DIR}/python_packages/stablehlo/mlir"
   INSTALL_PREFIX "python_packages/stablehlo/mlir"
   DECLARED_SOURCES
     MLIRPythonSources
     MLIRPythonExtension.RegisterEverything
+    ChloPythonSources
+    ChloPythonExtensions
     StablehloPythonSources
     StablehloPythonExtensions
   COMMON_CAPI_LINK_LIBS
-    StablehloPythonCAPI
+    StablehloUnifiedPythonCAPI
   )
+
+################################################################################
+# Tests
+################################################################################
+
+add_subdirectory(tests)

--- a/integrations/python/ChloModule.cpp
+++ b/integrations/python/ChloModule.cpp
@@ -1,0 +1,80 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+   Copyright 2022 The StableHLO Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "integrations/c/ChloAttributes.h"
+#include "integrations/c/ChloDialect.h"
+#include "mlir-c/IR.h"
+#include "mlir/Bindings/Python/PybindAdaptors.h"
+
+namespace py = pybind11;
+
+namespace {
+
+auto toPyString(MlirStringRef mlirStringRef) {
+  return py::str(mlirStringRef.data, mlirStringRef.length);
+}
+
+}  // namespace
+
+PYBIND11_MODULE(_chlo, m) {
+  m.doc() = "chlo main python extension";
+
+  //
+  // Dialects.
+  //
+
+  m.def(
+      "register_dialect",
+      [](MlirContext context, bool load) {
+        MlirDialectHandle dialect = mlirGetDialectHandle__chlo__();
+        mlirDialectHandleRegisterDialect(dialect, context);
+        if (load) {
+          mlirDialectHandleLoadDialect(dialect, context);
+        }
+      },
+      py::arg("context"), py::arg("load") = true);
+
+  //
+  // Attributes.
+  //
+
+  mlir::python::adaptors::mlir_attribute_subclass(
+      m, "ComparisonDirectionAttr", chloAttributeIsAComparisonDirectionAttr)
+      .def_classmethod(
+          "get",
+          [](py::object cls, const std::string &direction, MlirContext ctx) {
+            return cls(chloComparisonDirectionAttrGet(
+                ctx, mlirStringRefCreate(direction.c_str(), direction.size())));
+          },
+          py::arg("cls"), py::arg("comparison_direction"),
+          py::arg("context") = py::none(),
+          "Creates a ComparisonDirection attribute with the given direction.")
+      .def_property_readonly("comparison_direction", [](MlirAttribute self) {
+        return toPyString(chloComparisonDirectionAttrGetDirection(self));
+      });
+
+  mlir::python::adaptors::mlir_attribute_subclass(
+      m, "ComparisonTypeAttr", chloAttributeIsAComparisonTypeAttr)
+      .def_classmethod(
+          "get",
+          [](py::object cls, const std::string &type, MlirContext ctx) {
+            return cls(chloComparisonTypeAttrGet(
+                ctx, mlirStringRefCreate(type.c_str(), type.size())));
+          },
+          py::arg("cls"), py::arg("comparison_type"),
+          py::arg("context") = py::none(),
+          "Creates a ComparisonType attribute with the given type.")
+      .def_property_readonly("comparison_type", [](MlirAttribute self) {
+        return toPyString(chloComparisonTypeAttrGetType(self));
+      });
+}

--- a/integrations/python/StablehloModule.cpp
+++ b/integrations/python/StablehloModule.cpp
@@ -1,0 +1,452 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+   Copyright 2022 The StableHLO Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "integrations/c/StablehloAttributes.h"
+#include "integrations/c/StablehloDialect.h"
+#include "integrations/c/StablehloTypes.h"
+#include "mlir-c/IR.h"
+#include "mlir/Bindings/Python/PybindAdaptors.h"
+
+namespace py = pybind11;
+
+namespace {
+// Returns a vector containing integers extracted from an attribute using the
+// two provided callbacks.
+std::vector<int64_t> attributePropertyVector(
+    MlirAttribute attr, llvm::function_ref<intptr_t(MlirAttribute)> sizeFn,
+    llvm::function_ref<int64_t(MlirAttribute, intptr_t)> getFn) {
+  std::vector<int64_t> result;
+  intptr_t size = sizeFn(attr);
+  result.reserve(size);
+  for (intptr_t i = 0; i < size; ++i) {
+    result.push_back(getFn(attr, i));
+  }
+  return result;
+}
+
+auto toPyString(MlirStringRef mlirStringRef) {
+  return py::str(mlirStringRef.data, mlirStringRef.length);
+}
+
+}  // namespace
+
+PYBIND11_MODULE(_stablehlo, m) {
+  m.doc() = "stablehlo main python extension";
+
+  //
+  // Dialects.
+  //
+
+  m.def(
+      "register_dialect",
+      [](MlirContext context, bool load) {
+        MlirDialectHandle dialect = mlirGetDialectHandle__stablehlo__();
+        mlirDialectHandleRegisterDialect(dialect, context);
+        if (load) {
+          mlirDialectHandleLoadDialect(dialect, context);
+        }
+      },
+      py::arg("context"), py::arg("load") = true);
+
+  //
+  // Types.
+  //
+
+  mlir::python::adaptors::mlir_type_subclass(m, "TokenType",
+                                             stablehloTypeIsAToken)
+      .def_classmethod(
+          "get",
+          [](py::object cls, MlirContext ctx) {
+            return cls(stablehloTokenTypeGet(ctx));
+          },
+          py::arg("cls"), py::arg("context") = py::none(),
+          "Creates a Token type.");
+
+  //
+  // Attributes.
+  //
+
+  auto scatteredDimsToOperandDimsFunc = [](MlirAttribute self) {
+    return attributePropertyVector(
+        self, stablehloScatterDimensionNumbersGetScatteredDimsToOperandDimsSize,
+        stablehloScatterDimensionNumbersGetScatteredDimsToOperandDimsElem);
+  };
+
+  mlir::python::adaptors::mlir_attribute_subclass(
+      m, "ScatterDimensionNumbers",
+      stablehloAttributeIsAScatterDimensionNumbers)
+      .def_classmethod(
+          "get",
+          [](py::object cls, const std::vector<int64_t> &updateWindowDims,
+             const std::vector<int64_t> &insertedWindowDims,
+             const std::vector<int64_t> &scatteredDimsToOperandDims,
+             int64_t indexVectorDim, MlirContext ctx) {
+            return cls(stablehloScatterDimensionNumbersGet(
+                ctx, updateWindowDims.size(), updateWindowDims.data(),
+                insertedWindowDims.size(), insertedWindowDims.data(),
+                scatteredDimsToOperandDims.size(),
+                scatteredDimsToOperandDims.data(), indexVectorDim));
+          },
+          py::arg("cls"), py::arg("update_window_dims"),
+          py::arg("inserted_window_dims"),
+          py::arg("scattered_dims_to_operand_dims"),
+          py::arg("index_vector_dim"), py::arg("context") = py::none(),
+          "Creates a ScatterDimensionNumbers with the given dimension "
+          "configuration.")
+      .def_property_readonly(
+          "update_window_dims",
+          [](MlirAttribute self) {
+            return attributePropertyVector(
+                self, stablehloScatterDimensionNumbersGetUpdateWindowDimsSize,
+                stablehloScatterDimensionNumbersGetUpdateWindowDimsElem);
+          })
+      .def_property_readonly(
+          "inserted_window_dims",
+          [](MlirAttribute self) {
+            return attributePropertyVector(
+                self, stablehloScatterDimensionNumbersGetInsertedWindowDimsSize,
+                stablehloScatterDimensionNumbersGetInsertedWindowDimsElem);
+          })
+      .def_property_readonly("scattered_dims_to_operand_dims",
+                             scatteredDimsToOperandDimsFunc)
+      .def_property_readonly("index_vector_dim", [](MlirAttribute self) {
+        return stablehloDimensionNumbersGetIndexVectorDim(self);
+      });
+
+  mlir::python::adaptors::mlir_attribute_subclass(
+      m, "GatherDimensionNumbers", stablehloAttributeIsAGatherDimensionNumbers)
+      .def_classmethod(
+          "get",
+          [](py::object cls, const std::vector<int64_t> &offsetDims,
+             const std::vector<int64_t> &collapsedSliceDims,
+             const std::vector<int64_t> &startIndexMap, int64_t indexVectorDim,
+             MlirContext ctx) {
+            return cls(stablehloGatherDimensionNumbersGet(
+                ctx, offsetDims.size(), offsetDims.data(),
+                collapsedSliceDims.size(), collapsedSliceDims.data(),
+                startIndexMap.size(), startIndexMap.data(), indexVectorDim));
+          },
+          py::arg("cls"), py::arg("offset_dims"),
+          py::arg("collapsed_slice_dims"), py::arg("start_index_map"),
+          py::arg("index_vector_dim"), py::arg("context") = py::none(),
+          "Creates a GatherDimensionNumbers attribute with the given dimension "
+          "configuration.")
+      .def_property_readonly(
+          "offset_dims",
+          [](MlirAttribute self) {
+            return attributePropertyVector(
+                self, stablehloGatherDimensionNumbersGetOffsetDimsSize,
+                stablehloGatherDimensionNumbersGetOffsetDimsElem);
+          })
+      .def_property_readonly(
+          "collapsed_slice_dims",
+          [](MlirAttribute self) {
+            return attributePropertyVector(
+                self, stablehloGatherDimensionNumbersGetCollapsedSliceDimsSize,
+                stablehloGatherDimensionNumbersGetCollapsedSliceDimsElem);
+          })
+      .def_property_readonly(
+          "start_index_map",
+          [](MlirAttribute self) {
+            return attributePropertyVector(
+                self, stablehloGatherDimensionNumbersGetStartIndexMapSize,
+                stablehloGatherDimensionNumbersGetStartIndexMapElem);
+          })
+      .def_property_readonly("index_vector_dim", [](MlirAttribute self) {
+        return stablehloGatherDimensionNumbersGetIndexVectorDim(self);
+      });
+
+  mlir::python::adaptors::mlir_attribute_subclass(
+      m, "DotDimensionNumbers", stablehloAttributeIsADotDimensionNumbers)
+      .def_classmethod(
+          "get",
+          [](py::object cls, const std::vector<int64_t> &lhsBatchingDims,
+             const std::vector<int64_t> &rhsBatchingDims,
+             const std::vector<int64_t> &lhsContractingDims,
+             const std::vector<int64_t> &rhsContractingDims, MlirContext ctx) {
+            return cls(stablehloDotDimensionNumbersGet(
+                ctx, lhsBatchingDims.size(), lhsBatchingDims.data(),
+                rhsBatchingDims.size(), rhsBatchingDims.data(),
+                lhsContractingDims.size(), lhsContractingDims.data(),
+                rhsContractingDims.size(), rhsContractingDims.data()));
+          },
+          py::arg("cls"), py::arg("lhs_batching_dimensions"),
+          py::arg("rhs_batching_dimensions"),
+          py::arg("lhs_contracting_dimensions"),
+          py::arg("rhs_contracting_dimensions"),
+          py::arg("context") = py::none(),
+          "Creates a DotDimensionNumbers attribute with the given dimension "
+          "configuration.")
+      .def_property_readonly(
+          "lhs_batching_dimensions",
+          [](MlirAttribute self) {
+            return attributePropertyVector(
+                self, stablehloDotDimensionNumbersGetLhsBatchingDimensionsSize,
+                stablehloDotDimensionNumbersGetLhsBatchingDimensionsElem);
+          })
+      .def_property_readonly(
+          "rhs_batching_dimensions",
+          [](MlirAttribute self) {
+            return attributePropertyVector(
+                self, stablehloDotDimensionNumbersGetRhsBatchingDimensionsSize,
+                stablehloDotDimensionNumbersGetRhsBatchingDimensionsElem);
+          })
+      .def_property_readonly(
+          "lhs_contracting_dimensions",
+          [](MlirAttribute self) {
+            return attributePropertyVector(
+                self,
+                stablehloDotDimensionNumbersGetLhsContractingDimensionsSize,
+                stablehloDotDimensionNumbersGetLhsContractingDimensionsElem);
+          })
+      .def_property_readonly(
+          "rhs_contracting_dimensions", [](MlirAttribute self) {
+            return attributePropertyVector(
+                self,
+                stablehloDotDimensionNumbersGetRhsContractingDimensionsSize,
+                stablehloDotDimensionNumbersGetRhsContractingDimensionsElem);
+          });
+
+  mlir::python::adaptors::mlir_attribute_subclass(
+      m, "ConvDimensionNumbers", stablehloAttributeIsAConvDimensionNumbers)
+      .def_classmethod(
+          "get",
+          [](py::object cls, int64_t inputBatchDimension,
+             int64_t inputFeatureDimension,
+             const std::vector<int64_t> inputSpatialDimensions,
+             int64_t kernelInputFeatureDimension,
+             int64_t kernelOutputFeatureDimension,
+             const std::vector<int64_t> kernelSpatialDimensions,
+             int64_t outputBatchDimension, int64_t outputFeatureDimension,
+             const std::vector<int64_t> outputSpatialDimensions,
+             MlirContext ctx) {
+            return cls(stablehloConvDimensionNumbersGet(
+                ctx, inputBatchDimension, inputFeatureDimension,
+                inputSpatialDimensions.size(), inputSpatialDimensions.data(),
+                kernelInputFeatureDimension, kernelOutputFeatureDimension,
+                kernelSpatialDimensions.size(), kernelSpatialDimensions.data(),
+                outputBatchDimension, outputFeatureDimension,
+                outputSpatialDimensions.size(),
+                outputSpatialDimensions.data()));
+          },
+          py::arg("cls"), py::arg("input_batch_dimension"),
+          py::arg("input_feature_dimension"),
+          py::arg("input_spatial_dimensions"),
+          py::arg("kernel_input_feature_dimension"),
+          py::arg("kernel_output_feature_dimension"),
+          py::arg("kernel_spatial_dimensions"),
+          py::arg("output_batch_dimension"),
+          py::arg("output_feature_dimension"),
+          py::arg("output_spatial_dimensions"), py::arg("ctx") = py::none(),
+          "Creates a ConvDimensionNumbers attribute with the given dimension "
+          "configuration.")
+      .def_property_readonly(
+          "input_batch_dimension",
+          [](MlirAttribute self) {
+            return stablehloConvDimensionNumbersGetInputBatchDimension(self);
+          })
+      .def_property_readonly(
+          "input_feature_dimension",
+          [](MlirAttribute self) {
+            return stablehloConvDimensionNumbersGetInputFeatureDimension(self);
+          })
+      .def_property_readonly(
+          "input_spatial_dimensions",
+          [](MlirAttribute self) {
+            return attributePropertyVector(
+                self,
+                stablehloConvDimensionNumbersGetInputSpatialDimensionsSize,
+                stablehloConvDimensionNumbersGetInputSpatialDimensionsElem);
+          })
+      .def_property_readonly(
+          "kernel_input_feature_dimension",
+          [](MlirAttribute self) {
+            return stablehloConvDimensionNumbersGetKernelInputFeatureDimension(
+                self);
+          })
+      .def_property_readonly(
+          "kernel_output_feature_dimension",
+          [](MlirAttribute self) {
+            return stablehloConvDimensionNumbersGetKernelOutputFeatureDimension(
+                self);
+          })
+      .def_property_readonly(
+          "kernel_spatial_dimensions",
+          [](MlirAttribute self) {
+            return attributePropertyVector(
+                self,
+                stablehloConvDimensionNumbersGetKernelSpatialDimensionsSize,
+                stablehloConvDimensionNumbersGetKernelSpatialDimensionsElem);
+          })
+      .def_property_readonly(
+          "output_batch_dimension",
+          [](MlirAttribute self) {
+            return stablehloConvDimensionNumbersGetOutputBatchDimension(self);
+          })
+      .def_property_readonly(
+          "output_feature_dimension",
+          [](MlirAttribute self) {
+            return stablehloConvDimensionNumbersGetOutputFeatureDimension(self);
+          })
+      .def_property_readonly(
+          "output_spatial_dimensions", [](MlirAttribute self) {
+            return attributePropertyVector(
+                self,
+                stablehloConvDimensionNumbersGetOutputSpatialDimensionsSize,
+                stablehloConvDimensionNumbersGetOutputSpatialDimensionsElem);
+          });
+
+  mlir::python::adaptors::mlir_attribute_subclass(
+      m, "ComparisonDirectionAttr",
+      stablehloAttributeIsAComparisonDirectionAttr)
+      .def_classmethod(
+          "get",
+          [](py::object cls, const std::string &direction, MlirContext ctx) {
+            return cls(stablehloComparisonDirectionAttrGet(
+                ctx, mlirStringRefCreate(direction.c_str(), direction.size())));
+          },
+          py::arg("cls"), py::arg("comparison_direction"),
+          py::arg("context") = py::none(),
+          "Creates a ComparisonDirection attribute with the given direction.")
+      .def_property_readonly("comparison_direction", [](MlirAttribute self) {
+        return toPyString(stablehloComparisonDirectionAttrGetDirection(self));
+      });
+
+  mlir::python::adaptors::mlir_attribute_subclass(
+      m, "ComparisonTypeAttr", stablehloAttributeIsAComparisonTypeAttr)
+      .def_classmethod(
+          "get",
+          [](py::object cls, const std::string &type, MlirContext ctx) {
+            return cls(stablehloComparisonTypeAttrGet(
+                ctx, mlirStringRefCreate(type.c_str(), type.size())));
+          },
+          py::arg("cls"), py::arg("comparison_type"),
+          py::arg("context") = py::none(),
+          "Creates a ComparisonType attribute with the given type.")
+      .def_property_readonly("comparison_type", [](MlirAttribute self) {
+        return toPyString(stablehloComparisonTypeAttrGetType(self));
+      });
+
+  mlir::python::adaptors::mlir_attribute_subclass(
+      m, "PrecisionAttr", stablehloAttributeIsAPrecisionAttr)
+      .def_classmethod(
+          "get",
+          [](py::object cls, const std::string &type, MlirContext ctx) {
+            return cls(stablehloPrecisionAttrGet(
+                ctx, mlirStringRefCreate(type.c_str(), type.size())));
+          },
+          py::arg("cls"), py::arg("precision_type"),
+          py::arg("context") = py::none(),
+          "Creates a Precision attribute with the given type.")
+      .def_property_readonly("precision_type", [](MlirAttribute self) {
+        return toPyString(stablehloPrecisionAttrGetPrecision(self));
+      });
+
+  mlir::python::adaptors::mlir_attribute_subclass(
+      m, "FftTypeAttr", stablehloAttributeIsAFftTypeAttr)
+      .def_classmethod(
+          "get",
+          [](py::object cls, const std::string &type, MlirContext ctx) {
+            return cls(stablehloFftTypeAttrGet(
+                ctx, mlirStringRefCreate(type.c_str(), type.size())));
+          },
+          py::arg("cls"), py::arg("fft_type"), py::arg("context") = py::none(),
+          "Creates a FftType attribute with the given type.")
+      .def_property_readonly("fft_type", [](MlirAttribute self) {
+        return toPyString(stablehloFftTypeAttrGetFftType(self));
+      });
+
+  mlir::python::adaptors::mlir_attribute_subclass(
+      m, "TransposeAttr", stablehloAttributeIsATransposeAttr)
+      .def_classmethod(
+          "get",
+          [](py::object cls, const std::string &type, MlirContext ctx) {
+            return cls(stablehloTransposeAttrGet(
+                ctx, mlirStringRefCreate(type.c_str(), type.size())));
+          },
+          py::arg("cls"), py::arg("transpose_type"),
+          py::arg("context") = py::none(),
+          "Creates a Transpose attribute with the given type.")
+      .def_property_readonly("transpose_type", [](MlirAttribute self) {
+        return toPyString(stablehloTransposeAttrGetTranspose(self));
+      });
+
+  mlir::python::adaptors::mlir_attribute_subclass(
+      m, "RngDistributionAttr", stablehloAttributeIsARngDistributionAttr)
+      .def_classmethod(
+          "get",
+          [](py::object cls, const std::string &distribution, MlirContext ctx) {
+            return cls(stablehloRngDistributionAttrGet(
+                ctx, mlirStringRefCreate(distribution.c_str(),
+                                         distribution.size())));
+          },
+          py::arg("cls"), py::arg("rng_distribution"),
+          py::arg("context") = py::none(),
+          "Creates a RngDistribution attribute with the given rng "
+          "distribution.")
+      .def_property_readonly("rng_distribution", [](MlirAttribute self) {
+        auto distribution =
+            stablehloRngDistributionAttrGetRngDistribution(self);
+        return py::str(distribution.data, distribution.length);
+      });
+
+  mlir::python::adaptors::mlir_attribute_subclass(
+      m, "RngAlgorithmAttr", stablehloAttributeIsARngAlgorithmAttr)
+      .def_classmethod(
+          "get",
+          [](py::object cls, const std::string &algorithm, MlirContext ctx) {
+            return cls(stablehloRngAlgorithmAttrGet(
+                ctx, mlirStringRefCreate(algorithm.c_str(), algorithm.size())));
+          },
+          py::arg("cls"), py::arg("rng_algorithm"),
+          py::arg("context") = py::none(),
+          "Creates a RngAlgorithm attribute with the given rng algorithm.")
+      .def_property_readonly("rng_algorithm", [](MlirAttribute self) {
+        auto algorithm = stablehloRngAlgorithmAttrGetRngAlgorithm(self);
+        return py::str(algorithm.data, algorithm.length);
+      });
+
+  mlir::python::adaptors::mlir_attribute_subclass(
+      m, "ChannelHandle", stablehloAttributeIsChannelHandle)
+      .def_classmethod(
+          "get",
+          [](py::object cls, int64_t handle, int64_t type, MlirContext ctx) {
+            return cls(stablehloChannelHandleGet(ctx, handle, type));
+          },
+          py::arg("cls"), py::arg("handle"), py::arg("type"),
+          py::arg("context") = py::none(), "Creates a ChannelHandle attribute.")
+      .def_property_readonly("handle",
+                             [](MlirAttribute self) {
+                               return stablehloChannelHandleGetHandle(self);
+                             })
+      .def_property_readonly("channel_type", [](MlirAttribute self) {
+        return stablehloChannelHandleGetType(self);
+      });
+
+  mlir::python::adaptors::mlir_attribute_subclass(
+      m, "TypeExtensions", stablehloAttributeIsTypeExtensions)
+      .def_classmethod(
+          "get",
+          [](py::object cls, const std::vector<int64_t> &bounds,
+             MlirContext ctx) {
+            return cls(
+                stablehloTypeExtensionsGet(ctx, bounds.size(), bounds.data()));
+          },
+          py::arg("cls"), py::arg("bounds"), py::arg("context") = py::none(),
+          "Creates a TypeExtensions with the given bounds.")
+      .def_property_readonly("bounds", [](MlirAttribute self) {
+        return attributePropertyVector(self,
+                                       stablehloTypeExtensionsGetBoundsSize,
+                                       stablehloTypeExtensionsGetBoundsElem);
+      });
+}

--- a/integrations/python/mlir/dialects/ChloOps.td
+++ b/integrations/python/mlir/dialects/ChloOps.td
@@ -1,0 +1,23 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+   Copyright 2022 The StableHLO Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef STABLEHLO_INTEGRATIONS_PYTHON_CHLO_OPS
+#define STABLEHLO_INTEGRATIONS_PYTHON_CHLO_OPS
+
+include "mlir/Bindings/Python/Attributes.td"
+include "dialect/ChloOps.td"
+
+#endif

--- a/integrations/python/mlir/dialects/StablehloOps.td
+++ b/integrations/python/mlir/dialects/StablehloOps.td
@@ -1,0 +1,23 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+   Copyright 2022 The StableHLO Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef STABLEHLO_INTEGRATIONS_PYTHON_STABLEHLO_OPS
+#define STABLEHLO_INTEGRATIONS_PYTHON_STABLEHLO_OPS
+
+include "mlir/Bindings/Python/Attributes.td"
+include "dialect/StablehloOps.td"
+
+#endif

--- a/integrations/python/mlir/dialects/chlo.py
+++ b/integrations/python/mlir/dialects/chlo.py
@@ -1,0 +1,19 @@
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2022 The StableHLO Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+# pylint: disable=wildcard-import,relative-beyond-top-level,g-import-not-at-top
+from ._chlo_ops_gen import *
+from .._mlir_libs._chlo import *

--- a/integrations/python/mlir/dialects/chlo.py
+++ b/integrations/python/mlir/dialects/chlo.py
@@ -17,6 +17,7 @@
 # pylint: disable=wildcard-import,relative-beyond-top-level,g-import-not-at-top
 from ._chlo_ops_gen import *
 
+
 def register_dialect(context, load=True):
   from .._mlir_libs import _chlo
   _chlo.register_dialect(context, load=load)

--- a/integrations/python/mlir/dialects/stablehlo.py
+++ b/integrations/python/mlir/dialects/stablehlo.py
@@ -1,0 +1,19 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2022 The StableHLO Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+# pylint: disable=wildcard-import,relative-beyond-top-level,g-import-not-at-top
+from ._stablehlo_ops_gen import *
+from .._mlir_libs._stablehlo import *

--- a/integrations/python/mlir/dialects/stablehlo.py
+++ b/integrations/python/mlir/dialects/stablehlo.py
@@ -16,4 +16,7 @@
 
 # pylint: disable=wildcard-import,relative-beyond-top-level,g-import-not-at-top
 from ._stablehlo_ops_gen import *
-from .._mlir_libs._stablehlo import *
+
+def register_dialect(context, load=True):
+  from .._mlir_libs import _stablehlo
+  _stablehlo.register_dialect(context, load=load)

--- a/integrations/python/mlir/dialects/stablehlo.py
+++ b/integrations/python/mlir/dialects/stablehlo.py
@@ -17,6 +17,7 @@
 # pylint: disable=wildcard-import,relative-beyond-top-level,g-import-not-at-top
 from ._stablehlo_ops_gen import *
 
+
 def register_dialect(context, load=True):
   from .._mlir_libs import _stablehlo
   _stablehlo.register_dialect(context, load=load)

--- a/integrations/python/tests/CMakeLists.txt
+++ b/integrations/python/tests/CMakeLists.txt
@@ -5,18 +5,25 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+add_custom_target(check-stablehlo-python)
 
-# pylint: disable=wildcard-import,relative-beyond-top-level,g-import-not-at-top
-from ._chlo_ops_gen import *
+function(add_stablehlo_python_test test_name file_name)
+add_custom_target(${test_name}
+  PYTHONPATH=${STABLEHLO_BINARY_DIR}/python_packages/stablehlo:$ENV{PYTHONPATH} ${Python3_EXECUTABLE} ${file_name}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  DEPENDS
+    StablehloUnifiedPythonModules
+)
+add_dependencies(check-stablehlo-python ${test_name})
+endfunction()
 
-def register_dialect(context, load=True):
-  from .._mlir_libs import _chlo
-  _chlo.register_dialect(context, load=load)
+add_stablehlo_python_test(stablehlo-python-smoketest smoketest.py)
+
+add_dependencies(check-stablehlo check-stablehlo-python)

--- a/integrations/python/tests/smoketest.py
+++ b/integrations/python/tests/smoketest.py
@@ -1,0 +1,43 @@
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2022 The StableHLO Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Simple smoketest for the Python API."""
+
+# pylint: disable=wildcard-import,undefined-variable
+
+from mlir.dialects import chlo
+from mlir.dialects import stablehlo
+from mlir.ir import *
+
+ASM = """
+func.func @test(%arg0: tensor<?xf32>, %arg1: tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %0 = chlo.broadcast_add %arg0, %arg1 : (tensor<?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
+  %1 = stablehlo.add %0, %0 : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
+  func.return %1 : tensor<?x?xf32>
+}
+"""
+
+with Context() as context:
+  chlo.register_dialect(context)
+  stablehlo.register_dialect(context)
+
+  m = Module.parse(ASM)
+  assert m is not None
+  block = m.body.operations[0].regions[0].blocks[0]
+  assert block is not None
+  assert block.operations[0] is not None
+  assert block.operations[1] is not None
+  assert block.operations[2] is not None
+  print("StableHLO Python bindings seem to work")


### PR DESCRIPTION
In this pull request, I took the existing Python bindings for MLIR-HLO
and mostly copy/pasted them into the StableHLO repository.

One change from MLIR-HLO is that we have two separate bindings for
CHLO and StableHLO in the StableHLO repository. This follows the recent
trend in both repositories where we severed the dependency from CHLO
to MHLO.