### PR TITLE
Update the "Discussions" link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,7 +4,7 @@ contact_links:
     url: https://github.com/openxla/stablehlo/issues/new
     about: If you know what you're doing (especially collaborators)
   - name: 🗣 Start a discussion on GitHub
-    url: https://github.com/openxla/stablehlo/discussions
+    url: https://github.com/orgs/openxla/discussions/new
     about: For early feedback on a design or other proposal
   - name: 💬 Join us on Discord
     url: https://discord.gg/Wqr8vWZKKJ


### PR DESCRIPTION
At the GitHub organization level, we've restructured discussions, so
that they all end up at https://github.com/orgs/openxla/discussions,
similarly to how we have the OpenXLA Discord server and
multiple channels within that server.