### PR TITLE
adding links to elaborative testing

### DIFF
--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -231,6 +231,8 @@ the IEEE-754 specification.
 // %result: [[6, 8], [10, 12]]
 ```
 
+&nbsp;[More Examples](https://github.com/sdasgup3/stablehlo/blob/main/stablehlo/tests/interpret_add.mlir)
+
 [Back to Ops](#index-of-documented-ops)
 
 ## stablehlo.and
@@ -357,6 +359,8 @@ Produces a `result` tensor from a constant `value`.
 %result = stablehlo.constant dense<[(0.0, 1.0), (2.0, 3.0)]> : tensor<2xcomplex<f32>>
 // %result: [(0.0, 1.0), (2.0, 3.0)]
 ```
+
+&nbsp;[More Examples](https://github.com/sdasgup3/stablehlo/blob/main/stablehlo/tests/interpret_constant.mlir)
 
 [Back to Ops](#index-of-documented-ops)
 
@@ -950,6 +954,8 @@ specification. Numeric precision is implementation-defined.
 %result = stablehlo.sine %operand : tensor<2x2xf32>
 // %result: [[0.0, 1.0], [0.0, -1.0]]
 ```
+
+&nbsp;[More Examples](https://github.com/sdasgup3/stablehlo/blob/main/stablehlo/tests/interpret_sine.mlir)
 
 [Back to Ops](#index-of-documented-ops)
 

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -231,7 +231,7 @@ the IEEE-754 specification.
 // %result: [[6, 8], [10, 12]]
 ```
 
-&nbsp;[More Examples](https://github.com/sdasgup3/stablehlo/blob/main/stablehlo/tests/interpret_add.mlir)
+&nbsp;[More Examples](../stablehlo/tests/interpret_add.mlir)
 
 [Back to Ops](#index-of-documented-ops)
 
@@ -344,23 +344,11 @@ Produces a `result` tensor from a constant `value`.
 ### Examples
 
 ```mlir
-%result = stablehlo.constant dense<true> : tensor<pred>
-// %result: true
-
-%result = stablehlo.constant dense<0> : tensor<i32>
-// %result: 0
-
 %result = stablehlo.constant dense<[[0.0, 1.0], [2.0, 3.0]]> : tensor<2x2xf32>
-// %result: [
-//       [0.0, 1.0],
-//       [2.0, 3.0]
-//     ]
-
-%result = stablehlo.constant dense<[(0.0, 1.0), (2.0, 3.0)]> : tensor<2xcomplex<f32>>
-// %result: [(0.0, 1.0), (2.0, 3.0)]
+// %result: [[0.0, 1.0], [2.0, 3.0]]
 ```
 
-&nbsp;[More Examples](https://github.com/sdasgup3/stablehlo/blob/main/stablehlo/tests/interpret_constant.mlir)
+&nbsp;[More Examples](../stablehlo/tests/interpret_constant.mlir)
 
 [Back to Ops](#index-of-documented-ops)
 
@@ -955,7 +943,7 @@ specification. Numeric precision is implementation-defined.
 // %result: [[0.0, 1.0], [0.0, -1.0]]
 ```
 
-&nbsp;[More Examples](https://github.com/sdasgup3/stablehlo/blob/main/stablehlo/tests/interpret_sine.mlir)
+&nbsp;[More Examples](../stablehlo/tests/interpret_sine.mlir)
 
 [Back to Ops](#index-of-documented-ops)
 


### PR DESCRIPTION
fixes #36 

The indent is to differentiate the added link to the following "Back to Ops" link. 