### PR TITLE
Build with all warnings as errors.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,9 +47,8 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   project(stablehlo LANGUAGES CXX C)
   set(CMAKE_C_STANDARD 11)
   set(CMAKE_CXX_STANDARD 17)
-  
-  # Issue with LLD and -Werror. Similar to golang/go#41527, iree-org/iree#7450
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror") 
+  set(LLVM_ENABLE_WARNINGS ON)
+  set(LLVM_ENABLE_WERROR ON)
 endif()
 
 #-------------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,9 +50,6 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   
   # Issue with LLD and -Werror. Similar to golang/go#41527, iree-org/iree#7450
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror") 
-  if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-command-line-argument") 
-  endif()
 endif()
 
 #-------------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,12 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   project(stablehlo LANGUAGES CXX C)
   set(CMAKE_C_STANDARD 11)
   set(CMAKE_CXX_STANDARD 17)
+  
+  # Issue with LLD and -Werror. Similar to golang/go#41527, iree-org/iree#7450
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror") 
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-command-line-argument") 
+  endif()
 endif()
 
 #-------------------------------------------------------------------------------

--- a/stablehlo/reference/Tensor.h
+++ b/stablehlo/reference/Tensor.h
@@ -40,8 +40,8 @@ class Buffer : public llvm::RefCountedBase<Buffer> {
   Buffer(Buffer &&other) = default;
   /// @}
 
-  /// Assignment operator.
-  Buffer &operator=(Buffer &&other) = default;
+  /// Move assignment operator deleted in RefCountedBase
+  Buffer &operator=(Buffer &&other) = delete;
 
   /// Returns type of the Buffer object.
   ShapedType getType() { return type_; }


### PR DESCRIPTION
Fixes a build warning with `Tensor.h`:

```
In file included from /usr/local/google/home/gleasonk/Coding/openxla/stablehlo/stablehlo/reference/Tensor.cpp:16:
/usr/local/google/home/gleasonk/Coding/openxla/stablehlo/stablehlo/reference/Tensor.h:44:11: error: explicitly defaulted move assignment operator is implicitly deleted [-Werror,-Wdefaulted-function-deleted]
  Buffer &operator=(Buffer &&other) = default;
          ^
/usr/local/google/home/gleasonk/Coding/openxla/stablehlo/stablehlo/reference/Tensor.h:33:16: note: move assignment operator of 'Buffer' is implicitly deleted because base class 'llvm::RefCountedBase<Buffer>' has a deleted move assignment operator
class Buffer : public llvm::RefCountedBase<Buffer> {
               ^
/usr/local/google/home/gleasonk/Coding/llvm-project/llvm/include/llvm/ADT/IntrusiveRefCntPtr.h:82:19: note: 'operator=' has been explicitly marked deleted here
  RefCountedBase &operator=(const RefCountedBase &) = delete;
                  ^
1 error generated.
```

Also note: there is an issue with clang regarding `-Werror` and `lld`. Without the ` -Wno-unused-command-line-argument` flag, it errors with:

```
cmake -GNinja \
  -B"$STABLEHLO_BUILD_DIR" \
  -DLLVM_ENABLE_LLD=ON \
  -DCMAKE_BUILD_TYPE=Release \
  -DLLVM_ENABLE_ASSERTIONS=On \
  -DMLIR_DIR="$LLVM_BUILD_DIR/lib/cmake/mlir" \
  -DCMAKE_CXX_COMPILER=clang++ \
  -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
  -DCMAKE_C_COMPILER=clang \
  -DCMAKE_C_COMPILER_LAUNCHER=ccache

-- The CXX compiler identification is Clang 14.0.6
-- The C compiler identification is Clang 14.0.6
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/clang++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/clang - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Building StableHLO standalone
-- Performing Test Terminfo_LINKABLE
-- Performing Test Terminfo_LINKABLE - Success
-- Found Terminfo: /usr/lib/x86_64-linux-gnu/libtinfo.so  
-- Found ZLIB: /usr/lib/x86_64-linux-gnu/libz.so (found version "1.2.11") 
-- Found LibXml2: /usr/lib/x86_64-linux-gnu/libxml2.so (found version "2.9.14") 
-- Using MLIRConfig.cmake in: /usr/local/google/home/gleasonk/Coding/llvm-build/lib/cmake/mlir
-- Using LLVMConfig.cmake in: /usr/local/google/home/gleasonk/Coding/llvm-build/lib/cmake/llvm
-- Linker detection: GNU ld
-- Performing Test LLVM_LIBSTDCXX_MIN
-- Performing Test LLVM_LIBSTDCXX_MIN - Success
-- Performing Test LLVM_LIBSTDCXX_SOFT_ERROR
-- Performing Test LLVM_LIBSTDCXX_SOFT_ERROR - Success
-- Performing Test CXX_SUPPORTS_CUSTOM_LINKER
-- Performing Test CXX_SUPPORTS_CUSTOM_LINKER - Failed
CMake Error at /usr/local/google/home/gleasonk/Coding/llvm-build/lib/cmake/llvm/HandleLLVMOptions.cmake:309 (message):
  Host compiler does not support '-fuse-ld=lld'
Call Stack (most recent call first):
  CMakeLists.txt:75 (include)
...
-----------------------------------------------------------------
$ cat <build_dir>/CMakeFiles/CMakeError.log
Performing C++ SOURCE FILE Test CXX_SUPPORTS_CUSTOM_LINKER failed with the following output:
Change Dir: /usr/local/google/home/gleasonk/Coding/stablehlo-build/CMakeFiles/CMakeTmp

Run Build Command(s):/usr/bin/ninja cmTC_d5508 && [1/2] Building CXX object CMakeFiles/cmTC_d5508.dir/src.cxx.o
FAILED: CMakeFiles/cmTC_d5508.dir/src.cxx.o 
/usr/bin/clang++ -DCXX_SUPPORTS_CUSTOM_LINKER  -Wall -Werror  -fuse-ld=lld -std=gnu++17 -MD -MT CMakeFiles/cmTC_d5508.dir/src.cxx.o -MF CMakeFiles/cmTC_d5508.dir/src.cxx.o.d -o CMakeFiles/cmTC_d5508.dir/src.cxx.o -c /usr/local/google/home/gleasonk/Coding/stablehlo-build/CMakeFiles/CMakeTmp/src.cxx
clang: error: argument unused during compilation: '-fuse-ld=lld' [-Werror,-Wunused-command-line-argument]
ninja: build stopped: subcommand failed.


Source file was:
int main() { return 0; }
```


Closes #125.