### PR TITLE
Use auto-generated pass create functions

### DIFF
--- a/stablehlo/tests/TestUtils.cpp
+++ b/stablehlo/tests/TestUtils.cpp
@@ -146,10 +146,6 @@ struct HloTestInferPass : public impl::HloTestInferPassBase<HloTestInferPass> {
   }
 };
 
-std::unique_ptr<OperationPass<func::FuncOp>> createHloTestInferPass() {
-  return std::make_unique<HloTestInferPass>();
-}
-
 #define GEN_PASS_REGISTRATION
 #include "stablehlo/tests/TestUtils.h.inc"
 

--- a/stablehlo/tests/TestUtils.td
+++ b/stablehlo/tests/TestUtils.td
@@ -18,6 +18,5 @@ include "mlir/Pass/PassBase.td"
 
 def HloTestInferPass : Pass<"hlo-test-infer", "func::FuncOp"> {
   let summary = "Uses test ops to invoke InferShapedTypeOpInterface methods.";
-  let constructor = "createHloTestInferPass()";
   let dependentDialects = ["shape::ShapeDialect"];
 }


### PR DESCRIPTION
Figured it out - the constructor gets auto-generated when an explicit constructor field is not specified in ODS.