### PR TITLE
Add type inference for stablehlo.reduce

### DIFF
--- a/dialect/StablehloOps.cpp
+++ b/dialect/StablehloOps.cpp
@@ -458,7 +458,7 @@ LogicalResult verifyReducerShape(
   //  BV(j) : j-th init-value of reducer-function
   //  R(i)  : i-th return-type
   //
-  //  Note that: |I(i)| == V(j)| == |BI(i)| == |BV(j)| == |R(i)|
+  //  Note that: |I(i)| == |V(j)| == |BI(i)| == |BV(j)| == |R(i)|
   //
   //  Here are the type-constraints among V(j), BI(i), BV(j), and R(i).
   //    C1 : Check that BI(i) and R(i) have same shape and element-type.
@@ -537,7 +537,8 @@ LogicalResult verifyReducerShape(
          outputShapeIdx < static_cast<int64_t>(allowedDimensions.size()) &&
          argShapeIdx < static_cast<int64_t>(argShape.size());
          outputShapeIdx++)
-      if (allowedDimensions[outputShapeIdx] == argShape[argShapeIdx])
+      if (allowedDimensions[outputShapeIdx] == argShape[argShapeIdx] ||
+          argShape[argShapeIdx] == ShapedType::kDynamicSize)
         argShapeIdx++;
 
     if (argShapeIdx != static_cast<int64_t>(argShape.size()))
@@ -3952,17 +3953,19 @@ ParseResult ReduceOp::parse(OpAsmParser& parser, OperationState& result) {
   return success();
 }
 
-LogicalResult ReduceOp::verify() {
-  // Check that there are even number of operands and >= 2.
-  if (getNumOperands() % 2 != 0 || getOperands().empty())
-    return emitOpError() << "expects the size of operands to be even and >= 2";
-
+LogicalResult ReduceOp::inferReturnTypeComponents(
+    MLIRContext *, Optional<Location> location, ValueShapeRange operands,
+    DictionaryAttr attributes, RegionRange regions,
+    SmallVectorImpl<ShapedTypeComponents> &inferredReturnShapes) {
   // Collect the input and init-value operands. Note that the operand-type is
   // enforced as "TensorType" by ODS.
-  int64_t numInputs = getNumOperands() / 2;
+  if (operands.size() % 2 != 0 || operands.size() == 0)
+    return emitOptionalError(location, "expects the size of operands to be even and >= 2");
+  int64_t numInputs = operands.size() / 2;
   auto operandTensorTypes = llvm::to_vector<4>(llvm::map_range(
-      getOperandTypes(),
-      [](Type t) -> TensorType { return t.cast<TensorType>(); }));
+      operands.getTypes(),
+      [](Type t) -> TensorType
+      { return t.cast<TensorType>(); }));
   ArrayRef<TensorType> inputArgTypes(operandTensorTypes.begin(),
                                      operandTensorTypes.begin() + numInputs);
   ArrayRef<TensorType> initValueTypes(operandTensorTypes.begin() + numInputs,
@@ -3985,11 +3988,11 @@ LogicalResult ReduceOp::verify() {
     for (int64_t inputIdx = 0; inputIdx < numInputs; ++inputIdx) {
       if (failed(mlir::verifyCompatibleShape(inputArgTypes[rankedInputIdx],
                                              inputArgTypes[inputIdx]))) {
-        return emitOpError()
-               << "expects all inputs to have compatible shapes. Shape at"
-               << " input-index " << inputIdx
-               << " is not compatible with shape at input-index "
-               << rankedInputIdx;
+        return emitOptionalError(
+            location, "'", ReduceOp::getOperationName(), "' op ",
+            "expects all inputs to have compatible shapes. Shape at",
+            " input-index ", inputIdx,
+            " is not compatible with shape at input-index ", rankedInputIdx);
       }
     }
   }
@@ -3997,18 +4000,20 @@ LogicalResult ReduceOp::verify() {
   // Check that
   //   1. the dimensions of reduce-op are in-bounds for the given shape.
   //   2. the dimension-attribute have no duplicate entries.
+  ReduceOp::Adaptor adaptor(operands, attributes, regions);
   DenseSet<int64_t> dimensionsToReduceSet;
-  for (int64_t dimension : dimensions().getValues<int64_t>()) {
+  for (int64_t dimension : adaptor.dimensions().getValues<int64_t>()) {
     if ((!allInputsUnranked &&
          dimension >= inputArgTypes[rankedInputIdx].getRank()) ||
         dimension < 0) {
-      return emitError() << "Out-of-bounds dimension " << dimension
-                         << " for input-tensor rank: "
-                         << inputArgTypes[rankedInputIdx].getRank();
+      return emitOptionalError(
+          location, "Out-of-bounds dimension ", dimension,
+          " for input-tensor rank: ", inputArgTypes[rankedInputIdx].getRank());
     }
 
     if (!dimensionsToReduceSet.insert(dimension).second) {
-      return emitError() << "Duplicate reduction dimension: " << dimension;
+      return emitOptionalError(location,
+                               "Duplicate reduction dimension: ", dimension);
     }
   }
 
@@ -4024,46 +4029,19 @@ LogicalResult ReduceOp::verify() {
     }
   }
 
-  Block& block = body().front();
+  Block& block = adaptor.body().front();
   SmallVector<TensorType> accumulatorSubShapes;
-  if (failed(verifyReducerShape(this->getLoc(), block, inputArgTypes,
+  if (failed(verifyReducerShape(location.getValue(), block, inputArgTypes,
                                 initValueTypes, numInputs, newDimensions,
                                 allInputsUnranked, accumulatorSubShapes)))
     return failure();
-
-  // Check if the reduce-op's result-type matches with the one derived from
-  // the reducer-block and dimensions attribute.
-  if (getResults().size() != accumulatorSubShapes.size())
-    return emitError() << "Unexpected number of reduce-op's returned values: "
-                       << getResults().size() << " vs "
-                       << accumulatorSubShapes.size() << " (expected)";
-
-  for (int64_t shapeIdx = 0;
-       shapeIdx < static_cast<int64_t>(accumulatorSubShapes.size());
-       shapeIdx++) {
-    // The result-type is enforced as "TensorType" by ODS.
-    auto opResultType = getResult(shapeIdx).getType().cast<TensorType>();
-
-    // Check element-type.
-    if (accumulatorSubShapes[shapeIdx].getElementType() !=
-        opResultType.getElementType()) {
-      return emitError()
-             << "Unexpected element-type for reduce-op's return value at index "
-             << shapeIdx << ": " << opResultType.getElementType() << " vs "
-             << accumulatorSubShapes[shapeIdx].getElementType()
-             << " (expected)";
-    }
-
-    // Check shape.
-    if (!allInputsUnranked && opResultType.hasRank() &&
-        failed(verifyCompatibleShape(newDimensions, opResultType.getShape()))) {
-      Type expectedResultType = RankedTensorType::get(
-          newDimensions, accumulatorSubShapes[shapeIdx].getElementType());
-      return emitError()
-             << "Unexpected type for reduce-op's return value at index "
-             << shapeIdx << ": " << opResultType << " vs " << expectedResultType
-             << " (expected)";
-    }
+  
+  for (auto resultType : accumulatorSubShapes)
+  {
+    if (resultType.isa<RankedTensorType>())
+      inferredReturnShapes.emplace_back(newDimensions, resultType.getElementType());
+    else
+      inferredReturnShapes.emplace_back(resultType.getElementType());
   }
 
   return success();

--- a/dialect/StablehloOps.td
+++ b/dialect/StablehloOps.td
@@ -1259,6 +1259,7 @@ def StableHLO_AllToAllOp : StableHLO_Op<"all_to_all",
 def StableHLO_ReduceOp: StableHLO_ShapedInterfaceOp<"reduce", [
       RecursiveSideEffects,
       SameVariadicOperandSize,
+      InferTensorTypeWithReify,
       SingleBlockImplicitTerminator<"ReturnOp">
     ]> {
   let summary = "Reduce operator";
@@ -1281,11 +1282,21 @@ def StableHLO_ReduceOp: StableHLO_ShapedInterfaceOp<"reduce", [
       "DenseIntElementsAttr":$dimensions)>];
 
   let hasCustomAssemblyFormat = 1;
-  let hasVerifier = 1;
 
   // TODO(hinsu): Verify that the attached body arguments and results are
   // compatible with reduce op's operands.
   let regions = (region SizedRegion<1>:$body);
+
+  let extraClassDeclaration = [{
+    // Method from InferTypeOpInterface interface.
+    static bool isCompatibleReturnTypes(TypeRange l, TypeRange r) {
+      if (l.size() != r.size()) return false;
+      for (auto [lt, rt] : llvm::zip(l, r))
+        if (!mlir::hlo::isCompatibleForHloTypeInference(lt, rt))
+          return false;
+      return true;
+    }
+  }];
 }
 
 //===----------------------------------------------------------------------===//

--- a/tests/infer_stablehlo.mlir
+++ b/tests/infer_stablehlo.mlir
@@ -311,6 +311,24 @@ func.func @complex_sparsity(%arg0: tensor<10x10xf32, #CSR>, %arg1: tensor<10x10x
 
 // -----
 
+// CHECK-LABEL: func @reduce
+func.func @reduce(%arg0: tensor<4x4xf32>, %arg1 : tensor<4xf32>)
+    -> (tensor<4xindex>) {
+  %0 = "mhlo.reduce"(%arg0, %arg1) ({
+
+  ^bb0(%arg2: tensor<4xf32>, %arg3: tensor<4xf32> ):
+    %1 = "mhlo.add"(%arg2, %arg3) : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
+    "mhlo.return"(%1) : (tensor<4xf32>) -> ()
+
+  }) {dimensions = dense<[0]> : tensor<1xi64>} : (tensor<4x4xf32>, tensor<4xf32>) -> tensor<4xf32>
+  %2 = "mhlo_test.get_return_type_components"(%0)
+      : (tensor<4xf32>) -> tensor<4xindex>
+// CHECK: %1 = "mhlo_test.get_return_type_components"(%0) : (tensor<4xf32>) -> tensor<4xindex>
+  func.return %2: tensor<4xindex>
+}
+
+// -----
+
 // CHECK-LABEL: @tensor_bounds
 func.func @tensor_bounds(%arg0: tensor<3x5xf32>, %arg1: tensor<i32>) -> tensor<*xindex> {
   %result = "stablehlo.set_dimension_size"(%arg0, %arg1) {dimension = 0 : i64} : (tensor<3x5xf32>, tensor<i32>) -> tensor<*xf32>

--- a/tests/verify_reduce.mlir
+++ b/tests/verify_reduce.mlir
@@ -35,8 +35,8 @@ func.func @reduce_complex_type(%arg0: tensor<1x2xcomplex<f32>>, %arg1 : tensor<c
 
 // -----
 
-// CHECK-LABEL:    func @reduce_unranked
-func.func @reduce_unranked(%arg0: tensor<*xf32>, %arg1 : tensor<*xf32>)
+// CHECK-LABEL:    func @reduce_single_operand_unranked
+func.func @reduce_single_operand_unranked(%arg0: tensor<*xf32>, %arg1 : tensor<*xf32>)
     -> (tensor<*xf32>) {
   %0 = "stablehlo.reduce"(%arg0, %arg1) ({
 
@@ -77,6 +77,23 @@ func.func @reduce_unranked(%arg0: tensor<4x4xf32>, %arg1: tensor<4x4xf32>,
   func.return %0#0, %0#1 : tensor<*xf32>, tensor<*xf32>
 }
 
+// ----
+
+// CHECK-LABEL:    func @reduce_mix_rank_and_unranked
+func.func @reduce_mix_rank_and_unranked(%arg0: tensor<4x4xf32>, %arg1: tensor<*xf32>,
+    %arg2: tensor<4xf32>, %arg3: tensor<*xf32>) -> (tensor<4xf32>, tensor<*xf32>) {
+  %0:2 = "stablehlo.reduce"(%arg0, %arg1, %arg2, %arg3) ({
+
+  ^bb0(%arg4: tensor<4xf32>, %arg5: tensor<*xf32>, %arg6: tensor<4xf32>, %arg7: tensor<*xf32>):
+    %1 = "stablehlo.add"(%arg4, %arg6) : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
+    %2 = "stablehlo.add"(%arg5, %arg7) : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
+    "stablehlo.return"(%1, %2) : (tensor<4xf32>, tensor<*xf32>) -> ()
+
+  }) {dimensions = dense<[1]> : tensor<1xi64>} : (tensor<4x4xf32>, tensor<*xf32>, tensor<4xf32>, tensor<*xf32>) -> (tensor<4xf32>, tensor<*xf32>)
+
+  func.return %0#0, %0#1 : tensor<4xf32>, tensor<*xf32>
+}
+
 // Next, we have the invalid testcases.
 
 // -----
@@ -84,7 +101,7 @@ func.func @reduce_unranked(%arg0: tensor<4x4xf32>, %arg1: tensor<4x4xf32>,
 func.func @reduce_odd_num_args(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>,
     %arg2: tensor<f32>, %arg3: tensor<f32>) -> (tensor<?xf32>, tensor<?xf32>) {
 
-  // expected-error@+1 {{'stablehlo.reduce' op expects the size of operands to be even and >= 2}}
+  // expected-error@+1 {{expects the size of operands to be even and >= 2}}
   %0:2 = "stablehlo.reduce"(%arg0, %arg1, %arg2) ({
 
   ^bb0(%arg4: tensor<f32>, %arg5: tensor<f32>, %arg6: tensor<f32>, %arg7: tensor<f32>):
@@ -102,7 +119,7 @@ func.func @reduce_odd_num_args(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>,
 func.func @reduce_zero_args(%arg0: tensor<?x?xf32>, %arg1 : tensor<f32>)
     -> (tensor<?xf32>) {
 
-  // expected-error@+1 {{'stablehlo.reduce' op expects the size of operands to be even and >= 2}}
+  // expected-error@+1 {{expects the size of operands to be even and >= 2}}
   %0 = "stablehlo.reduce"() ({
 
   ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32> ):
@@ -242,7 +259,7 @@ func.func @verify_reducer_function(%arg0: tensor<?x?xf32>, %arg1 : tensor<f32>)
   // expected-error@+1 {{Reduction-region here must produce tensor-typed result(s), but produces 'f32' instead}}
   %0 = "stablehlo.reduce"(%arg0, %arg1) ({
 
-  ^bb0(%arg2: f32, %arg3: f32 ):
+  ^bb0(%arg2: f32, %arg3: f32):
     %1 = "llvm.add"(%arg2, %arg3) : (f32, f32) -> f32
     "stablehlo.return"(%1) : (f32) -> ()
 
@@ -316,7 +333,7 @@ func.func @verify_reducer_function(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xi32
 
   ^bb0(%arg4: tensor<f32>, %arg5: tensor<f32>, %arg6: tensor<f32>, %arg7: tensor<i32>):
     %1 = "stablehlo.add"(%arg4, %arg6) : (tensor<f32>, tensor<f32>) -> tensor<f32>
-    %2 = "stablehlo.max"(%arg4, %arg6) : (tensor<f32>, tensor<f32>) -> tensor<f32>
+    %2 = "stablehlo.maximum"(%arg4, %arg6) : (tensor<f32>, tensor<f32>) -> tensor<f32>
     "stablehlo.return"(%1, %2) : (tensor<f32>, tensor<f32>) -> ()
 
   }) {dimensions = dense<[1]> : tensor<1xi64>} : (tensor<?x?xf32>, tensor<?x?xi32>, tensor<f32>, tensor<f32>) -> (tensor<?xf32>, tensor<?xi32>)
@@ -352,7 +369,7 @@ func.func @verify_reducer_function(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xi32
 
   ^bb0(%arg4: tensor<f32>, %arg5: tensor<f32>, %arg6: tensor<f32>, %arg7: tensor<f32>):
     %1 = "stablehlo.add"(%arg4, %arg6) : (tensor<f32>, tensor<f32>) -> tensor<f32>
-    %2 = "stablehlo.max"(%arg4, %arg6) : (tensor<f32>, tensor<f32>) -> tensor<f32>
+    %2 = "stablehlo.maximum"(%arg4, %arg6) : (tensor<f32>, tensor<f32>) -> tensor<f32>
     "stablehlo.return"(%1, %2) : (tensor<f32>, tensor<f32>) -> ()
 
   }) {dimensions = dense<[1]> : tensor<1xi64>} : (tensor<?x?xf32>, tensor<?x?xi32>, tensor<f32>, tensor<f32>) -> (tensor<?xf32>, tensor<?xf32>)
@@ -399,7 +416,7 @@ func.func @verify_reducer_function(%arg0: tensor<8x5xf32>, %arg1 : tensor<4xf32>
 func.func @reduce_verify_rettype(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xi32>,
     %arg2: tensor<f32>, %arg3: tensor<i32>) -> (tensor<?xf32>) {
 
-  // expected-error@+1 {{Unexpected number of reduce-op's returned values: 3 vs 2 (expected)}}
+  // expected-error@+1 {{inferred type(s) 'tensor<?xf32>', 'tensor<?xi32>' are incompatible with return type(s) of operation 'tensor<?xf32>', 'tensor<?xi32>', 'tensor<?xi32>'}}
   %0:3 = "stablehlo.reduce"(%arg0, %arg1, %arg2, %arg3) ({
 
   ^bb0(%arg4: tensor<f32>, %arg5: tensor<i32>, %arg6: tensor<f32>, %arg7: tensor<i32>):
@@ -417,7 +434,7 @@ func.func @reduce_verify_rettype(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xi32>,
 func.func @reduce_verify_rettype(%arg0: tensor<?x?xf32>, %arg1 : tensor<f32>)
     -> (tensor<?x?xi32>) {
 
-  // expected-error@+1 {{Unexpected number of reduce-op's returned values: 2 vs 1 (expected)}}
+  // expected-error@+1 {{'stablehlo.reduce' op inferred type(s) 'tensor<?xf32>' are incompatible with return type(s) of operation 'tensor<?xf32>', 'tensor<?xf32>'}}
   %0:2 = "stablehlo.reduce"(%arg0, %arg1) ({
 
   ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32> ):
@@ -434,7 +451,7 @@ func.func @reduce_verify_rettype(%arg0: tensor<?x?xf32>, %arg1 : tensor<f32>)
 func.func @reduce_verify_rettype(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xi32>,
     %arg2: tensor<f32>, %arg3: tensor<i32>) -> (tensor<?xf32>) {
 
-  // expected-error@+1 {{Unexpected element-type for reduce-op's return value at index 1: 'f32' vs 'i32' (expected)}}
+  // expected-error@+1 {{'stablehlo.reduce' op inferred type(s) 'tensor<?xf32>', 'tensor<?xi32>' are incompatible with return type(s) of operation 'tensor<?xf32>', 'tensor<?x?xf32>'}}
   %0:2 = "stablehlo.reduce"(%arg0, %arg1, %arg2, %arg3) ({
 
   ^bb0(%arg4: tensor<f32>, %arg5: tensor<i32>, %arg6: tensor<f32>, %arg7: tensor<i32>):
@@ -452,7 +469,7 @@ func.func @reduce_verify_rettype(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xi32>,
 func.func @reduce_verify_rettype(%arg0: tensor<?x?xf32>, %arg1 : tensor<f32>)
     -> (tensor<?xi32>) {
 
-  // expected-error@+1 {{Unexpected element-type for reduce-op's return value at index 0: 'i32' vs 'f32' (expected)}}
+  // expected-error@+1 {{'stablehlo.reduce' op inferred type(s) 'tensor<?xf32>' are incompatible with return type(s) of operation 'tensor<?xi32>'}}
   %0 = "stablehlo.reduce"(%arg0, %arg1) ({
 
   ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32> ):
@@ -469,7 +486,7 @@ func.func @reduce_verify_rettype(%arg0: tensor<?x?xf32>, %arg1 : tensor<f32>)
 func.func @reduce_verify_rettype(%arg0: tensor<?x?xf32>, %arg1 : tensor<f32>)
     -> (tensor<?x?xi32>) {
 
-  // expected-error@+1 {{Unexpected type for reduce-op's return value at index 0: 'tensor<?x?xf32>' vs 'tensor<?xf32>' (expected)}}
+  // expected-error@+1 {{'stablehlo.reduce' op inferred type(s) 'tensor<?xf32>' are incompatible with return type(s) of operation 'tensor<?x?xf32>'}}
   %0 = "stablehlo.reduce"(%arg0, %arg1) ({
 
   ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32> ):

--- a/tests/verify_reduce.mlir
+++ b/tests/verify_reduce.mlir
@@ -253,23 +253,6 @@ func.func @verify_reducer_function(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32
 
 // -----
 
-func.func @verify_reducer_function(%arg0: tensor<?x?xf32>, %arg1 : tensor<f32>)
-    -> (tensor<f32>) {
-
-  // expected-error@+1 {{Reduction-region here must produce tensor-typed result(s), but produces 'f32' instead}}
-  %0 = "stablehlo.reduce"(%arg0, %arg1) ({
-
-  ^bb0(%arg2: f32, %arg3: f32):
-    %1 = "llvm.add"(%arg2, %arg3) : (f32, f32) -> f32
-    "stablehlo.return"(%1) : (f32) -> ()
-
-  }) {dimensions = dense<[1]> : tensor<1xi64>} : (tensor<?x?xf32>, tensor<f32>) -> tensor<f32>
-
-    func.return %0: tensor<f32>
-}
-
-// -----
-
 func.func @verify_reducer_function(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xi32>,
     %arg2: tensor<f32>, %arg3: tensor<i32>) -> (tensor<?xf32>, tensor<?xi32>) {
 


### PR DESCRIPTION
The new `ReduceOp::inferReturnTypeComponents()` replaces the old `ReduceOp::verify()` with all the checking logic.

Note that a unit test is removed: it had a `llvm.add` inside its region, and intended to return a scale from its region and catch the error in `ReduceOp::verify()`. Now when we replace verifier with infer function, there will be two errors:
1. `'llvm.add' op operand #0 must be integer or LLVM dialect-compatible vector of integer, but got 'f32'`: can be fixed by change `f32` -> `i32`
2. In the last line of region, stablehlo.return supports return tensor only, instead of scalar: No way to fix this.

The HEAD code tolerated these errors because the `ReduceOp::verify()` fails first. Now decide to remove this unit test which is a case that will not happen. 


