### PR TITLE
Refactor op syntax in the spec draft

### DIFF
--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -21,7 +21,7 @@ Following are the supported element types in StableHLO:
     dynamic range, but with greatly reduced precision. This also ensures
     identical behavior for underflows, overflows, and NaNs. However, `bf16`
     handles denormals differently from `f32`: it flushes them to zero.
-  * **Complex types** represents a pair of floating-point types. Supported ones
+  * **Complex types** represent a pair of floating-point types. Supported ones
     are `complex<f32>` (represents a par of `f32`) and `complex<f64>`
     (represents a pair of `f64`).
 


### PR DESCRIPTION
When reviewing #170, I was looking at
`%result = stablehlo.reshape %operand : tensor<3x2xi32>` which was used as an example of reshape, and I realized that it might be pretty confusing to readers because it doesn't say anything about the tensor which is being reshaped.

First I thought to propose using whatever syntax we're currently using in StableHLO, i.e `... : (tensor<2x3xi32> -> tensor<3x2xi32>)`, but then I realized that we shouldn't expect spec readers to know implementation details of the StableHLO dialect, which can also change over time.

Given that, I'd like to propose that we consistently use MLIR generic syntax in examples, and additionally drop the informal mnemonic + signature notation used to introduce ops.

Finally, I'd also like to propose that we align type names in the spec with type names in MLIR. Currently, we have some misalignments, e.g. `pred` vs `i1`, `c64` vs `complex<f32>`, which don't buy us much and make examples would look weird.