### PR TITLE
Migrate away from kEmitAccessorPrefix_Raw

### DIFF
--- a/stablehlo/dialect/ChloOps.cpp
+++ b/stablehlo/dialect/ChloOps.cpp
@@ -435,7 +435,7 @@ LogicalResult RankSpecializationClusterOp::verify() {
 
   // All operands of nested ops must be defined in the body or declared by the
   // cluster.
-  Block* body = getBody();
+  Block* body = SingleBlock::getBody();
   for (Operation& nested : body->without_terminator()) {
     if (!llvm::all_of(nested.getOpOperands(), [&](OpOperand& operand) {
           Operation* def = operand.get().getDefiningOp();

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -5617,12 +5617,13 @@ LogicalResult WhileOp::verify() {
 /// assignment ::= ssa-value `=` ssa-value
 void WhileOp::print(OpAsmPrinter& p) {
   p << '(';
-  llvm::interleaveComma(llvm::zip(getBody()->getArguments(), getOperands()), p,
-                        [&](auto zip) {
-                          p.printOperand(std::get<0>(zip));
-                          p << " = ";
-                          p.printOperand(std::get<1>(zip));
-                        });
+  llvm::interleaveComma(
+      llvm::zip(SingleBlock::getBody()->getArguments(), getOperands()), p,
+      [&](auto zip) {
+        p.printOperand(std::get<0>(zip));
+        p << " = ";
+        p.printOperand(std::get<1>(zip));
+      });
   p << ")";
   if (getNumOperands()) {
     p << " : ";


### PR DESCRIPTION
Raw has been deprecated and will be removed soon. The migration for CHLO/StableHLO has started in MLIR-HLO, but the recent internal infrastructure changes in tensorflow/mlir-hlo@3227ee1 have rolled it back. This progress needs to be restored. Closes #129 