### PR TITLE
Update ODS links to reference StableHLO spec

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -29,8 +29,8 @@ one of the following tracking labels.
 
 | StableHLO Op             | Specification | Verification |  Type Inference   |  Pretty Printing  | Interpreter |
 |:-------------------------|:-------------:|:------------:|:-----------------:|:-----------------:|:-----------:|
-| abs                      |      yes      |     yes*     |       yes*        |        yes        |     no      |
-| add                      |      yes      |     yes*     |       yes*        |        yes        |     yes     |
+| abs                      |      no       |     yes*     |        yes        |        yes        |     no      |
+| add                      |      no       |     yes*     |        yes        |        yes        |     yes     |
 | after_all                |      no       |      no      |        no         |        yes        |     no      |
 | all_gather               |      no       |     yes*     |        no         |        no         |     no      |
 | all_reduce               |      no       |      no      |        no         |        no         |     no      |
@@ -62,7 +62,7 @@ one of the following tracking labels.
 | cross-replica-sum        |      no       |      no      |       yes*        |        no         |     no      |
 | cstr_reshapable          |      no       |     yes*     |        no         |        yes        |     no      |
 | custom_call              |      no       |     yes*     |    infeasible     |        yes        |     no      |
-| divide                   |      yes      |     yes*     |       yes*        |        yes        |     no      |
+| divide                   |      yes      |      no      |        yes        |        yes        |     no      |
 | dot                      |      no       |     yes*     | yes(need-revisit) |        yes        |     no      |
 | dot_general              |      no       |     yes*     |       yes*        |        no         |     no      |
 | dynamic_broadcast_in_dim |      no       |     yes*     |        no         |        no         |     no      |
@@ -90,8 +90,8 @@ one of the following tracking labels.
 | log_plus_one             |      no       |     yes*     |       yes*        |        yes        |     no      |
 | logistic                 |      yes      |     yes      |        yes        |        yes        |     no      |
 | map                      |      no       |     yes*     |        no         |        no         |     no      |
-| maximum                  |      yes      |     yes*     |       yes*        |        yes        |     yes     |
-| minimum                  |      yes      |     yes*     |       yes*        |        yes        |     yes     |
+| maximum                  |      no       |     yes*     |        yes        |        yes        |     yes     |
+| minimum                  |      no       |     yes*     |        yes        |        yes        |     yes     |
 | multiply                 |      no       |     yes*     |       yes*        |        yes        |     no      |
 | negate                   |      yes      |     yes      |        yes        |        yes        |     yes     |
 | not                      |      yes      |     yes      |        yes        |        yes        |     no      |
@@ -108,7 +108,7 @@ one of the following tracking labels.
 | reduce_precision         |      no       |     yes*     |       yes*        |        yes        |     no      |
 | reduce_scatter           |      no       |     yes*     |        no         |        no         |     no      |
 | reduce_window            |      no       |     yes*     |       yes*        |        no         |     no      |
-| remainder                |      yes      |     yes*     |       yes*        |        yes        |     no      |
+| remainder                |      yes      |      no      |        yes        |        yes        |     no      |
 | replica_id               |      no       |     yes*     | yes(need-revisit) |        yes        |     no      |
 | reshape                  |      yes      |     yes      |    infeasible     |        yes        |     yes     |
 | return                   |      no       |     yes*     |        no         |        yes        |     no      |
@@ -131,7 +131,7 @@ one of the following tracking labels.
 | slice                    |      no       |     yes*     |       yes*        |        no         |     no      |
 | sort                     |      no       |     yes*     |       yes*        |        no         |     no      |
 | sqrt                     |      yes      |     yes      |        yes        |        yes        |     no      |
-| subtract                 |      yes      |     yes*     |       yes*        |        yes        |     yes     |
+| subtract                 |      yes      |      no      |        yes        |        yes        |     yes     |
 | tanh                     |      yes      |     yes      |        yes        |        yes        |     yes     |
 | torch_index_select       |      no       |      no      |        no         |        no         |     no      |
 | trace                    |      no       |     yes*     |        no         |        yes        |     no      |

--- a/docs/status.md
+++ b/docs/status.md
@@ -29,13 +29,13 @@ one of the following tracking labels.
 
 | StableHLO Op             | Specification | Verification |  Type Inference   |  Pretty Printing  | Interpreter |
 |:-------------------------|:-------------:|:------------:|:-----------------:|:-----------------:|:-----------:|
-| abs                      |      yes      |     yes*     |       yes*        |        yes        |     no      |
-| add                      |      yes      |     yes*     |       yes*        |        yes        |     yes     |
+| abs                      |      yes      |     yes      |        yes        |        yes        |     no      |
+| add                      |      yes      |     yes      |        yes        |        yes        |     yes     |
 | after_all                |      no       |      no      |        no         |        yes        |     no      |
 | all_gather               |      no       |     yes*     |        no         |        no         |     no      |
 | all_reduce               |      no       |      no      |        no         |        no         |     no      |
-| all_to_all               |      no       |     yes*     |       yes*        |        no         |     no      |
-| and                      |      yes      |     yes*     |       yes*        |        yes        |     no      |
+| all_to_all               |      no       |     yes      |        yes        |        no         |     no      |
+| and                      |      yes      |     yes      |        yes        |        yes        |     no      |
 | atan2                    |      no       |     yes*     |       yes*        |        yes        |     no      |
 | batch_norm_grad          |      no       |     yes*     |       yes*        |        no         |     no      |
 | batch_norm_inference     |      no       |     yes*     |       yes*        |        no         |     no      |
@@ -45,7 +45,7 @@ one of the following tracking labels.
 | broadcast                |      no       |     yes*     |       yes*        |        no         |     no      |
 | case                     |      no       |     yes*     |       yes*        |        no         |     no      |
 | cbrt                     |      no       |     yes*     |       yes*        |        yes        |     no      |
-| ceil                     |      yes      |     yes*     |       yes*        |        yes        |     yes     |
+| ceil                     |      yes      |     yes      |        yes        |        yes        |     yes     |
 | cholesky                 |      no       |     yes*     |       yes*        |        yes        |     no      |
 | clamp                    |      no       |     yes*     |       yes*        |        yes        |     no      |
 | count_leading_zeros      |      no       |     yes*     |       yes*        |        yes        |     no      |
@@ -54,15 +54,15 @@ one of the following tracking labels.
 | complex                  |      no       |     yes*     |       yes*        |        yes        |     no      |
 | compute_reshape_shape    |      no       |      no      |        no         |        yes        |     no      |
 | concatenate              |      yes      |     yes      |        yes        |        yes        |     no      |
