### PR TITLE
Backward compat with the old way of registering CHLO

### DIFF
--- a/stablehlo/integrations/python/mlir/dialects/chlo.py
+++ b/stablehlo/integrations/python/mlir/dialects/chlo.py
@@ -21,3 +21,8 @@ from ._chlo_ops_gen import *
 def register_dialect(context, load=True):
   from .._mlir_libs import _chlo
   _chlo.register_dialect(context, load=load)
+
+
+# Backward compatibility with the old way of registering CHLO dialect
+def register_chlo_dialect(context, load=True):
+  register_dialect(context, load)


### PR DESCRIPTION
We aren't promising source compatibility of our APIs yet, but this one is easy to provide, and it was useful for downstream users of MLIR-HLO.