### PR TITLE
Add specifications for and, or, xor, not operators

### DIFF
--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -9,7 +9,9 @@ Following are the supported element types in StableHLO:
     document as `si<N>`, where the bit-width N ∊ {4, 8, 16, 32, 64}
     * Unsigned integer referred to in the document as `ui<N>`, where the
     bit-width N ∊ {4, 8, 16, 32, 64}
-  * **Boolean types** referred to in the document as `pred`
+  * **Boolean types** referred to in the document as `pred`. Exact
+  representation of boolean types (e.g. 1 byte per boolean vs 1 bit per boolean)
+  is implementation-defined.
   * **Floating-point types**
     * Single precision `f32`, double precision `f64` and half precision `f16`
     floating-points complying with [IEEE 754
@@ -88,7 +90,7 @@ The specification of an op comprises of the following components (in the order
 
 Performs element-wise addition of two tensors `lhs` and `rhs` and produces a
 `result` tensor. For integer element types, if the element-wise sum has an
-unsigned/signed overflow/underflow, the result is implementation defined and one
+unsigned/signed overflow/underflow, the result is implementation-defined and one
 of the followings:
 
   * mathematical result modulo $2^n$, where n is the bit width of the result.
@@ -168,7 +170,7 @@ logical operation.
 // Logical operation with with boolean tensors
   // %x: [[false, false], [true, true]]
   // %y: [[false, true], [false, true]]
-  %z = stablehlo.or %x, %y : tensor<2x2xpred>
+  %z = stablehlo.and %x, %y : tensor<2x2xpred>
   // %z: [[false, false], [false, true]]
 ```
 

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -5,7 +5,6 @@
 Following are the supported element types in StableHLO:
 
   * **Integer types**
-
     * Signed integer with two’s complement representation. Referred to in the
     document as `si<N>`, where the bit-width N ∊ {4, 8, 16, 32, 64}
     * Unsigned integer referred to in the document as `ui<N>`, where the
@@ -21,7 +20,7 @@ Following are the supported element types in StableHLO:
  * **Complex types** represents a pair of floating-point types. Supported ones
  are `c64` (represents paired `f32`) and `c128` (represents paired `f64`).
 
-StableHLO supports a Tensor type `tensor`, to model the type of a n-dimensional
+StableHLO supports a type `tensor`, to model the type of a n-dimensional
 array, represented in the opset as `tensor<SxE>` such that
 
   * Shape `S` is a list of number of elements in each of the dimensions and
@@ -37,7 +36,7 @@ of supported types and a list of ops in static single-assignment (SSA) form
 which is terminated by a return op which produces the results of the function.
 StableHLO ops take operands and produce results.
 
-```
+```mlir
 ml_program.func @example_func(%arg: tensor<4x16xf32>) -> tensor<4x16xf32> {
  %1 = stablehlo.floor %arg : tensor<4x16xf32>
  %2 = stablehlo.ceil %arg : tensor<4x16xf32>
@@ -121,11 +120,56 @@ specification.
 
 ### Examples
 
-```c
+```mlir
 // %x: [[1, 2], [3, 4]]
 // %y: [[5, 6], [7, 8]]
 %z = stablehlo.add %x, %y : tensor<2x2xf32>
 // %z: [[6, 8], [10, 12]]
+```
+
+## stablehlo.and
+
+`stablehlo.and(lhs, rhs) -> result`
+
+### Semantics
+
+Performs element-wise bitwise AND of two tensors `lhs` and `rhs` of integer types
+and produces a `result` tensor. For boolean tensors, it computes the logical
+operation.
+
+## Arguments
+
+| Name | Type |
+|-|-|
+| `lhs` | tensor of integer or boolean element types |
+| `rhs` | tensor of integer or boolean element types |
+
+## Results
+
+| Name | Type |
+|-|-|
+| `result` | tensor of integer or boolean element types |
+
+## Constraints
+
+  * `lhs`, `rhs` have the same type.
+  * Supported shapes: all static shapes.
+  * `result` must have the same type as that of `lhs` (or `rhs`).
+
+## Examples
+
+```mlir
+// Bitwise operation with with integer tensors
+  // %x: [[1, 2], [3, 4]]
+  // %y: [[5, 6], [7, 8]]
+  %z = stablehlo.and %x, %y : tensor<2x2xsi32>
+  // %z: [[1, 2], [3, 0]]
+
+// Logical operation with with boolean tensors
+  // %x: [[false, false], [true, true]]
+  // %y: [[false, true], [false, true]]
+  %z = stablehlo.or %x, %y : tensor<2x2xpred>
+  // %z: [[false, false], [false, true]]
 ```
 
 ## stablehlo.maximum
@@ -161,7 +205,7 @@ the (real, imaginary) pairs.
 
 ### Examples
 
-```
+```mlir
 // %lhs: [[1, 2], [7, 8]]
 // %rhs: [[5, 6], [3, 4]]
 %result = stablehlo.max %lhs, %rhs : tensor<2x2xi32>
@@ -201,9 +245,139 @@ the (real, imaginary) pairs.
 
 ### Examples
 
-```
+```mlir
 // %lhs: [[1, 2], [7, 8]]
 // %rhs: [[5, 6], [3, 4]]
 %result = stablehlo.min %lhs, %rhs : tensor<2x2xi32>
 // %result: [[1, 2], [3, 4]]
+```
+
+## stablehlo.not
+
+`stablehlo.not(operand) -> result`
+
+### Semantics
+
+Performs element-wise bitwise NOT of tensor `operand` of type integer and
+produces a `result` tensor. For boolean tensors, it computes the logical NOT.
+
+### Arguments
+
+| Name | Type |
+|-|-|
+| `operand` | tensor of integer or boolean element types |
+
+### Results
+
+| `result` | tensor of integer or boolean element types |
+
+### Constraints
+
+  * Supported shapes: all static shapes.
+  * `result` must have the same type as that of `operand`.
+
+### Examples
+
+```mlir
+// Bitwise operation with with integer tensors
+  // %x: [[1, 2], [3, 4]]
+  %z = stablehlo.not %x : tensor<2x2xsi32>
+  // %z: [[-2, -3], [-4, -5]]
+
+// Bitwise operation with with boolean tensors
+  // %x: [true, false]
+  %z = "stablehlo.not"(%x) : (tensor<2xpred>) -> tensor<2xpred>
+  // %z: [false, true]
+```
+
+
+## stablehlo.or
+
+`stablehlo.or(lhs, rhs) -> result`
+
+### Semantics
+
+Performs element-wise bitwise OR of two tensors `lhs` and `rhs` of integer types
+and produces a `result` tensor. For boolean tensors, it computes the logical
+operation.
+
+## Arguments
+
+| Name | Type |
+|-|-|
+| `lhs` | tensor of integer or boolean element types |
+| `rhs` | tensor of integer or boolean element types |
+
+## Results
+
+| Name | Type |
+|-|-|
+| `result` | tensor of integer or boolean element types |
+
+## Constraints
+
+  * `lhs`, `rhs` have the same type.
+  * Supported shapes: all static shapes.
+  * `result` must have the same type as that of `lhs` (or `rhs`).
+
+## Examples
+
+```mlir
+// Bitwise operation with with integer tensors
+  // %x: [[1, 2], [3, 4]]
+  // %y: [[5, 6], [7, 8]]
+  %z = stablehlo.or %x, %y : tensor<2x2xsi32>
+  // %z: [[5, 6], [7, 12]]
+
+// Logical operation with with boolean tensors
+  // %x: [[false, false], [true, true]]
+  // %y: [[false, true], [false, true]]
+  %z = stablehlo.or %x, %y : tensor<2x2xpred>
+  // %z: [[false, true], [true, true]]
+```
+
+## stablehlo.xor
+
+`stablehlo.xor(lhs, rhs) -> result`
+
+### Semantics
+
+Performs element-wise bitwise XOR of two tensors `lhs` and `rhs` of integer
+types and produces a `result` tensor. For boolean tensors, it computes the
+logical operation.
+
+## Arguments
+
+| Name | Type |
+|-|-|
+| `lhs` | tensor of integer or boolean element types |
+| `rhs` | tensor of integer or boolean element types |
+
+
+## Results
+
+| Name | Type |
+|-|-|
+| `result` | tensor of integer or boolean element types |
+
+## Constraints
+
+  * `lhs`, `rhs` have the same type.
+  * Supported shapes: all static shapes.
+  * `result` must have the same type as that of `lhs` (or `rhs`).
+
+## Examples
+
+```mlir
+// Bitwise operation with with integer tensors
+  // %x: [[1, 2], [3, 4]]
+  // %y: [[5, 6], [7, 8]]
+  %z = stablehlo.xor %x, %y : tensor<2x2xsi32>
+  // %z: [[4, 4], [4, 12]]
+
+// Logical operation with with boolean tensors
+  // %x: [[false, false], [true, true]]
+  // %y: [[false, true], [false, true]]
+  %z = stablehlo.xor %x, %y : tensor<2x2xpred>
+  // %z: [[false, true], [true, false]]
 ```

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -133,11 +133,11 @@ specification.
 
 ### Semantics
 
-Performs element-wise bitwise AND of two tensors `lhs` and `rhs` of integer types
-and produces a `result` tensor. For boolean tensors, it computes the logical
-operation.
+Performs element-wise bitwise AND of two tensors `lhs` and `rhs` of integer
+types and produces a `result` tensor. For boolean tensors, it computes the
+logical operation.
 
-## Arguments
+## Operands
 
 | Name | Type |
 |-|-|
@@ -268,7 +268,6 @@ produces a `result` tensor. For boolean tensors, it computes the logical NOT.
 | `operand` | tensor of integer or boolean element types |
 
 ### Results
-
 | `result` | tensor of integer or boolean element types |
 
 ### Constraints
@@ -290,7 +289,6 @@ produces a `result` tensor. For boolean tensors, it computes the logical NOT.
   // %z: [false, true]
 ```
 
-
 ## stablehlo.or
 
 `stablehlo.or(lhs, rhs) -> result`
@@ -301,7 +299,7 @@ Performs element-wise bitwise OR of two tensors `lhs` and `rhs` of integer types
 and produces a `result` tensor. For boolean tensors, it computes the logical
 operation.
 
-## Arguments
+## Operands
 
 | Name | Type |
 |-|-|
@@ -346,7 +344,7 @@ Performs element-wise bitwise XOR of two tensors `lhs` and `rhs` of integer
 types and produces a `result` tensor. For boolean tensors, it computes the
 logical operation.
 
-## Arguments
+## Operands
 
 | Name | Type |
 |-|-|


### PR DESCRIPTION
fixes https://github.com/openxla/stablehlo/issues/53

Has the following changes:
  - A few spec types:
       -  Fix the header of the table names from "Operand Names" to "Name" and "Result Name" to "Name". The redundant prefixes can be derived from the section name.
       - not consider tensor as keyword. 
  - Addition of the spec of the Bitwise ops. 