### PR TITLE
Use multi-dimensional indices to access tensor elements

### DIFF
--- a/docs/interpreter.md
+++ b/docs/interpreter.md
@@ -17,12 +17,12 @@ this means that we don't have to implement our own machinery for storing values
 of different types inside `Element`.
 
 `Tensor` class has the following APIs to interact with its individual elements:
-  - `Element Tensor::get(llvm::ArrayRef<int64_t> indices)`: To extract an
-     individual tensor element at multi-dimensional index `indices` as `Element`
+  - `Element Tensor::get(llvm::ArrayRef<int64_t> index)`: To extract an
+     individual tensor element at multi-dimensional index `index` as `Element`
      object.
-  - `void Tensor::set(llvm::ArrayRef<int64_t> indices, Element element);`:
+  - `void Tensor::set(llvm::ArrayRef<int64_t> index, Element element);`:
   To insert an `Element` object `element` into a tensor at multi-dimensional
-  index `indices`.
+  index `index`.
 
 ## Working of the interpreter
 
@@ -50,7 +50,7 @@ an `Element` object, is stored in the final `result` tensor.
 Tensor eval(AddOp op, const Tensor &lhs, const Tensor &rhs) {
   Tensor result(op.getType());
 
-  for (auto it = lhs.indexBegin(); it != lhs.indexEnd(); ++it)
+  for (auto it = lhs.index_begin(); it != lhs.index_end(); ++it)
     result.set(*it, lhs.get(*it) + rhs.get(*it));
 
   return result;

--- a/stablehlo/reference/CMakeLists.txt
+++ b/stablehlo/reference/CMakeLists.txt
@@ -21,6 +21,15 @@ add_mlir_library(StablehloReferenceElement
   MLIRSupport
 )
 
+add_mlir_library(StablehloReferenceIndex
+  PARTIAL_SOURCES_INTENDED
+  Index.cpp
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+  MLIRSupport
+)
+
 add_mlir_library(StablehloReferenceTensor
   PARTIAL_SOURCES_INTENDED
   Tensor.cpp
@@ -28,6 +37,7 @@ add_mlir_library(StablehloReferenceTensor
   LINK_LIBS PUBLIC
   MLIRIR
   StablehloReferenceElement
+  StablehloReferenceIndex
 )
 
 add_mlir_library(StablehloReferenceOps

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -67,15 +67,15 @@ bool isSupportedComplexType(Type type) {
   return complexElemTy.isF32() || complexElemTy.isF64();
 }
 
-APFloat getFloatValue(Element element) {
+APFloat getFloatValue(const Element &element) {
   return element.getValue().cast<FloatAttr>().getValue();
 }
 
-APInt getIntegerValue(Element element) {
+APInt getIntegerValue(const Element &element) {
   return element.getValue().cast<IntegerAttr>().getValue();
 }
 
-std::complex<APFloat> getComplexValue(Element element) {
+std::complex<APFloat> getComplexValue(const Element &element) {
   auto arryOfAttr = element.getValue().cast<ArrayAttr>().getValue();
   return std::complex<APFloat>(arryOfAttr[0].cast<FloatAttr>().getValue(),
                                arryOfAttr[1].cast<FloatAttr>().getValue());

--- a/stablehlo/reference/Index.cpp
+++ b/stablehlo/reference/Index.cpp
@@ -30,7 +30,7 @@ IndexSpaceIterator &IndexSpaceIterator::operator++() {
   if (!index_)
     llvm::report_fatal_error("Incrementing a past-the-end iterator.");
 
-  if(shape_.empty()) index_.reset();
+  if (shape_.empty()) index_.reset();
 
   for (int64_t i = shape_.size() - 1; i >= 0; --i) {
     (*index_)[i] += 1;

--- a/stablehlo/reference/Index.cpp
+++ b/stablehlo/reference/Index.cpp
@@ -30,6 +30,8 @@ IndexSpaceIterator &IndexSpaceIterator::operator++() {
   if (!index_)
     llvm::report_fatal_error("Incrementing a past-the-end iterator.");
 
+  if(shape_.empty()) index_.reset();
+
   for (int64_t i = shape_.size() - 1; i >= 0; --i) {
     (*index_)[i] += 1;
     if ((*index_)[i] >= shape_[i]) {

--- a/stablehlo/reference/Index.cpp
+++ b/stablehlo/reference/Index.cpp
@@ -1,0 +1,54 @@
+/* Copyright 2022 The StableHLO Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "stablehlo/reference/Index.h"
+
+namespace mlir {
+namespace stablehlo {
+
+IndexSpaceIterator::IndexSpaceIterator(const std::vector<int64_t> &shape,
+                                       bool lastIndex)
+    : shape_(shape) {
+  auto shapeSize = shape.size();
+  if (lastIndex) {
+    counter_ = 1;
+    for (auto shapeElm : shape) counter_ *= shapeElm;
+  } else {
+    counter_ = 0;
+    indices_.resize(shapeSize);
+  }
+}
+
+IndexSpaceIterator &IndexSpaceIterator::operator++() {
+  for (int64_t i = shape_.size() - 1; i >= 0; --i) {
+    indices_[i] += 1;
+    if (indices_[i] >= shape_[i]) {
+      indices_[i] = 0;
+    } else {
+      break;
+    }
+  }
+  counter_++;
+  return *this;
+}
+
+IndexSpaceIterator IndexSpaceIterator::operator++(int) {
+  IndexSpaceIterator tempIter = *this;
+  ++*this;
+  return tempIter;
+}
+
+}  // namespace stablehlo
+}  // namespace mlir

--- a/stablehlo/reference/Index.h
+++ b/stablehlo/reference/Index.h
@@ -17,17 +17,17 @@ limitations under the License.
 #define STABLEHLO_REFERENCE_INDEX_H_
 
 #include <cstdint>
-#include <vector>
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Error.h"
 
 namespace mlir {
 namespace stablehlo {
 
 /// Iterates over the index space of a tensor with a given shape, producing
-/// indices in lexicographical order. As an example, for a tensor with shape
+/// index in lexicographical order. As an example, for a tensor with shape
 /// [2,3], the iterator enumerates the indices (0,0), (0,1), (0,2), (1,0),
 /// (1,1), (1,2) and <END> (special past-the-end element which cannot be
 /// dereferenced).
@@ -36,7 +36,10 @@ class IndexSpaceIterator {
   /// \name Constructor
   IndexSpaceIterator(llvm::ArrayRef<int64_t> shape,
                      llvm::Optional<llvm::SmallVector<int64_t>> index)
-      : shape_(shape), index_(index){};
+      : shape_(shape), index_(index) {
+    if (llvm::any_of(shape, [](int64_t shapeElm) { return shapeElm < 0; }))
+      llvm::report_fatal_error("Iterator supports static shapes only.");
+  }
 
   /// Get the current index.
   /// At any point in time, the iterator can either reference an actual index

--- a/stablehlo/reference/Index.h
+++ b/stablehlo/reference/Index.h
@@ -27,7 +27,7 @@ namespace mlir {
 namespace stablehlo {
 
 /// Iterates over the index space of a tensor with a given shape, producing
-/// index in lexicographical order. As an example, for a tensor with shape
+/// indices in lexicographical order. As an example, for a tensor with shape
 /// [2,3], the iterator enumerates the indices (0,0), (0,1), (0,2), (1,0),
 /// (1,1), (1,2) and <END> (special past-the-end element which cannot be
 /// dereferenced).
@@ -60,8 +60,6 @@ class IndexSpaceIterator {
   /// Incrementing past the last index will result in a past-the-end iterator
   /// which cannot be dereferenced. Incrementing even further will result in
   /// a fatal error.
-  /// For scalar tensor, which empty 'shape_', incrementing the index result in
-  /// past-the-end iterator.
   IndexSpaceIterator &operator++();
   IndexSpaceIterator operator++(int);
 

--- a/stablehlo/reference/Index.h
+++ b/stablehlo/reference/Index.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include <vector>
 
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/Optional.h"
 #include "llvm/ADT/SmallVector.h"
 
 namespace mlir {
@@ -28,24 +29,34 @@ namespace stablehlo {
 /// Iterates over the index space of a tensor with a given shape, producing
 /// indices in lexicographical order. As an example, for a tensor with shape
 /// [2,3], the iterator enumerates the indices (0,0), (0,1), (0,2), (1,0),
-/// (1,1), and (1,2).
+/// (1,1), (1,2) and <END> (special past-the-end element which cannot be
+/// dereferenced).
 class IndexSpaceIterator {
  public:
   /// \name Constructor
-  explicit IndexSpaceIterator(llvm::ArrayRef<int64_t> shape, int64_t counter);
+  IndexSpaceIterator(llvm::ArrayRef<int64_t> shape,
+                     llvm::Optional<llvm::SmallVector<int64_t>> index)
+      : shape_(shape), index_(index){};
 
-  /// Get the current indices.
-  llvm::ArrayRef<int64_t> operator*() const { return indices_; }
+  /// Get the current index.
+  /// At any point in time, the iterator can either reference an actual index
+  /// or the past-the-end element in the index space.
+  /// Dereferencing a past-the-end iterator will result in a fatal error.
+  llvm::ArrayRef<int64_t> operator*() const;
 
+  /// Compare the iterator to another iterator.
+  /// Two iterators are equal if they have the same underlying shape and
+  /// reference the same element in the index space.
   bool operator==(const IndexSpaceIterator &it) {
-    return shape_ == it.shape_ && counter_ == it.counter_;
+    return shape_ == it.shape_ && index_ == it.index_;
   }
-
   bool operator!=(const IndexSpaceIterator &it) { return !(*this == it); }
 
-  /// Increment to the next valid index while iterating over the index space
-  /// of a tensor in lexicographical order. Incrementing beyond the last index
-  /// results in fatal error.
+  /// Increment to the next index while iterating over the index space
+  /// of a tensor in lexicographical order.
+  /// Incrementing past the last index will result in a past-the-end iterator
+  /// which cannot be dereferenced. Incrementing even further will result in
+  /// a fatal error.
   IndexSpaceIterator &operator++();
   IndexSpaceIterator operator++(int);
 
@@ -53,17 +64,9 @@ class IndexSpaceIterator {
   /// Shape of the tensor whose index space to be iterated on.
   llvm::SmallVector<int64_t> shape_;
 
-  /// Current multi-dimentional index.
-  llvm::SmallVector<int64_t> indices_;
-
-  /// Counter for the number of indices iterated. This is also used to set-up
-  /// past-the-end iterator.
-  int64_t counter_;
-
-  /// For a tensor with shape 'shape_', 'num_elements_' provodes the total
-  /// number of indices to iterate on. Helps to flag increments beyong the last
-  /// (in lexicographical order) indices.
-  int64_t num_elements_;
+  /// Current multi-dimensional index.
+  /// If the optional is empty, then we're at the end
+  llvm::Optional<llvm::SmallVector<int64_t>> index_;
 };
 
 }  // namespace stablehlo

--- a/stablehlo/reference/Index.h
+++ b/stablehlo/reference/Index.h
@@ -57,6 +57,8 @@ class IndexSpaceIterator {
   /// Incrementing past the last index will result in a past-the-end iterator
   /// which cannot be dereferenced. Incrementing even further will result in
   /// a fatal error.
+  /// For scalar tensor, which empty 'shape_', incrementing the index result in
+  /// past-the-end iterator.
   IndexSpaceIterator &operator++();
   IndexSpaceIterator operator++(int);
 

--- a/stablehlo/reference/Index.h
+++ b/stablehlo/reference/Index.h
@@ -1,0 +1,59 @@
+/* Copyright 2022 The StableHLO Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef STABLEHLO_REFERENCE_INDEX_H_
+#define STABLEHLO_REFERENCE_INDEX_H_
+
+#include <cstdint>
+#include <vector>
+
+#include "llvm/ADT/ArrayRef.h"
+
+namespace mlir {
+namespace stablehlo {
+
+/// Iterator over the indices of a tensor in major-to-minor order. As an
+/// example, for a tensor with shape [2,3], the iterator enumerates the
+/// indices (0,0), (0,1), (0,2), (1,0), (1,1), and (1,2).
+class IndexSpaceIterator {
+ public:
+  /// \name Constructors
+  explicit IndexSpaceIterator(const std::vector<int64_t> &shape,
+                              bool lastIndex = false);
+
+  /// Get the current index.
+  llvm::ArrayRef<int64_t> operator*() const { return indices_; }
+
+  bool operator==(const IndexSpaceIterator &it) {
+    return shape_ == it.shape_ && counter_ == it.counter_;
+  }
+
+  bool operator!=(const IndexSpaceIterator &it) { return !(*this == it); }
+
+  /// Increment to the next valid index while iterating over the dimensions in
+  /// major-to-minor order.
+  IndexSpaceIterator &operator++();
+  IndexSpaceIterator operator++(int);
+
+ private:
+  std::vector<int64_t> shape_;
+  std::vector<int64_t> indices_;
+  int64_t counter_;
+};
+
+}  // namespace stablehlo
+}  // namespace mlir
+
+#endif  // STABLEHLO_REFERENCE_INDEX_H_

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -23,7 +23,7 @@ namespace stablehlo {
 
 Tensor eval(AddOp op, const Tensor &lhs, const Tensor &rhs) {
   Tensor result(op.getType());
-  for (auto it = lhs.indexBegin(); it != lhs.indexEnd(); ++it)
+  for (auto it = lhs.index_begin(); it != lhs.index_end(); ++it)
     result.set(*it, lhs.get(*it) + rhs.get(*it));
 
   return result;
@@ -31,7 +31,7 @@ Tensor eval(AddOp op, const Tensor &lhs, const Tensor &rhs) {
 
 Tensor eval(CeilOp op, const Tensor &operand) {
   Tensor result(op.getType());
-  for (auto it = operand.indexBegin(); it != operand.indexEnd(); ++it)
+  for (auto it = operand.index_begin(); it != operand.index_end(); ++it)
     result.set(*it, ceil(operand.get(*it)));
 
   return result;
@@ -51,7 +51,7 @@ Tensor eval(CosineOp op, const Tensor &operand) {
 
 Tensor eval(FloorOp op, const Tensor &operand) {
   Tensor result(op.getType());
-  for (auto it = operand.indexBegin(); it != operand.indexEnd(); ++it)
+  for (auto it = operand.index_begin(); it != operand.index_end(); ++it)
     result.set(*it, floor(operand.get(*it)));
 
   return result;
@@ -59,7 +59,7 @@ Tensor eval(FloorOp op, const Tensor &operand) {
 
 Tensor eval(SineOp op, const Tensor &operand) {
   Tensor result(op.getType());
-  for (auto it = operand.indexBegin(); it != operand.indexEnd(); ++it)
+  for (auto it = operand.index_begin(); it != operand.index_end(); ++it)
     result.set(*it, sine(operand.get(*it)));
 
   return result;

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -23,20 +23,17 @@ namespace stablehlo {
 
 Tensor eval(AddOp op, const Tensor &lhs, const Tensor &rhs) {
   Tensor result(op.getType());
+  for (auto it = lhs.indexBegin(); it != lhs.indexEnd(); ++it)
+    result.set(*it, lhs.get(*it) + rhs.get(*it));
 
-  DimensionIterator dimIter(lhs.getType().getShape());
-  while (dimIter.canIncrement()) {
-    auto nextIndex = dimIter.getNextIndex();
-    result.set(nextIndex, lhs.get(nextIndex) + rhs.get(nextIndex));
-  }
   return result;
 }
 
 Tensor eval(CeilOp op, const Tensor &operand) {
   Tensor result(op.getType());
-  for (auto i = 0; i < operand.getNumElements(); ++i) {
-    result.set(i, ceil(operand.get(i)));
-  }
+  for (auto it = operand.indexBegin(); it != operand.indexEnd(); ++it)
+    result.set(*it, ceil(operand.get(*it)));
+
   return result;
 }
 
@@ -54,20 +51,17 @@ Tensor eval(CosineOp op, const Tensor &operand) {
 
 Tensor eval(FloorOp op, const Tensor &operand) {
   Tensor result(op.getType());
-  for (auto i = 0; i < operand.getNumElements(); ++i) {
-    result.set(i, floor(operand.get(i)));
-  }
+  for (auto it = operand.indexBegin(); it != operand.indexEnd(); ++it)
+    result.set(*it, floor(operand.get(*it)));
+
   return result;
 }
 
 Tensor eval(SineOp op, const Tensor &operand) {
   Tensor result(op.getType());
+  for (auto it = operand.indexBegin(); it != operand.indexEnd(); ++it)
+    result.set(*it, sine(operand.get(*it)));
 
-  DimensionIterator dimIter(operand.getType().getShape());
-  while (dimIter.canIncrement()) {
-    auto nextIndex = dimIter.getNextIndex();
-    result.set(nextIndex, sine(operand.get(nextIndex)));
-  }
   return result;
 }
 

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -16,14 +16,18 @@ limitations under the License.
 #include "stablehlo/reference/Ops.h"
 
 #include "stablehlo/reference/Element.h"
+#include "stablehlo/reference/Tensor.h"
 
 namespace mlir {
 namespace stablehlo {
 
 Tensor eval(AddOp op, const Tensor &lhs, const Tensor &rhs) {
   Tensor result(op.getType());
-  for (auto i = 0; i < lhs.getNumElements(); ++i) {
-    result.set(i, lhs.get(i) + rhs.get(i));
+
+  DimensionIterator dimIter(lhs.getType().getShape());
+  while (dimIter.canIncrement()) {
+    auto nextIndex = dimIter.getNextIndex();
+    result.set(nextIndex, lhs.get(nextIndex) + rhs.get(nextIndex));
   }
   return result;
 }
@@ -58,8 +62,11 @@ Tensor eval(FloorOp op, const Tensor &operand) {
 
 Tensor eval(SineOp op, const Tensor &operand) {
   Tensor result(op.getType());
-  for (auto i = 0; i < operand.getNumElements(); ++i) {
-    result.set(i, sine(operand.get(i)));
+
+  DimensionIterator dimIter(operand.getType().getShape());
+  while (dimIter.canIncrement()) {
+    auto nextIndex = dimIter.getNextIndex();
+    result.set(nextIndex, sine(operand.get(nextIndex)));
   }
   return result;
 }

--- a/stablehlo/reference/Tensor.cpp
+++ b/stablehlo/reference/Tensor.cpp
@@ -59,7 +59,7 @@ int64_t getSizeInBytes(Type type) {
 // Assumption: Only static shapes, with non-zero elements, are supported.
 std::vector<int64_t> computeStride(ArrayRef<int64_t> shape) {
   std::vector<int64_t> stride(shape.size());
-  if(shape.size() == 0) return stride;
+  if (shape.size() == 0) return stride;
 
   stride[shape.size() - 1] = 1;
   for (int i = shape.size() - 2; i >= 0; --i) {

--- a/stablehlo/reference/Tensor.cpp
+++ b/stablehlo/reference/Tensor.cpp
@@ -58,16 +58,14 @@ int64_t getSizeInBytes(Type type) {
 //
 // Assumption: Only static shapes, with non-zero elements, are supported.
 std::vector<int64_t> computeStride(ArrayRef<int64_t> shape) {
-  if (std::any_of(shape.begin(), shape.end(),
-                  [](int64_t i) { return i == 0 || i < 0; }))
-    llvm::report_fatal_error(
-        StringRef("Only static shapes with non-zero elemnsts are supported."));
-
   std::vector<int64_t> stride(shape.size());
+  if(shape.size() == 0) return stride;
+
   stride[shape.size() - 1] = 1;
   for (int i = shape.size() - 2; i >= 0; --i) {
     stride[i] = stride[i + 1] * shape[i + 1];
   }
+
   return stride;
 }
 

--- a/stablehlo/reference/Tensor.cpp
+++ b/stablehlo/reference/Tensor.cpp
@@ -357,15 +357,13 @@ void Tensor::set(ArrayRef<int64_t> indices, const Element &element) {
 
 IndexSpaceIterator Tensor::index_begin() const {
   auto shape = getType().getShape();
-  std::vector<int64_t> indices(shape.size());
-  return IndexSpaceIterator(shape, 0);
+  SmallVector<int64_t> indices(shape.size());
+  return IndexSpaceIterator(shape, indices);
 }
 
 IndexSpaceIterator Tensor::index_end() const {
   auto shape = getType().getShape();
-  int64_t numElements = 1;
-  for (auto shapeElm : shape) numElements *= shapeElm;
-  return IndexSpaceIterator(getType().getShape(), numElements);
+  return IndexSpaceIterator(shape, {});
 }
 
 void Tensor::print(raw_ostream &os) const {

--- a/stablehlo/reference/Tensor.cpp
+++ b/stablehlo/reference/Tensor.cpp
@@ -51,9 +51,9 @@ int64_t getSizeInBytes(Type type) {
   report_fatal_error(std::move(err));
 }
 
-// Flattens multi-dimensional index 'index' of a tensor to a linearized
-// index into the underlying storage using the dimension strides `strides_`.
-int64_t flattenindex(ArrayRef<int64_t> shape, ArrayRef<int64_t> index) {
+// Flattens multi-dimensional index 'index' of a tensor to a linearized index
+// into the underlying storage where elements are laid out in canonical order.
+int64_t flattenIndex(ArrayRef<int64_t> shape, ArrayRef<int64_t> index) {
   int64_t idx = 0;
   if (shape.empty()) return idx;
 
@@ -116,7 +116,7 @@ Element Tensor::get(ArrayRef<int64_t> index) const {
   Type elementType = getType().getElementType();
   char *elementPtr =
       impl_->getData() +
-      getSizeInBytes(elementType) * flattenindex(getType().getShape(), index);
+      getSizeInBytes(elementType) * flattenIndex(getType().getShape(), index);
 
   // Handle floating-point types.
   if (elementType.isF16()) {
@@ -242,7 +242,7 @@ void Tensor::set(ArrayRef<int64_t> index, const Element &element) {
   Type elementType = getType().getElementType();
   char *elementPtr =
       impl_->getData() +
-      getSizeInBytes(elementType) * flattenindex(getType().getShape(), index);
+      getSizeInBytes(elementType) * flattenIndex(getType().getShape(), index);
 
   // Handle floating-point types.
   if (elementType.isF16() || elementType.isBF16()) {

--- a/stablehlo/reference/Tensor.h
+++ b/stablehlo/reference/Tensor.h
@@ -48,6 +48,9 @@ class Buffer : public llvm::RefCountedBase<Buffer> {
   /// Returns type of the Buffer object.
   ShapedType getType() { return type_; }
 
+  /// Updates type of the Buffer object.
+  void setType(ShapedType type) { type_ = type; }
+
   /// Returns the raw data as a byte array.
   char *getData() { return data_.data(); }
 
@@ -69,29 +72,36 @@ class Tensor {
   Tensor();
   explicit Tensor(ShapedType type);
   explicit Tensor(DenseElementsAttr attr);
-  Tensor(const Tensor &other) = default;
+  Tensor(const Tensor &other);
   /// @}
 
   /// Assignment operator.
-  Tensor &operator=(const Tensor &other) = default;
+  Tensor &operator=(const Tensor &other);
 
   /// Returns type of the Tensor object.
   ShapedType getType() const;
 
+  /// Updates type of the Tensor object.
+  void setType(ShapedType type);
+
+  /// Updates stride of the Tensor object.
+  std::vector<int64_t> getStrides() const { return strides_; }
+
+  /// Updates stride of the Tensor object.
+  void setStrides(const std::vector<int64_t> &stride) { strides_ = stride; };
+
   /// Returns the number of elements.
   int64_t getNumElements() const;
 
-  /// Provides read access, via a linearized element index, into the
-  /// underlying storage.
-  Element get(int64_t index) const;
+  /// Provides read access to the tensor element indexed at 'indices'.
+  Element get(const std::vector<int64_t> &indices) const;
 
-  /// Provides write access, via a linearized element index, into the
-  /// underlying storage.
+  /// Provides write access to the tensor element indexed at 'indices'.
   ///
-  /// \param index The index to write to.
+  /// \param indices The multi-dimensional index to write to.
   /// \param element The Element object \a element is used to update the
-  /// underlying storage pointed to by \a index.
-  void set(int64_t index, Element element);
+  /// underlying storage pointed to by \a indices.
+  void set(const std::vector<int64_t> &indices, const Element &element);
 
   /// Print utilities for Tensor objects.
   void print(raw_ostream &os) const;
@@ -101,6 +111,11 @@ class Tensor {
 
  private:
   llvm::IntrusiveRefCntPtr<detail::Buffer> impl_;
+  std::vector<int64_t> strides_;
+
+  // Flattens multi-dimensional index `indices` of a tensor to a linearized
+  // index into the underlying storage using the dimension strides `strides_`.
+  int64_t flattenIndices(const std::vector<int64_t> &indices) const;
 };
 
 /// Print utilities for Tensor objects.
@@ -108,6 +123,53 @@ inline raw_ostream &operator<<(raw_ostream &os, Tensor tensor) {
   tensor.print(os);
   return os;
 }
+
+/// Iterator over the indices of a tensor in  major-to-minor order. As an
+/// example, for a tensor with shape [2,3], the iterator enumerates the
+/// following indices (0,0), (0,1), (0,2), (1,0), (1,1), and (1,2) in that
+/// order.
+class DimensionIterator {
+ public:
+  /// \name Constructors
+  DimensionIterator(std::vector<int64_t> shape)
+      : dimensions_(shape), indices_(shape.size()) {
+    if (shape.size() == 0)
+      llvm::report_fatal_error(
+          StringRef("Shape with zero size not supported."));
+    indices_[shape.size() - 1] = -1;
+  }
+
+  /// Get the next index while iterating over the dimensions in major-to-minor
+  /// order.
+  std::vector<int64_t> getNextIndex() const { return indices_; }
+
+  /// Returns true: If it is possible to increment to the next valid index while
+  /// iterating over the dimensions in major-to-minor order.
+  /// Returns false: When all the valid indices are visited.
+  bool canIncrement() {
+    for (int64_t i = dimensions_.size() - 1; i >= 0; --i) {
+      indices_[i] += 1;
+      if (indices_[i] >= dimensions_[i]) {
+        indices_[i] = 0;
+      } else {
+        return true;
+      }
+    }
+    return false;
+  }
+
+ private:
+  std::vector<int64_t> dimensions_;
+  std::vector<int64_t> indices_;
+};
+
+// Computes the stride of a tensor shape: The number of locations in memory
+// between beginnings of successive array elements, measured in units of the
+// size of the array's elements.
+// Example: For a tensor shape [1,2,3], stride = [6,3,1]
+//
+// Assumption: Only static shapes, with non-zero elements, are supported.
+std::vector<int64_t> computeStride(ArrayRef<int64_t> shape);
 
 /// Creates a Tensor using `type` as the static type and data provided as an
 /// array of string literal which will be parsed using the corresponding element

--- a/stablehlo/reference/Tensor.h
+++ b/stablehlo/reference/Tensor.h
@@ -82,15 +82,15 @@ class Tensor {
   /// Returns the number of elements.
   int64_t getNumElements() const;
 
-  /// Provides read access to the tensor element indexed at 'indices'.
-  Element get(ArrayRef<int64_t> indices) const;
+  /// Provides read access to the tensor element indexed at 'index'.
+  Element get(ArrayRef<int64_t> index) const;
 
-  /// Provides write access to the tensor element indexed at 'indices'.
+  /// Provides write access to the tensor element indexed at 'index'.
   ///
-  /// \param indices The multi-dimensional index to write to.
+  /// \param index The multi-dimensional index to write to.
   /// \param element The Element object \a element is used to update the
-  /// underlying storage pointed to by \a indices.
-  void set(ArrayRef<int64_t> indices, const Element &element);
+  /// underlying storage pointed to by \a index.
+  void set(ArrayRef<int64_t> index, const Element &element);
 
   /// Prints Tensor objects.
   void print(raw_ostream &os) const;

--- a/stablehlo/reference/Tensor.h
+++ b/stablehlo/reference/Tensor.h
@@ -70,11 +70,11 @@ class Tensor {
   Tensor();
   explicit Tensor(ShapedType type);
   explicit Tensor(DenseElementsAttr attr);
-  Tensor(const Tensor &other);
+  Tensor(const Tensor &other) = default;
   /// @}
 
   /// Assignment operator.
-  Tensor &operator=(const Tensor &other);
+  Tensor &operator=(const Tensor &other) = default;
 
   /// Returns type of the Tensor object.
   ShapedType getType() const;
@@ -83,32 +83,25 @@ class Tensor {
   int64_t getNumElements() const;
 
   /// Provides read access to the tensor element indexed at 'indices'.
-  Element get(llvm::ArrayRef<int64_t> indices) const;
+  Element get(ArrayRef<int64_t> indices) const;
 
   /// Provides write access to the tensor element indexed at 'indices'.
   ///
   /// \param indices The multi-dimensional index to write to.
   /// \param element The Element object \a element is used to update the
   /// underlying storage pointed to by \a indices.
-  void set(llvm::ArrayRef<int64_t> indices, const Element &element);
+  void set(ArrayRef<int64_t> indices, const Element &element);
 
-  /// Print utilities for Tensor objects.
+  /// Prints Tensor objects.
   void print(raw_ostream &os) const;
-
-  /// Print utilities for Tensor objects.
   void dump() const;
 
-  /// Iterator utils.
-  IndexSpaceIterator indexBegin() const;
-  IndexSpaceIterator indexEnd() const;
+  /// Iterate over the index space of a Tensor object.
+  IndexSpaceIterator index_begin() const;
+  IndexSpaceIterator index_end() const;
 
  private:
   llvm::IntrusiveRefCntPtr<detail::Buffer> impl_;
-  std::vector<int64_t> strides_;
-
-  // Flattens multi-dimensional index `indices` of a tensor to a linearized
-  // index into the underlying storage using the dimension strides `strides_`.
-  int64_t flattenIndices(llvm::ArrayRef<int64_t> indices) const;
 };
 
 /// Print utilities for Tensor objects.


### PR DESCRIPTION
Tensor class currently supports APIs like `Tensor::get(int64_t index)` and `Tensor::set(int64t index, const Element &e)` which provides linearized access to the underlying storage, that is, the `index` points directly to the underlying storage byte array. This kind of "raw" indexing on tensor was done because, that way, it was simple to bootstrap the interpreter,  and secondly, it works pretty well for the element-wise operations. We understood that with more complex ops these APIs might need to be revised, which is what this PR is about.

Instead of using the raw indexing, we can use a more intuitive logical multi-dimensional indices based on the shape of the tensor. Internally we can use dimension [strides](https://en.wikipedia.org/wiki/Stride_of_an_array) to map the muiti-dimensional index to the linearlized raw index. This has the following benefits:

1. Logical indexing is natural  and more intuitive than raw index.
2. Hides the implementation details (how elements of a tensor are actually laid out in memory) from Tensor APIs.