-| constant                 |      yes      |     yes*     |       yes*        |        yes        |     yes     |
+| constant                 |      yes      |     yes      |        yes        |        yes        |     yes     |
 | convert                  |      no       |     yes*     |    infeasible     |        yes        |     no      |
 | convolution              |      no       |     yes*     |        no         | yes(need-revisit) |     no      |
-| cosine                   |      yes      |     yes*     |       yes*        |        yes        |     yes     |
+| cosine                   |      yes      |     yes      |        yes        |        yes        |     yes     |
 | create_token             |      no       |     yes*     |        no         |        yes        |     no      |
 | cross-replica-sum        |      no       |      no      |       yes*        |        no         |     no      |
 | cstr_reshapable          |      no       |     yes*     |        no         |        yes        |     no      |
 | custom_call              |      no       |     yes*     |    infeasible     |        yes        |     no      |
-| divide                   |      yes      |     yes*     |       yes*        |        yes        |     no      |
+| divide                   |      yes      |     yes      |        yes        |        yes        |     no      |
 | dot                      |      no       |     yes*     | yes(need-revisit) |        yes        |     no      |
 | dot_general              |      no       |     yes*     |       yes*        |        no         |     no      |
 | dynamic_broadcast_in_dim |      no       |     yes*     |        no         |        no         |     no      |
@@ -74,10 +74,10 @@ one of the following tracking labels.
 | dynamic_slice            |      no       |     yes*     |       yes*        |        no         |     no      |
 | dynamic_update_slice     |      no       |     yes*     |        no         |        yes        |     no      |
 | einsum                   |      no       |      no      |        no         |        no         |     no      |
-| exponential              |      yes      |     yes*     |       yes*        |        yes        |     no      |
+| exponential              |      yes      |     yes      |        yes        |        yes        |     no      |
 | exponential_minus_one    |      no       |     yes*     |       yes*        |        yes        |     no      |
 | fft                      |      no       |     yes*     |       yes*        |        no         |     no      |
-| floor                    |      yes      |     yes*     |       yes*        |        yes        |     yes     |
+| floor                    |      yes      |     yes      |        yes        |        yes        |     yes     |
 | gather                   |      no       |     yes*     |       yes*        |        no         |     no      |
 | get_dimension_size       |      no       |     yes*     |        no         |        yes        |     no      |
 | get_tuple_element        |      no       |     yes*     | yes(need-revisit) |        yes        |     no      |
@@ -86,17 +86,17 @@ one of the following tracking labels.
 | infeed                   |      no       |     yes*     |        no         |        no         |     no      |
 | iota                     |      yes      |     yes      |    infeasible     |        yes        |     yes     |
 | is_finite                |      no       |     yes*     |       yes*        |        yes        |     no      |
-| log                      |      yes      |     yes*     |       yes*        |        yes        |     no      |
+| log                      |      yes      |     yes      |        yes        |        yes        |     no      |
 | log_plus_one             |      no       |     yes*     |       yes*        |        yes        |     no      |
-| logistic                 |      yes      |     yes*     |       yes*        |        yes        |     no      |
+| logistic                 |      yes      |     yes      |        yes        |        yes        |     no      |
 | map                      |      no       |     yes*     |        no         |        no         |     no      |
-| maximum                  |      yes      |     yes*     |       yes*        |        yes        |     yes     |
-| minimum                  |      yes      |     yes*     |       yes*        |        yes        |     yes     |
+| maximum                  |      yes      |     yes      |        yes        |        yes        |     yes     |
+| minimum                  |      yes      |     yes      |        yes        |        yes        |     yes     |
 | multiply                 |      no       |     yes*     |       yes*        |        yes        |     no      |
-| negate                   |      yes      |     yes*     |       yes*        |        yes        |     yes     |
-| not                      |      yes      |     yes*     |       yes*        |        yes        |     no      |
+| negate                   |      yes      |     yes      |        yes        |        yes        |     yes     |
+| not                      |      yes      |     yes      |        yes        |        yes        |     no      |
 | optimization_barrier     |      no       |     yes*     |        no         |        yes        |     no      |
-| or                       |      yes      |     yes*     |       yes*        |        yes        |     no      |
+| or                       |      yes      |     yes      |        yes        |        yes        |     no      |
 | outfeed                  |      no       |     yes*     |        no         |        no         |     no      |
 | pad                      |      no       |     yes*     |       yes*        |        no         |     no      |
 | popcnt                   |      no       |     yes*     |       yes*        |        yes        |     no      |
@@ -108,7 +108,7 @@ one of the following tracking labels.
 | reduce_precision         |      no       |     yes*     |       yes*        |        yes        |     no      |
 | reduce_scatter           |      no       |     yes*     |        no         |        no         |     no      |
 | reduce_window            |      no       |     yes*     |       yes*        |        no         |     no      |
-| remainder                |      yes      |     yes*     |       yes*        |        yes        |     no      |
+| remainder                |      yes      |     yes      |        yes        |        yes        |     no      |
 | replica_id               |      no       |     yes*     | yes(need-revisit) |        yes        |     no      |
 | reshape                  |      yes      |     yes      |    infeasible     |        yes        |     yes     |
 | return                   |      no       |     yes*     |        no         |        yes        |     no      |
@@ -117,7 +117,7 @@ one of the following tracking labels.
 | rng                      |      no       |     yes*     |       yes*        |        yes        |     no      |
 | round_nearest_afz        |      no       |     yes*     |       yes*        |        yes        |     no      |
 | round_nearest_even       |      no       |     yes*     |       yes*        |        yes        |     no      |
-| rsqrt                    |      yes      |     yes*     |       yes*        |        yes        |     no      |
+| rsqrt                    |      yes      |     yes      |        yes        |        yes        |     no      |
 | scatter                  |      no       |     yes*     |        no         |        no         |     no      |
 | select                   |      no       |     yes*     |       yes*        |        yes        |     no      |
 | select_and_scatter       |      no       |     yes*     |        no         |        no         |     no      |
@@ -127,12 +127,12 @@ one of the following tracking labels.
 | shift_right_arithmetic   |      no       |     yes*     |       yes*        |        yes        |     no      |
 | shift_right_logical      |      no       |     yes*     |       yes*        |        yes        |     no      |
 | sign                     |      no       |     yes*     |       yes*        |        yes        |     no      |
