### PR TITLE
Don't run Build and Test Action if only doc or readme changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ TensorFlow, JAX and PyTorch, as well as ML compilers including XLA and IREE.
 # Development
 
 We're using GitHub issues / pull requests to organize development and
-GitHub discussions to have longer discussions. We also have a `#stablehlo`
+[GitHub discussions](https://github.com/orgs/openxla/discussions/categories/stablehlo) 
+to have longer discussions. We also have a `#stablehlo`
 channel on [the OpenXLA Discord server](https://discord.gg/PeWUTaecrA).
 
 # Community

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -136,8 +136,8 @@ defined and one of the following:
 
 ### Constraints
 
-  * (C1) `result` has the same shape as the `operand`.
-  * (C2) `result` has the same element type as the `operand` except when the
+  * (C1)  `operand` and `result` have the same shape.
+  * (C2)  `operand` and `result` have the same element type, except when the
   element type of the `operand` is complex type, in which case the element type
   of the `result` is the element type of the complex type (e.g. the element type
   of the `result` is `f64` for operand type `c128`).
@@ -438,7 +438,7 @@ implementation-defined.
 
 ### Constraints
 
-  * (C1) `result` must have the same type as that of `operand`.
+  * (C1) `operand` and `result` have the same type.
 
 ### Examples
 
@@ -851,7 +851,7 @@ logical operation.
 
 ## Constraints
 
-  * (C1) `operand` and `result` have the same type.
+  * (C1) `lhs`, `rhs` and `result` have the same type.
 
 ## Examples
 


### PR DESCRIPTION
Doesn't run if all files in PR are `*.md` or `docs/...`. This will prevent B&T from running for spec updates.

Closes #110