### PR TITLE
Revisit use of mlir::Attribute storage of Element Class

### DIFF
--- a/docs/interpreter.md
+++ b/docs/interpreter.md
@@ -69,7 +69,7 @@ We can use the interpreter mechanism to fold operations with constant operand
 values. The following code snippet demonstrates an idea of the implementation
 for folding `stablehlo::AddOp` with floating-point typed operands:
 
-```
+```C++
 OpFoldResult AddOp::fold(ArrayRef<Attribute> attrs) {
   DenseElementsAttr lhsData = attrs[0].dyn_cast<DenseElementsAttr>();
   DenseElementsAttr rhsData = attrs[1].dyn_cast<DenseElementsAttr>();
@@ -106,7 +106,7 @@ In the current implementation, we package the inputs (MLIR program + input data
 values) and outputs in a
 [lit-based](https://llvm.org/docs/CommandGuide/lit.html) test as follows:
 
-```c++
+```C++
 // CHECK-LABEL: Evaluated results of function: add_op_test_ui4
 func.func @add_op_test_ui4() -> tensor<2xui4> {
   %0 = stablehlo.constant dense<[0, 2]> : tensor<2xui4>

--- a/docs/interpreter.md
+++ b/docs/interpreter.md
@@ -12,9 +12,12 @@ representing its data laid out in
 objects are reference-counted to simplify memory management.
 
 Individual elements of a tensor are represented using `Element` class which uses
-`mlir::Attribute` for storage. Using `mlir::Attribute` simplifies things because
-this means that we don't have to implement our own machinery for storing values
-of different types inside `Element`.
+discriminated union holding one of `APInt` or `vector<APFloat>` for storage. The
+later is used for storing elements with floating-point or complex types. Note
+that we use `mlir::Attribute` while constructing an `Element` object (via
+    `Element(Type type, Attribute attr)`) or extracting value from `Element`
+object (via `Attribute Element::getValue()`), in order to simplify these
+interfaces.
 
 `Tensor` class has the following APIs to interact with its individual elements:
   - `Element Tensor::get(llvm::ArrayRef<int64_t> index)`: To extract an

--- a/docs/interpreter.md
+++ b/docs/interpreter.md
@@ -12,12 +12,8 @@ representing its data laid out in
 objects are reference-counted to simplify memory management.
 
 Individual elements of a tensor are represented using `Element` class which uses
-discriminated union holding one of `APInt` or `vector<APFloat>` for storage. The
-later is used for storing elements with floating-point or complex types. Note
-that we use `mlir::Attribute` while constructing an `Element` object (via
-    `Element(Type type, Attribute attr)`) or extracting value from `Element`
-object (via `Attribute Element::getValue()`), in order to simplify these
-interfaces.
+discriminated union holding one of `APInt`, `APFloat` or `pair<APFloat,APFloat>`
+for storage. The last one is used for storing elements with complex types.
 
 `Tensor` class has the following APIs to interact with its individual elements:
   - `Element Tensor::get(llvm::ArrayRef<int64_t> index)`: To extract an

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -244,7 +244,11 @@ Element tanh(const Element &e) {
       [](std::complex<double> e) { return std::tanh(e); });
 }
 
-void Element::print(raw_ostream &os) const { value_.print(os); }
+bool Element::operator!=(const Element &other) const {
+  return !(*this == other);
+}
+
+void Element::print(raw_ostream &os) const { getValue().print(os); }
 
 void Element::dump() const {
   print(llvm::errs());

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -244,10 +244,6 @@ Element tanh(const Element &e) {
       [](std::complex<double> e) { return std::tanh(e); });
 }
 
-bool Element::operator!=(const Element &other) const {
-  return !(*this == other);
-}
-
 void Element::print(raw_ostream &os) const { getValue().print(os); }
 
 void Element::dump() const {

--- a/stablehlo/reference/Element.h
+++ b/stablehlo/reference/Element.h
@@ -50,18 +50,15 @@ class Element {
 
   /// Returns the underlying integer value stored in an Element object with
   /// integer type.
-  APFloat getFloatValue() const { return std::get<APFloat>(value_); }
+  APInt getIntegerValue() const;
 
   /// Returns the underlying floating-point value stored in an Element object
   /// with floating-point type.
-  APInt getIntegerValue() const { return std::get<APInt>(value_); }
+  APFloat getFloatValue() const;
 
   /// Returns the underlying complex value stored in an Element object with
   /// complex type.
-  std::complex<APFloat> getComplexValue() const {
-    auto floatPair = std::get<std::pair<APFloat, APFloat>>(value_);
-    return std::complex<APFloat>(floatPair.first, floatPair.second);
-  }
+  std::complex<APFloat> getComplexValue() const;
 
   /// Overloaded + operator.
   Element operator+(const Element &other) const;
@@ -100,6 +97,13 @@ inline raw_ostream &operator<<(raw_ostream &os, Element element) {
   element.print(os);
   return os;
 }
+
+/// Check if the type 'type' comforms with what is supported in StableHLO.
+bool isSupportedUnsignedIntegerType(Type type);
+bool isSupportedSignedIntegerType(Type type);
+bool isSupportedIntegerType(Type type);
+bool isSupportedFloatType(Type type);
+bool isSupportedComplexType(Type type);
 
 }  // namespace stablehlo
 }  // namespace mlir

--- a/stablehlo/reference/Element.h
+++ b/stablehlo/reference/Element.h
@@ -27,6 +27,9 @@ limitations under the License.
 namespace mlir {
 namespace stablehlo {
 
+/// Class to represent an element of a tensor. An Element object stores the
+/// element type of the tensor and, depending on that element type, a constant
+/// value of type integer, floating-paint, or complex type.
 class Element {
  public:
   /// \name Constructors

--- a/stablehlo/reference/Element.h
+++ b/stablehlo/reference/Element.h
@@ -16,6 +16,11 @@ limitations under the License.
 #ifndef STABLHLO_REFERENCE_ELEMENT_H
 #define STABLHLO_REFERENCE_ELEMENT_H
 
+#include <variant>
+#include <vector>
+
+#include "llvm/ADT/APFloat.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/raw_ostream.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Types.h"
@@ -27,7 +32,7 @@ class Element {
  public:
   /// \name Constructors
   /// @{
-  Element(Type type, Attribute value) : type_(type), value_(value) {}
+  Element(Type type, Attribute attr);
 
   Element(const Element &other) = default;
   /// @}
@@ -39,7 +44,7 @@ class Element {
   Type getType() const { return type_; }
 
   /// Returns the underlying storage of Element object.
-  Attribute getValue() const { return value_; }
+  Attribute getValue() const;
 
   /// Overloaded + operator.
   Element operator+(const Element &other) const;
@@ -55,7 +60,7 @@ class Element {
 
  private:
   Type type_;
-  Attribute value_;
+  std::variant<APInt, std::vector<APFloat>> value_;
 };
 
 /// Returns element-wise ceil of Element object.

--- a/stablehlo/reference/Element.h
+++ b/stablehlo/reference/Element.h
@@ -98,7 +98,8 @@ inline raw_ostream &operator<<(raw_ostream &os, Element element) {
   return os;
 }
 
-/// Check if the type 'type' comforms with what is supported in StableHLO.
+/// Check if the type 'type' comfirms with what is supported in the StableHLO
+/// spec.
 bool isSupportedUnsignedIntegerType(Type type);
 bool isSupportedSignedIntegerType(Type type);
 bool isSupportedIntegerType(Type type);

--- a/stablehlo/reference/Element.h
+++ b/stablehlo/reference/Element.h
@@ -21,6 +21,7 @@ limitations under the License.
 
 #include "llvm/ADT/APFloat.h"
 #include "llvm/Support/raw_ostream.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Types.h"
 
 namespace mlir {
@@ -30,10 +31,10 @@ class Element {
  public:
   /// \name Constructors
   /// @{
-  Element(Type type, APInt val) : type_(type), value_(val) {}
-  Element(Type type, APFloat val) : type_(type), value_(val) {}
-  Element(Type type, std::complex<APFloat> val)
-      : type_(type), value_(std::make_pair(val.real(), val.imag())) {}
+  Element(Type type, APInt value) : type_(type), value_(value) {}
+  Element(Type type, APFloat value) : type_(type), value_(value) {}
+  Element(Type type, std::complex<APFloat> value)
+      : type_(type), value_(std::make_pair(value.real(), value.imag())) {}
 
   Element(const Element &other) = default;
   /// @}
@@ -44,8 +45,16 @@ class Element {
   /// Returns type of the Element object.
   Type getType() const { return type_; }
 
+  /// Returns the underlying integer value stored in an Element object with
+  /// integer type.
   APFloat getFloatValue() const { return std::get<APFloat>(value_); }
+
+  /// Returns the underlying floating-point value stored in an Element object
+  /// with floating-point type.
   APInt getIntegerValue() const { return std::get<APInt>(value_); }
+
+  /// Returns the underlying complex value stored in an Element object with
+  /// complex type.
   std::complex<APFloat> getComplexValue() const {
     auto floatPair = std::get<std::pair<APFloat, APFloat>>(value_);
     return std::complex<APFloat>(floatPair.first, floatPair.second);

--- a/stablehlo/reference/Tensor.cpp
+++ b/stablehlo/reference/Tensor.cpp
@@ -74,27 +74,6 @@ int64_t flattenIndex(ArrayRef<int64_t> shape, ArrayRef<int64_t> index) {
   return idx;
 }
 
-bool isSupportedUnsignedIntegerType(Type type) {
-  return type.isUnsignedInteger(4) || type.isUnsignedInteger(8) ||
-         type.isUnsignedInteger(16) || type.isUnsignedInteger(32) ||
-         type.isUnsignedInteger(64);
-}
-
-bool isSupportedSignedIntegerType(Type type) {
-  // TODO(#22): StableHLO, as bootstrapped from MHLO, inherits signless
-  // integers which was added in MHLO for legacy reasons. Going forward,
-  // StableHLO will adopt signfull integer semantics with signed and unsigned
-  // integer variants.
-  return type.isSignlessInteger(4) || type.isSignlessInteger(8) ||
-         type.isSignlessInteger(16) || type.isSignlessInteger(32) ||
-         type.isSignlessInteger(64);
-}
-
-bool isSupportedIntegerType(Type type) {
-  return isSupportedUnsignedIntegerType(type) ||
-         isSupportedSignedIntegerType(type);
-}
-
 }  // namespace
 
 namespace detail {
@@ -364,10 +343,7 @@ void Tensor::print(raw_ostream &os) const {
   os << "}";
 }
 
-void Tensor::dump() const {
-  print(llvm::errs());
-  llvm::errs() << "\n";
-}
+void Tensor::dump() const { print(llvm::errs()); }
 
 Tensor makeTensor(ShapedType type, ArrayRef<StringRef> strData) {
   auto elemType = type.getElementType();

--- a/stablehlo/reference/Tensor.h
+++ b/stablehlo/reference/Tensor.h
@@ -23,7 +23,6 @@ limitations under the License.
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/raw_ostream.h"
 #include "mlir/IR/BuiltinAttributes.h"
-#include "mlir/IR/BuiltinTypes.h"
 #include "stablehlo/reference/Element.h"
 #include "stablehlo/reference/Index.h"
 

--- a/stablehlo/reference/Tensor.h
+++ b/stablehlo/reference/Tensor.h
@@ -61,7 +61,8 @@ class Buffer : public llvm::RefCountedBase<Buffer> {
 
 }  // namespace detail
 
-/// Helper class to access the tensor elements in a linearized layout.
+/// Class to model a tensor, an n-dimensional array. Provide access to
+/// individual elements of the tensor using n-dimensional indices.
 class Tensor {
  public:
   /// \name Constructors

--- a/stablehlo/tests/interpret_add.mlir
+++ b/stablehlo/tests/interpret_add.mlir
@@ -241,8 +241,8 @@ func.func @add_op_test_c64() -> tensor<2xcomplex<f32>> {
   %2 = stablehlo.add %0, %1 : tensor<2xcomplex<f32>>
   func.return %2 : tensor<2xcomplex<f32>>
   // CHECK-NEXT: tensor<2xcomplex<f32>>
-  // CHECK-NEXT: #complex.number<:f32 3.000000e+00, 5.000000e+00> : complex<f32>
-  // CHECK-NEXT: #complex.number<:f32 1.500000e+01, 1.100000e+01> : complex<f32> 
+  // CHECK-NEXT: [3.000000e+00 : f32, 5.000000e+00 : f32]
+  // CHECK-NEXT: [1.500000e+01 : f32, 1.100000e+01 : f32]
 }
 
 // -----
@@ -254,6 +254,6 @@ func.func @add_op_test_c128() -> tensor<2xcomplex<f64>> {
   %2 = stablehlo.add %0, %1 : tensor<2xcomplex<f64>>
   func.return %2 : tensor<2xcomplex<f64>>
   // CHECK-NEXT: tensor<2xcomplex<f64>>
-  // CHECK-NEXT: #complex.number<:f64 3.000000e+00, 5.000000e+00> : complex<f64>
-  // CHECK-NEXT: #complex.number<:f64 1.500000e+01, 1.100000e+01> : complex<f64>
+  // CHECK-NEXT: [3.000000e+00 : f64, 5.000000e+00 : f64
+  // CHECK-NEXT: [1.500000e+01 : f64, 1.100000e+01 : f64
 }

--- a/stablehlo/tests/interpret_add.mlir
+++ b/stablehlo/tests/interpret_add.mlir
@@ -254,6 +254,6 @@ func.func @add_op_test_c128() -> tensor<2xcomplex<f64>> {
   %2 = stablehlo.add %0, %1 : tensor<2xcomplex<f64>>
   func.return %2 : tensor<2xcomplex<f64>>
   // CHECK-NEXT: tensor<2xcomplex<f64>>
-  // CHECK-NEXT: [3.000000e+00, 5.000000e+00]
-  // CHECK-NEXT: [1.500000e+01, 1.100000e+01]
+  // CHECK-NEXT: [3.000000e+00 : f64, 5.000000e+00 : f64]
+  // CHECK-NEXT: [1.500000e+01 : f64, 1.100000e+01 : f64]
 }

--- a/stablehlo/tests/interpret_add.mlir
+++ b/stablehlo/tests/interpret_add.mlir
@@ -241,8 +241,8 @@ func.func @add_op_test_c64() -> tensor<2xcomplex<f32>> {
   %2 = stablehlo.add %0, %1 : tensor<2xcomplex<f32>>
   func.return %2 : tensor<2xcomplex<f32>>
   // CHECK-NEXT: tensor<2xcomplex<f32>>
-  // CHECK-NEXT: [3.000000e+00 : f32, 5.000000e+00 : f32]
-  // CHECK-NEXT: [1.500000e+01 : f32, 1.100000e+01 : f32]
+  // CHECK-NEXT: #complex.number<:f32 3.000000e+00, 5.000000e+00> : complex<f32>
+  // CHECK-NEXT: #complex.number<:f32 1.500000e+01, 1.100000e+01> : complex<f32> 
 }
 
 // -----
@@ -254,6 +254,6 @@ func.func @add_op_test_c128() -> tensor<2xcomplex<f64>> {
   %2 = stablehlo.add %0, %1 : tensor<2xcomplex<f64>>
   func.return %2 : tensor<2xcomplex<f64>>
   // CHECK-NEXT: tensor<2xcomplex<f64>>
-  // CHECK-NEXT: [3.000000e+00 : f64, 5.000000e+00 : f64]
-  // CHECK-NEXT: [1.500000e+01 : f64, 1.100000e+01 : f64]
+  // CHECK-NEXT: #complex.number<:f64 3.000000e+00, 5.000000e+00> : complex<f64>
+  // CHECK-NEXT: #complex.number<:f64 1.500000e+01, 1.100000e+01> : complex<f64>
 }

--- a/stablehlo/tests/interpret_constant.mlir
+++ b/stablehlo/tests/interpret_constant.mlir
@@ -215,8 +215,8 @@ func.func @constant_op_test_c64() -> tensor<2xcomplex<f32>> {
   %0 = stablehlo.constant dense<[(1.5, 2.5), (3.5, 4.5)]> : tensor<2xcomplex<f32>>
   func.return %0 : tensor<2xcomplex<f32>>
   // CHECK-NEXT: tensor<2xcomplex<f32>>
-  // CHECK-NEXT: [1.500000e+00 : f32, 2.500000e+00 : f32]
-  // CHECK-NEXT: [3.500000e+00 : f32, 4.500000e+00 : f32]
+  // CHECK-NEXT: #complex.number<:f32 1.500000e+00, 2.500000e+00> : complex<f32>
+  // CHECK-NEXT: #complex.number<:f32 3.500000e+00, 4.500000e+00> : complex<f32> 
 }
 
 // -----
@@ -226,6 +226,6 @@ func.func @constant_op_test_c128() -> tensor<2xcomplex<f64>> {
   %0 = stablehlo.constant dense<[(1.5, 2.5), (3.5, 4.5)]> : tensor<2xcomplex<f64>>
   func.return %0 : tensor<2xcomplex<f64>>
   // CHECK-NEXT: tensor<2xcomplex<f64>>
-  // CHECK-NEXT: [1.500000e+00 : f64, 2.500000e+00 : f64]
-  // CHECK-NEXT: [3.500000e+00 : f64, 4.500000e+00 : f64]
+  // CHECK-NEXT: #complex.number<:f64 1.500000e+00, 2.500000e+00> : complex<f64>
+  // CHECK-NEXT: #complex.number<:f64 3.500000e+00, 4.500000e+00> : complex<f64>
 }

--- a/stablehlo/tests/interpret_constant.mlir
+++ b/stablehlo/tests/interpret_constant.mlir
@@ -215,8 +215,8 @@ func.func @constant_op_test_c64() -> tensor<2xcomplex<f32>> {
   %0 = stablehlo.constant dense<[(1.5, 2.5), (3.5, 4.5)]> : tensor<2xcomplex<f32>>
   func.return %0 : tensor<2xcomplex<f32>>
   // CHECK-NEXT: tensor<2xcomplex<f32>>
-  // CHECK-NEXT: #complex.number<:f32 1.500000e+00, 2.500000e+00> : complex<f32>
-  // CHECK-NEXT: #complex.number<:f32 3.500000e+00, 4.500000e+00> : complex<f32> 
+  // CHECK-NEXT: [1.500000e+00 : f32, 2.500000e+00 : f32]
+  // CHECK-NEXT: [3.500000e+00 : f32, 4.500000e+00 : f32]
 }
 
 // -----
@@ -226,6 +226,6 @@ func.func @constant_op_test_c128() -> tensor<2xcomplex<f64>> {
   %0 = stablehlo.constant dense<[(1.5, 2.5), (3.5, 4.5)]> : tensor<2xcomplex<f64>>
   func.return %0 : tensor<2xcomplex<f64>>
   // CHECK-NEXT: tensor<2xcomplex<f64>>
-  // CHECK-NEXT: #complex.number<:f64 1.500000e+00, 2.500000e+00> : complex<f64>
-  // CHECK-NEXT: #complex.number<:f64 3.500000e+00, 4.500000e+00> : complex<f64>
+  // CHECK-NEXT: [1.500000e+00 : f64, 2.500000e+00 : f64]
+  // CHECK-NEXT: [3.500000e+00 : f64, 4.500000e+00 : f64]
 }

--- a/stablehlo/tests/interpret_constant.mlir
+++ b/stablehlo/tests/interpret_constant.mlir
@@ -226,6 +226,6 @@ func.func @constant_op_test_c128() -> tensor<2xcomplex<f64>> {
   %0 = stablehlo.constant dense<[(1.5, 2.5), (3.5, 4.5)]> : tensor<2xcomplex<f64>>
   func.return %0 : tensor<2xcomplex<f64>>
   // CHECK-NEXT: tensor<2xcomplex<f64>>
-  // CHECK-NEXT: [1.500000e+00, 2.500000e+00]
-  // CHECK-NEXT: [3.500000e+00, 4.500000e+00]
+  // CHECK-NEXT: [1.500000e+00 : f64, 2.500000e+00 : f64]
+  // CHECK-NEXT: [3.500000e+00 : f64, 4.500000e+00 : f64]
 }

--- a/stablehlo/tests/interpret_cosine.mlir
+++ b/stablehlo/tests/interpret_cosine.mlir
@@ -90,8 +90,8 @@ func.func @cosine_op_test_c64() -> tensor<2xcomplex<f32>> {
   %1 = stablehlo.cosine %0 : tensor<2xcomplex<f32>>
   func.return %1 : tensor<2xcomplex<f32>>
   // CHECK-NEXT: tensor<2xcomplex<f32>>
-  // CHECK-NEXT: #complex.number<:f32 4.337810e-01, -6.03504848> : complex<f32>
-  // CHECK-NEXT: #complex.number<:f32 -42.1537743, 15.7863016> : complex<f32>
+  // CHECK-NEXT: [4.337810e-01 : f32, -6.03504848 : f32]
+  // CHECK-NEXT: [-42.1537743 : f32, 15.7863016 : f32]
 }
 
 // -----
@@ -102,6 +102,6 @@ func.func @cosine_op_test_c128() -> tensor<2xcomplex<f64>> {
   %1 = stablehlo.cosine %0 : tensor<2xcomplex<f64>>
   func.return %1 : tensor<2xcomplex<f64>>
   // CHECK-NEXT: tensor<2xcomplex<f64>>
-  // CHECK-NEXT: #complex.number<:f64 0.43378099760770306, -6.0350486377665726> : complex<f64>
-  // CHECK-NEXT: #complex.number<:f64 -42.153773835602316, 15.786301507647636> : complex<f64>
+  // CHECK-NEXT: [0.43378099760770306 : f64, -6.0350486377665726 : f64]
+  // CHECK-NEXT: [-42.153773835602316 : f64, 15.786301507647636 : f64]
 }

--- a/stablehlo/tests/interpret_cosine.mlir
+++ b/stablehlo/tests/interpret_cosine.mlir
@@ -90,8 +90,8 @@ func.func @cosine_op_test_c64() -> tensor<2xcomplex<f32>> {
   %1 = stablehlo.cosine %0 : tensor<2xcomplex<f32>>
   func.return %1 : tensor<2xcomplex<f32>>
   // CHECK-NEXT: tensor<2xcomplex<f32>>
-  // CHECK-NEXT: [4.337810e-01 : f32, -6.03504848 : f32]
-  // CHECK-NEXT: [-42.1537743 : f32, 15.7863016 : f32]
+  // CHECK-NEXT: #complex.number<:f32 4.337810e-01, -6.03504848> : complex<f32>
+  // CHECK-NEXT: #complex.number<:f32 -42.1537743, 15.7863016> : complex<f32>
 }
 
 // -----
@@ -102,6 +102,6 @@ func.func @cosine_op_test_c128() -> tensor<2xcomplex<f64>> {
   %1 = stablehlo.cosine %0 : tensor<2xcomplex<f64>>
   func.return %1 : tensor<2xcomplex<f64>>
   // CHECK-NEXT: tensor<2xcomplex<f64>>
-  // CHECK-NEXT: [0.43378099760770306, -6.0350486377665726]
-  // CHECK-NEXT: [-42.153773835602316, 15.786301507647636]
+  // CHECK-NEXT: #complex.number<:f64 0.43378099760770306, -6.0350486377665726> : complex<f64>
+  // CHECK-NEXT: #complex.number<:f64 -42.153773835602316, 15.786301507647636> : complex<f64>
 }

--- a/stablehlo/tests/interpret_sine.mlir
+++ b/stablehlo/tests/interpret_sine.mlir
@@ -90,8 +90,8 @@ func.func @sine_op_test_c64() -> tensor<2xcomplex<f32>> {
   %1 = stablehlo.sine %0 : tensor<2xcomplex<f32>>
   func.return %1 : tensor<2xcomplex<f32>>
   // CHECK-NEXT: tensor<2xcomplex<f32>>
-  // CHECK-NEXT: #complex.number<:f32 6.1169281, 0.427974522>
-  // CHECK-NEXT: #complex.number<:f32 -15.7901983, -42.1433716>
+  // CHECK-NEXT: [6.1169281 : f32, 0.427974522 : f32]
+  // CHECK-NEXT: [-15.7901983 : f32, -42.1433716 : f32]
 }
 
 // -----
@@ -102,6 +102,6 @@ func.func @sine_op_test_c128() -> tensor<2xcomplex<f64>> {
   %1 = stablehlo.sine %0 : tensor<2xcomplex<f64>>
   func.return %1 : tensor<2xcomplex<f64>>
   // CHECK-NEXT: tensor<2xcomplex<f64>>
-  // CHECK-NEXT: #complex.number<:f64 6.1169280123693124, 0.42797453450615125>
-  // CHECK-NEXT: #complex.number<:f64 -15.790198357309713, -42.143370741504995>
+  // CHECK-NEXT: [6.1169280123693124 : f64, 0.42797453450615125 : f64]
+  // CHECK-NEXT: [-15.790198357309713 : f64, -42.143370741504995 : f64]
 }

--- a/stablehlo/tests/interpret_sine.mlir
+++ b/stablehlo/tests/interpret_sine.mlir
@@ -90,8 +90,8 @@ func.func @sine_op_test_c64() -> tensor<2xcomplex<f32>> {
   %1 = stablehlo.sine %0 : tensor<2xcomplex<f32>>
   func.return %1 : tensor<2xcomplex<f32>>
   // CHECK-NEXT: tensor<2xcomplex<f32>>
-  // CHECK-NEXT: [6.1169281 : f32, 0.427974522 : f32]
-  // CHECK-NEXT: [-15.7901983 : f32, -42.1433716 : f32]
+  // CHECK-NEXT: #complex.number<:f32 6.1169281, 0.427974522>
+  // CHECK-NEXT: #complex.number<:f32 -15.7901983, -42.1433716>
 }
 
 // -----
@@ -102,6 +102,6 @@ func.func @sine_op_test_c128() -> tensor<2xcomplex<f64>> {
   %1 = stablehlo.sine %0 : tensor<2xcomplex<f64>>
   func.return %1 : tensor<2xcomplex<f64>>
   // CHECK-NEXT: tensor<2xcomplex<f64>>
-  // CHECK-NEXT: [6.1169280123693124 : f64, 0.42797453450615125 : f64]
-  // CHECK-NEXT: [-15.790198357309713 : f64, -42.143370741504995 : f64]
+  // CHECK-NEXT: #complex.number<:f64 6.1169280123693124, 0.42797453450615125>
+  // CHECK-NEXT: #complex.number<:f64 -15.790198357309713, -42.143370741504995>
 }

--- a/stablehlo/tests/interpret_sine.mlir
+++ b/stablehlo/tests/interpret_sine.mlir
@@ -102,6 +102,6 @@ func.func @sine_op_test_c128() -> tensor<2xcomplex<f64>> {
   %1 = stablehlo.sine %0 : tensor<2xcomplex<f64>>
   func.return %1 : tensor<2xcomplex<f64>>
   // CHECK-NEXT: tensor<2xcomplex<f64>>
-  // CHECK-NEXT: [6.1169280123693124, 0.42797453450615125]
-  // CHECK-NEXT: [-15.790198357309713, -42.143370741504995]
+  // CHECK-NEXT: [6.1169280123693124 : f64, 0.42797453450615125 : f64]
+  // CHECK-NEXT: [-15.790198357309713 : f64, -42.143370741504995 : f64]
 }

--- a/stablehlo/tests/interpret_subtract.mlir
+++ b/stablehlo/tests/interpret_subtract.mlir
@@ -253,6 +253,6 @@ func.func @subtract_op_test_c128() -> tensor<2xcomplex<f64>> {
   %2 = stablehlo.subtract %0, %1 : tensor<2xcomplex<f64>>
   func.return %2 : tensor<2xcomplex<f64>>
   // CHECK-NEXT: tensor<2xcomplex<f64>>
-  // CHECK-NEXT: [0.000000e+00, 0.000000e+00]
-  // CHECK-NEXT: [0.000000e+00, 0.000000e+00]
+  // CHECK-NEXT: [0.000000e+00 : f64, 0.000000e+00 : f64]
+  // CHECK-NEXT: [0.000000e+00 : f64, 0.000000e+00 : f64]
 }

--- a/stablehlo/tests/interpret_tanh.mlir
+++ b/stablehlo/tests/interpret_tanh.mlir
@@ -90,8 +90,8 @@ func.func @tanh_op_test_c64() -> tensor<2xcomplex<f32>> {
   %1 = stablehlo.tanh %0 : tensor<2xcomplex<f32>>
   func.return %1 : tensor<2xcomplex<f32>>
   // CHECK-NEXT: tensor<2xcomplex<f32>>
-  // CHECK-NEXT: [0.967786788 : f32, -0.0926378369 : f32]
-  // CHECK-NEXT: [1.00166273 : f32, 7.52857188E-4 : f32]
+  // CHECK-NEXT:#complex.number<:f32 0.967786788, -0.0926378369>
+  // CHECK-NEXT:#complex.number<:f32 1.00166273, 7.52857188E-4>
 }
 
 // -----
@@ -102,6 +102,6 @@ func.func @tanh_op_test_c128() -> tensor<2xcomplex<f64>> {
   %1 = stablehlo.tanh %0 : tensor<2xcomplex<f64>>
   func.return %1 : tensor<2xcomplex<f64>>
   // CHECK-NEXT: tensor<2xcomplex<f64>>
-  // CHECK-NEXT: [0.96778680215277412, -0.092637836268419898]
-  // CHECK-NEXT: [1.0016627850956348, 7.5285721538218659E-4]
+  // CHECK-NEXT: #complex.number<:f64 0.96778680215277412, -0.092637836268419898>
+  // CHECK-NEXT: #complex.number<:f64 1.0016627850956348, 7.5285721538218659E-4>
 }

--- a/stablehlo/tests/interpret_tanh.mlir
+++ b/stablehlo/tests/interpret_tanh.mlir
@@ -90,8 +90,8 @@ func.func @tanh_op_test_c64() -> tensor<2xcomplex<f32>> {
   %1 = stablehlo.tanh %0 : tensor<2xcomplex<f32>>
   func.return %1 : tensor<2xcomplex<f32>>
   // CHECK-NEXT: tensor<2xcomplex<f32>>
-  // CHECK-NEXT:#complex.number<:f32 0.967786788, -0.0926378369>
-  // CHECK-NEXT:#complex.number<:f32 1.00166273, 7.52857188E-4>
+  // CHECK-NEXT: [0.967786788 : f32, -0.0926378369 : f32]
+  // CHECK-NEXT: [1.00166273 : f32, 7.52857188E-4 : f32]
 }
 
 // -----
@@ -102,6 +102,6 @@ func.func @tanh_op_test_c128() -> tensor<2xcomplex<f64>> {
   %1 = stablehlo.tanh %0 : tensor<2xcomplex<f64>>
   func.return %1 : tensor<2xcomplex<f64>>
   // CHECK-NEXT: tensor<2xcomplex<f64>>
-  // CHECK-NEXT: #complex.number<:f64 0.96778680215277412, -0.092637836268419898>
-  // CHECK-NEXT: #complex.number<:f64 1.0016627850956348, 7.5285721538218659E-4>
+  // CHECK-NEXT: [0.96778680215277412 : f64, -0.092637836268419898 : f64]
+  // CHECK-NEXT: [1.0016627850956348 : f64, 7.5285721538218659E-4 : f64]
 }


### PR DESCRIPTION
The proposal here is to use a discriminated union of APInt and APFloat as the storage mechanism for Element objects.


fixes https://github.com/openxla/stablehlo/issues/79