### PR TITLE
Add Python API Testing to GitHub Actions

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -19,7 +19,7 @@ runs:
     with:
       repository: llvm/llvm-project
       ref: ${{ inputs.llvm-version }}
-      path: llvm-project
+      path: llvm-project 
       fetch-depth: 1
 
   # Get ninja for cmake build.
@@ -39,3 +39,18 @@ runs:
     with:
       key: ${{ runner.os }}-stablehlo_build_assets-${{ inputs.llvm-version }}
       max-size: 4G
+
+  # Install Python/Numpy for API tests
+  - name: Install Python and Pip
+    uses: actions/setup-python@v4
+    with:
+      python-version: '3.10.6'
+      cache: 'pip' # caching pip dependencies
+  - name: Install MLIR python requirements
+    shell: bash
+    run: |
+      pwd
+      ls
+      ls llvm-project
+      ls $GITHUB_WORKSPACE/llvm-project
+      pip install -r $GITHUB_WORKSPACE/llvm-project/mlir/python/requirements.txt

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -19,7 +19,7 @@ runs:
     with:
       repository: llvm/llvm-project
       ref: ${{ inputs.llvm-version }}
-      path: llvm-project 
+      path: llvm-project
       fetch-depth: 1
 
   # Get ninja for cmake build.
@@ -49,8 +49,4 @@ runs:
   - name: Install MLIR python requirements
     shell: bash
     run: |
-      pwd
-      ls
-      ls llvm-project
-      ls $GITHUB_WORKSPACE/llvm-project
       pip install -r $GITHUB_WORKSPACE/llvm-project/mlir/python/requirements.txt

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -25,10 +25,10 @@ concurrency:
 jobs:
   build-test:
     env:
-      LLVM_PROJ_DIR: "llvm-project"
+      LLVM_PROJECT_DIR: "llvm-project"
       LLVM_BUILD_DIR: "llvm-build"
       STABLEHLO_BUILD_DIR: "stablehlo-build"
-      STABLEHLO_API_BUILD_DIR: "stablehlo-api-build"
+      STABLEHLO_PYTHON_BUILD_DIR: "stablehlo-python-build"
     strategy:
       fail-fast: false
       matrix:
@@ -58,7 +58,7 @@ jobs:
     - name: Configure and Build LLVM os-arch='${{ matrix.os-arch }}'
       shell: bash
       run: |
-        ./build_tools/github_actions/ci_build_llvm.sh "$LLVM_PROJ_DIR" "$LLVM_BUILD_DIR"
+        ./build_tools/github_actions/ci_build_llvm.sh "$LLVM_PROJECT_DIR" "$LLVM_BUILD_DIR"
 
     - name: Build and Test StableHLO os-arch='${{ matrix.os-arch }}'
       shell: bash
@@ -68,4 +68,4 @@ jobs:
     - name: Build and Test StableHLO Python API os-arch='${{ matrix.os-arch }}'
       shell: bash
       run: |
-        ./build_tools/github_actions/ci_build_stablehlo_api.sh "$LLVM_PROJ_DIR" "$STABLEHLO_API_BUILD_DIR" "$GITHUB_WORKSPACE"
+        ./build_tools/github_actions/ci_build_stablehlo_python_api.sh "$LLVM_PROJECT_DIR" "$STABLEHLO_PYTHON_BUILD_DIR" "$GITHUB_WORKSPACE"

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -24,6 +24,11 @@ concurrency:
 # Use Cached LLVM to improve build times.
 jobs:
   build-test:
+    env:
+      LLVM_PROJ_DIR: "llvm-project"
+      LLVM_BUILD_DIR: "llvm-build"
+      STABLEHLO_BUILD_DIR: "stablehlo-build"
+      STABLEHLO_API_BUILD_DIR: "stablehlo-api-build"
     strategy:
       fail-fast: false
       matrix:
@@ -53,8 +58,14 @@ jobs:
     - name: Configure and Build LLVM os-arch='${{ matrix.os-arch }}'
       shell: bash
       run: |
-        ./build_tools/github_actions/ci_build_llvm.sh "$GITHUB_WORKSPACE/llvm-project/" "$GITHUB_WORKSPACE/llvm-build"
+        ./build_tools/github_actions/ci_build_llvm.sh "$LLVM_PROJ_DIR" "$LLVM_BUILD_DIR"
 
     - name: Build and Test StableHLO os-arch='${{ matrix.os-arch }}'
+      shell: bash
       run: |