-| sine                     |      yes      |     yes*     |       yes*        |        yes        |     yes     |
+| sine                     |      yes      |     yes      |        yes        |        yes        |     yes     |
 | slice                    |      no       |     yes*     |       yes*        |        no         |     no      |
 | sort                     |      no       |     yes*     |       yes*        |        no         |     no      |
-| sqrt                     |      yes      |     yes*     |       yes*        |        yes        |     no      |
+| sqrt                     |      yes      |     yes      |        yes        |        yes        |     no      |
 | subtract                 |      yes      |     yes      |        yes        |        yes        |     yes     |
-| tanh                     |      yes      |     yes*     |       yes*        |        yes        |     yes     |
+| tanh                     |      yes      |     yes      |        yes        |        yes        |     yes     |
 | torch_index_select       |      no       |      no      |        no         |        no         |     no      |
 | trace                    |      no       |     yes*     |        no         |        yes        |     no      |
 | transpose                |      yes      |     yes      |        yes        |        no         |     yes     |
@@ -142,4 +142,4 @@ one of the following tracking labels.
 | uniform_dequantize       |      no       |     yes*     |       yes*        |        yes        |     no      |
 | uniform_quantize         |      no       |     yes*     |    infeasible     |        yes        |     no      |
 | while                    |      no       |     yes*     |       yes*        | yes(need-revisit) |     no      |
-| xor                      |      yes      |     yes*     |       yes*        |        yes        |     no      |
+| xor                      |      yes      |     yes      |        yes        |        yes        |     no      |

--- a/docs/status.md
+++ b/docs/status.md
@@ -29,12 +29,12 @@ one of the following tracking labels.
 
 | StableHLO Op             | Specification | Verification |  Type Inference   |  Pretty Printing  | Interpreter |
 |:-------------------------|:-------------:|:------------:|:-----------------:|:-----------------:|:-----------:|
-| abs                      |      yes      |     yes      |        yes        |        yes        |     no      |
-| add                      |      yes      |     yes      |        yes        |        yes        |     yes     |
+| abs                      |      yes      |     yes*     |       yes*        |        yes        |     no      |
+| add                      |      yes      |     yes*     |       yes*        |        yes        |     yes     |
 | after_all                |      no       |      no      |        no         |        yes        |     no      |
 | all_gather               |      no       |     yes*     |        no         |        no         |     no      |
 | all_reduce               |      no       |      no      |        no         |        no         |     no      |
-| all_to_all               |      no       |     yes      |        yes        |        no         |     no      |
+| all_to_all               |      no       |     yes*     |       yes*        |        no         |     no      |
 | and                      |      yes      |     yes      |        yes        |        yes        |     no      |
 | atan2                    |      no       |     yes*     |       yes*        |        yes        |     no      |
 | batch_norm_grad          |      no       |     yes*     |       yes*        |        no         |     no      |
@@ -62,7 +62,7 @@ one of the following tracking labels.
 | cross-replica-sum        |      no       |      no      |       yes*        |        no         |     no      |
 | cstr_reshapable          |      no       |     yes*     |        no         |        yes        |     no      |
 | custom_call              |      no       |     yes*     |    infeasible     |        yes        |     no      |
-| divide                   |      yes      |     yes      |        yes        |        yes        |     no      |
+| divide                   |      yes      |     yes*     |       yes*        |        yes        |     no      |
 | dot                      |      no       |     yes*     | yes(need-revisit) |        yes        |     no      |
 | dot_general              |      no       |     yes*     |       yes*        |        no         |     no      |
 | dynamic_broadcast_in_dim |      no       |     yes*     |        no         |        no         |     no      |
@@ -90,8 +90,8 @@ one of the following tracking labels.
 | log_plus_one             |      no       |     yes*     |       yes*        |        yes        |     no      |
 | logistic                 |      yes      |     yes      |        yes        |        yes        |     no      |
 | map                      |      no       |     yes*     |        no         |        no         |     no      |
-| maximum                  |      yes      |     yes      |        yes        |        yes        |     yes     |
-| minimum                  |      yes      |     yes      |        yes        |        yes        |     yes     |
+| maximum                  |      yes      |     yes*     |       yes*        |        yes        |     yes     |
+| minimum                  |      yes      |     yes*     |       yes*        |        yes        |     yes     |
 | multiply                 |      no       |     yes*     |       yes*        |        yes        |     no      |
 | negate                   |      yes      |     yes      |        yes        |        yes        |     yes     |
 | not                      |      yes      |     yes      |        yes        |        yes        |     no      |
@@ -108,7 +108,7 @@ one of the following tracking labels.
 | reduce_precision         |      no       |     yes*     |       yes*        |        yes        |     no      |
 | reduce_scatter           |      no       |     yes*     |        no         |        no         |     no      |
 | reduce_window            |      no       |     yes*     |       yes*        |        no         |     no      |
-| remainder                |      yes      |     yes      |        yes        |        yes        |     no      |
+| remainder                |      yes      |     yes*     |       yes*        |        yes        |     no      |
 | replica_id               |      no       |     yes*     | yes(need-revisit) |        yes        |     no      |
 | reshape                  |      yes      |     yes      |    infeasible     |        yes        |     yes     |
 | return                   |      no       |     yes*     |        no         |        yes        |     no      |
@@ -131,7 +131,7 @@ one of the following tracking labels.
 | slice                    |      no       |     yes*     |       yes*        |        no         |     no      |
 | sort                     |      no       |     yes*     |       yes*        |        no         |     no      |
 | sqrt                     |      yes      |     yes      |        yes        |        yes        |     no      |
-| subtract                 |      yes      |     yes      |        yes        |        yes        |     yes     |
+| subtract                 |      yes      |     yes*     |       yes*        |        yes        |     yes     |
 | tanh                     |      yes      |     yes      |        yes        |        yes        |     yes     |
 | torch_index_select       |      no       |      no      |        no         |        no         |     no      |
 | trace                    |      no       |     yes*     |        no         |        yes        |     no      |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -892,7 +892,16 @@ def StableHLO_SubtractOp : StableHLO_BinaryElementwiseOp<"subtract",
       [NoSideEffect, HLO_CompatibleOperandsAndResultType]> {
   let summary = "Subtraction operator";
   let description = [{
+    Performs element-wise subtraction of two tensors `lhs` and `rhs` and
+    produces a `result` tensor.
+
+    See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlosubtract
+
+    Example:
+    ```mlir
+    %0 = stablehlo.subtract %arg0, %arg0 : tensor<2xi32>
+    ```
   }];
 }
 
