### PR TITLE
Assorted cleanup

### DIFF
--- a/stablehlo/reference/Interpreter.cpp
+++ b/stablehlo/reference/Interpreter.cpp
@@ -65,9 +65,8 @@ llvm::Expected<SmallVector<Tensor>> eval(func::FuncOp func,
     auto fetchOperand = [&](Value value) -> Tensor {
       auto it = stackFrame.find(value);
       if (it != stackFrame.end()) return it->second;
-
-      auto err = invalidArgument("Expected a terminator when evaluating func");
-      report_fatal_error(std::move(err));
+      report_fatal_error(
+          invalidArgument("Expected a terminator when evaluating func"));
     };
     auto populateResults = [&](ArrayRef<Tensor> runtimeValues) {
       assert(op.getNumResults() == runtimeValues.size());

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -24,8 +24,7 @@ namespace {
 
 // Appies the permutation `perm` to an array `array` where perm[i] indicates the
 // location where the current array[i] goes.
-std::vector<int64_t> permute(ArrayRef<int64_t> array,
-                             SmallVector<int64_t> perm) {
+std::vector<int64_t> permute(ArrayRef<int64_t> array, ArrayRef<int64_t> perm) {
   std::vector<int64_t> result(array.size());
   for (size_t i = 0; i < array.size(); i++) result[i] = array[perm[i]];
   return result;

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -24,14 +24,10 @@ namespace {
 
 // Appies the permutation `perm` to an array `array` where perm[i] indicates the
 // location where the current array[i] goes.
-std::vector<int64_t> permute(
-    ArrayRef<int64_t> array,
-    mlir::detail::ElementsAttrRange<
-        mlir::DenseElementsAttr::ElementIterator<int64_t>>
-        perm) {
+std::vector<int64_t> permute(ArrayRef<int64_t> array,
+                             SmallVector<int64_t> perm) {
   std::vector<int64_t> result(array.size());
   for (size_t i = 0; i < array.size(); i++) result[i] = array[perm[i]];
-
   return result;
 }
 
@@ -118,8 +114,8 @@ Tensor eval(TransposeOp op, const Tensor &operand) {
   Tensor result(op.getType());
   for (auto operandIt = operand.index_begin(); operandIt != operand.index_end();
        ++operandIt) {
-    auto resultIndex =
-        permute(*operandIt, op.getPermutation().getValues<int64_t>());
+    auto resultIndex = permute(
+        *operandIt, llvm::to_vector(op.getPermutation().getValues<int64_t>()));
     result.set(resultIndex, operand.get(*operandIt));
   }
   return result;

--- a/stablehlo/reference/Tensor.cpp
+++ b/stablehlo/reference/Tensor.cpp
@@ -44,8 +44,8 @@ int64_t getSizeInBytes(Type type) {
   if (auto complexType = type.dyn_cast<mlir::ComplexType>())
     return getSizeInBytes(complexType.getElementType()) * 2;
 
-  auto err = invalidArgument("Unsupported type: %s", debugString(type).c_str());
-  report_fatal_error(std::move(err));
+  report_fatal_error(
+      invalidArgument("Unsupported type: %s", debugString(type).c_str()));
 }
 
 // Flattens multi-dimensional index 'index' of a tensor to a linearized index
@@ -206,9 +206,8 @@ Element Tensor::get(ArrayRef<int64_t> index) const {
     }
   }
 
-  auto err = invalidArgument("Unsupported element type: %s",
-                             debugString(elementType).c_str());
-  report_fatal_error(std::move(err));
+  report_fatal_error(invalidArgument("Unsupported element type: %s",
+                                     debugString(elementType).c_str()));
 }
 
 void Tensor::set(ArrayRef<int64_t> index, const Element &element) {
@@ -322,9 +321,8 @@ void Tensor::set(ArrayRef<int64_t> index, const Element &element) {
     }
   }
 
-  auto err = invalidArgument("Unsupported element type: %s",
-                             debugString(elementType).c_str());
-  report_fatal_error(std::move(err));
+  report_fatal_error(invalidArgument("Unsupported element type: %s",
+                                     debugString(elementType).c_str()));
 }
 
 IndexSpaceIterator Tensor::index_begin() const {
@@ -363,9 +361,9 @@ Tensor makeTensor(ShapedType type, ArrayRef<StringRef> strData) {
     auto complexElemTy = complexTy.getElementType();
     auto floatType = complexElemTy.dyn_cast<FloatType>();
     if (!floatType) {
-      auto err = invalidArgument("Unsupported element type %s for complex type",
-                                 debugString(complexElemTy).c_str());
-      report_fatal_error(std::move(err));
+      report_fatal_error(
+          invalidArgument("Unsupported element type %s for complex type",
+                          debugString(complexElemTy).c_str()));
     }
 
     auto floatValues = llvm::to_vector(
@@ -397,9 +395,8 @@ Tensor makeTensor(ShapedType type, ArrayRef<StringRef> strData) {
     return Tensor(DenseElementsAttr::get(type, intValues));
   }
 
-  auto err =
-      invalidArgument("Unsupported type: %s", debugString(elemType).c_str());
-  report_fatal_error(std::move(err));
+  report_fatal_error(
+      invalidArgument("Unsupported type: %s", debugString(elemType).c_str()));
 }
 
 }  // namespace stablehlo


### PR DESCRIPTION
* Inlines various errors directly into report_fatal_error (there doesn't seem to be a use case for having a temporary variable which is then immediately moved).
* Uses SmallVector in permute (Sandeep, you were right - the actual type is such a mouthful!).