### PR TITLE
Fix up headers in the interpreter

### DIFF
--- a/stablehlo/reference/Interpreter.h
+++ b/stablehlo/reference/Interpreter.h
@@ -29,8 +29,8 @@ namespace stablehlo {
 ///
 /// Assuming that the function under evaluation has passed verifier,
 /// similarly to what's required by constant folding.
-llvm::Expected<SmallVector<Tensor>> eval(func::FuncOp func,
-                                         ArrayRef<Tensor> args);
+llvm::Expected<llvm::SmallVector<Tensor>> eval(func::FuncOp func,
+                                               llvm::ArrayRef<Tensor> args);
 
 }  // namespace stablehlo
 }  // namespace mlir

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -16,6 +16,7 @@ limitations under the License.
 #ifndef STABLHLO_REFERENCE_OPS_H
 #define STABLHLO_REFERENCE_OPS_H
 
+#include "mlir/IR/BuiltinAttributes.h"
 #include "stablehlo/dialect/StablehloOps.h"
 #include "stablehlo/reference/Tensor.h"
 

--- a/stablehlo/reference/Tensor.h
+++ b/stablehlo/reference/Tensor.h
@@ -18,7 +18,9 @@ limitations under the License.
 
 #include <vector>
 
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/Support/raw_ostream.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -110,7 +112,7 @@ inline raw_ostream &operator<<(raw_ostream &os, Tensor tensor) {
 /// Creates a Tensor using `type` as the static type and data provided as an
 /// array of string literal which will be parsed using the corresponding element
 /// type.
-Tensor makeTensor(ShapedType type, ArrayRef<StringRef> strData);
+Tensor makeTensor(ShapedType type, llvm::ArrayRef<llvm::StringRef> strData);
 
 }  // namespace stablehlo
 }  // namespace mlir


### PR DESCRIPTION
Add missing includes, fully qualify llvm::ArrayRef, llvm::SmallVector and llvm::StringRef.