### PR TITLE
Enforce compatible indices and shape while indexing into Tensor

### DIFF
--- a/stablehlo/reference/Index.cpp
+++ b/stablehlo/reference/Index.cpp
@@ -20,6 +20,16 @@ limitations under the License.
 namespace mlir {
 namespace stablehlo {
 
+LogicalResult verifyIndex(llvm::ArrayRef<int64_t> shape,
+                          llvm::ArrayRef<int64_t> index) {
+  if (shape.size() != index.size()) return failure();
+
+  for (auto [shapeDim, indexDim] : llvm::zip(shape, index))
+    if (indexDim < 0 || indexDim >= shapeDim) return failure();
+
+  return success();
+}
+
 llvm::ArrayRef<int64_t> IndexSpaceIterator::operator*() const {
   if (!index_)
     llvm::report_fatal_error("Dereferencing a past-the-end iterator.");

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -91,8 +91,8 @@ Tensor eval(SubtractOp op, const Tensor &lhs, const Tensor &rhs) {
 
 Tensor eval(TanhOp op, const Tensor &operand) {
   Tensor result(op.getType());
-  for (auto i = 0; i < operand.getNumElements(); ++i) {
-    result.set(i, tanh(operand.get(i)));
+  for (auto it = operand.index_begin(); it != operand.index_end(); ++it) {
+    result.set(*it, tanh(operand.get(*it)));
   }
   return result;
 }

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -42,8 +42,8 @@ Tensor eval(ConstantOp op, ElementsAttr value) {
 
 Tensor eval(CosineOp op, const Tensor &operand) {
   Tensor result(op.getType());
-  for (auto i = 0; i < operand.getNumElements(); ++i) {
-    result.set(i, cosine(operand.get(i)));
+  for (auto it = operand.index_begin(); it != operand.index_end(); ++it) {
+    result.set(*it, cosine(operand.get(*it)));
   }
   return result;
 }

--- a/stablehlo/reference/Tensor.cpp
+++ b/stablehlo/reference/Tensor.cpp
@@ -65,22 +65,10 @@ std::complex<APFloat> getComplexValue(Element element) {
 // Flattens multi-dimensional index 'index' of a tensor to a linearized index
 // into the underlying storage where elements are laid out in canonical order.
 int64_t flattenIndex(ArrayRef<int64_t> shape, ArrayRef<int64_t> index) {
-  // 'shape' should have non-negative dimension sizes.
-  if (llvm::any_of(shape, [](int64_t dim) { return dim < 0; })) {
+  if (failed(verifyIndex(shape, index)))
     llvm::report_fatal_error(
-        "Cannot index a tensor with shape having dimension sizes < 0.");
-  }
-
-  // 'index' should be a valid index in the index space of a tensor with shape
-  // 'shape'.
-  if (shape.size() != index.size() ||
-      any_of(llvm::zip(shape, index), [](std::tuple<int64_t, int64_t> zip) {
-        return std::get<1>(zip) < 0 || std::get<1>(zip) >= std::get<0>(zip);
-      })) {
-    llvm::report_fatal_error(
-        StringRef("Incompatible index and shape found in: ") +
+        llvm::StringRef("Incompatible index and shape found in: ") +
         LLVM_PRETTY_FUNCTION);
-  }
 
   int64_t idx = 0;
   if (shape.empty()) return idx;

--- a/stablehlo/reference/Tensor.cpp
+++ b/stablehlo/reference/Tensor.cpp
@@ -330,7 +330,7 @@ void Tensor::set(ArrayRef<int64_t> index, const Element &element) {
 IndexSpaceIterator Tensor::index_begin() const {
   auto shape = getType().getShape();
 
-  if(any_of(shape, [](int64_t dimSize) {return dimSize == 0;}))
+  if (any_of(shape, [](int64_t dimSize) { return dimSize == 0; }))
     return IndexSpaceIterator(shape, {});
 
   SmallVector<int64_t> index(shape.size());

--- a/stablehlo/reference/Tensor.cpp
+++ b/stablehlo/reference/Tensor.cpp
@@ -48,20 +48,6 @@ int64_t getSizeInBytes(Type type) {
   report_fatal_error(std::move(err));
 }
 
-APFloat getFloatValue(Element element) {
-  return element.getValue().cast<FloatAttr>().getValue();
-}
-
-APInt getIntegerValue(Element element) {
-  return element.getValue().cast<IntegerAttr>().getValue();
-}
-
-std::complex<APFloat> getComplexValue(Element element) {
-  auto arryOfAttr = element.getValue().cast<ArrayAttr>().getValue();
-  return std::complex<APFloat>(arryOfAttr[0].cast<FloatAttr>().getValue(),
-                               arryOfAttr[1].cast<FloatAttr>().getValue());
-}
-
 // Flattens multi-dimensional index 'index' of a tensor to a linearized index
 // into the underlying storage where elements are laid out in canonical order.
 int64_t flattenIndex(ArrayRef<int64_t> shape, ArrayRef<int64_t> index) {
@@ -343,6 +329,10 @@ void Tensor::set(ArrayRef<int64_t> index, const Element &element) {
 
 IndexSpaceIterator Tensor::index_begin() const {
   auto shape = getType().getShape();
+
+  if(any_of(shape, [](int64_t dimSize) {return dimSize == 0;}))
+    return IndexSpaceIterator(shape, {});
+
   SmallVector<int64_t> index(shape.size());
   return IndexSpaceIterator(shape, index);
 }

--- a/stablehlo/tests/interpret_add.mlir
+++ b/stablehlo/tests/interpret_add.mlir
@@ -257,3 +257,27 @@ func.func @add_op_test_c128() -> tensor<2xcomplex<f64>> {
   // CHECK-NEXT: [3.000000e+00 : f64, 5.000000e+00 : f64
   // CHECK-NEXT: [1.500000e+01 : f64, 1.100000e+01 : f64
 }
+
+// -----
+
+// CHECK-LABEL: Evaluated results of function: add_op_scalar
+func.func @add_op_scalar() -> tensor<i4> {
+  %0 = stablehlo.constant dense<2> : tensor<i4>
+  %1 = stablehlo.constant dense<3> : tensor<i4>
+  %2 = stablehlo.add %0, %1 : tensor<i4>
+  func.return %2 : tensor<i4>
+  // CHECK-NEXT: tensor<i4>
+  // CHECK-NEXT: 5 : i4
+}
+
+// -----
+
+// CHECK-LABEL: Evaluated results of function: add_op_tensor_shape_with_zero_dim_size
+func.func @add_op_tensor_shape_with_zero_dim_size() -> tensor<2x0x3xi4> {
+  %0 = stablehlo.constant dense<2> : tensor<2x0x3xi4>
+  %1 = stablehlo.constant dense<3> : tensor<2x0x3xi4>
+  %2 = stablehlo.add %0, %1 : tensor<2x0x3xi4>
+  func.return %2 : tensor<2x0x3xi4>
+  // CHECK-NEXT: tensor<2x0x3xi4>
+  // CHECK-NOT: [0-9]+
+}


### PR DESCRIPTION
Ideally, we are supposed to use valid indices from the index space of a Tensor to access individual elements. An invalid index might lead of OOB access. While testing the interpreter we found that the eval function of cosine op is still using the linearized index to access the tensor elements. 

```
Tensor eval(CosineOp op, const Tensor &operand) {
  Tensor result(op.getType());
  for (auto i = 0; i < operand.getNumElements(); ++i) {
    result.set(i, cosine(operand.get(i)));
  }
  return result;
}
``` 

While calling the `Tensor::get(rrayRef<int64_t>)`  API, these linear indices are implicitly converted to an `ArrayRef<int64_t>` of size 1. For a tensor with >= 1 rank, these are illegal indices and might cause OOB based on the shape and choice of index. 
We realized that it is  left over  from https://github.com/openxla/stablehlo/pull/167 which we fix here (to use multi-dimensional index instead).

Next the PR add checks, in `flatenIndex` and `IndexSpaceIterator::IndexSpaceIterator`, to ensure that index is compatible with the shape of the tensor. 