### PR TITLE
Add .vscode to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 llvm-project
 llvm-build
+.vscode


### PR DESCRIPTION
VS Code makes a directory `.vscode/` with json configurations in it for C++ extensions. If we end up wanting certain configs for vs code to be stored in this repo, we can edit this later, for now will save a lot of trouble to ignore everything.