### PR TITLE
Remove mlir_runner_utils_dir replacement from lit.cfg.py

### DIFF
--- a/stablehlo/tests/lit.cfg.py
+++ b/stablehlo/tests/lit.cfg.py
@@ -20,7 +20,6 @@ import os
 
 import lit.formats
 from lit.llvm import llvm_config
-from lit.llvm.subst import ToolSubst
 import lit.util
 
 # Configuration file for the 'lit' test runner.
@@ -67,10 +66,6 @@ tools = [
     'stablehlo-opt',
     'stablehlo-interpreter',
     'mlir-cpu-runner',
-    ToolSubst(
-        '%mlir_runner_utils_dir',
-        config.mlir_runner_utils_dir,
-        unresolved='ignore'),
 ]
 
 llvm_config.add_tool_substitutions(tools, tool_dirs)

--- a/stablehlo/tests/lit.site.cfg.py.in
+++ b/stablehlo/tests/lit.site.cfg.py.in
@@ -44,7 +44,6 @@ config.llvm_host_triple = '@LLVM_HOST_TRIPLE@'
 config.host_arch = "@HOST_ARCH@"
 config.stablehlo_src_root = "@STABLEHLO_SOURCE_DIR@"
 config.stablehlo_obj_root = "@CMAKE_BINARY_DIR@"
-config.mlir_runner_utils_dir = os.path.join(config.llvm_obj_root, "lib")
 
 # Support substitution of the tools_dir with user parameters. This is
 # used when we can't determine the tool dir at configuration time.


### PR DESCRIPTION
This is going away (or has already gone away) in MLIR upstream.
Context: https://reviews.llvm.org/D133270.