### PR TITLE
Replace uses of __PRETTY_FUNCTION__ with LLVM_PRETTY_FUNCTION

### DIFF
--- a/stablehlo/dialect/ChloBytecode.cpp
+++ b/stablehlo/dialect/ChloBytecode.cpp
@@ -16,6 +16,7 @@ limitations under the License.
 #include "stablehlo/dialect/ChloBytecode.h"
 
 #include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Bytecode/BytecodeImplementation.h"
 #include "mlir/IR/Diagnostics.h"
@@ -35,18 +36,18 @@ limitations under the License.
 #define _EXTRACT_AFTER(a, b) \
   llvm::StringRef(a).substr(llvm::StringRef(a).find(b))
 
-#define _LOG_CALL_TO(func)                                                    \
-  DEBUG_WITH_TYPE(                                                            \
-      "chlo-bytecode",                                                        \
-      llvm::errs() << "Called: " << _EXTRACT_AFTER(__PRETTY_FUNCTION__, func) \
-                   << '\n')
+#define _LOG_CALL_TO(func)                                                     \
+  DEBUG_WITH_TYPE("chlo-bytecode",                                             \
+                  llvm::errs()                                                 \
+                      << "Called: "                                            \
+                      << _EXTRACT_AFTER(LLVM_PRETTY_FUNCTION, func) << '\n')
 
 #define LOG_WRITE_CALL _LOG_CALL_TO("write")
 #define LOG_READ_CALL _LOG_CALL_TO(__func__)
-#define LOG_NOT_IMPLEMENTED \
-  DEBUG_WITH_TYPE(          \
-      "chlo-bytecode",      \
-      llvm::errs() << "***Not Implemented: " << __PRETTY_FUNCTION__ << '\n')
+#define LOG_NOT_IMPLEMENTED                                                    \
+  DEBUG_WITH_TYPE("chlo-bytecode", llvm::errs()                                \
+                                       << "***Not Implemented: "               \
+                                       << LLVM_PRETTY_FUNCTION << '\n')
 
 //===----------------------------------------------------------------------===//
 // Encoding

--- a/stablehlo/dialect/ChloBytecode.cpp
+++ b/stablehlo/dialect/ChloBytecode.cpp
@@ -37,17 +37,17 @@ limitations under the License.
   llvm::StringRef(a).substr(llvm::StringRef(a).find(b))
 
 #define _LOG_CALL_TO(func)                                                     \
-  DEBUG_WITH_TYPE("chlo-bytecode",                                             \
-                  llvm::errs()                                                 \
-                      << "Called: "                                            \
-                      << _EXTRACT_AFTER(LLVM_PRETTY_FUNCTION, func) << '\n')
+  DEBUG_WITH_TYPE(                                                             \
+      "chlo-bytecode",                                                         \
+      llvm::errs() << "Called: " << _EXTRACT_AFTER(LLVM_PRETTY_FUNCTION, func) \
+                   << '\n')
 
 #define LOG_WRITE_CALL _LOG_CALL_TO("write")
 #define LOG_READ_CALL _LOG_CALL_TO(__func__)
-#define LOG_NOT_IMPLEMENTED                                                    \
-  DEBUG_WITH_TYPE("chlo-bytecode", llvm::errs()                                \
-                                       << "***Not Implemented: "               \
-                                       << LLVM_PRETTY_FUNCTION << '\n')
+#define LOG_NOT_IMPLEMENTED \
+  DEBUG_WITH_TYPE(          \
+      "chlo-bytecode",      \
+      llvm::errs() << "***Not Implemented: " << LLVM_PRETTY_FUNCTION << '\n')
 
 //===----------------------------------------------------------------------===//
 // Encoding

--- a/stablehlo/dialect/StablehloBytecode.cpp
+++ b/stablehlo/dialect/StablehloBytecode.cpp
@@ -36,10 +36,10 @@ limitations under the License.
   llvm::StringRef(a).substr(llvm::StringRef(a).find(b))
 
 #define _LOG_CALL_TO(func)                                                     \
-  DEBUG_WITH_TYPE("stablehlo-bytecode",                                        \
-                  llvm::errs()                                                 \
-                      << "Called: "                                            \
-                      << _EXTRACT_AFTER(LLVM_PRETTY_FUNCTION, func) << '\n')
+  DEBUG_WITH_TYPE(                                                             \
+      "stablehlo-bytecode",                                                    \
+      llvm::errs() << "Called: " << _EXTRACT_AFTER(LLVM_PRETTY_FUNCTION, func) \
+                   << '\n')
 
 #define LOG_WRITE_CALL _LOG_CALL_TO("write")
 #define LOG_READ_CALL _LOG_CALL_TO(__func__)

--- a/stablehlo/dialect/StablehloBytecode.cpp
+++ b/stablehlo/dialect/StablehloBytecode.cpp
@@ -16,6 +16,7 @@ limitations under the License.
 #include "stablehlo/dialect/StablehloBytecode.h"
 
 #include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Bytecode/BytecodeImplementation.h"
 #include "mlir/IR/Diagnostics.h"
@@ -34,18 +35,18 @@ limitations under the License.
 #define _EXTRACT_AFTER(a, b) \
   llvm::StringRef(a).substr(llvm::StringRef(a).find(b))
 
-#define _LOG_CALL_TO(func)                                                    \
-  DEBUG_WITH_TYPE(                                                            \
-      "stablehlo-bytecode",                                                   \
-      llvm::errs() << "Called: " << _EXTRACT_AFTER(__PRETTY_FUNCTION__, func) \
-                   << '\n')
+#define _LOG_CALL_TO(func)                                                     \
+  DEBUG_WITH_TYPE("stablehlo-bytecode",                                        \
+                  llvm::errs()                                                 \
+                      << "Called: "                                            \
+                      << _EXTRACT_AFTER(LLVM_PRETTY_FUNCTION, func) << '\n')
 
 #define LOG_WRITE_CALL _LOG_CALL_TO("write")
 #define LOG_READ_CALL _LOG_CALL_TO(__func__)
 #define LOG_NOT_IMPLEMENTED \
   DEBUG_WITH_TYPE(          \
       "stablehlo-bytecode", \
-      llvm::errs() << "***Not Implemented: " << __PRETTY_FUNCTION__ << '\n')
+      llvm::errs() << "***Not Implemented: " << LLVM_PRETTY_FUNCTION << '\n')
 
 //===----------------------------------------------------------------------===//
 // Encoding


### PR DESCRIPTION
Use `LLVM_PRETTY_FUNCTION` instead of `__PRETTY_FUNCTION__` since it is portable. IREE had reported build errors on windows using `__PRETTY_FUNCTION__` for this reason.

Tested debug trace locally, and verified that all uses were changed with the following:

```bash
./openxla/stablehlo$ grep -rnw . -e ".*PRETTY.*"
./stablehlo/dialect/ChloBytecode.cpp:43:                      << _EXTRACT_AFTER(LLVM_PRETTY_FUNCTION, func) << '\n')
./stablehlo/dialect/ChloBytecode.cpp:50:                                       << LLVM_PRETTY_FUNCTION << '\n')
./stablehlo/dialect/StablehloBytecode.cpp:42:                      << _EXTRACT_AFTER(LLVM_PRETTY_FUNCTION, func) << '\n')
./stablehlo/dialect/StablehloBytecode.cpp:49:      llvm::errs() << "***Not Implemented: " << LLVM_PRETTY_FUNCTION << '\n')
```

Closes #147 