### PR TITLE
Add type inference for stablehlo.reduce_window

### DIFF
--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -178,36 +178,44 @@ Value maybeCastTo(OpBuilder& b, Location loc, Value value, Type type) {
 //===----------------------------------------------------------------------===//
 
 // Convert a 1D dense int64 attribute to a list of values.
-SmallVector<int64_t> convertDenseIntAttr(
-    llvm::Optional<mlir::DenseIntElementsAttr> optionalAttr) {
+FailureOr<SmallVector<int64_t>> convertDenseIntAttr(
+    Optional<DenseIntElementsAttr> optionalAttr, Optional<Location> loc) {
   if (!optionalAttr.has_value()) return SmallVector<int64_t>{};
 
-  mlir::DenseIntElementsAttr attr = *optionalAttr;
+  DenseIntElementsAttr attr = *optionalAttr;
+  auto attrType = attr.getType().cast<RankedTensorType>();  // ensured by ODS.
+  if (attrType.getRank() != 1)
+    return (emitOptionalError(
+                loc, "expects the shape of attribute to be 1-D, but got {",
+                attrType.getShape(), "}."),
+            failure());
   auto values = attr.getValues<int64_t>();
-  return {values.begin(), values.end()};
+  return SmallVector<int64_t>{values.begin(), values.end()};
 }
 
-// Convert a 1D or Nx2 dense int64 attribute to a list of tuples.
-FailureOr<SmallVector<std::pair<int64_t, int64_t>>> convertNx2Attribute(
-    llvm::Optional<mlir::DenseIntElementsAttr> optionalAttr, Location loc) {
+// Convert a 1D or Nx2 dense int64 padding attribute to a list of tuples.
+FailureOr<SmallVector<std::pair<int64_t, int64_t>>> convertPaddingAttribute(
+    Optional<DenseIntElementsAttr> optionalAttr, Optional<Location> loc) {
   if (!optionalAttr.has_value())
     return SmallVector<std::pair<int64_t, int64_t>>{};
-  mlir::DenseIntElementsAttr attr = *optionalAttr;
 
+  DenseIntElementsAttr attr = *optionalAttr;
   auto attrType = attr.getType().cast<RankedTensorType>();  // ensured by ODS.
   if (attrType.getRank() > 1) {
     if (attrType.getRank() != 2 || attrType.getShape()[1] != 2)
-      return (mlir::emitError(loc) << "expects the shape of padding-attribute "
-                                      "to be {N, 2}, but got {"
-                                   << attrType.getShape() << "}.",
-              failure());
+      return (
+          emitOptionalError(
+              loc,
+              "expects the shape of padding-attribute to be {N, 2}, but got {",
+              attrType.getShape(), "}."),
+          failure());
   } else {
     // Padding values can be provided as a 1D vector as well.
     if (attr.getValues<int64_t>().size() % 2 != 0)
-      return (mlir::emitError(loc)
-                  << "expects the padding-entries to have even number of "
-                     "elements, but got "
-                  << attr.getValues<int64_t>().size() << " elements.",
+      return (emitOptionalError(loc,
+                                "expects the padding-entries to have even "
+                                "number of elements, but got ",
+                                attr.getValues<int64_t>().size(), " elements."),
               failure());
   }
 
@@ -287,16 +295,14 @@ verifyWindowAttributesAndInferWindowDimensions(
     ArrayRef<int64_t> windowDimensions, ArrayRef<int64_t> windowStrides,
     ArrayRef<std::pair<int64_t, int64_t>> padding,
     ArrayRef<int64_t> lhsDilation, ArrayRef<int64_t> rhsDilation,
-    Location loc) {
+    Optional<Location> loc) {
   const auto verifySize = [&](const size_t attrSize,
                               StringRef attrName) -> LogicalResult {
     if (attrSize == 0 || attrSize == windowDimensions.size()) return success();
-    return mlir::emitError(loc)
-           << "expects " << attrName
-           << " to have same dimension-size as size of "
-              "window dimensions "
-              "("
-           << windowDimensions.size() << "), but got: " << attrSize << ".";
+    return emitOptionalError(
+        loc, "expects ", attrName,
+        " to have same dimension-size as size of window dimensions (",
+        windowDimensions.size(), "), but got: ", attrSize, ".");
   };
 
   if (failed(verifySize(windowStrides.size(), "window-strides")))
@@ -313,32 +319,32 @@ verifyWindowAttributesAndInferWindowDimensions(
 
     dim.size = windowDimensions[i];
     if (!isDynamicDimSize(dim.size) && dim.size <= 0)
-      return (mlir::emitError(loc)
-                  << "expects window to have positive value for " << i
-                  << "-th window dimension, but got " << dim.size << ".",
-              failure());
+      return (
+          emitOptionalError(loc, "expects window to have positive value for ",
+                            i, "-th window dimension, but got ", dim.size, "."),
+          failure());
 
     if (!windowStrides.empty()) dim.stride = windowStrides[i];
     if (dim.stride <= 0)
-      return (mlir::emitError(loc)
-                  << "expects window to have positive stride for " << i
-                  << "-th window dimension, but got " << dim.stride << ".",
+      return (emitOptionalError(
+                  loc, "expects window to have positive stride for ", i,
+                  "-th window dimension, but got ", dim.stride, "."),
               failure());
 
     if (!lhsDilation.empty()) dim.baseDilation = lhsDilation[i];
     if (dim.baseDilation <= 0)
-      return (mlir::emitError(loc) << "expects window to have positive base "
-                                      "dilation factor for "
-                                   << i << "-th window dimension, but got "
-                                   << dim.baseDilation << ".",
-              failure());
+      return (
+          emitOptionalError(
+              loc, "expects window to have positive base dilation factor for ",
+              i, "-th window dimension, but got ", dim.baseDilation, "."),
+          failure());
 
     if (!rhsDilation.empty()) dim.windowDilation = rhsDilation[i];
     if (dim.windowDilation <= 0)
-      return (mlir::emitError(loc) << "expects window to have positive window "
-                                      "dilation factor for "
-                                   << i << "-th window dimension, but got "
-                                   << dim.windowDilation << ".",
+      return (emitOptionalError(
+                  loc,
+                  "expects window to have positive window dilation factor for ",
+                  i, "-th window dimension, but got ", dim.windowDilation, "."),
               failure());
 
     if (!padding.empty()) {
@@ -1649,10 +1655,6 @@ LogicalResult GatherOp::inferReturnTypeComponents(
     MLIRContext* context, Optional<Location> location, ValueShapeRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
-  // TODO(zhouxin) remove this comment after the ordering issue is clear.
-  // This can get called before other op verify methods, so we have to do a
-  // bunch of verification up front. With a better story for ordering and/or
-  // multi-phase op verification, this should hopefully all go away.
   Location loc = location.value_or(UnknownLoc::get(context));
   auto errorEmitter = [&loc]() {
     return mlir::emitError(loc)
@@ -2120,14 +2122,18 @@ LogicalResult ConvolutionOp::verify() {
   for (size_t i = 0; i < windowDimensions.size(); i++)
     windowDimensions[i] = rhsType.getShape()[kernelSpatialDimensions[i]];
 
-  auto paddingOrErr = convertNx2Attribute(this->padding(), getLoc());
+  auto paddingOrErr = convertPaddingAttribute(this->padding(), getLoc());
   if (failed(paddingOrErr)) return failure();
-  SmallVector<std::pair<int64_t, int64_t>> padding = *paddingOrErr;
 
+  auto windowStridesOrErr = convertDenseIntAttr(window_strides(), getLoc());
+  if (failed(windowStridesOrErr)) return failure();
+  auto lhsDilationOrErr = convertDenseIntAttr(lhs_dilation(), getLoc());
+  if (failed(lhsDilationOrErr)) return failure();
+  auto rhsDilationOrErr = convertDenseIntAttr(rhs_dilation(), getLoc());
+  if (failed(rhsDilationOrErr)) return failure();
   auto windowOrErr = verifyWindowAttributesAndInferWindowDimensions(
-      windowDimensions, convertDenseIntAttr(window_strides()), padding,
-      convertDenseIntAttr(lhs_dilation()), convertDenseIntAttr(rhs_dilation()),
-      getLoc());
+      windowDimensions, *windowStridesOrErr, *paddingOrErr, *lhsDilationOrErr,
+      *rhsDilationOrErr, getLoc());
   if (failed(windowOrErr)) return failure();
 
   // P4.
@@ -3468,28 +3474,6 @@ LogicalResult RecvOp::verify() {
 // ReduceWindowOp
 //===----------------------------------------------------------------------===//
 
-namespace {
-// Infer the return-type of ReduceWindowOp.
-SmallVector<TensorType> inferReduceWindowOpReturnType(
-    ArrayRef<TensorType> inputTypes, ArrayRef<TensorType> initTypes,
-    const ArrayRef<WindowDimension> window) {
-  SmallVector<TensorType> outputTypes;
-  for (size_t i = 0; i < inputTypes.size(); ++i) {
-    if (!inputTypes[i].hasRank()) {
-      outputTypes.push_back(
-          UnrankedTensorType::get(initTypes[i].getElementType()));
-      continue;
-    }
-
-    outputTypes.push_back(RankedTensorType::get(
-        inferWindowOutputShape(inputTypes[i].getShape(), window),
-        initTypes[i].getElementType()));
-  }
-
-  return outputTypes;
-}
-}  // namespace
-
 // We intend to verify the following properties
 //  P1. The sizes of 'inputs' and 'init_values' must be at least 1.
 //  P2. All `inputs` need to have compatible shapes.
@@ -3497,108 +3481,98 @@ SmallVector<TensorType> inferReduceWindowOpReturnType(
 //        where input is an element of 'inputs'.
 //  P4. Verify and collect the window atributes.
 //  P5. Verify the inner block defining the reducer function.
-//  P6. Verify the return type.
-LogicalResult ReduceWindowOp::verify() {
+LogicalResult ReduceWindowOp::inferReturnTypeComponents(
+    MLIRContext*, Optional<Location> location, ValueShapeRange operands,
+    DictionaryAttr attributes, RegionRange regions,
+    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   // P1.
-  // Note that the ODS ensures that there are even number of operands; Check if
-  // that number is not zero.
-  if (getOperands().empty())
-    return emitOpError() << "expects the size of operands to be >= 2.";
-
   // Collect the input and init-value operands. Note that the operand-type is
   // enforced as "TensorType" by ODS.
-  int64_t numInputs = getNumOperands() / 2;
+  if (operands.size() % 2 != 0 || operands.size() == 0)
+    return emitOptionalError(
+        location, "expects the size of operands to be even and >= 2");
+  int64_t numInputs = operands.size() / 2;
   auto operandTensorTypes = llvm::to_vector<4>(llvm::map_range(
-      getOperandTypes(),
+      operands.getTypes(),
       [](Type t) -> TensorType { return t.cast<TensorType>(); }));
-  ArrayRef<TensorType> inputTypes(operandTensorTypes.begin(),
-                                  operandTensorTypes.begin() + numInputs);
-  ArrayRef<TensorType> initTypes(operandTensorTypes.begin() + numInputs,
-                                 operandTensorTypes.end());
+  ArrayRef<TensorType> inputArgTypes(operandTensorTypes.begin(),
+                                     operandTensorTypes.begin() + numInputs);
+  ArrayRef<TensorType> initValueTypes(operandTensorTypes.begin() + numInputs,
+                                      operandTensorTypes.end());
+
+  // Check for unranked tensors in input operands.
+  int64_t rankedInputIdx = -1;
+  for (int64_t inputIdx = 0; inputIdx < numInputs; ++inputIdx) {
+    if (inputArgTypes[inputIdx].hasRank()) {
+      rankedInputIdx = inputIdx;
+      break;
+    }
+  }
+
+  bool allInputsUnranked = (rankedInputIdx == -1);
 
   // P2.
-  if (failed(verifyCompatibleShapes(operands().getTypes())))
-    return emitOpError() << "requires same shape for all inputs";
+  if (!allInputsUnranked) {
+    for (int64_t inputIdx = 0; inputIdx < numInputs; ++inputIdx) {
+      if (failed(mlir::verifyCompatibleShape(inputArgTypes[rankedInputIdx],
+                                             inputArgTypes[inputIdx]))) {
+        return emitOptionalError(
+            location, "'", ReduceOp::getOperationName(), "' op ",
+            "expects all inputs to have compatible shapes. Shape at",
+            " input-index ", inputIdx,
+            " is not compatible with shape at input-index ", rankedInputIdx);
+      }
+    }
+  }
 
   // P3.
-  SmallVector<int64_t> windowDims =
-      convertDenseIntAttr(this->window_dimensions());
-  for (const auto inputType : inputTypes) {
+  ReduceWindowOp::Adaptor adaptor(operands, attributes, regions);
+  auto windowDimsOrErr =
+      convertDenseIntAttr(adaptor.window_dimensions(), location);
+  if (failed(windowDimsOrErr)) return failure();
+  for (const auto inputType : inputArgTypes) {
     if (!inputType.hasRank()) continue;
-    if (inputType.getRank() != static_cast<int64_t>(windowDims.size()))
-      return emitOpError()
-             << "expects window-dimensions size == input rank, but got "
-                "window-dimensions size: "
-             << windowDims.size() << " and input: " << inputType
-             << " with rank = " << inputType.getRank() << ".";
+    if (inputType.getRank() != static_cast<int64_t>((*windowDimsOrErr).size()))
+      return emitOptionalError(
+          location, "expects window-dimensions size == input rank, but got ",
+          "window-dimensions size: ", (*windowDimsOrErr).size(),
+          " and input: ", inputType, " with rank = ", inputType.getRank(), ".");
   }
 
   // P4.
-  auto paddingOrErr = convertNx2Attribute(this->padding(), getLoc());
+  auto paddingOrErr = convertPaddingAttribute(adaptor.padding(), location);
   if (failed(paddingOrErr)) return failure();
-  SmallVector<std::pair<int64_t, int64_t>> padding = *paddingOrErr;
 
+  auto windowStridesOrErr =
+      convertDenseIntAttr(adaptor.window_strides(), location);
+  if (failed(windowStridesOrErr)) return failure();
+  auto baseDilationsOrErr =
+      convertDenseIntAttr(adaptor.base_dilations(), location);
+  if (failed(baseDilationsOrErr)) return failure();
+  auto windowDilationsOrErr =
+      convertDenseIntAttr(adaptor.window_dilations(), location);
+  if (failed(windowDilationsOrErr)) return failure();
   auto windowOrErr = verifyWindowAttributesAndInferWindowDimensions(
-      windowDims, convertDenseIntAttr(window_strides()), padding,
-      /*lhs_dilation=*/convertDenseIntAttr(base_dilations()),
-      /*rhs_dilation=*/convertDenseIntAttr(this->window_dilations()), getLoc());
+      *windowDimsOrErr, *windowStridesOrErr, *paddingOrErr,
+      /*lhs_dilation=*/*baseDilationsOrErr,
+      /*rhs_dilation=*/*windowDilationsOrErr, location);
   if (failed(windowOrErr)) return failure();
 
   // P5.
-  bool allInputsUnranked =
-      llvm::all_of(inputTypes, [](TensorType t) { return !t.hasRank(); });
-
-  Block& block = body().front();
+  Block& block = adaptor.body().front();
   SmallVector<TensorType> accumulatorSubshapes;
-  if (failed(verifyReducerShape(this->getLoc(), block, inputTypes, initTypes,
-                                numInputs, windowDims, allInputsUnranked,
+  if (failed(verifyReducerShape(location, block, inputArgTypes, initValueTypes,
+                                numInputs, *windowDimsOrErr, allInputsUnranked,
                                 accumulatorSubshapes)))
     return failure();
 
-  // P6.
-  if (numInputs != getNumResults())
-    return emitOpError() << "expects " << numInputs
-                         << " result values, but got " << getNumResults()
-                         << ".";
-
-  // The result-type is enforced as "TensorType" by ODS.
-  auto resultTensorTypes = llvm::to_vector<4>(llvm::map_range(
-      getResultTypes(),
-      [](Type t) -> TensorType { return t.cast<TensorType>(); }));
-
-  // Check if the element-type of results match with the ones derived from
-  // the reducer-block. Already ensured that  |accumulator_subshapes| ==
-  // num_inputs == num_of_results.
-  for (int64_t shapeIdx = 0;
-       shapeIdx < static_cast<int64_t>(accumulatorSubshapes.size());
-       shapeIdx++) {
-    if (accumulatorSubshapes[shapeIdx].getElementType() !=
-        resultTensorTypes[shapeIdx].getElementType()) {
-      return emitError()
-             << "expects the element-type of reduce-op's return-value at index "
-             << shapeIdx
-             << " to match the element-type of reducer-block's "
-                "corresponding return-value, but got "
-             << resultTensorTypes[shapeIdx].getElementType() << " and "
-             << accumulatorSubshapes[shapeIdx].getElementType() << " resp.";
-    }
-  }
-
-  // Check if the shape of results match with the ones derived from
-  // the input-types and wndow-attributes.
-  auto inferredReturnTypes = inferReduceWindowOpReturnType(
-      inputTypes, accumulatorSubshapes, *windowOrErr);
-
-  for (size_t i = 0; i < getNumResults(); i++) {
-    if (failed(verifyCompatibleShape(resultTensorTypes[i],
-                                     inferredReturnTypes[i]))) {
-      return emitOpError()
-             << "expects result at index " << i
-             << " to have compatible shape with the corresponding "
-                "inferred type, but got "
-             << resultTensorTypes[i] << " and " << inferredReturnTypes[i]
-             << " resp.";
-    }
+  for (size_t i = 0; i < inputArgTypes.size(); ++i) {
+    if (!inputArgTypes[i].hasRank())
+      inferredReturnShapes.emplace_back(initValueTypes[i].getElementType());
+    else
+      inferredReturnShapes.emplace_back(
+          inferWindowOutputShape(inputArgTypes[i].getShape(), *windowOrErr),
+          initValueTypes[i].getElementType());
   }
 
   return success();
@@ -4044,10 +4018,18 @@ ParseResult ReduceOp::parse(OpAsmParser& parser, OperationState& result) {
   return success();
 }
 
+// We intend to verify the following properties
+//  P1. Verify the sizes of 'inputs' and 'init_values' must be at least 1.
+//  P2. Verify all `inputs` need to have compatible shapes.
+//  P3. Verify that
+//      1. the dimensions of reduce-op are in-bounds for the given shape.
+//      2. the dimension-attribute have no duplicate entries.
+//  P4. Verify the inner block defining the reducer function.
 LogicalResult ReduceOp::inferReturnTypeComponents(
     MLIRContext*, Optional<Location> location, ValueShapeRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
+  // P1.
   // Collect the input and init-value operands. Note that the operand-type is
   // enforced as "TensorType" by ODS.
   if (operands.size() % 2 != 0 || operands.size() == 0)
@@ -4073,8 +4055,7 @@ LogicalResult ReduceOp::inferReturnTypeComponents(
 
   bool allInputsUnranked = (rankedInputIdx == -1);
 
-  // Check that all input operands have compatible shapes. The element types may
-  // be different.
+  // P2.
   if (!allInputsUnranked) {
     for (int64_t inputIdx = 0; inputIdx < numInputs; ++inputIdx) {
       if (failed(mlir::verifyCompatibleShape(inputArgTypes[rankedInputIdx],
@@ -4088,9 +4069,7 @@ LogicalResult ReduceOp::inferReturnTypeComponents(
     }
   }
 
-  // Check that
-  //   1. the dimensions of reduce-op are in-bounds for the given shape.
-  //   2. the dimension-attribute have no duplicate entries.
+  // P3.
   ReduceOp::Adaptor adaptor(operands, attributes, regions);
   DenseSet<int64_t> dimensionsToReduceSet;
   for (int64_t dimension : adaptor.dimensions().getValues<int64_t>()) {
@@ -4108,7 +4087,7 @@ LogicalResult ReduceOp::inferReturnTypeComponents(
     }
   }
 
-  // Verify the inner block defining the reducer function.
+  // P4.
   SmallVector<int64_t> newDimensions;
   if (!allInputsUnranked) {
     for (int inputIdx = 0; inputIdx < inputArgTypes[rankedInputIdx].getRank();
@@ -5199,24 +5178,27 @@ LogicalResult SelectAndScatterOp::verify() {
     return failure();
 
   // P3.
-  SmallVector<int64_t> windowDims =
-      convertDenseIntAttr(this->window_dimensions());
+  auto windowDimsOrErr = convertDenseIntAttr(window_dimensions(), getLoc());
+  if (failed(windowDimsOrErr)) return failure();
   if (operandType.hasRank()) {
-    if (operandType.getRank() != static_cast<int64_t>(windowDims.size()))
+    if (operandType.getRank() !=
+        static_cast<int64_t>((*windowDimsOrErr).size()))
       return emitOpError()
              << "expects window-dimensions size == operand rank, but got "
                 "window-dimensions size: "
-             << windowDims.size() << " and operand-type: " << operandType
+             << (*windowDimsOrErr).size()
+             << " and operand-type: " << operandType
              << " with rank = " << operandType.getRank() << ".";
   }
 
   // P4.
-  auto paddingOrErr = convertNx2Attribute(this->padding(), getLoc());
+  auto paddingOrErr = convertPaddingAttribute(padding(), getLoc());
   if (failed(paddingOrErr)) return failure();
-  SmallVector<std::pair<int64_t, int64_t>> padding = *paddingOrErr;
 
+  auto windowStridesOrErr = convertDenseIntAttr(window_strides(), getLoc());
+  if (failed(windowStridesOrErr)) return failure();
   auto windowOrErr = verifyWindowAttributesAndInferWindowDimensions(
-      windowDims, convertDenseIntAttr(window_strides()), padding,
+      *windowDimsOrErr, *windowStridesOrErr, *paddingOrErr,
       /*lhs_dilation=*/{}, /*rhs_dilation=*/{}, getLoc());
   if (failed(windowOrErr)) return failure();
 

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2438,7 +2438,8 @@ def StableHLO_TriangularSolveOp: StableHLO_Op<"triangular_solve",
 def StableHLO_ReduceWindowOp: StableHLO_Op<"reduce_window", [
       RecursiveSideEffects,
       SameVariadicOperandSize,
-      SingleBlockImplicitTerminator<"ReturnOp">
+      SingleBlockImplicitTerminator<"ReturnOp">,
+      InferTensorType,
     ]> {
   let summary = "ReduceWindow operator";
   let description = [{
@@ -2448,9 +2449,6 @@ def StableHLO_ReduceWindowOp: StableHLO_Op<"reduce_window", [
     See https://www.tensorflow.org/xla/operation_semantics#reducewindow.
   }];
 
-  // TODO(hinsu): Verify that padding attribute is 2-d and the remaining
-  // attributes are 1-d. Attributes' leading dimension should match rank of the
-  // operands.
   let arguments = (ins
     Variadic<HLO_Tensor>:$operands,
     Variadic<HLO_Tensor>:$init_values,
@@ -2466,8 +2464,6 @@ def StableHLO_ReduceWindowOp: StableHLO_Op<"reduce_window", [
 
   let results = (outs Variadic<HLO_Tensor>);
 
-  // TODO(hinsu): Verify that the attached body arguments and results are
-  // compatible with reduce op's operands.
   let regions = (region SizedRegion<1>:$body);
 
   // Builder for non-variadic version of the operation.
@@ -2486,12 +2482,21 @@ def StableHLO_ReduceWindowOp: StableHLO_Op<"reduce_window", [
     }]>
   ];
 
-  let hasVerifier = 1;
   // TODO(hinsu): Implement custom printer and parser.
 
   let extraClassDeclaration = [{
-     // Get the operation used for reduction applied to `result_index`th result.
-     Operation *getReductionOp(int result_index);
+    // Get the operation used for reduction applied to `result_index`th result.
+    Operation *getReductionOp(int result_index);
+
+    // Relax the strict default implementation with one that allows
+    // for StableHLO-specific differences.
+    static bool isCompatibleReturnTypes(TypeRange l, TypeRange r) {
+      if (l.size() != r.size()) return false;
+      for (auto [lt, rt] : llvm::zip(l, r))
+        if (!mlir::hlo::isCompatibleForHloTypeInference(lt, rt))
+          return false;
+      return true;
+    }
   }];
 }
 

--- a/stablehlo/tests/verify_conv.mlir
+++ b/stablehlo/tests/verify_conv.mlir
@@ -521,35 +521,7 @@ func.func @invalid_conv_dimensions(%arg0 : tensor<100x26x26x32xf32>, %arg1 : ten
     >,
     feature_group_count = 1 : i64,
     lhs_dilation = dense<1> : tensor<2xi64>,
-    padding = dense<2> : tensor<6xi64>,
-    rhs_dilation = dense<1> : tensor<2xi64>,
-    window_strides = dense<1> : tensor<2xi64>
-  } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>) ->
-    tensor<100x28x28x1xf32>
-  func.return %result : tensor<100x28x28x1xf32>
-}
-
-// -----
-
-func.func @invalid_conv_dimensions(%arg0 : tensor<100x26x26x32xf32>, %arg1 : tensor<3x3x1x32xf32>) ->
-    tensor<100x28x28x1xf32> {
-  // expected-error@+1 {{expects the padding-entries to have even number of elements, but got 5 elements.}}
-  %result = "stablehlo.convolution"(%arg0, %arg1) {
-    batch_group_count = 1 : i64,
-    dimension_numbers = #stablehlo.conv<raw
-      input_batch_dimension = 0,
-      input_feature_dimension = 3,
-      input_spatial_dimensions = [1, 2],
-      kernel_input_feature_dimension = 3,
-      kernel_output_feature_dimension = 2,
-      kernel_spatial_dimensions = [0, 1],
-      output_batch_dimension = 0,
-      output_feature_dimension = 3,
-      output_spatial_dimensions = [1, 2]
-    >,
-    feature_group_count = 1 : i64,
-    lhs_dilation = dense<1> : tensor<2xi64>,
-    padding = dense<2> : tensor<5xi64>,
+    padding = dense<2> : tensor<3x2xi64>,
     rhs_dilation = dense<1> : tensor<2xi64>,
     window_strides = dense<1> : tensor<2xi64>
   } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>) ->

--- a/stablehlo/tests/verify_reduce_window.mlir
+++ b/stablehlo/tests/verify_reduce_window.mlir
@@ -19,6 +19,8 @@ func.func @reduce_window(%arg0: tensor<4x2xf32>, %arg1: tensor<4x2xi32>,
   func.return %0#0, %0#1 : tensor<2x2xf32>, tensor<2x2xi32>
 }
 
+// -----
+
 func.func @reduce_window_with_unranked_dynamic_dims(%arg0: tensor<*xf32>,
     %arg1: tensor<4x?xi32>, %init0: tensor<f32>, %init1: tensor<i32>) ->
         (tensor<?x?xf32>, tensor<*xi32>) {
@@ -39,6 +41,8 @@ func.func @reduce_window_with_unranked_dynamic_dims(%arg0: tensor<*xf32>,
   func.return %0#0, %0#1 : tensor<?x?xf32>, tensor<*xi32>
 }
 
+// -----
+
 func.func @reduce_window_with_non_scalar_block_arg1(%arg0: tensor<4x2xf32>,
     %init0: tensor<4xf32>) -> tensor<2x1xf32> {
   %0 = "stablehlo.reduce_window"(%arg0, %init0) ({
@@ -54,6 +58,8 @@ func.func @reduce_window_with_non_scalar_block_arg1(%arg0: tensor<4x2xf32>,
          : (tensor<4x2xf32>, tensor<4xf32>) -> (tensor<2x1xf32>)
   func.return %0 : tensor<2x1xf32>
 }
+
+// -----
 
 func.func @reduce_window_with_non_scalar_block_arg2(%arg0: tensor<4x2xf32>,
     %init0: tensor<2xf32>) -> tensor<2x1xf32> {
@@ -74,7 +80,7 @@ func.func @reduce_window_with_non_scalar_block_arg2(%arg0: tensor<4x2xf32>,
 // -----
 
 func.func @reduce_window_invalid_inputs() -> (tensor<2x2xf32>, tensor<2x2xi32>) {
-  // expected-error @+1 {{expects the size of operands to be >= 2.}}
+  // expected-error @+1 {{expects the size of operands to be even and >= 2}}
   %0:2 = "stablehlo.reduce_window"() ({
          ^bb0(%a0: tensor<f32>, %a1: tensor<i32>,
                 %b0: tensor<f32>, %b1: tensor<i32>):
@@ -94,7 +100,7 @@ func.func @reduce_window_invalid_inputs() -> (tensor<2x2xf32>, tensor<2x2xi32>) 
 func.func @reduce_window_invalid_inputs(%arg0: tensor<4x2xf32>,
     %arg1: tensor<4x3xi32>, %init0: tensor<f32>, %init1: tensor<i32>) ->
     (tensor<2x2xf32>, tensor<2x2xi32>) {
-  // expected-error @+1 {{requires same shape for all inputs}}
+  // expected-error @+1 {{expects all inputs to have compatible shapes}}
   %0:2 = "stablehlo.reduce_window"(%arg0, %arg1, %init0, %init1) ({
          ^bb0(%a0: tensor<f32>, %a1: tensor<i32>,
                 %b0: tensor<f32>, %b1: tensor<i32>):
@@ -241,7 +247,7 @@ func.func @reduce_window_invalid_attributes(%arg0: tensor<4x2xf32>,
 
 // -----
 
-func.func @reduce_window_invalid_attributes(%arg0: tensor<4x2xf32>,
+func.func @reduce_window_invalid_padding_attributes(%arg0: tensor<4x2xf32>,
     %arg1: tensor<4x2xi32>, %init0: tensor<f32>, %init1: tensor<i32>) ->
     (tensor<2x2xf32>, tensor<2x2xi32>) {
   // expected-error @+1 {{expects the shape of padding-attribute to be {N, 2}, but got {4, 1}.}}
@@ -254,6 +260,27 @@ func.func @reduce_window_invalid_attributes(%arg0: tensor<4x2xf32>,
             })
          { padding = dense<[[2], [2], [0], [0]]> : tensor<4x1xi64>,
            window_dimensions = dense<[5, 1]> : tensor<2xi64>,
+           window_strides = dense<[3, 1]> : tensor<2xi64> }
+         : (tensor<4x2xf32>, tensor<4x2xi32>, tensor<f32>, tensor<i32>) ->
+              (tensor<2x2xf32>, tensor<2x2xi32>)
+  func.return %0#0, %0#1 : tensor<2x2xf32>, tensor<2x2xi32>
+}
+
+// -----
+
+func.func @reduce_window_invalid_attributes(%arg0: tensor<4x2xf32>, %arg1: tensor<4x2xi32>,
+                    %init0: tensor<f32>, %init1: tensor<i32>) ->
+                      (tensor<2x2xf32>, tensor<2x2xi32>) {
+  // expected-error @+1 {{expects the shape of attribute to be 1-D}}
+  %0:2 = "stablehlo.reduce_window"(%arg0, %arg1, %init0, %init1) ({
+         ^bb0(%a0: tensor<f32>, %a1: tensor<i32>,
+                %b0: tensor<f32>, %b1: tensor<i32>):
+              %2 = stablehlo.add %a0, %b0 : tensor<f32>
+              %3 = stablehlo.add %a1, %b1 : tensor<i32>
+              "stablehlo.return"(%2, %3) : (tensor<f32>, tensor<i32>) -> ()
+            })
+         { padding = dense<[[2, 2], [0, 0]]> : tensor<2x2xi64>,
+           window_dimensions = dense<[[5, 1]]> : tensor<1x2xi64>,
            window_strides = dense<[3, 1]> : tensor<2xi64> }
          : (tensor<4x2xf32>, tensor<4x2xi32>, tensor<f32>, tensor<i32>) ->
               (tensor<2x2xf32>, tensor<2x2xi32>)
@@ -374,7 +401,7 @@ func.func @reduce_window_invalid_attributes(%arg0: tensor<4x2xf32>,
 func.func @reduce_window_invalid_ret_type(%arg0: tensor<4x2xf32>,
     %arg1: tensor<4x2xi32>, %init0: tensor<f32>, %init1: tensor<i32>) ->
         tensor<2x2xf32> {
-  // expected-error @+1 {{expects 2 result values, but got 1.}}
+  // expected-error @+1 {{inferred type(s) 'tensor<2x2xf32>', 'tensor<2x2xi32>' are incompatible with return type(s) of operation 'tensor<2x2xf32>'}}
   %0 = "stablehlo.reduce_window"(%arg0, %arg1, %init0, %init1) ({
          ^bb0(%a0: tensor<f32>, %a1: tensor<i32>,
                 %b0: tensor<f32>, %b1: tensor<i32>):
@@ -396,7 +423,7 @@ func.func @reduce_window_invalid_ret_type(%arg0: tensor<4x2xf32>,
 func.func @reduce_window_invalid_ret_type(%arg0: tensor<4x2xf32>,
     %arg1: tensor<4x2xi32>, %init0: tensor<f32>, %init1: tensor<i32>) ->
         (tensor<2x2xf32>, tensor<2x3xi32>) {
-  // expected-error @+1 {{expects result at index 1 to have compatible shape with the corresponding inferred type, but got 'tensor<2x3xi32>' and 'tensor<2x2xi32>' resp.}}
+  // expected-error @+1 {{inferred type(s) 'tensor<2x2xf32>', 'tensor<2x2xi32>' are incompatible with return type(s) of operation 'tensor<2x2xf32>', 'tensor<2x3xi32>'}}
   %0:2 = "stablehlo.reduce_window"(%arg0, %arg1, %init0, %init1) ({
          ^bb0(%a0: tensor<f32>, %a1: tensor<i32>,
                 %b0: tensor<f32>, %b1: tensor<i32>):
@@ -418,7 +445,7 @@ func.func @reduce_window_invalid_ret_type(%arg0: tensor<4x2xf32>,
 func.func @reduce_window_invalid_ret_type(%arg0: tensor<4x2xf32>,
     %arg1: tensor<4x2xi32>, %init0: tensor<f32>, %init1: tensor<i32>) ->
         (tensor<2x2xi32>, tensor<2x2xi32>) {
-  // expected-error @+1 {{expects the element-type of reduce-op's return-value at index 0 to match the element-type of reducer-block's corresponding return-value, but got 'i32' and 'f32' resp.}}
+  // expected-error @+1 {{inferred type(s) 'tensor<2x2xf32>', 'tensor<2x2xi32>' are incompatible with return type(s) of operation 'tensor<2x2xi32>', 'tensor<2x2xi32>'}}
   %0:2 = "stablehlo.reduce_window"(%arg0, %arg1, %init0, %init1) ({
          ^bb0(%a0: tensor<f32>, %a1: tensor<i32>,
                 %b0: tensor<f32>, %b1: tensor<i32>):
@@ -488,26 +515,6 @@ func.func @reduce_window_invalid_reducer(%arg0: tensor<4x2xf32>,
               %3 = stablehlo.add %a1, %b1 : tensor<i32>
               "stablehlo.return"(%2,%3,%2) : (tensor<f32>, tensor<i32>, tensor<f32>)
                   -> ()
-            })
-         { padding = dense<[[2, 2], [0, 0]]> : tensor<2x2xi64>,
-           window_dimensions = dense<[5, 1]> : tensor<2xi64>,
-           window_strides = dense<[3, 1]> : tensor<2xi64> }
-         : (tensor<4x2xf32>, tensor<4x2xi32>, tensor<f32>, tensor<i32>) ->
-              (tensor<2x2xf32>, tensor<2x2xi32>)
-  func.return %0#0, %0#1 : tensor<2x2xf32>, tensor<2x2xi32>
-}
-
-// -----
-
-func.func @reduce_window_invalid_reducer(%arg0: tensor<4x2xf32>,
-    %arg1: tensor<4x2xi32>, %init0: tensor<f32>, %init1: tensor<i32>) ->
-    (tensor<2x2xf32>, tensor<2x2xi32>) {
-  // expected-error@+1 {{Reduction-region here must produce tensor-typed result(s), but produces 'f32' instead}}
-  %0:2 = "stablehlo.reduce_window"(%arg0, %arg1, %init0, %init1) ({
-         ^bb0(%a0: f32, %a1: i32, %b0: f32, %b1: i32):
-              %2 = "llvm.add" (%a0, %b0) : (f32, f32) -> f32
-              %3 = "llvm.add" (%a1, %b1) : (i32, i32) -> i32
-              "stablehlo.return"(%2,%3) : (f32, i32) -> ()
             })
          { padding = dense<[[2, 2], [0, 0]]> : tensor<2x2xi64>,
            window_dimensions = dense<[5, 1]> : tensor<2xi64>,

--- a/stablehlo/tests/verify_select_and_scatter.mlir
+++ b/stablehlo/tests/verify_select_and_scatter.mlir
@@ -338,34 +338,6 @@ func.func @select_and_scatter_invalid_attributes(
     %arg1: tensor<10x12x12x64xf32>) -> tensor<10x24x24x64xf32> {
     %0 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
 
-    // expected-error @+1 {{expects the padding-entries to have even number of elements, but got 5 elements.}}
-    %1 = "stablehlo.select_and_scatter"(%arg0, %arg1, %0) ({
-    ^bb0(%arg3: tensor<f32>, %arg4: tensor<f32>):
-      %2 = "stablehlo.compare"(%arg3, %arg4) {
-        comparison_direction = #stablehlo<comparison_direction GE>
-        } : (tensor<f32>, tensor<f32>) -> tensor<i1>
-      "stablehlo.return"(%2) : (tensor<i1>) -> ()
-    },  {
-    ^bb0(%arg3: tensor<f32>, %arg4: tensor<f32>):
-      %2 = stablehlo.add %arg3, %arg4 : tensor<f32>
-      "stablehlo.return"(%2) : (tensor<f32>) -> ()
-    }) {
-      window_dimensions = dense<[1, 2, 2, 1]> : tensor<4xi64>,
-      window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>,
-      padding = dense<[2, 2, 0, 0, 0]> : tensor<5xi64>
-    } : (tensor<10x24x24x64xf32>, tensor<10x12x12x64xf32>, tensor<f32>) ->
-          tensor<10x24x24x64xf32>
-
-    func.return %1 : tensor<10x24x24x64xf32>
-}
-
-// -----
-
-func.func @select_and_scatter_invalid_attributes(
-    %arg0: tensor<10x24x24x64xf32>,
-    %arg1: tensor<10x12x12x64xf32>) -> tensor<10x24x24x64xf32> {
-    %0 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
-
     // expected-error @+1 {{expects window to have positive value for 3-th window dimension, but got 0.}}
     %1 = "stablehlo.select_and_scatter"(%arg0, %arg1, %0) ({
     ^bb0(%arg3: tensor<f32>, %arg4: tensor<f32>):


### PR DESCRIPTION
The new `ReduceWindowOp::inferReturnTypeComponents()` replaces the old `ReduceWindowOp::verify()` with all the checking logic. And expect to cover all XLA checks as well.

And invalid test with `llvm.add` is removed in the same reason as the description of [the PR of "Type inference of ReduceOp"](https://github.com/openxla/stablehlo/pull/50). Please see the reason there.

`ReduceWindowOp` has similar but not same code as `ReduceOp` which is not ideal. So align them to be same in P1~P2 checks.

To address the legacy TODOs, `convertDenseIntAttr` add check for 1-D tensor, and change all caller respectively. Those ops like `SelectAndScatterOp` will be fully addressed in later PRs recently.