### PR TITLE
Fix lit checks with ops having implementation defined precision

### DIFF
--- a/stablehlo/tests/interpret_cosine.mlir
+++ b/stablehlo/tests/interpret_cosine.mlir
@@ -71,9 +71,9 @@ func.func @cosine_op_test_f64() -> tensor<11xf64> {
   // CHECK-NEXT: tensor<11xf64>
   // CHECK-NEXT: 1.000000e+00 : f64
   // CHECK-NEXT: 1.000000e+00 : f64
-  // CHECK-NEXT: 0.54030230586813977 : f64
-  // CHECK-NEXT: 0.992197667229329 : f64
-  // CHECK-NEXT: 0.99500416527802582 : f64
+  // CHECK-NEXT: 0.540302305868{{[0-9]+}} : f64
+  // CHECK-NEXT: 0.992197667229{{[0-9]+}} : f64
+  // CHECK-NEXT: 0.995004165278{{[0-9]+}} : f64
   // CHECK-NEXT: -1.000000e+00 : f64
   // CHECK-NEXT: 0xFFF8000000000000 : f64
   // CHECK-NEXT: 0xFFF8000000000000 : f64
@@ -102,6 +102,6 @@ func.func @cosine_op_test_c128() -> tensor<2xcomplex<f64>> {
   %1 = stablehlo.cosine %0 : tensor<2xcomplex<f64>>
   func.return %1 : tensor<2xcomplex<f64>>
   // CHECK-NEXT: tensor<2xcomplex<f64>>
-  // CHECK-NEXT: [0.43378099760770306 : f64, -6.0350486377665726 : f64]
-  // CHECK-NEXT: [-42.153773835602316 : f64, 15.786301507647636 : f64]
+  // CHECK-NEXT: [0.433780997607{{[0-9]+}} : f64, -6.035048637766{{[0-9]+}} : f64]
+  // CHECK-NEXT: [-42.153773835602{{[0-9]+}} : f64, 15.786301507647{{[0-9]+}} : f64]
 }

--- a/stablehlo/tests/interpret_sine.mlir
+++ b/stablehlo/tests/interpret_sine.mlir
@@ -72,9 +72,9 @@ func.func @sine_op_test_f64() -> tensor<11xf64> {
   // CHECK-NEXT: 0.000000e+00 : f64
   // CHECK-NEXT: -0.000000e+00 : f64
   // CHECK-NEXT: 0.8414709848078965 : f64
-  // CHECK-NEXT: 0.12467473338522769 : f64
-  // CHECK-NEXT: 0.099833416646828154 : f64
-  // CHECK-NEXT: 1.2246467991473532E-16 : f64
+  // CHECK-NEXT: 0.124674733385{{[0-9]+}} : f64
+  // CHECK-NEXT: 0.099833416646{{[0-9]+}} : f64
+  // CHECK-NEXT: 1.224646799147{{[0-9]+}}E-16 : f64
   // CHECK-NEXT: 0xFFF8000000000000 : f64
   // CHECK-NEXT: 0xFFF8000000000000 : f64
   // CHECK-NEXT: 0x7FFFFFFFFFFFFFFF : f64
@@ -102,6 +102,6 @@ func.func @sine_op_test_c128() -> tensor<2xcomplex<f64>> {
   %1 = stablehlo.sine %0 : tensor<2xcomplex<f64>>
   func.return %1 : tensor<2xcomplex<f64>>
   // CHECK-NEXT: tensor<2xcomplex<f64>>
-  // CHECK-NEXT: [6.1169280123693124 : f64, 0.42797453450615125 : f64]
-  // CHECK-NEXT: [-15.790198357309713 : f64, -42.143370741504995 : f64]
+  // CHECK-NEXT: [6.116928012369{{[0-9]+}} : f64, 0.427974534506{{[0-9]+}} : f64]
+  // CHECK-NEXT: [-15.790198357309{{[0-9]+}} : f64, -42.143370741504{{[0-9]+}} : f64]
 }

--- a/stablehlo/tests/interpret_tanh.mlir
+++ b/stablehlo/tests/interpret_tanh.mlir
@@ -71,10 +71,10 @@ func.func @tanh_op_test_f64() -> tensor<11xf64> {
   // CHECK-NEXT: tensor<11xf64>
   // CHECK-NEXT: 0.000000e+00 : f64
   // CHECK-NEXT: -0.000000e+00 : f64
-  // CHECK-NEXT: 0.76159415595576485 : f64
-  // CHECK-NEXT: 0.12435300177159619 : f64
-  // CHECK-NEXT: 0.099667994624955819 : f64
-  // CHECK-NEXT: 0.99627207622074998 : f64
+  // CHECK-NEXT: 0.761594155955{{[0-9]+}} : f64
+  // CHECK-NEXT: 0.124353001771{{[0-9]+}} : f64
+  // CHECK-NEXT: 0.099667994624{{[0-9]+}} : f64
+  // CHECK-NEXT: 0.996272076220{{[0-9]+}} : f64
   // CHECK-NEXT: 1.000000e+00 : f64
   // CHECK-NEXT: -1.000000e+00 : f64
   // CHECK-NEXT: 0x7FFFFFFFFFFFFFFF : f64
@@ -102,6 +102,6 @@ func.func @tanh_op_test_c128() -> tensor<2xcomplex<f64>> {
   %1 = stablehlo.tanh %0 : tensor<2xcomplex<f64>>
   func.return %1 : tensor<2xcomplex<f64>>
   // CHECK-NEXT: tensor<2xcomplex<f64>>
-  // CHECK-NEXT: [0.96778680215277412 : f64, -0.092637836268419898 : f64]
-  // CHECK-NEXT: [1.0016627850956348 : f64, 7.5285721538218659E-4 : f64]
+  // CHECK-NEXT: [0.967786802152{{[0-9]+}} : f64, -0.092637836268{{[0-9]+}} : f64]
+  // CHECK-NEXT: [1.001662785095{{[0-9]+}} : f64, 7.528572153821{{[0-9]+}}E-4 : f64]
 }


### PR DESCRIPTION
The current mode of testing the implementation is to use LLVM's lit-test framework to syntactically match the output of the operation with a (user provided) golden output. We do have some ops (like sine, cosine, tanh) which might produce results with implementation defined precision, failing the lit checks. 

To avoid that this PR allows the lit checks to match the accuracy up to 12 places after the decimal point. The number 12 is chosen   arbitrary but provides a descent approximation of the checked values.  