### PR TITLE
Fix CMake build

### DIFF
--- a/stablehlo/dialect/CMakeLists.txt
+++ b/stablehlo/dialect/CMakeLists.txt
@@ -72,6 +72,11 @@ add_mlir_dialect_library(ChloOps
   MLIRQuantDialect
 )
 
+target_include_directories(ChloOps INTERFACE
+  $<BUILD_INTERFACE:${STABLEHLO_SOURCE_DIR}>
+  $<BUILD_INTERFACE:${STABLEHLO_BINARY_DIR}>
+)
+
 add_mlir_dialect_library(StablehloRegister
   PARTIAL_SOURCES_INTENDED
   Register.cpp
@@ -106,6 +111,7 @@ add_mlir_dialect_library(StablehloOps
   LINK_LIBS PUBLIC
   StablehloBase
   MLIRArithDialect
+  MLIRDataLayoutInterfaces
   MLIRInferTypeOpInterface
   MLIRIR
   MLIRQuantDialect
@@ -113,4 +119,9 @@ add_mlir_dialect_library(StablehloOps
   MLIRSparseTensorDialect
   MLIRSupport
   MLIRTensorDialect
+)
+
+target_include_directories(StablehloOps INTERFACE
+  $<BUILD_INTERFACE:${STABLEHLO_SOURCE_DIR}>
+  $<BUILD_INTERFACE:${STABLEHLO_BINARY_DIR}>
 )

--- a/stablehlo/tools/CMakeLists.txt
+++ b/stablehlo/tools/CMakeLists.txt
@@ -38,7 +38,6 @@ mlir_check_all_link_libraries(stablehlo-opt)
 add_llvm_executable(stablehlo-interpreter StablehloInterpreterMain.cpp)
 llvm_update_compile_flags(stablehlo-interpreter)
 target_link_libraries(stablehlo-interpreter PRIVATE
-  MLIRDataLayoutInterfaces
   MLIRFuncDialect
   MLIRIR
   MLIRSupport


### PR DESCRIPTION
This patch reorders the libraries linked into the stablehlo-interpreter
target, since otherwise, the CMake build fails with the error:

    StablehloOps.cpp: undefined reference to `mlir::DataLayout::closest`

This patch also adds `target_include_directories()` for the
`StablehloBase` and `StablehloBroadcastUtils` so that path to the
Stablehlo header files is added to the include path of downstream
targets.