-        ./build_tools/github_actions/ci_build_stablehlo.sh "$GITHUB_WORKSPACE/llvm-build" "$GITHUB_WORKSPACE/stablehlo-build"
+        ./build_tools/github_actions/ci_build_stablehlo.sh "$LLVM_BUILD_DIR" "$STABLEHLO_BUILD_DIR"
+
+    - name: Build and Test StableHLO Python API os-arch='${{ matrix.os-arch }}'
+      shell: bash
+      run: |
+        ./build_tools/github_actions/ci_build_stablehlo_api.sh "$LLVM_PROJ_DIR" "$STABLEHLO_API_BUILD_DIR" "$GITHUB_WORKSPACE"

--- a/build_tools/github_actions/ci_build_stablehlo_api.sh
+++ b/build_tools/github_actions/ci_build_stablehlo_api.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Copyright 2022 The StableHLO Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [[ $# -ne 3 ]] ; then
+  echo "Usage: $0 <llvm_project_dir> <stablehlo_api_build_dir> <stablehlo_root_dir>"
+  exit 1
+fi
+
+LLVM_PROJ_DIR="$1"
+STABLEHLO_API_BUILD_DIR="$2"
+STABLEHLO_ROOT_DIR="$3"
+
+# Configure StableHLO Bindings
+cmake -GNinja \
+  -B"$STABLEHLO_API_BUILD_DIR" \
+  $LLVM_PROJ_DIR/llvm \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DLLVM_ENABLE_PROJECTS=mlir \
+  -DLLVM_EXTERNAL_PROJECTS=stablehlo \
+  -DLLVM_EXTERNAL_STABLEHLO_SOURCE_DIR="$STABLEHLO_ROOT_DIR" \
+  -DLLVM_TARGETS_TO_BUILD=host \
+  -DPython3_EXECUTABLE=$(which python3) \
+  -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
+  -DSTABLEHLO_ENABLE_BINDINGS_PYTHON=ON \
+  -DCMAKE_CXX_COMPILER=clang++ \
+  -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+  -DCMAKE_C_COMPILER=clang \
+  -DCMAKE_C_COMPILER_LAUNCHER=ccache
+
+# Build and Check StableHLO Python Bindings
+cd "$STABLEHLO_API_BUILD_DIR"
+ninja check-stablehlo-python

--- a/build_tools/github_actions/ci_build_stablehlo_python_api.sh
+++ b/build_tools/github_actions/ci_build_stablehlo_python_api.sh
@@ -17,14 +17,14 @@ if [[ $# -ne 3 ]] ; then
   exit 1
 fi
 
-LLVM_PROJ_DIR="$1"
+LLVM_PROJECT_DIR="$1"
 STABLEHLO_PYTHON_BUILD_DIR="$2"
 STABLEHLO_ROOT_DIR="$3"
 
 # Configure StableHLO Python Bindings
 cmake -GNinja \
   -B"$STABLEHLO_PYTHON_BUILD_DIR" \
-  $LLVM_PROJ_DIR/llvm \
+  $LLVM_PROJECT_DIR/llvm \
   -DCMAKE_BUILD_TYPE=Release \
   -DLLVM_ENABLE_PROJECTS=mlir \
   -DLLVM_EXTERNAL_PROJECTS=stablehlo \

--- a/build_tools/github_actions/ci_build_stablehlo_python_api.sh
+++ b/build_tools/github_actions/ci_build_stablehlo_python_api.sh
@@ -18,12 +18,12 @@ if [[ $# -ne 3 ]] ; then
 fi
 
 LLVM_PROJ_DIR="$1"
-STABLEHLO_API_BUILD_DIR="$2"
+STABLEHLO_PYTHON_BUILD_DIR="$2"
 STABLEHLO_ROOT_DIR="$3"
 
-# Configure StableHLO Bindings
+# Configure StableHLO Python Bindings
 cmake -GNinja \
-  -B"$STABLEHLO_API_BUILD_DIR" \
+  -B"$STABLEHLO_PYTHON_BUILD_DIR" \
   $LLVM_PROJ_DIR/llvm \
   -DCMAKE_BUILD_TYPE=Release \
   -DLLVM_ENABLE_PROJECTS=mlir \
@@ -39,5 +39,5 @@ cmake -GNinja \
   -DCMAKE_C_COMPILER_LAUNCHER=ccache
 
 # Build and Check StableHLO Python Bindings
-cd "$STABLEHLO_API_BUILD_DIR"
+cd "$STABLEHLO_PYTHON_BUILD_DIR"
 ninja check-stablehlo-python


### PR DESCRIPTION
- Added build script for Python API `ci_build_stablehlo_api.sh`
- Added a github action to build and check Python API.
- Added to `buildAndTest.yaml`. 
- Modified `setup-build` to also install required python libraries for mlir bindings.

Timing (first time cost any time we bump llvm version):
- First time cost: ~1.5hr 
- With ccache, following builds: ~3min

_Open question:_
I have a feeling a lot of common LLVM machinery is being built twice. Is there a way to combine API bindings build with the LLVM build? Do we want to do this?

Closes #62.