@@ -2185,7 +2194,15 @@ def StableHLO_ReshapeOp: StableHLO_Op<"reshape",
       [NoSideEffect, SameOperandsAndResultElementType]> {
   let summary = "Reshape operator";
   let description = [{
+    Performs reshape of `operand` tensor to a `result` tensor.
+
+    See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehloreshape
+
+    Example:
+    ```mlir
+    %0 = stablehlo.reshape %arg0 : (tensor<2xf32>) -> tensor<1x2xf32>
+    ```
   }];
 
   let arguments = (ins HLO_Tensor:$operand);
@@ -2442,7 +2459,16 @@ def StableHLO_TransposeOp: StableHLO_ShapedInterfaceOp<"transpose",
       DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
   let summary = "Transpose operator";
   let description = [{
+    Permutes the dimensions of `operand` tensor using `permutation` and produces
+    a `result` tensor.
+
+    See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlotranspose
+
+    Example:
+    ```mlir
+    %0 = "stablehlo.transpose"(%arg0) {permutation = dense<[2, 1, 0]> : tensor<3xi64>} : (tensor<2x3x2xi32>) -> tensor<2x3x2xi32>
+    ```
   }];
   let arguments = (ins
     HLO_Tensor:$operand,

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -72,7 +72,7 @@ def StableHLO_ConstantOp : StableHLO_Op<"constant",
     [ConstantLike, NoSideEffect, DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
   let summary = "Constant operator";
   let description = [{
-    Represents a constant value.
+    https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehloconstant
   }];
   let arguments = (ins
     ElementsAttr:$value
@@ -195,16 +195,7 @@ def StableHLO_AbsOp: StableHLO_UnaryElementwiseOp<"abs",
      TensorOf<[HLO_SInt, HLO_Float, HLO_Complex]>> {
   let summary = "Absolute value operator";
   let description = [{
-    Returns `abs(operand)` element-wise.
-
-    See
-    https://www.tensorflow.org/xla/operation_semantics#element-wise_unary_functions.
-
-    Example:
-
-    ```mlir
-    %0 = stablehlo.abs %arg0 : tensor<3xi32>
-    ```
+    https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehloabs
   }];
 }
 
@@ -228,16 +219,7 @@ def StableHLO_CeilOp: StableHLO_UnaryElementwiseOp<"ceil",
     [NoSideEffect, HLO_CompatibleOperandsAndResultType], HLO_FpTensor> {
   let summary = "Ceil operator";
   let description = [{
-    Returns `Ceil(operand)` element-wise.
-
-    See
-    https://www.tensorflow.org/xla/operation_semantics#element-wise_unary_functions.
-
-    Example:
-
-    ```mlir
-    %0 = stablehlo.ceil %arg0 : tensor<2xf32>
-    ```
+    https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehloceil
   }];
 }
 def StableHLO_ConvertOp : StableHLO_UnaryElementwiseOp<"convert",
@@ -280,16 +262,7 @@ def StableHLO_CosineOp: StableHLO_UnaryElementwiseOp<"cosine",
     [NoSideEffect, HLO_CompatibleOperandsAndResultType], HLO_FpOrComplexTensor> {
   let summary = "Cos operator";
   let description = [{
-    Returns `Cos(operand)` element-wise.
-
-    See
-    https://www.tensorflow.org/xla/operation_semantics#element-wise_unary_functions.
-
-    Example:
-
-    ```mlir
-    %0 = stablehlo.cosine %arg0 : tensor<2xf32>
-    ```
+    https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlocosine
   }];
 }
 
@@ -297,16 +270,7 @@ def StableHLO_ExpOp: StableHLO_UnaryElementwiseOp<"exponential",
     [NoSideEffect, HLO_CompatibleOperandsAndResultType], HLO_FpOrComplexTensor> {
   let summary = "Exponential operator";
   let description = [{
-    Returns `e^(operand)` element-wise.
-
-    See
-    https://www.tensorflow.org/xla/operation_semantics#element-wise_unary_functions.
-
-    Example:
-
-    ```mlir
-    %0 = stablehlo.exponential %arg0 : tensor<2xf32>
-    ```
+    https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehloexp
   }];
 }
 def StableHLO_Expm1Op: StableHLO_UnaryElementwiseOp<"exponential_minus_one",
@@ -329,16 +293,7 @@ def StableHLO_FloorOp: StableHLO_UnaryElementwiseOp<"floor",
     [NoSideEffect, HLO_CompatibleOperandsAndResultType], HLO_FpTensor> {
   let summary = "Floor operator";
   let description = [{
-    Returns `Floor(operand)` element-wise.
-
-    See
-    https://www.tensorflow.org/xla/operation_semantics#element-wise_unary_functions.
-
-    Example:
-
-    ```mlir
-    %0 = stablehlo.floor %arg0 : tensor<2xf32>
-    ```
+    https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlofloor
   }];
 }
 def StableHLO_ImagOp: StableHLO_UnaryElementwiseOp<"imag",
@@ -386,16 +341,7 @@ def StableHLO_LogOp: StableHLO_UnaryElementwiseOp<"log",
     [NoSideEffect, HLO_CompatibleOperandsAndResultType], HLO_FpOrComplexTensor> {
   let summary = "Logarithm operator";
   let description = [{
-    Returns `log(operand)` element-wise.
-
-    See
-    https://www.tensorflow.org/xla/operation_semantics#element-wise_unary_functions.
-
-    Example:
-
-    ```mlir
-    %0 = stablehlo.log %arg0 : tensor<2xf32>
-    ```
+    https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlolog
   }];
 }
 def StableHLO_Log1pOp: StableHLO_UnaryElementwiseOp<"log_plus_one",
@@ -418,32 +364,14 @@ def StableHLO_LogisticOp: StableHLO_UnaryElementwiseOp<"logistic",
     [NoSideEffect, HLO_CompatibleOperandsAndResultType], HLO_FpOrComplexTensor> {
   let summary = "Logistic operator";
   let description = [{
-    Returns `logistic(operand)` element-wise.
-
-    See
-    https://www.tensorflow.org/xla/operation_semantics#element-wise_unary_functions.
-
-    Example:
-
-    ```mlir
-    %0 = stablehlo.logistic %arg0 : tensor<2x2xf32>
-    ```
+    https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlologistic
   }];
 }
 def StableHLO_NotOp: StableHLO_UnaryElementwiseOp<"not",
     [NoSideEffect, HLO_CompatibleOperandsAndResultType], HLO_PredOrIntTensor> {
   let summary = "Not operator";
   let description = [{
-    Returns biwise-NOT of `operand` element-wise. The input tensor must be
-    of type integer `HLO_Int` or boolean `HLO_Pred`.
-
-    Note: For boolean tensor, the bitwise-NOT is equivalent to logical-NOT.
-
-    Example:
-
-    ```mlir
-    %0 = stablehlo.not %arg0 : tensor<5x3x1xi1>
-    ```
+    https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlonot
   }];
 }
 
@@ -451,16 +379,7 @@ def StableHLO_NegOp: StableHLO_UnaryElementwiseOp<"negate",
     [NoSideEffect, HLO_CompatibleOperandsAndResultType], HLO_IntFpOrComplexTensor> {
   let summary = "Negation operator";
   let description = [{
-    Returns `-operand` element-wise.
-
-    See
-    https://www.tensorflow.org/xla/operation_semantics#element-wise_unary_functions.
-
-    Example:
-
-    ```mlir
-    %0 = stablehlo.negate %arg0 : tensor<2x3xi32>
-    ```
+    https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlonegate
   }];
 }
 
@@ -535,16 +454,7 @@ def StableHLO_RsqrtOp: StableHLO_UnaryElementwiseOp<"rsqrt",
     [NoSideEffect, HLO_CompatibleOperandsAndResultType], HLO_FpOrComplexTensor> {
   let summary = "Reciprocal Square-root operator";
   let description = [{
-    Returns `1.0 / sqrt(operand)` element-wise.
-
-    See
-    https://www.tensorflow.org/xla/operation_semantics#element-wise_unary_functions.
-
-    Example:
-
-    ```mlir
-    %0 = stablehlo.rsqrt %arg0 : tensor<2xf32>
-    ```
+    https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlorsqrt
   }];
 }
 def StableHLO_SignOp: StableHLO_UnaryElementwiseOp<"sign",
@@ -577,16 +487,7 @@ def StableHLO_SineOp: StableHLO_UnaryElementwiseOp<"sine",
     [NoSideEffect, HLO_CompatibleOperandsAndResultType], HLO_FpOrComplexTensor> {
   let summary = "Sin operator";
   let description = [{
-    Returns `Sin(operand)` element-wise.
-
-    See
-    https://www.tensorflow.org/xla/operation_semantics#element-wise_unary_functions.
-
-    Example:
-
-    ```mlir
-    %0 = stablehlo.sine %arg0 : tensor<2xf32>
-    ```
+    https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlosine
   }];
 }
 
@@ -594,16 +495,7 @@ def StableHLO_SqrtOp: StableHLO_UnaryElementwiseOp<"sqrt",
     [NoSideEffect, HLO_CompatibleOperandsAndResultType], HLO_FpOrComplexTensor> {
   let summary = "Square-root operator";
   let description = [{
-    Returns `sqrt(operand)` element-wise.
-
-    See
-    https://www.tensorflow.org/xla/operation_semantics#element-wise_unary_functions.
-
-    Example:
-
-    ```mlir
-    %0 = stablehlo.sqrt %arg0 : tensor<2xf32>
-    ```
+    https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlosqrt
   }];
 }
 
@@ -612,16 +504,7 @@ def StableHLO_TanhOp: StableHLO_UnaryElementwiseOp<"tanh",
     HLO_FpOrComplexTensor> {
   let summary = "Tanh operator";
   let description = [{
-    Returns `tanh(operand)` element-wise.
-
-    See
-    https://www.tensorflow.org/xla/operation_semantics#element-wise_unary_functions.
-
-    Example:
-
-    ```mlir
-    %0 = stablehlo.tanh %arg0 : tensor<2xf32>
-    ```
+    https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlotanh
   }];
 }
 //===----------------------------------------------------------------------===//
@@ -662,17 +545,7 @@ def StableHLO_AddOp : StableHLO_BinaryElementwiseOp<"add",
       [Commutative, NoSideEffect, HLO_CompatibleOperandsAndResultType]> {
   let summary = "Addition operator";
   let description = [{
-    Returns `lhs + rhs` element-wise.
-
-    See
-    https://www.tensorflow.org/xla/operation_semantics#element-wise_binary_arithmetic_operations.
-
-    Example:
-
-    ```mlir
-    %0 = stablehlo.add %arg0, %arg1 : tensor<4xf32>
-    %1 = stablehlo.add %arg2, %arg3 : (tensor<4xf32, #CSR>, tensor<4xf32, #DCSR>) -> tensor<4xf32, #CSR>
-    ```
+    https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehloadd
   }];
 }
 
@@ -719,16 +592,7 @@ def StableHLO_DivOp : StableHLO_BinaryElementwiseOp<"divide",
       [NoSideEffect, HLO_CompatibleOperandsAndResultType]> {
   let summary = "Division operator";
   let description = [{
-    Returns `lhs / rhs` element-wise.
-
-    See
-    https://www.tensorflow.org/xla/operation_semantics#element-wise_binary_arithmetic_operations.
-
-    Example:
-
-    ```mlir
-    %0 = stablehlo.divide %arg0, %arg0 : tensor<2xi32>
-    ```
+    https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlodivide
   }];
 }
 
@@ -736,16 +600,7 @@ def StableHLO_MaxOp : StableHLO_BinaryElementwiseOp<"maximum",
       [Commutative, NoSideEffect, HLO_CompatibleOperandsAndResultType]> {
   let summary = "Maximum operator";
   let description = [{
-    Returns `max(lhs, rhs)` element-wise.
-
-    See
-    https://www.tensorflow.org/xla/operation_semantics#element-wise_binary_arithmetic_operations.
-
-    Example:
-
-    ```mlir
-    %0 = stablehlo.maximum %arg0, %arg1 : tensor<4xf32>
-    ```
+    https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlomaximum
   }];
 }
 
@@ -753,16 +608,7 @@ def StableHLO_MinOp : StableHLO_BinaryElementwiseOp<"minimum",
       [Commutative, NoSideEffect, HLO_CompatibleOperandsAndResultType]> {
   let summary = "Minimum operator";
   let description = [{
-    Returns `min(lhs, rhs)` element-wise.
-
-    See
-    https://www.tensorflow.org/xla/operation_semantics#element-wise_binary_arithmetic_operations.
-
-    Example:
-
-    ```mlir
-    %0 = stablehlo.minimum %arg0, %arg1 : tensor<4xf32>
-    ```
+    https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlominimum
   }];
 }
 
@@ -803,16 +649,7 @@ def StableHLO_RemOp : StableHLO_BinaryElementwiseOp<"remainder",
       [NoSideEffect, HLO_CompatibleOperandsAndResultType]> {
   let summary = "Remainder operator";
   let description = [{
-    Returns `lhs % rhs` element-wise.
-
-    See
-    https://www.tensorflow.org/xla/operation_semantics#element-wise_binary_arithmetic_operations.
-
-    Example:
-
-    ```mlir
-    %0 = stablehlo.remainder %arg0, %arg1 : (ensor<4xi64>
-    ```
+    https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehloremainder
   }];
 }
 
@@ -871,16 +708,7 @@ def StableHLO_SubtractOp : StableHLO_BinaryElementwiseOp<"subtract",
       [NoSideEffect, HLO_CompatibleOperandsAndResultType]> {
   let summary = "Subtraction operator";
   let description = [{
-    Returns `lhs - rhs` element-wise.
-
-    See
-    https://www.tensorflow.org/xla/operation_semantics#element-wise_binary_arithmetic_operations.
-
-    Example:
-
-    ```mlir
-    %0 = stablehlo.subtract %arg0, %arg0 : tensor<2xi32>
-    ```
+    https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlosubtract
   }];
 }
 
@@ -901,48 +729,21 @@ class StableHLO_BinaryBiwiseOrLogicalElementwiseOp<string mnemonic> :
 def StableHLO_AndOp: StableHLO_BinaryBiwiseOrLogicalElementwiseOp<"and"> {
   let summary = "And operator";
   let description = [{
-    Returns biwise-AND of `lhs` and `rhs` element-wise. The input tensors must
-    be of type integer `HLO_Int` or boolean `HLO_Pred`.
-
-    Note: For boolean tensor, the bitwise-AND is equivalent to logical-AND.
-
-    Example:
-
-    ```mlir
-    %0 = stablehlo.and %arg0, %arg1 : tensor<i1>
-    ```
+    https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehloand
   }];
 }
 
 def StableHLO_OrOp: StableHLO_BinaryBiwiseOrLogicalElementwiseOp<"or"> {
   let summary = "Or operator";
   let description = [{
-    Returns biwise-OR of `lhs` and `rhs` element-wise. The input tensors must
-    be of type integer `HLO_Int` or boolean `HLO_Pred`.
-
-    Note: For boolean tensor, the bitwise-OR is equivalent to logical-OR.
-
-    Example:
-
-    ```mlir
-    %0 = stablehlo.or %arg0, %arg1 : tensor<2xi1>
-    ```
+    https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehloor
   }];
 }
 
 def StableHLO_XorOp : StableHLO_BinaryBiwiseOrLogicalElementwiseOp<"xor"> {
   let summary = "Xor operator";
   let description = [{
-    Returns biwise-XOR of `lhs` and `rhs` element-wise. The input tensors must
-    be of type integer `HLO_Int` or boolean `HLO_Pred`.
-
-    Note: For boolean tensor, the bitwise-XOR is equivalent to logical-XOR.
-
-    Example:
-
-    ```mlir
-    %0 = stablehlo.xor %arg0, %arg1 : tensor<2xi32>
-    ```
+    https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehloxor
   }];
 }
 
@@ -2173,15 +1974,7 @@ def StableHLO_ReshapeOp: StableHLO_Op<"reshape",
       [NoSideEffect, SameOperandsAndResultElementType]> {
   let summary = "Reshape operator";
   let description = [{
-    Reshapes the dimensions of `operand` into a new configuration.
-
-    See https://www.tensorflow.org/xla/operation_semantics#reshape.
-
-    Example:
-
-    ```mlir
-    %0 = stablehlo.reshape %arg0 : (tensor<2xf32>) -> tensor<1x2xf32>
-    ```
+    https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehloreshape
   }];
 
   let arguments = (ins HLO_Tensor:$operand);
@@ -2438,11 +2231,7 @@ def StableHLO_TransposeOp: StableHLO_ShapedInterfaceOp<"transpose",
       DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
   let summary = "Transpose operator";
   let description = [{
-    Permutes the dimensions of `operand` according to the given `permutation`.
-
-    `res_dimensions[i] = operand_dimensions[permutation[i]]`
-
-    See https://www.tensorflow.org/xla/operation_semantics#transpose.
+    https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlotranspose
   }];
   let arguments = (ins
     HLO_Tensor:$operand,

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -72,7 +72,13 @@ def StableHLO_ConstantOp : StableHLO_Op<"constant",
     [ConstantLike, NoSideEffect, DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
   let summary = "Constant operator";
   let description = [{
+    Produces a `result` tensor from a constant `value`.
+
+    See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehloconstant
+
+    Example:
+    %0 = stablehlo.constant dense<[[0.0, 1.0], [2.0, 3.0]]> : tensor<2x2xf32>
   }];
   let arguments = (ins
     ElementsAttr:$value
@@ -195,7 +201,16 @@ def StableHLO_AbsOp: StableHLO_UnaryElementwiseOp<"abs",
      TensorOf<[HLO_SInt, HLO_Float, HLO_Complex]>> {
   let summary = "Absolute value operator";
   let description = [{
+    Performs element-wise absolute value of `operand` tensor and produces a
+    `result` tensor.
+
+    See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehloabs
+
+    Example:
+    ```mlir
+    %0 = stablehlo.abs %arg0 : tensor<3xi32>
+    ```
   }];
 }
 
@@ -215,13 +230,23 @@ def StableHLO_CbrtOp: StableHLO_UnaryElementwiseOp<"cbrt",
     ```
   }];
 }
+
 def StableHLO_CeilOp: StableHLO_UnaryElementwiseOp<"ceil",
     [NoSideEffect, HLO_CompatibleOperandsAndResultType], HLO_FpTensor> {
   let summary = "Ceil operator";
   let description = [{
+    Performs element-wise ceil of `operand` tensor and produces a `result` tensor.
+
+    See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehloceil
+
+    Example:
+    ```mlir
+    %0 = stablehlo.ceil %arg0 : tensor<2xf32>
+    ```
   }];
 }
+
 def StableHLO_ConvertOp : StableHLO_UnaryElementwiseOp<"convert",
     [NoSideEffect, SameOperandsAndResultShape], HLO_Tensor> {
   let summary = "Convert operator";
@@ -262,7 +287,17 @@ def StableHLO_CosineOp: StableHLO_UnaryElementwiseOp<"cosine",
     [NoSideEffect, HLO_CompatibleOperandsAndResultType], HLO_FpOrComplexTensor> {
   let summary = "Cos operator";
   let description = [{
+    Performs element-wise cosine operation on `operand` tensor and produces a
+    `result` tensor, implementing the `cos` operation from the IEEE-754
+    specification.
+
+    See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlocosine
+
+    Example:
+    ```mlir
+    %0 = stablehlo.cosine %arg0 : tensor<2xf32>
+    ```
   }];
 }
 
@@ -270,9 +305,19 @@ def StableHLO_ExpOp: StableHLO_UnaryElementwiseOp<"exponential",
     [NoSideEffect, HLO_CompatibleOperandsAndResultType], HLO_FpOrComplexTensor> {
   let summary = "Exponential operator";
   let description = [{
-    https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehloexp
+    Performs element-wise exponential operation on `operand` tensor and produces
+    a `result` tensor.
+
+    See:
+    https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehloexponential
+
+    Example:
+    ```mlir
+    %0 = stablehlo.exponential %arg0 : tensor<2xf32>
+    ```
   }];
 }
+
 def StableHLO_Expm1Op: StableHLO_UnaryElementwiseOp<"exponential_minus_one",
     [NoSideEffect, HLO_CompatibleOperandsAndResultType], HLO_FpOrComplexTensor> {
   let summary = "Exponential minus one operator";
@@ -289,13 +334,24 @@ def StableHLO_Expm1Op: StableHLO_UnaryElementwiseOp<"exponential_minus_one",
     ```
   }];
 }
+
 def StableHLO_FloorOp: StableHLO_UnaryElementwiseOp<"floor",
     [NoSideEffect, HLO_CompatibleOperandsAndResultType], HLO_FpTensor> {
   let summary = "Floor operator";
   let description = [{
+    Performs element-wise floor of `operand` tensor and produces a `result`
+    tensor.
+
+    See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlofloor
+
+    Example:
+    ```mlir
+    %0 = stablehlo.floor %arg0 : tensor<2xf32>
+    ```
   }];
 }
+
 def StableHLO_ImagOp: StableHLO_UnaryElementwiseOp<"imag",
     [NoSideEffect, DeclareOpInterfaceMethods<InferTypeOpInterface>],
     HLO_FpOrComplexTensor, HLO_FpTensor> {
@@ -341,9 +397,19 @@ def StableHLO_LogOp: StableHLO_UnaryElementwiseOp<"log",
     [NoSideEffect, HLO_CompatibleOperandsAndResultType], HLO_FpOrComplexTensor> {
   let summary = "Logarithm operator";
   let description = [{
+    Performs element-wise logarithm operation on `operand` tensor and produces a
+    `result` tensor.
+
+    See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlolog
+
+    Example:
+    ```mlir
+    %0 = stablehlo.log %arg0 : tensor<2xf32>
+    ```
   }];
 }
+
 def StableHLO_Log1pOp: StableHLO_UnaryElementwiseOp<"log_plus_one",
     [NoSideEffect, HLO_CompatibleOperandsAndResultType], HLO_FpOrComplexTensor> {
   let summary = "Log1p operator";
@@ -360,18 +426,38 @@ def StableHLO_Log1pOp: StableHLO_UnaryElementwiseOp<"log_plus_one",
     ```
   }];
 }
+
 def StableHLO_LogisticOp: StableHLO_UnaryElementwiseOp<"logistic",
     [NoSideEffect, HLO_CompatibleOperandsAndResultType], HLO_FpOrComplexTensor> {
   let summary = "Logistic operator";
   let description = [{
+    Performs element-wise logistic (sigmoid) function on `operand` tensor and
+    produces a `result` tensor.
+
+    See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlologistic
+
+    Example:
+    ```mlir
+    %0 = stablehlo.logistic %arg0 : tensor<2x2xf32>
+    ```
   }];
 }
+
 def StableHLO_NotOp: StableHLO_UnaryElementwiseOp<"not",
     [NoSideEffect, HLO_CompatibleOperandsAndResultType], HLO_PredOrIntTensor> {
   let summary = "Not operator";
   let description = [{
+    Performs element-wise bitwise NOT of tensor `operand` of type integer and
+    produces a `result` tensor.
+
+    See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlonot
+
+    Example:
+    ```mlir
+    %0 = stablehlo.not %arg0 : tensor<5x3x1xi1>
+    ```
   }];
 }
 
@@ -379,7 +465,16 @@ def StableHLO_NegOp: StableHLO_UnaryElementwiseOp<"negate",
     [NoSideEffect, HLO_CompatibleOperandsAndResultType], HLO_IntFpOrComplexTensor> {
   let summary = "Negation operator";
   let description = [{
+    Performs element-wise negation of `operand` tensor and produces a `result`
+    tensor.
+
+    See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlonegate
+
+    Example:
+    ```mlir
+    %0 = stablehlo.negate %arg0 : tensor<2x3xi32>
+    ```
   }];
 }
 
@@ -399,6 +494,7 @@ def StableHLO_PopulationCountOp: StableHLO_UnaryElementwiseOp<"popcnt",
     ```
   }];
 }
+
 def StableHLO_RealOp: StableHLO_UnaryElementwiseOp<"real",
     [NoSideEffect, DeclareOpInterfaceMethods<InferTypeOpInterface>],
     HLO_FpOrComplexTensor, HLO_FpTensor> {
@@ -454,9 +550,20 @@ def StableHLO_RsqrtOp: StableHLO_UnaryElementwiseOp<"rsqrt",
     [NoSideEffect, HLO_CompatibleOperandsAndResultType], HLO_FpOrComplexTensor> {
   let summary = "Reciprocal Square-root operator";
   let description = [{
+    Performs element-wise reciprocal square root operation on `operand` tensor
+    and produces a `result` tensor, implementing the `rSqrt` operation from the
+    IEEE-754 specification.
+
+    See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlorsqrt
+
+    Example:
+    ```mlir
+    %0 = stablehlo.rsqrt %arg0 : tensor<2xf32>
+    ```
   }];
 }
+
 def StableHLO_SignOp: StableHLO_UnaryElementwiseOp<"sign",
     [NoSideEffect, HLO_CompatibleOperandsAndResultType],
     TensorOf<[HLO_SInt, HLO_Float, HLO_Complex]>> {
@@ -487,7 +594,17 @@ def StableHLO_SineOp: StableHLO_UnaryElementwiseOp<"sine",
     [NoSideEffect, HLO_CompatibleOperandsAndResultType], HLO_FpOrComplexTensor> {
   let summary = "Sin operator";
   let description = [{
+    Performs element-wise sine operation on `operand` tensor and produces a
+    `result` tensor, implementing the `sin` operation from the IEEE-754
+    specification.
+
+    See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlosine
+
+    Example:
+    ```mlir
+    %0 = stablehlo.sine %arg0 : tensor<2xf32>
+    ```
   }];
 }
 
@@ -495,7 +612,17 @@ def StableHLO_SqrtOp: StableHLO_UnaryElementwiseOp<"sqrt",
     [NoSideEffect, HLO_CompatibleOperandsAndResultType], HLO_FpOrComplexTensor> {
   let summary = "Square-root operator";
   let description = [{
+    Performs element-wise square root operation on `operand` tensor and produces
+    a `result` tensor, implementing the `squareRoot` operation from the IEEE-754
+    specification.
+
+    See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlosqrt
+
+    Example:
+    ```mlir
+    %0 = stablehlo.sqrt %arg0 : tensor<2xf32>
+    ```
   }];
 }
 
@@ -504,9 +631,20 @@ def StableHLO_TanhOp: StableHLO_UnaryElementwiseOp<"tanh",
     HLO_FpOrComplexTensor> {
   let summary = "Tanh operator";
   let description = [{
+    Performs element-wise tanh operation on `operand` tensor and produces a
+    `result` tensor, implementing the `tanh` operation from the IEEE-754
+    specification.
+
+    See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlotanh
+
+    Example:
+    ```mlir
+    %0 = stablehlo.tanh %arg0 : tensor<2xf32>
+    ```
   }];
 }
+
 //===----------------------------------------------------------------------===//
 // StableHLO binary elementwise op definitions.
 //===----------------------------------------------------------------------===//
@@ -545,7 +683,16 @@ def StableHLO_AddOp : StableHLO_BinaryElementwiseOp<"add",
       [Commutative, NoSideEffect, HLO_CompatibleOperandsAndResultType]> {
   let summary = "Addition operator";
   let description = [{
+    Performs element-wise addition of two tensors `lhs` and `rhs` and produces a
+    `result` tensor.
+
+    See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehloadd
+
+    Example:
+    ```mlir
+    %0 = stablehlo.add %arg0, %arg1 : tensor<4xf32>
+    ```
   }];
 }
 
@@ -592,7 +739,16 @@ def StableHLO_DivOp : StableHLO_BinaryElementwiseOp<"divide",
       [NoSideEffect, HLO_CompatibleOperandsAndResultType]> {
   let summary = "Division operator";
   let description = [{
+    Performs element-wise division of dividend `lhs` and divisor `rhs` tensors
+    and produces a `result` tensor.
+
+    See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlodivide
+
+    Example:
+    ```mlir
+    %0 = stablehlo.divide %arg0, %arg0 : tensor<2xi32>
+    ```
   }];
 }
 
@@ -600,7 +756,16 @@ def StableHLO_MaxOp : StableHLO_BinaryElementwiseOp<"maximum",
       [Commutative, NoSideEffect, HLO_CompatibleOperandsAndResultType]> {
   let summary = "Maximum operator";
   let description = [{
+    Performs element-wise max operation on tensors `lhs` and `rhs` and produces
+    a `result` tensor.
+
+    See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlomaximum
+
+    Example:
+    ```mlir
+    %0 = stablehlo.maximum %arg0, %arg1 : tensor<4xf32>
+    ```
   }];
 }
 
@@ -608,7 +773,16 @@ def StableHLO_MinOp : StableHLO_BinaryElementwiseOp<"minimum",
       [Commutative, NoSideEffect, HLO_CompatibleOperandsAndResultType]> {
   let summary = "Minimum operator";
   let description = [{
+    Performs element-wise min operation on tensors `lhs` and `rhs` and produces a
+    `result` tensor.
+
+    See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlominimum
+
+    Example:
+    ```mlir
+    %0 = stablehlo.minimum %arg0, %arg1 : tensor<4xf32>
+    ```
   }];
 }
 
@@ -645,11 +819,21 @@ def StableHLO_PowOp : StableHLO_BinaryElementwiseOp<"power",
     ```
   }];
 }
+
 def StableHLO_RemOp : StableHLO_BinaryElementwiseOp<"remainder",
       [NoSideEffect, HLO_CompatibleOperandsAndResultType]> {
   let summary = "Remainder operator";
   let description = [{
+    Performs element-wise remainder of dividend `lhs` and divisor `rhs` tensors
+    and produces a `result` tensor.
+
+    See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehloremainder
+
+    Example:
+    ```mlir
+    %0 = stablehlo.remainder %arg0, %arg1 : (ensor<4xi64>
+    ```
   }];
 }
 
@@ -729,21 +913,48 @@ class StableHLO_BinaryBiwiseOrLogicalElementwiseOp<string mnemonic> :
 def StableHLO_AndOp: StableHLO_BinaryBiwiseOrLogicalElementwiseOp<"and"> {
   let summary = "And operator";
   let description = [{
+    Performs element-wise bitwise AND of two tensors `lhs` and `rhs` of integer
+    types and produces a `result` tensor.
+
+    See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehloand
+
+    Example:
+    ```mlir
+    %0 = stablehlo.and %arg0, %arg1 : tensor<i1>
+    ```
   }];
 }
 
 def StableHLO_OrOp: StableHLO_BinaryBiwiseOrLogicalElementwiseOp<"or"> {
   let summary = "Or operator";
   let description = [{
+    Performs element-wise bitwise OR of two tensors `lhs` and `rhs` of integer types
+    and produces a `result` tensor.
+
+    See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehloor
+
+    Example:
+    ```mlir
+    %0 = stablehlo.or %arg0, %arg1 : tensor<2xi1>
+    ```
   }];
 }
 
 def StableHLO_XorOp : StableHLO_BinaryBiwiseOrLogicalElementwiseOp<"xor"> {
   let summary = "Xor operator";
   let description = [{
+    Performs element-wise bitwise XOR of two tensors `lhs` and `rhs` of integer
+    types and produces a `result` tensor.
+
+    See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehloxor
+
+    Example:
+    ```mlir
+    %0 = stablehlo.xor %arg0, %arg1 : tensor<2xi32>
+    ```
   }];
 }
 


### PR DESCRIPTION
Updates the ODS description to include:
* One sentence description from the spec
* Link to the spec
* Pretty print syntax

The changes in `status.md` for Verification and Type Inference columns are also now in sync with the spec.