### PR TITLE
update spec of add, maximum, and minimum w.r.t supporting bool type

### DIFF
--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -252,7 +252,7 @@ of the following:
 
 For floating-point element types, it implements the `addition` operation from
 the IEEE-754 specification. For boolean element types, the behavior is same as
-[stablehlo.xor](#stablehloor).
+[stablehlo.or](#stablehloor).
 
 ### Operands
 
@@ -770,7 +770,7 @@ Performs element-wise max operation on tensors `lhs` and `rhs` and produces a
 `result` tensor. For floating-point element types, it implements the `maximum`
 operation from the IEEE-754 specification. For complex element type, it performs
 lexicographic comparison on the (real, imaginary) pairs with corner cases TBD.
-For boolean element types, it follows the order `true` > `false`.
+For boolean element types, the behavior is same as [stablehlo.or](#stablehloor).
 
 ### Operands
 
@@ -810,7 +810,8 @@ Performs element-wise min operation on tensors `lhs` and `rhs` and produces a
 `result` tensor. For floating-point element types, it implements the `minimum`
 operation from the IEEE-754 specification. For complex element type, it performs
 lexicographic comparison on the (real, imaginary) pairs with corner cases TBD.
-For boolean element types, it follows the order `true` > `false`.
+For boolean element types, the behavior is same as
+[stablehlo.and](#stablehloand).
 
 ### Operands
 

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -251,20 +251,21 @@ of the following:
   unsigned underflow).
 
 For floating-point element types, it implements the `addition` operation from
-the IEEE-754 specification.
+the IEEE-754 specification. For boolean element types, the behavior is same as
+[stablehlo.xor](#stablehloor).
 
 ### Operands
 
 | Name  | Type                                                        |
 |-------|-------------------------------------------------------------|
-| `lhs` | tensor of integer, floating-point, or complex element types |
-| `rhs` | tensor of integer, floating-point, or complex element types |
+| `lhs` | tensor of all supported element types |
+| `rhs` | tensor of all supported element types |
 
 ### Results
 
 | Name     | Type                                                        |
 |----------|-------------------------------------------------------------|
-| `result` | tensor of integer, floating-point, or complex element types |
+| `result` | tensor of all supported element types |
 
 ### Constraints
 
@@ -769,19 +770,20 @@ Performs element-wise max operation on tensors `lhs` and `rhs` and produces a
 `result` tensor. For floating-point element types, it implements the `maximum`
 operation from the IEEE-754 specification. For complex element type, it performs
 lexicographic comparison on the (real, imaginary) pairs with corner cases TBD.
+For boolean element types, it follows the order `true` > `false`.
 
 ### Operands
 
 | Name  | Type                                                        |
 |-------|-------------------------------------------------------------|
-| `lhs` | tensor of integer, floating-point, or complex element types |
-| `rhs` | tensor of integer, floating-point, or complex element types |
+| `lhs` | tensor of all supported element types |
+| `rhs` | tensor of all supported element types |
 
 ### Results
 
 | Name     | Type                                                        |
 |----------|-------------------------------------------------------------|
-| `result` | tensor of integer, floating-point, or complex element types |
+| `result` | tensor of all supported element types |
 
 ### Constraints
 
@@ -808,19 +810,20 @@ Performs element-wise min operation on tensors `lhs` and `rhs` and produces a
 `result` tensor. For floating-point element types, it implements the `minimum`
 operation from the IEEE-754 specification. For complex element type, it performs
 lexicographic comparison on the (real, imaginary) pairs with corner cases TBD.
+For boolean element types, it follows the order `true` > `false`.
 
 ### Operands
 
 | Name  | Type                                                        |
 |-------|-------------------------------------------------------------|
-| `lhs` | tensor of integer, floating-point, or complex element types |
-| `rhs` | tensor of integer, floating-point, or complex element types |
+| `lhs` | tensor of all supported element types |
+| `rhs` | tensor of all supported element types |
 
 ### Results
 
 | Name     | Type                                                        |
 |----------|-------------------------------------------------------------|
-| `result` | tensor of integer, floating-point, or complex element types |
+| `result` | tensor of all supported element types |
 
 ### Constraints
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -30,7 +30,7 @@ one of the following tracking labels.
 | StableHLO Op             | Specification | Verification |  Type Inference   |  Pretty Printing  | Interpreter |
 |:-------------------------|:-------------:|:------------:|:-----------------:|:-----------------:|:-----------:|
 | abs                      |      yes      |     yes      |       yes         |        yes        |     no      |
-| add                      |      yes      |     yes      |       yes         |        yes        |     no      |
+| add                      |      yes*     |     yes      |       yes         |        yes        |     no      |
 | add                      |      yes      |     yes      |       yes         |        yes        |     no      |
 | after_all                |      no       |      no      |        no         |        yes        |     no      |
 | all_gather               |      no       |     yes*     |        no         |        no         |     no      |

--- a/docs/status.md
+++ b/docs/status.md
@@ -30,7 +30,8 @@ one of the following tracking labels.
 | StableHLO Op             | Specification | Verification |  Type Inference   |  Pretty Printing  | Interpreter |
 |:-------------------------|:-------------:|:------------:|:-----------------:|:-----------------:|:-----------:|
 | abs                      |      yes      |     yes      |       yes         |        yes        |     no      |
-| add                      |      no       |     yes*     |       yes*        |        yes        |     yes     |
+| add                      |      yes      |     yes      |       yes         |        yes        |     no      |
+| add                      |      yes      |     yes      |       yes         |        yes        |     no      |
 | after_all                |      no       |      no      |        no         |        yes        |     no      |
 | all_gather               |      no       |     yes*     |        no         |        no         |     no      |
 | all_reduce               |      no       |      no      |        no         |        no         |     no      |
@@ -90,8 +91,8 @@ one of the following tracking labels.
 | log_plus_one             |      no       |     yes*     |       yes*        |        yes        |     no      |
 | logistic                 |      yes      |     yes      |        yes        |        yes        |     no      |
 | map                      |      no       |     yes*     |        no         |        no         |     no      |
-| maximum                  |      no       |     yes*     |       yes*        |        yes        |     yes     |
-| minimum                  |      no       |     yes*     |       yes*        |        yes        |     yes     |
+| maximum                  |      yes      |     yes      |       yes         |        yes        |     no      |
+| minimum                  |      yes      |     yes      |       yes         |        yes        |     no      |
 | multiply                 |      no       |     yes*     |       yes*        |        yes        |     no      |
 | negate                   |      yes      |     yes      |        yes        |        yes        |     yes     |
 | not                      |      yes      |     yes      |        yes        |        yes        |     no      |

--- a/docs/status.md
+++ b/docs/status.md
@@ -30,7 +30,7 @@ one of the following tracking labels.
 | StableHLO Op             | Specification | Verification |  Type Inference   |  Pretty Printing  | Interpreter |
 |:-------------------------|:-------------:|:------------:|:-----------------:|:-----------------:|:-----------:|
 | abs                      |      yes      |     yes      |       yes         |        yes        |     no      |
-| add                      |      yes*     |     yes      |       yes         |        yes        |     no      |
+| add                      |      yes      |     yes      |       yes         |        yes        |     no      |
 | add                      |      yes      |     yes      |       yes         |        yes        |     no      |
 | after_all                |      no       |      no      |        no         |        yes        |     no      |
 | all_gather               |      no       |     yes*     |        no         |        no         |     no      |


### PR DESCRIPTION
Partially solves https://github.com/openxla/stablehlo/issues/262 w.r.t the ops add, maximum, and minimum.
That way these ops will be aligned with the ODS and the HLO semantics. 