### PR TITLE
Remove "Additional context" from bug and FR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -35,9 +35,3 @@ body:
       label: Version information
       description: What version of our software are you using?
       placeholder: This could be a git commit hash.
-  - type: textarea
-    id: additional-context
-    attributes:
-      label: Additional context
-      description: Add any other context about the problem here.
-      placeholder: For example, did what you were trying work before?

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -15,9 +15,3 @@ body:
         What would you like added or changed?
     validations:
       required: true
-  - type: textarea
-    id: additional-context
-    attributes:
-      label: Additional context
-      description: Add any other context about your request here.
-      placeholder: For example, is a similar feature already implemented?


### PR DESCRIPTION
So far, additional context in our tickets has always been empty.
Let's remove it for the time being.