### PR TITLE
Populate progress of verifier and type inference.

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -20,126 +20,127 @@ one of the following tracking labels.
     - **yes**: complete
     - **wip**: semi-complete: Work in progress or under review.
     - **no**: not complete yet, but part of [the roadmap](https://github.com/openxla/stablehlo#roadmap).
- - Customized labels
-    - Verifier
-       - **match-xla**:  verifier in sync with  [XLA semantics](https://www.tensorflow.org/xla/operation_semantics).
-       - **match-spec**: verifier in sync with [StableHLO semantics](https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md).
-
+ - Customized labels for Verifier and Type Inference 
+    - **yes(match-xla)**:  in sync with  [XLA semantics](https://www.tensorflow.org/xla/operation_semantics).
+    - **yes(match-spec)**: in sync with [StableHLO semantics](https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md).
+    - **yes(need-revisit)**: implemented but need revisit for the sync with XLA or spec
+    - **no-plan**: infeasible or no plan to implement by design
+    
 ## Status
 
-| StableHLO Op (114) | Specification (21) | Verification | Type Inference | Prettyprinting | Interpreter (2) |
+| StableHLO Op (114) | Specification (21) | Verifier(104) | Type Inference(79) | Prettyprinting | Interpreter (2) |
 |:--|:--:|:--:|:--:|:--:|:--:|
-| AbsOp |yes||||no|
-| AddOp |yes|||| yes|
-| AfterAllOp |no||||no |
-| AllGatherOp |no||||no|
-| AllReduceOp |no||||no|
-| AllToAllOp |no||||no|
-| AndOp |yes|||| no|
-| Atan2Op |no||||no|
-| BatchNormGradOp |no||||no|
-| BatchNormInferenceOp |no||||no|
-| BatchNormTrainingOp |no||||no|
-| BitcastConvertOp |no||||no|
-| BroadcastInDimOp |no||||no|
-| BroadcastOp |no||||no|
-| CaseOp |no||||no|
-| CbrtOp |no||||no|
-| CeilOp |yes||||no|
-| CholeskyOp |no||||no|
-| ClampOp |no||||no|
-| ClzOp |no||||no|
-| CollectivePermuteOp |no||||no|
-| CompareOp |no||||no|
-| ComplexOp |no||||no|
-| ComputeReshapeShapeOp |no||||no|
-| ConcatenateOp |no||||no|
-| ConstantOp |yes|||| yes|
-| ConvertOp |no||||no|
-| ConvolutionOp |no||||no|
-| CosineOp |yes||||no|
-| CreateTokenOp |no||||no|
-| CrossReplicaSumOp |no||||no|
-| CstrReshapableOp |no||||no|
-| CustomCallOp |no||||no|
-| DivOp |yes||||no|
-| DotGeneralOp |no||||no|
-| DotOp |no||||no|
-| DynamicBroadcastInDimOp |no||||no|
-| DynamicConvOp |no||||no|
-| DynamicGatherOp |no||||no|
-| DynamicIotaOp |no||||no|
-| DynamicPadOp |no||||no|
-| DynamicReshapeOp |no||||no|
-| DynamicSliceOp |no||||no|
-| DynamicUpdateSliceOp |no||||no|
-| EinsumOp |no||||no|
-| Expm1Op |no||||no|
-| ExpOp |no||||no|
-| FftOp |no||||no|
-| FloorOp |yes||||no|
-| GatherOp |no||||no|
-| GetDimensionSizeOp |no||||no|
-| GetTupleElementOp |no||||no|
-| IfOp |no||||no|
-| ImagOp |no||||no|
-| InfeedOp |no||||no|
-| IotaOp |no||||no|
-| IsFiniteOp |no||||no|
-| Log1pOp |no||||no|
-| LogisticOp |yes||||no|
-| LogOp |yes||||no|
-| MapOp |no||||no|
-| MaxOp |yes||||no|
-| MinOp |yes||||no|
-| MulOp |no||||no|
-| NegOp |yes||||no|
-| NotOp |yes||||no|
-| OptimizationBarrierOp |no||||no|
-| OrOp |yes||||no|
-| OutfeedOp |no||||no|
-| PadOp |no||||no|
-| PopulationCountOp |no||||no|
-| PowOp |no||||no|
-| RealDynamicSliceOp |no||||no|
-| RealOp |no||||no|
-| RecvOp |no||||no|
-| ReduceOp |no||||no|
-| ReducePrecisionOp |no||||no|
-| ReduceScatterOp |no||||no|
-| ReduceWindowOp |no||||no|
-| RemOp |yes||||no|
-| ReplicaIdOp |no||||no|
-| ReshapeOp |no||||no|
-| ReturnOp |no||||no|
-| ReverseOp |no||||no|
-| RngBitGeneratorOp |no||||no|
-| RngOp |no||||no|
-| RoundNearestEvenOp |no||||no|
-| RoundOp |no||||no|
-| RsqrtOp |yes||||no|
-| ScatterOp |no||||no|
-| SelectAndScatterOp |no||||no|
-| SelectOp |no||||no|
-| SendOp |no||||no|
-| SetDimensionSizeOp |no||||no|
-| ShiftLeftOp |no||||no|
-| ShiftRightArithmeticOp |no||||no|
-| ShiftRightLogicalOp |no||||no|
-| SignOp |no||||no|
-| SineOp |yes||||no|
-| SliceOp |no||||no|
-| SortOp |no||||no|
-| SqrtOp |yes||||no|
-| SubtractOp |no||||no|
-| TanhOp |yes||||no|
-| TorchIndexSelectOp |no||||no|
-| TraceOp |no||||no|
-| TransposeOp |no||||no|
-| TriangularSolveOp |no||||no|
-| TupleOp |no||||no|
-| UnaryEinsumOp |no||||no|
-| UniformDequantizeOp |no||||no|
-| UniformQuantizeOp |no||||no|
-| WhileOp |no||||no|
-| XorOp |yes||||no|
+| AbsOp |yes|yes(match-xla)|yes(match-xla)||no|
+| AddOp |yes|yes(match-xla)|yes(match-xla)|| yes|
+| AfterAllOp |no|no|no||no |
+| AllGatherOp |no|yes(match-xla)|no||no|
+| AllReduceOp |no|no|no||no|
+| AllToAllOp |no|yes(match-xla)|yes(match-xla)||no|
+| AndOp |yes|yes(match-xla)|yes(match-xla)|| no|
+| Atan2Op |no|yes(match-xla)|yes(match-xla)||no|
+| BatchNormGradOp |no|yes(match-xla)|yes(match-xla)||no|
+| BatchNormInferenceOp |no|yes(match-xla)|yes(match-xla)||no|
+| BatchNormTrainingOp |no|yes(match-xla)|yes(match-xla)||no|
+| BitcastConvertOp |no|yes(match-xla)|no-plan||no|
+| BroadcastInDimOp |no|yes(match-xla)|no-plan||no|
+| BroadcastOp |no|yes(match-xla)|yes(match-xla)||no|
+| CaseOp |no|yes(match-xla)|wip||no|
+| CbrtOp |no|yes(match-xla)|yes(match-xla)||no|
+| CeilOp |yes|yes(match-xla)|yes(match-xla)||no|
+| CholeskyOp |no|yes(match-xla)|yes(match-xla)||no|
+| ClampOp |no|yes(match-xla)|yes(match-xla)||no|
+| ClzOp |no|yes(match-xla)|yes(match-xla)||no|
+| CollectivePermuteOp |no|yes(match-xla)|yes(match-xla)||no|
+| CompareOp |no|yes(match-xla)|yes(match-xla)||no|
+| ComplexOp |no|yes(match-xla)|yes(match-xla)||no|
+| ComputeReshapeShapeOp |no|no|no||no|
+| ConcatenateOp |no|yes(match-xla)|yes(match-xla)||no|
+| ConstantOp |yes|yes(match-xla)|yes(match-xla)|| yes|
+| ConvertOp |no|yes(match-xla)|no-plan||no|
+| ConvolutionOp |no|yes(match-xla)|no||no|
+| CosineOp |yes|yes(match-xla)|yes(match-xla)||no|
+| CreateTokenOp |no|yes(match-xla)|no||no|
+| CrossReplicaSumOp |no|no|yes(match-xla)||no|
+| CstrReshapableOp |no|yes(match-xla)|no||no|
+| CustomCallOp |no|yes(match-xla)|no-plan||no|
+| DivOp |yes|yes(match-xla)|yes(match-xla)||no|
+| DotGeneralOp |no|yes(match-xla)|wip||no|
+| DotOp |no|yes(match-xla)|yes(need-revisit)||no|
+| DynamicBroadcastInDimOp |no|yes(match-xla)|no||no|
+| DynamicConvOp |no|no|no||no|
+| DynamicGatherOp |no|no|yes(need-revisit)||no|
+| DynamicIotaOp |no|no|no||no|
+| DynamicPadOp |no|yes(match-xla)|no||no|
+| DynamicReshapeOp |no|yes(match-xla)|no||no|
+| DynamicSliceOp |no|yes(match-xla)|yes(match-xla)||no|
+| DynamicUpdateSliceOp |no|yes(match-xla)|no||no|
+| EinsumOp |no|no|no||no|
+| Expm1Op |no|yes(match-xla)|yes(match-xla)||no|
+| ExpOp |no|yes(match-xla)|yes(match-xla)||no|
+| FftOp |no|yes(match-xla)|yes(match-xla)||no|
+| FloorOp |yes|yes(match-xla)|yes(match-xla)||no|
+| GatherOp |no|yes(match-xla)|yes(match-xla)||no|
+| GetDimensionSizeOp |no|yes(match-xla)|no||no|
+| GetTupleElementOp |no|yes(match-xla)|yes(need-revisit)||no|
+| IfOp |no|yes(match-xla)|wip||no|
+| ImagOp |no|yes(match-xla)|yes(match-xla)||no|
+| InfeedOp |no|yes(match-xla)|no||no|
+| IotaOp |no|yes(match-xla)|no-plan||no|
+| IsFiniteOp |no|yes(match-xla)|yes(match-xla)||no|
+| Log1pOp |no|yes(match-xla)|yes(match-xla)||no|
+| LogisticOp |yes|yes(match-xla)|yes(match-xla)||no|
+| LogOp |yes|yes(match-xla)|yes(match-xla)||no|
+| MapOp |no|yes(match-xla)|no||no|
+| MaxOp |yes|yes(match-xla)|yes(match-xla)||no|
+| MinOp |yes|yes(match-xla)|yes(match-xla)||no|
+| MulOp |no|yes(match-xla)|yes(match-xla)||no|
+| NegOp |yes|yes(match-xla)|yes(match-xla)||no|
+| NotOp |yes|yes(match-xla)|yes(match-xla)||no|
+| OptimizationBarrierOp |no|yes(match-xla)|no||no|
+| OrOp |yes|yes(match-xla)|yes(match-xla)||no|
+| OutfeedOp |no|yes(match-xla)|no||no|
+| PadOp |no|yes(match-xla)|yes(match-xla)||no|
+| PopulationCountOp |no|yes(match-xla)|yes(match-xla)||no|
+| PowOp |no|yes(match-xla)|yes(match-xla)||no|
+| RealDynamicSliceOp |no|yes(match-xla)|no||no|
+| RealOp |no|yes(match-xla)|yes(match-xla)||no|
+| RecvOp |no|yes(match-xla)|no||no|
+| ReduceOp |no|yes(match-xla)|yes(match-xla)||no|
+| ReducePrecisionOp |no|yes(match-xla)|yes(match-xla)||no|
+| ReduceScatterOp |no|yes(match-xla)|no||no|
+| ReduceWindowOp |no|yes(match-xla)|yes(match-xla)||no|
+| RemOp |yes|yes(match-xla)|yes(match-xla)||no|
+| ReplicaIdOp |no|yes(match-xla)|yes(need-revisit)||no|
+| ReshapeOp |no|yes(match-xla)|no-plan||no|
+| ReturnOp |no|yes(match-xla)|no||no|
+| ReverseOp |no|yes(match-xla)|yes(match-xla)||no|
+| RngBitGeneratorOp |no|yes(match-xla)|no-plan||no|
+| RngOp |no|yes(match-xla)|yes(match-xla)||no|
+| RoundNearestEvenOp |no|yes(match-xla)|yes(match-xla)||no|
+| RoundOp |no|yes(match-xla)|yes(match-xla)||no|
+| RsqrtOp |yes|yes(match-xla)|yes(match-xla)||no|
+| ScatterOp |no|yes(match-xla)|no||no|
+| SelectAndScatterOp |no|yes(match-xla)|no||no|
+| SelectOp |no|yes(match-xla)|yes(match-xla)||no|
+| SendOp |no|yes(match-xla)|no||no|
+| SetDimensionSizeOp |no|yes(match-xla)|yes(need-revisit)||no|
+| ShiftLeftOp |no|yes(match-xla)|yes(match-xla)||no|
+| ShiftRightArithmeticOp |no|yes(match-xla)|yes(match-xla)||no|
+| ShiftRightLogicalOp |no|yes(match-xla)|yes(match-xla)||no|
+| SignOp |no|yes(match-xla)|yes(match-xla)||no|
+| SineOp |yes|yes(match-xla)|yes(match-xla)||no|
+| SliceOp |no|yes(match-xla)|yes(match-xla)||no|
+| SortOp |no|yes(match-xla)|no||no|
+| SqrtOp |yes|yes(match-xla)|yes(match-xla)||no|
+| SubtractOp |no|yes(match-xla)|yes(match-xla)||no|
+| TanhOp |yes|yes(match-xla)|yes(match-xla)||no|
+| TorchIndexSelectOp |no|no|no||no|
+| TraceOp |no|yes(match-xla)|no||no|
+| TransposeOp |no|yes(match-xla)|yes(match-xla)||no|
+| TriangularSolveOp |no|yes(match-xla)|no||no|
+| TupleOp |no|yes(match-xla)|yes(need-revisit)||no|
+| UnaryEinsumOp |no|no|no||no|
+| UniformDequantizeOp |no|yes(match-xla)|yes(match-xla)||no|
+| UniformQuantizeOp |no|yes(match-xla)|no-plan||no|
+| WhileOp |no|yes(match-xla)|no||no|
+| XorOp |yes|yes(match-xla)|yes(match-xla)||no|

--- a/docs/status.md
+++ b/docs/status.md
@@ -18,129 +18,128 @@ one of the following tracking labels.
 
  - Generic labels
     - **yes**: complete
-    - **wip**: semi-complete: Work in progress or under review.
     - **no**: not complete yet, but part of [the roadmap](https://github.com/openxla/stablehlo#roadmap).
  - Customized labels for Verifier and Type Inference 
-    - **yes(match-xla)**:  in sync with  [XLA semantics](https://www.tensorflow.org/xla/operation_semantics).
-    - **yes(match-spec)**: in sync with [StableHLO semantics](https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md).
+    - **yes\***:  in sync with  [XLA semantics](https://www.tensorflow.org/xla/operation_semantics).
+    - **yes**: in sync with [StableHLO semantics](https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md).
     - **yes(need-revisit)**: implemented but need revisit for the sync with XLA or spec
-    - **no-plan**: infeasible or no plan to implement by design
+    - **infeasible**: infeasible to implement by design
     
 ## Status
 
-| StableHLO Op (114) | Specification (21) | Verifier(104) | Type Inference(79) | Prettyprinting | Interpreter (2) |
+| StableHLO Op (114) | Specification (21) | Verifier(104) | Type Inference(82) | Prettyprinting | Interpreter (2) |
 |:--|:--:|:--:|:--:|:--:|:--:|
-| AbsOp |yes|yes(match-xla)|yes(match-xla)||no|
-| AddOp |yes|yes(match-xla)|yes(match-xla)|| yes|
+| AbsOp |yes|yes*|yes*||no|
+| AddOp |yes|yes*|yes*|| yes|
 | AfterAllOp |no|no|no||no |
-| AllGatherOp |no|yes(match-xla)|no||no|
+| AllGatherOp |no|yes*|no||no|
 | AllReduceOp |no|no|no||no|
-| AllToAllOp |no|yes(match-xla)|yes(match-xla)||no|
-| AndOp |yes|yes(match-xla)|yes(match-xla)|| no|
-| Atan2Op |no|yes(match-xla)|yes(match-xla)||no|
-| BatchNormGradOp |no|yes(match-xla)|yes(match-xla)||no|
-| BatchNormInferenceOp |no|yes(match-xla)|yes(match-xla)||no|
-| BatchNormTrainingOp |no|yes(match-xla)|yes(match-xla)||no|
-| BitcastConvertOp |no|yes(match-xla)|no-plan||no|
-| BroadcastInDimOp |no|yes(match-xla)|no-plan||no|
-| BroadcastOp |no|yes(match-xla)|yes(match-xla)||no|
-| CaseOp |no|yes(match-xla)|wip||no|
-| CbrtOp |no|yes(match-xla)|yes(match-xla)||no|
-| CeilOp |yes|yes(match-xla)|yes(match-xla)||no|
-| CholeskyOp |no|yes(match-xla)|yes(match-xla)||no|
-| ClampOp |no|yes(match-xla)|yes(match-xla)||no|
-| ClzOp |no|yes(match-xla)|yes(match-xla)||no|
-| CollectivePermuteOp |no|yes(match-xla)|yes(match-xla)||no|
-| CompareOp |no|yes(match-xla)|yes(match-xla)||no|
-| ComplexOp |no|yes(match-xla)|yes(match-xla)||no|
+| AllToAllOp |no|yes*|yes*||no|
+| AndOp |yes|yes*|yes*|| no|
+| Atan2Op |no|yes*|yes*||no|
+| BatchNormGradOp |no|yes*|yes*||no|
+| BatchNormInferenceOp |no|yes*|yes*||no|
+| BatchNormTrainingOp |no|yes*|yes*||no|
+| BitcastConvertOp |no|yes*|infeasible||no|
+| BroadcastInDimOp |no|yes*|infeasible||no|
+| BroadcastOp |no|yes*|yes*||no|
+| CaseOp |no|yes*|yes*||no|
+| CbrtOp |no|yes*|yes*||no|
+| CeilOp |yes|yes*|yes*||no|
+| CholeskyOp |no|yes*|yes*||no|
+| ClampOp |no|yes*|yes*||no|
+| ClzOp |no|yes*|yes*||no|
+| CollectivePermuteOp |no|yes*|yes*||no|
+| CompareOp |no|yes*|yes*||no|
+| ComplexOp |no|yes*|yes*||no|
 | ComputeReshapeShapeOp |no|no|no||no|
-| ConcatenateOp |no|yes(match-xla)|yes(match-xla)||no|
-| ConstantOp |yes|yes(match-xla)|yes(match-xla)|| yes|
-| ConvertOp |no|yes(match-xla)|no-plan||no|
-| ConvolutionOp |no|yes(match-xla)|no||no|
-| CosineOp |yes|yes(match-xla)|yes(match-xla)||no|
-| CreateTokenOp |no|yes(match-xla)|no||no|
-| CrossReplicaSumOp |no|no|yes(match-xla)||no|
-| CstrReshapableOp |no|yes(match-xla)|no||no|
-| CustomCallOp |no|yes(match-xla)|no-plan||no|
-| DivOp |yes|yes(match-xla)|yes(match-xla)||no|
-| DotGeneralOp |no|yes(match-xla)|wip||no|
-| DotOp |no|yes(match-xla)|yes(need-revisit)||no|
-| DynamicBroadcastInDimOp |no|yes(match-xla)|no||no|
+| ConcatenateOp |no|yes*|yes*||no|
+| ConstantOp |yes|yes*|yes*|| yes|
+| ConvertOp |no|yes*|infeasible||no|
+| ConvolutionOp |no|yes*|no||no|
+| CosineOp |yes|yes*|yes*||no|
+| CreateTokenOp |no|yes*|no||no|
+| CrossReplicaSumOp |no|no|yes*||no|
+| CstrReshapableOp |no|yes*|no||no|
+| CustomCallOp |no|yes*|infeasible||no|
+| DivOp |yes|yes*|yes*||no|
+| DotGeneralOp |no|yes*|yes*||no|
+| DotOp |no|yes*|yes(need-revisit)||no|
+| DynamicBroadcastInDimOp |no|yes*|no||no|
 | DynamicConvOp |no|no|no||no|
 | DynamicGatherOp |no|no|yes(need-revisit)||no|
 | DynamicIotaOp |no|no|no||no|
-| DynamicPadOp |no|yes(match-xla)|no||no|
-| DynamicReshapeOp |no|yes(match-xla)|no||no|
-| DynamicSliceOp |no|yes(match-xla)|yes(match-xla)||no|
-| DynamicUpdateSliceOp |no|yes(match-xla)|no||no|
+| DynamicPadOp |no|yes*|no||no|
+| DynamicReshapeOp |no|yes*|no||no|
+| DynamicSliceOp |no|yes*|yes*||no|
+| DynamicUpdateSliceOp |no|yes*|no||no|
 | EinsumOp |no|no|no||no|
-| Expm1Op |no|yes(match-xla)|yes(match-xla)||no|
-| ExpOp |no|yes(match-xla)|yes(match-xla)||no|
-| FftOp |no|yes(match-xla)|yes(match-xla)||no|
-| FloorOp |yes|yes(match-xla)|yes(match-xla)||no|
-| GatherOp |no|yes(match-xla)|yes(match-xla)||no|
-| GetDimensionSizeOp |no|yes(match-xla)|no||no|
-| GetTupleElementOp |no|yes(match-xla)|yes(need-revisit)||no|
-| IfOp |no|yes(match-xla)|wip||no|
-| ImagOp |no|yes(match-xla)|yes(match-xla)||no|
-| InfeedOp |no|yes(match-xla)|no||no|
-| IotaOp |no|yes(match-xla)|no-plan||no|
-| IsFiniteOp |no|yes(match-xla)|yes(match-xla)||no|
-| Log1pOp |no|yes(match-xla)|yes(match-xla)||no|
-| LogisticOp |yes|yes(match-xla)|yes(match-xla)||no|
-| LogOp |yes|yes(match-xla)|yes(match-xla)||no|
-| MapOp |no|yes(match-xla)|no||no|
-| MaxOp |yes|yes(match-xla)|yes(match-xla)||no|
-| MinOp |yes|yes(match-xla)|yes(match-xla)||no|
-| MulOp |no|yes(match-xla)|yes(match-xla)||no|
-| NegOp |yes|yes(match-xla)|yes(match-xla)||no|
-| NotOp |yes|yes(match-xla)|yes(match-xla)||no|
-| OptimizationBarrierOp |no|yes(match-xla)|no||no|
-| OrOp |yes|yes(match-xla)|yes(match-xla)||no|
-| OutfeedOp |no|yes(match-xla)|no||no|
-| PadOp |no|yes(match-xla)|yes(match-xla)||no|
-| PopulationCountOp |no|yes(match-xla)|yes(match-xla)||no|
-| PowOp |no|yes(match-xla)|yes(match-xla)||no|
-| RealDynamicSliceOp |no|yes(match-xla)|no||no|
-| RealOp |no|yes(match-xla)|yes(match-xla)||no|
-| RecvOp |no|yes(match-xla)|no||no|
-| ReduceOp |no|yes(match-xla)|yes(match-xla)||no|
-| ReducePrecisionOp |no|yes(match-xla)|yes(match-xla)||no|
-| ReduceScatterOp |no|yes(match-xla)|no||no|
-| ReduceWindowOp |no|yes(match-xla)|yes(match-xla)||no|
-| RemOp |yes|yes(match-xla)|yes(match-xla)||no|
-| ReplicaIdOp |no|yes(match-xla)|yes(need-revisit)||no|
-| ReshapeOp |no|yes(match-xla)|no-plan||no|
-| ReturnOp |no|yes(match-xla)|no||no|
-| ReverseOp |no|yes(match-xla)|yes(match-xla)||no|
-| RngBitGeneratorOp |no|yes(match-xla)|no-plan||no|
-| RngOp |no|yes(match-xla)|yes(match-xla)||no|
-| RoundNearestEvenOp |no|yes(match-xla)|yes(match-xla)||no|
-| RoundOp |no|yes(match-xla)|yes(match-xla)||no|
-| RsqrtOp |yes|yes(match-xla)|yes(match-xla)||no|
-| ScatterOp |no|yes(match-xla)|no||no|
-| SelectAndScatterOp |no|yes(match-xla)|no||no|
-| SelectOp |no|yes(match-xla)|yes(match-xla)||no|
-| SendOp |no|yes(match-xla)|no||no|
-| SetDimensionSizeOp |no|yes(match-xla)|yes(need-revisit)||no|
-| ShiftLeftOp |no|yes(match-xla)|yes(match-xla)||no|
-| ShiftRightArithmeticOp |no|yes(match-xla)|yes(match-xla)||no|
-| ShiftRightLogicalOp |no|yes(match-xla)|yes(match-xla)||no|
-| SignOp |no|yes(match-xla)|yes(match-xla)||no|
-| SineOp |yes|yes(match-xla)|yes(match-xla)||no|
-| SliceOp |no|yes(match-xla)|yes(match-xla)||no|
-| SortOp |no|yes(match-xla)|no||no|
-| SqrtOp |yes|yes(match-xla)|yes(match-xla)||no|
-| SubtractOp |no|yes(match-xla)|yes(match-xla)||no|
-| TanhOp |yes|yes(match-xla)|yes(match-xla)||no|
+| Expm1Op |no|yes*|yes*||no|
+| ExpOp |no|yes*|yes*||no|
+| FftOp |no|yes*|yes*||no|
+| FloorOp |yes|yes*|yes*||no|
+| GatherOp |no|yes*|yes*||no|
+| GetDimensionSizeOp |no|yes*|no||no|
+| GetTupleElementOp |no|yes*|yes(need-revisit)||no|
+| IfOp |no|yes*|yes*||no|
+| ImagOp |no|yes*|yes*||no|
+| InfeedOp |no|yes*|no||no|
+| IotaOp |no|yes*|infeasible||no|
+| IsFiniteOp |no|yes*|yes*||no|
+| Log1pOp |no|yes*|yes*||no|
+| LogisticOp |yes|yes*|yes*||no|
+| LogOp |yes|yes*|yes*||no|
+| MapOp |no|yes*|no||no|
+| MaxOp |yes|yes*|yes*||no|
+| MinOp |yes|yes*|yes*||no|
+| MulOp |no|yes*|yes*||no|
+| NegOp |yes|yes*|yes*||no|
+| NotOp |yes|yes*|yes*||no|
+| OptimizationBarrierOp |no|yes*|no||no|
+| OrOp |yes|yes*|yes*||no|
+| OutfeedOp |no|yes*|no||no|
+| PadOp |no|yes*|yes*||no|
+| PopulationCountOp |no|yes*|yes*||no|
+| PowOp |no|yes*|yes*||no|
+| RealDynamicSliceOp |no|yes*|no||no|
+| RealOp |no|yes*|yes*||no|
+| RecvOp |no|yes*|no||no|
+| ReduceOp |no|yes*|yes*||no|
+| ReducePrecisionOp |no|yes*|yes*||no|
+| ReduceScatterOp |no|yes*|no||no|
+| ReduceWindowOp |no|yes*|yes*||no|
+| RemOp |yes|yes*|yes*||no|
+| ReplicaIdOp |no|yes*|yes(need-revisit)||no|
+| ReshapeOp |no|yes*|infeasible||no|
+| ReturnOp |no|yes*|no||no|
+| ReverseOp |no|yes*|yes*||no|
+| RngBitGeneratorOp |no|yes*|infeasible||no|
+| RngOp |no|yes*|yes*||no|
+| RoundNearestEvenOp |no|yes*|yes*||no|
+| RoundOp |no|yes*|yes*||no|
+| RsqrtOp |yes|yes*|yes*||no|
+| ScatterOp |no|yes*|no||no|
+| SelectAndScatterOp |no|yes*|no||no|
+| SelectOp |no|yes*|yes*||no|
+| SendOp |no|yes*|no||no|
+| SetDimensionSizeOp |no|yes*|yes(need-revisit)||no|
+| ShiftLeftOp |no|yes*|yes*||no|
+| ShiftRightArithmeticOp |no|yes*|yes*||no|
+| ShiftRightLogicalOp |no|yes*|yes*||no|
+| SignOp |no|yes*|yes*||no|
+| SineOp |yes|yes*|yes*||no|
+| SliceOp |no|yes*|yes*||no|
+| SortOp |no|yes*|no||no|
+| SqrtOp |yes|yes*|yes*||no|
+| SubtractOp |no|yes*|yes*||no|
+| TanhOp |yes|yes*|yes*||no|
 | TorchIndexSelectOp |no|no|no||no|
-| TraceOp |no|yes(match-xla)|no||no|
-| TransposeOp |no|yes(match-xla)|yes(match-xla)||no|
-| TriangularSolveOp |no|yes(match-xla)|no||no|
-| TupleOp |no|yes(match-xla)|yes(need-revisit)||no|
+| TraceOp |no|yes*|no||no|
+| TransposeOp |no|yes*|yes*||no|
+| TriangularSolveOp |no|yes*|no||no|
+| TupleOp |no|yes*|yes(need-revisit)||no|
 | UnaryEinsumOp |no|no|no||no|
-| UniformDequantizeOp |no|yes(match-xla)|yes(match-xla)||no|
-| UniformQuantizeOp |no|yes(match-xla)|no-plan||no|
-| WhileOp |no|yes(match-xla)|no||no|
-| XorOp |yes|yes(match-xla)|yes(match-xla)||no|
+| UniformDequantizeOp |no|yes*|yes*||no|
+| UniformQuantizeOp |no|yes*|infeasible||no|
+| WhileOp |no|yes*|no||no|
+| XorOp |yes|yes*|yes*||no|

--- a/docs/status.md
+++ b/docs/status.md
@@ -20,14 +20,14 @@ one of the following tracking labels.
     - **yes**: complete
     - **no**: not complete yet, but part of [the roadmap](https://github.com/openxla/stablehlo#roadmap).
  - Customized labels for Verifier and Type Inference 
-    - **yes\***:  in sync with  [XLA semantics](https://www.tensorflow.org/xla/operation_semantics).
+    - **yes\***: in sync with  [XLA semantics](https://www.tensorflow.org/xla/operation_semantics).
     - **yes**: in sync with [StableHLO semantics](https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md).
     - **yes(need-revisit)**: implemented but need revisit for the sync with XLA or spec
     - **infeasible**: infeasible to implement by design
     
 ## Status
 
-| StableHLO Op (114) | Specification (21) | Verifier(104) | Type Inference(82) | Prettyprinting | Interpreter (2) |
+| StableHLO Op (114) | Specification (21) | Verification(104) | Type Inference(82) | Prettyprinting | Interpreter (2) |
 |:--|:--:|:--:|:--:|:--:|:--:|
 | AbsOp |yes|yes*|yes*||no|
 | AddOp |yes|yes*|yes*|| yes|


### PR DESCRIPTION
The new values in Markdown table of all 114 ops are copied from StableHLO audit sheets with local handy script and the rule to map the old value in sheets to the new value in Markdown table is:
``` 
convert_value_for_md = {
    'Yes (Declarative)': 'yes(match-xla)',
    'Yes (Imperative)': 'yes(match-xla)',
    'Yes (need revisit)': 'yes(need-revisit)',
    'TODO': 'no',
    'Yes (revisit)': 'yes(need-revisit)',
    'No (Infeasible)': 'no-plan',
    'WIP': 'wip',
}
```
The values of `Type Inference` column is clear and fully up to date. The `Verifier` column actually means both ODS and `verify()`. As `verify()` are removed for a lot of ops, the value of them are still set to `yes(match-xla)`. 
If an op's type inference is done or revisited in the future: its value of `Verify` column will also be revisited and updated at the same time (even if it's set to `yes`) now.
The sum number in the column title includes all kinds of `yes` and `no-plan`.

Please review and comment: I can update the sheet/table accordingly.