### PR TITLE
Unconditionally update `description` in op's ODS

### DIFF
--- a/docs/spec_checklist.md
+++ b/docs/spec_checklist.md
@@ -23,8 +23,8 @@ reviews:
          spec, check that the "Verification" and "Type Inference" columns in
          [status.md](https://github.com/openxla/stablehlo/blob/main/docs/status.md)
          say "yes".
-      1. ...and also update the `description` in op's ODS to link to the
-         corresponding section of the spec.
   1. Check whether the "Examples" section uses valid MLIR syntax by running
      `stablehlo-opt` on code examples.
   1. Check that the "Specification" column in status.md says "yes".
+  1. Check that the `description` in op's ODS links to the corresponding section
+     of the spec.


### PR DESCRIPTION
The current version of the checklist recommends to update `description` only if the implementation of the op conforms to the spec.

When I wrote that recommendation, it was deliberate. I thought that the process could be: 1) if the implementation doesn't conform don't update the description, 2) fix the tickets, 3) update the description.

But now I think that this simply introduces an extra step into the process (step number 3) without a good reason. If there's a spec for the op, it's already useful to make it part of documentation. And if there are some bugs in the implementation, that's fine as long as we have tickets for them.