### PR TITLE
Add additional special test cases for interpret_add.mlir and interpret_constant.mlir

### DIFF
--- a/stablehlo/tests/interpret_add.mlir
+++ b/stablehlo/tests/interpret_add.mlir
@@ -146,12 +146,12 @@ func.func @add_op_test_ui64() -> tensor<2xui64> {
 // -----
 
 // CHECK-LABEL: Evaluated results of function: add_op_test_bf16
-func.func @add_op_test_bf16() -> tensor<10xbf16> {
-  %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.140625, 0x7F80, 0x7F80, 0xFF80, 0x7F80]> : tensor<10xbf16>
-  %1 = stablehlo.constant dense<[0.0, -0.0, 7.0, 0.75, 0.3, 3.140625, 0.0, 0x7F80, 0xFF80, 0xFF80]> : tensor<10xbf16>
-  %2 = stablehlo.add %0, %1 : tensor<10xbf16>
-  func.return %2 : tensor<10xbf16>
-  // CHECK-NEXT: tensor<10xbf16>
+func.func @add_op_test_bf16() -> tensor<12xbf16> {
+  %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.140625, 0x7F80, 0x7F80, 0xFF80, 0x7F80, 0x7FFF, 0x0001]> : tensor<12xbf16>
+  %1 = stablehlo.constant dense<[0.0, -0.0, 7.0, 0.75, 0.3, 3.140625, 0.0, 0x7F80, 0xFF80, 0xFF80, 0xFFFF, 0x8001]> : tensor<12xbf16>
+  %2 = stablehlo.add %0, %1 : tensor<12xbf16>
+  func.return %2 : tensor<12xbf16>
+  // CHECK-NEXT: tensor<12xbf16>
   // CHECK-NEXT: 0.000000e+00 : bf16
   // CHECK-NEXT: -0.000000e+00 : bf16
   // CHECK-NEXT: 8.000000e+00 : bf16
@@ -162,17 +162,19 @@ func.func @add_op_test_bf16() -> tensor<10xbf16> {
   // CHECK-NEXT: 0x7F80 : bf16
   // CHECK-NEXT: 0xFF80 : bf16
   // CHECK-NEXT: 0x7FC0 : bf16
+  // CHECK-NEXT: 0x7FFF : bf16
+  // CHECK-NEXT: 0.000000e+00 : bf16
 }
 
 // -----
 
 // CHECK-LABEL: Evaluated results of function: add_op_test_f16
-func.func @add_op_test_f16() -> tensor<10xf16> {
-  %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.141, 0x7C00, 0x7C00, 0xFC00, 0x7C00]> : tensor<10xf16>
-  %1 = stablehlo.constant dense<[0.0, -0.0, 7.0, 0.75, 0.3, 3.141, 0.0, 0x7C00, 0xFC00, 0x7C00]> : tensor<10xf16>
-  %2 = stablehlo.add %0, %1 : tensor<10xf16>
-  func.return %2 : tensor<10xf16>
-  // CHECK-NEXT: tensor<10xf16>
+func.func @add_op_test_f16() -> tensor<12xf16> {
+  %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.141, 0x7C00, 0x7C00, 0xFC00, 0x7C00, 0x7FFF, 0x0001]> : tensor<12xf16>
+  %1 = stablehlo.constant dense<[0.0, -0.0, 7.0, 0.75, 0.3, 3.141, 0.0, 0x7C00, 0xFC00, 0xFC00, 0xFFFF, 0x8001]> : tensor<12xf16>
+  %2 = stablehlo.add %0, %1 : tensor<12xf16>
+  func.return %2 : tensor<12xf16>
+  // CHECK-NEXT: tensor<12xf16>
   // CHECK-NEXT: 0.000000e+00 : f16
   // CHECK-NEXT: -0.000000e+00 : f16
   // CHECK-NEXT: 8.000000e+00 : f16
@@ -182,18 +184,21 @@ func.func @add_op_test_f16() -> tensor<10xf16> {
   // CHECK-NEXT: 0x7C00 : f16
   // CHECK-NEXT: 0x7C00 : f16
   // CHECK-NEXT: 0xFC00 : f16
-  // CHECK-NEXT: 0x7C00 : f16
+  // CHECK-NEXT: 0x7E00 : f16
+  // CHECK-NEXT: 0x7FFF : f16
+  // CHECK-NEXT: 0.000000e+00 : f16
+
 }
 
 // -----
 
 // CHECK-LABEL: Evaluated results of function: add_op_test_f32
-func.func @add_op_test_f32() -> tensor<10xf32> {
-  %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.14159265, 0x7F800000, 0x7F800000, 0xFF800000, 0x7F800000]> : tensor<10xf32>
-  %1 = stablehlo.constant dense<[0.0, -0.0, 7.0, 0.75, 0.3, 3.14159265, 0.0, 0x7F800000, 0xFF800000, 0xFF800000]> : tensor<10xf32>
-  %2 = stablehlo.add %0, %1 : tensor<10xf32>
-  func.return %2 : tensor<10xf32>
-  // CHECK-NEXT: tensor<10xf32>
+func.func @add_op_test_f32() -> tensor<12xf32> {
+  %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.14159265, 0x7F800000, 0x7F800000, 0xFF800000, 0x7F800000, 0x7FFFFFFF, 0x00000001]> : tensor<12xf32>
+  %1 = stablehlo.constant dense<[0.0, -0.0, 7.0, 0.75, 0.3, 3.14159265, 0.0, 0x7F800000, 0xFF800000, 0xFF800000, 0xFFFFFFFF, 0x80000001]> : tensor<12xf32>
+  %2 = stablehlo.add %0, %1 : tensor<12xf32>
+  func.return %2 : tensor<12xf32>
+  // CHECK-NEXT: tensor<12xf32>
   // CHECK-NEXT: 0.000000e+00 : f32
   // CHECK-NEXT: -0.000000e+00 : f32
   // CHECK-NEXT: 8.000000e+00 : f32
@@ -204,17 +209,19 @@ func.func @add_op_test_f32() -> tensor<10xf32> {
   // CHECK-NEXT: 0x7F800000 : f32
   // CHECK-NEXT: 0xFF800000 : f32
   // CHECK-NEXT: 0x7FC00000 : f32
+  // CHECK-NEXT: 0x7FFFFFFF : f32
+  // CHECK-NEXT: 0.000000e+00 : f32
 }
 
 // -----
 
 // CHECK-LABEL: Evaluated results of function: add_op_test_f64
-func.func @add_op_test_f64() -> tensor<10xf64> {
-  %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.14159265358979323846, 0x7FF0000000000000, 0x7FF0000000000000, 0xFFF0000000000000, 0x7FF0000000000000]> : tensor<10xf64>
-  %1 = stablehlo.constant dense<[0.0, -0.0, 7.0, 0.75, 0.3, 3.14159265358979323846, 0.0, 0x7FF0000000000000, 0xFFF0000000000000, 0xFFF0000000000000]> : tensor<10xf64>
-  %2 = stablehlo.add %0, %1 : tensor<10xf64>
-  func.return %2 : tensor<10xf64>
-  // CHECK-NEXT: tensor<10xf64>
+func.func @add_op_test_f64() -> tensor<12xf64> {
+  %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.14159265358979323846, 0x7FF0000000000000, 0x7FF0000000000000, 0xFFF0000000000000, 0x7FF0000000000000, 0x7FFFFFFFFFFFFFFF, 0x0000000000000001]> : tensor<12xf64>
+  %1 = stablehlo.constant dense<[0.0, -0.0, 7.0, 0.75, 0.3, 3.14159265358979323846, 0.0, 0x7FF0000000000000, 0xFFF0000000000000, 0xFFF0000000000000, 0xFFFFFFFFFFFFFFFF, 0x8000000000000001]> : tensor<12xf64>
+  %2 = stablehlo.add %0, %1 : tensor<12xf64>
+  func.return %2 : tensor<12xf64>
+  // CHECK-NEXT: tensor<12xf64>
   // CHECK-NEXT: 0.000000e+00 : f64
   // CHECK-NEXT: -0.000000e+00 : f64
   // CHECK-NEXT: 8.000000e+00 : f64
@@ -225,6 +232,8 @@ func.func @add_op_test_f64() -> tensor<10xf64> {
   // CHECK-NEXT: 0x7FF0000000000000 : f64
   // CHECK-NEXT: 0xFFF0000000000000 : f64
   // CHECK-NEXT: 0x7FF8000000000000 : f64
+  // CHECK-NEXT: 0x7FFFFFFFFFFFFFFF : f64
+  // CHECK-NEXT: 0.000000e+00 : f64
 }
 
 // -----

--- a/stablehlo/tests/interpret_add.mlir
+++ b/stablehlo/tests/interpret_add.mlir
@@ -146,12 +146,12 @@ func.func @add_op_test_ui64() -> tensor<2xui64> {
 // -----
 
 // CHECK-LABEL: Evaluated results of function: add_op_test_bf16
-func.func @add_op_test_bf16() -> tensor<12xbf16> {
-  %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.140625, 0x7F80, 0x7F80, 0xFF80, 0x7F80, 0x7FFF, 0x0001]> : tensor<12xbf16>
-  %1 = stablehlo.constant dense<[0.0, -0.0, 7.0, 0.75, 0.3, 3.140625, 0.0, 0x7F80, 0xFF80, 0xFF80, 0xFFFF, 0x8001]> : tensor<12xbf16>
-  %2 = stablehlo.add %0, %1 : tensor<12xbf16>
-  func.return %2 : tensor<12xbf16>
-  // CHECK-NEXT: tensor<12xbf16>
+func.func @add_op_test_bf16() -> tensor<11xbf16> {
+  %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.140625, 0x7F80, 0x7F80, 0xFF80, 0x7F80, 0x0001]> : tensor<11xbf16>
+  %1 = stablehlo.constant dense<[0.0, -0.0, 7.0, 0.75, 0.3, 3.140625, 0.0, 0x7F80, 0xFF80, 0xFF80, 0x8001]> : tensor<11xbf16>
+  %2 = stablehlo.add %0, %1 : tensor<11xbf16>
+  func.return %2 : tensor<11xbf16>
+  // CHECK-NEXT: tensor<11xbf16>
   // CHECK-NEXT: 0.000000e+00 : bf16
   // CHECK-NEXT: -0.000000e+00 : bf16
   // CHECK-NEXT: 8.000000e+00 : bf16
@@ -162,19 +162,18 @@ func.func @add_op_test_bf16() -> tensor<12xbf16> {
   // CHECK-NEXT: 0x7F80 : bf16
   // CHECK-NEXT: 0xFF80 : bf16
   // CHECK-NEXT: 0x7FC0 : bf16
-  // CHECK-NEXT: 0x7FFF : bf16
   // CHECK-NEXT: 0.000000e+00 : bf16
 }
 
 // -----
 
 // CHECK-LABEL: Evaluated results of function: add_op_test_f16
-func.func @add_op_test_f16() -> tensor<12xf16> {
-  %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.141, 0x7C00, 0x7C00, 0xFC00, 0x7C00, 0x7FFF, 0x0001]> : tensor<12xf16>
-  %1 = stablehlo.constant dense<[0.0, -0.0, 7.0, 0.75, 0.3, 3.141, 0.0, 0x7C00, 0xFC00, 0xFC00, 0xFFFF, 0x8001]> : tensor<12xf16>
-  %2 = stablehlo.add %0, %1 : tensor<12xf16>
-  func.return %2 : tensor<12xf16>
-  // CHECK-NEXT: tensor<12xf16>
+func.func @add_op_test_f16() -> tensor<11xf16> {
+  %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.141, 0x7C00, 0x7C00, 0xFC00, 0x7C00, 0x0001]> : tensor<11xf16>
+  %1 = stablehlo.constant dense<[0.0, -0.0, 7.0, 0.75, 0.3, 3.141, 0.0, 0x7C00, 0xFC00, 0xFC00, 0x8001]> : tensor<11xf16>
+  %2 = stablehlo.add %0, %1 : tensor<11xf16>
+  func.return %2 : tensor<11xf16>
+  // CHECK-NEXT: tensor<11xf16>
   // CHECK-NEXT: 0.000000e+00 : f16
   // CHECK-NEXT: -0.000000e+00 : f16
   // CHECK-NEXT: 8.000000e+00 : f16
@@ -185,7 +184,6 @@ func.func @add_op_test_f16() -> tensor<12xf16> {
   // CHECK-NEXT: 0x7C00 : f16
   // CHECK-NEXT: 0xFC00 : f16
   // CHECK-NEXT: 0x7E00 : f16
-  // CHECK-NEXT: 0x7FFF : f16
   // CHECK-NEXT: 0.000000e+00 : f16
 
 }
@@ -193,12 +191,12 @@ func.func @add_op_test_f16() -> tensor<12xf16> {
 // -----
 
 // CHECK-LABEL: Evaluated results of function: add_op_test_f32
-func.func @add_op_test_f32() -> tensor<12xf32> {
-  %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.14159265, 0x7F800000, 0x7F800000, 0xFF800000, 0x7F800000, 0x7FFFFFFF, 0x00000001]> : tensor<12xf32>
-  %1 = stablehlo.constant dense<[0.0, -0.0, 7.0, 0.75, 0.3, 3.14159265, 0.0, 0x7F800000, 0xFF800000, 0xFF800000, 0xFFFFFFFF, 0x80000001]> : tensor<12xf32>
-  %2 = stablehlo.add %0, %1 : tensor<12xf32>
-  func.return %2 : tensor<12xf32>
-  // CHECK-NEXT: tensor<12xf32>
+func.func @add_op_test_f32() -> tensor<11xf32> {
+  %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.14159265, 0x7F800000, 0x7F800000, 0xFF800000, 0x7F800000, 0x00000001]> : tensor<11xf32>
+  %1 = stablehlo.constant dense<[0.0, -0.0, 7.0, 0.75, 0.3, 3.14159265, 0.0, 0x7F800000, 0xFF800000, 0xFF800000, 0x80000001]> : tensor<11xf32>
+  %2 = stablehlo.add %0, %1 : tensor<11xf32>
+  func.return %2 : tensor<11xf32>
+  // CHECK-NEXT: tensor<11xf32>
   // CHECK-NEXT: 0.000000e+00 : f32
   // CHECK-NEXT: -0.000000e+00 : f32
   // CHECK-NEXT: 8.000000e+00 : f32
@@ -209,19 +207,18 @@ func.func @add_op_test_f32() -> tensor<12xf32> {
   // CHECK-NEXT: 0x7F800000 : f32
   // CHECK-NEXT: 0xFF800000 : f32
   // CHECK-NEXT: 0x7FC00000 : f32
-  // CHECK-NEXT: 0x7FFFFFFF : f32
   // CHECK-NEXT: 0.000000e+00 : f32
 }
 
 // -----
 
 // CHECK-LABEL: Evaluated results of function: add_op_test_f64
-func.func @add_op_test_f64() -> tensor<12xf64> {
-  %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.14159265358979323846, 0x7FF0000000000000, 0x7FF0000000000000, 0xFFF0000000000000, 0x7FF0000000000000, 0x7FFFFFFFFFFFFFFF, 0x0000000000000001]> : tensor<12xf64>
-  %1 = stablehlo.constant dense<[0.0, -0.0, 7.0, 0.75, 0.3, 3.14159265358979323846, 0.0, 0x7FF0000000000000, 0xFFF0000000000000, 0xFFF0000000000000, 0xFFFFFFFFFFFFFFFF, 0x8000000000000001]> : tensor<12xf64>
-  %2 = stablehlo.add %0, %1 : tensor<12xf64>
-  func.return %2 : tensor<12xf64>
-  // CHECK-NEXT: tensor<12xf64>
+func.func @add_op_test_f64() -> tensor<11xf64> {
+  %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.14159265358979323846, 0x7FF0000000000000, 0x7FF0000000000000, 0xFFF0000000000000, 0x7FF0000000000000, 0x0000000000000001]> : tensor<11xf64>
+  %1 = stablehlo.constant dense<[0.0, -0.0, 7.0, 0.75, 0.3, 3.14159265358979323846, 0.0, 0x7FF0000000000000, 0xFFF0000000000000, 0xFFF0000000000000, 0x8000000000000001]> : tensor<11xf64>
+  %2 = stablehlo.add %0, %1 : tensor<11xf64>
+  func.return %2 : tensor<11xf64>
+  // CHECK-NEXT: tensor<11xf64>
   // CHECK-NEXT: 0.000000e+00 : f64
   // CHECK-NEXT: -0.000000e+00 : f64
   // CHECK-NEXT: 8.000000e+00 : f64
@@ -232,7 +229,7 @@ func.func @add_op_test_f64() -> tensor<12xf64> {
   // CHECK-NEXT: 0x7FF0000000000000 : f64
   // CHECK-NEXT: 0xFFF0000000000000 : f64
   // CHECK-NEXT: 0x7FF8000000000000 : f64
-  // CHECK-NEXT: 0x7FFFFFFFFFFFFFFF : f64
+
   // CHECK-NEXT: 0.000000e+00 : f64
 }
 

--- a/stablehlo/tests/interpret_constant.mlir
+++ b/stablehlo/tests/interpret_constant.mlir
@@ -131,44 +131,52 @@ func.func @constant_op_test_ui64() -> tensor<3xui64> {
 // -----
 
 // CHECK-LABEL: Evaluated results of function: constant_op_test_bf16
-func.func @constant_op_test_bf16() -> tensor<8xbf16> {
-  %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.140630, 0x7C00, 0xFC00]> : tensor<8xbf16>
-  func.return %0 : tensor<8xbf16>
-  // CHECK-NEXT: tensor<8xbf16>
+func.func @constant_op_test_bf16() -> tensor<12xbf16> {
+  %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.140630, 0x7F80, 0xFF80, 0x7FFF, 0xFFFF, 0x0001, 0x8001]> : tensor<12xbf16>
+  func.return %0 : tensor<12xbf16>
+  // CHECK-NEXT: tensor<12xbf16>
   // CHECK-NEXT: 0.000000e+00 : bf16
   // CHECK-NEXT: -0.000000e+00 : bf16
   // CHECK-NEXT: 1.000000e+00 : bf16
   // CHECK-NEXT: 1.250000e-01 : bf16
   // CHECK-NEXT: 1.000980e-01 : bf16
   // CHECK-NEXT: 3.140630e+00 : bf16
-  // CHECK-NEXT: 2.658460e+36 : bf16
-  // CHECK-NEXT: 2.658460e+36 : bf16
+  // CHECK-NEXT: 0x7F80 : bf16
+  // CHECK-NEXT: 0xFF80 : bf16
+  // CHECK-NEXT: 0x7FFF : bf16
+  // CHECK-NEXT: 0xFFFF : bf16
+  // CHECK-NEXT: 9.183550e-41 : bf16
+  // CHECK-NEXT: -9.183550e-41 : bf16
 }
 
 // -----
 
 // CHECK-LABEL: Evaluated results of function: constant_op_test_f16
-func.func @constant_op_test_f16() -> tensor<8xf16> {
-  %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.140630, 0x7F80, 0xFF80]> : tensor<8xf16>
-  func.return %0 : tensor<8xf16>
-  // CHECK-NEXT: tensor<8xf16>
+func.func @constant_op_test_f16() -> tensor<12xf16> {
+  %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.140630, 0x7C00, 0xFC00, 0x7FFF, 0xFFFF, 0x0001, 0x8001]> : tensor<12xf16>
+  func.return %0 : tensor<12xf16>
+  // CHECK-NEXT: tensor<12xf16>
   // CHECK-NEXT: 0.000000e+00 : f16
   // CHECK-NEXT: -0.000000e+00 : f16
   // CHECK-NEXT: 1.000000e+00 : f16
   // CHECK-NEXT: 1.250000e-01 : f16
   // CHECK-NEXT: 9.997550e-02 : f16
   // CHECK-NEXT: 3.140630e+00 : f16
-  // CHECK-NEXT: 0x7F80 : f16
-  // CHECK-NEXT: 0xFF80 : f16
+  // CHECK-NEXT: 0x7C00 : f16
+  // CHECK-NEXT: 0xFC00 : f16
+  // CHECK-NEXT: 0x7FFF : f16
+  // CHECK-NEXT: 0xFFFF : f16
+  // CHECK-NEXT: 5.960460e-08 : f16
+  // CHECK-NEXT: -5.960460e-08 : f16
 }
 
 // -----
 
 // CHECK-LABEL: Evaluated results of function: constant_op_test_f32
-func.func @constant_op_test_f32() -> tensor<8xf32> {
-  %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.14159274, 0x7F800000, 0xFF800000]> : tensor<8xf32>
-  func.return %0 : tensor<8xf32>
-  // CHECK-NEXT: tensor<8xf32>
+func.func @constant_op_test_f32() -> tensor<12xf32> {
+  %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.14159274, 0x7F800000, 0xFF800000, 0x7FFFFFFF, 0xFFFFFFFF, 0x00000001, 0x80000001]> : tensor<12xf32>
+  func.return %0 : tensor<12xf32>
+  // CHECK-NEXT: tensor<12xf32>
   // CHECK-NEXT: 0.000000e+00 : f32
   // CHECK-NEXT: -0.000000e+00 : f32
   // CHECK-NEXT: 1.000000e+00 : f32
@@ -177,15 +185,19 @@ func.func @constant_op_test_f32() -> tensor<8xf32> {
   // CHECK-NEXT: 3.14159274 : f32
   // CHECK-NEXT: 0x7F800000 : f32
   // CHECK-NEXT: 0xFF800000 : f32
+  // CHECK-NEXT: 0x7FFFFFFF : f32
+  // CHECK-NEXT: 0xFFFFFFFF : f32
+  // CHECK-NEXT: 1.401300e-45 : f32
+  // CHECK-NEXT: -1.401300e-45 : f32
 }
 
 // -----
 
 // CHECK-LABEL: Evaluated results of function: constant_op_test_f64
-func.func @constant_op_test_f64() -> tensor<8xf64> {
-  %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.1415926535897931, 0x7FF0000000000000, 0xFFF0000000000000]> : tensor<8xf64>
-  func.return %0 : tensor<8xf64>
-  // CHECK-NEXT: tensor<8xf64>
+func.func @constant_op_test_f64() -> tensor<12xf64> {
+  %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.1415926535897931, 0x7FF0000000000000, 0xFFF0000000000000, 0x7FFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF, 0x0000000000000001, 0x8000000000000001]> : tensor<12xf64>
+  func.return %0 : tensor<12xf64>
+  // CHECK-NEXT: tensor<12xf64>
   // CHECK-NEXT: 0.000000e+00 : f64
   // CHECK-NEXT: -0.000000e+00 : f64
   // CHECK-NEXT: 1.000000e+00 : f64
@@ -194,6 +206,10 @@ func.func @constant_op_test_f64() -> tensor<8xf64> {
   // CHECK-NEXT: 3.1415926535897931 : f64
   // CHECK-NEXT: 0x7FF0000000000000 : f64
   // CHECK-NEXT: 0xFFF0000000000000 : f64
+  // CHECK-NEXT: 0x7FFFFFFFFFFFFFFF : f64
+  // CHECK-NEXT: 0xFFFFFFFFFFFFFFFF : f64
+  // CHECK-NEXT: 4.940660e-324 : f64
+  // CHECK-NEXT: -4.940660e-324 : f64
 }
 
 // -----

--- a/stablehlo/tests/interpret_constant.mlir
+++ b/stablehlo/tests/interpret_constant.mlir
@@ -131,10 +131,10 @@ func.func @constant_op_test_ui64() -> tensor<3xui64> {
 // -----
 
 // CHECK-LABEL: Evaluated results of function: constant_op_test_bf16
-func.func @constant_op_test_bf16() -> tensor<12xbf16> {
-  %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.140630, 0x7F80, 0xFF80, 0x7FFF, 0xFFFF, 0x0001, 0x8001]> : tensor<12xbf16>
-  func.return %0 : tensor<12xbf16>
-  // CHECK-NEXT: tensor<12xbf16>
+func.func @constant_op_test_bf16() -> tensor<11xbf16> {
+  %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.140630, 0x7F80, 0xFF80, 0x7FFF, 0x0001, 0x8001]> : tensor<11xbf16>
+  func.return %0 : tensor<11xbf16>
+  // CHECK-NEXT: tensor<11xbf16>
   // CHECK-NEXT: 0.000000e+00 : bf16
   // CHECK-NEXT: -0.000000e+00 : bf16
   // CHECK-NEXT: 1.000000e+00 : bf16
@@ -144,7 +144,6 @@ func.func @constant_op_test_bf16() -> tensor<12xbf16> {
   // CHECK-NEXT: 0x7F80 : bf16
   // CHECK-NEXT: 0xFF80 : bf16
   // CHECK-NEXT: 0x7FFF : bf16
-  // CHECK-NEXT: 0xFFFF : bf16
   // CHECK-NEXT: 9.183550e-41 : bf16
   // CHECK-NEXT: -9.183550e-41 : bf16
 }
@@ -152,10 +151,10 @@ func.func @constant_op_test_bf16() -> tensor<12xbf16> {
 // -----
 
 // CHECK-LABEL: Evaluated results of function: constant_op_test_f16
-func.func @constant_op_test_f16() -> tensor<12xf16> {
-  %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.140630, 0x7C00, 0xFC00, 0x7FFF, 0xFFFF, 0x0001, 0x8001]> : tensor<12xf16>
-  func.return %0 : tensor<12xf16>
-  // CHECK-NEXT: tensor<12xf16>
+func.func @constant_op_test_f16() -> tensor<11xf16> {
+  %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.140630, 0x7C00, 0xFC00, 0x7FFF, 0x0001, 0x8001]> : tensor<11xf16>
+  func.return %0 : tensor<11xf16>
+  // CHECK-NEXT: tensor<11xf16>
   // CHECK-NEXT: 0.000000e+00 : f16
   // CHECK-NEXT: -0.000000e+00 : f16
   // CHECK-NEXT: 1.000000e+00 : f16
@@ -165,7 +164,6 @@ func.func @constant_op_test_f16() -> tensor<12xf16> {
   // CHECK-NEXT: 0x7C00 : f16
   // CHECK-NEXT: 0xFC00 : f16
   // CHECK-NEXT: 0x7FFF : f16
-  // CHECK-NEXT: 0xFFFF : f16
   // CHECK-NEXT: 5.960460e-08 : f16
   // CHECK-NEXT: -5.960460e-08 : f16
 }
@@ -173,10 +171,10 @@ func.func @constant_op_test_f16() -> tensor<12xf16> {
 // -----
 
 // CHECK-LABEL: Evaluated results of function: constant_op_test_f32
-func.func @constant_op_test_f32() -> tensor<12xf32> {
-  %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.14159274, 0x7F800000, 0xFF800000, 0x7FFFFFFF, 0xFFFFFFFF, 0x00000001, 0x80000001]> : tensor<12xf32>
-  func.return %0 : tensor<12xf32>
-  // CHECK-NEXT: tensor<12xf32>
+func.func @constant_op_test_f32() -> tensor<11xf32> {
+  %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.14159274, 0x7F800000, 0xFF800000, 0x7FFFFFFF, 0x00000001, 0x80000001]> : tensor<11xf32>
+  func.return %0 : tensor<11xf32>
+  // CHECK-NEXT: tensor<11xf32>
   // CHECK-NEXT: 0.000000e+00 : f32
   // CHECK-NEXT: -0.000000e+00 : f32
   // CHECK-NEXT: 1.000000e+00 : f32
@@ -186,7 +184,6 @@ func.func @constant_op_test_f32() -> tensor<12xf32> {
   // CHECK-NEXT: 0x7F800000 : f32
   // CHECK-NEXT: 0xFF800000 : f32
   // CHECK-NEXT: 0x7FFFFFFF : f32
-  // CHECK-NEXT: 0xFFFFFFFF : f32
   // CHECK-NEXT: 1.401300e-45 : f32
   // CHECK-NEXT: -1.401300e-45 : f32
 }
@@ -194,10 +191,10 @@ func.func @constant_op_test_f32() -> tensor<12xf32> {
 // -----
 
 // CHECK-LABEL: Evaluated results of function: constant_op_test_f64
-func.func @constant_op_test_f64() -> tensor<12xf64> {
-  %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.1415926535897931, 0x7FF0000000000000, 0xFFF0000000000000, 0x7FFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF, 0x0000000000000001, 0x8000000000000001]> : tensor<12xf64>
-  func.return %0 : tensor<12xf64>
-  // CHECK-NEXT: tensor<12xf64>
+func.func @constant_op_test_f64() -> tensor<11xf64> {
+  %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.1415926535897931, 0x7FF0000000000000, 0xFFF0000000000000, 0x7FFFFFFFFFFFFFFF, 0x0000000000000001, 0x8000000000000001]> : tensor<11xf64>
+  func.return %0 : tensor<11xf64>
+  // CHECK-NEXT: tensor<11xf64>
   // CHECK-NEXT: 0.000000e+00 : f64
   // CHECK-NEXT: -0.000000e+00 : f64
   // CHECK-NEXT: 1.000000e+00 : f64
@@ -207,7 +204,6 @@ func.func @constant_op_test_f64() -> tensor<12xf64> {
   // CHECK-NEXT: 0x7FF0000000000000 : f64
   // CHECK-NEXT: 0xFFF0000000000000 : f64
   // CHECK-NEXT: 0x7FFFFFFFFFFFFFFF : f64
-  // CHECK-NEXT: 0xFFFFFFFFFFFFFFFF : f64
   // CHECK-NEXT: 4.940660e-324 : f64
   // CHECK-NEXT: -4.940660e-324 : f64
 }


### PR DESCRIPTION
The current tests do not address all special values for floats.

The list of special values are:
* +/- 0
* +/- inf
* +/- NaN
* +/- Subnormal

However, the spec does not differentiate signedness of the NaN, so only the +NaN is tested. An investigation will be done in the near future to determine whether the tests include all special cases which are addressed in the spec for all ops in question. 