### PR TITLE
Update CHLO to use prefixed accessors

### DIFF
--- a/stablehlo/dialect/ChloOps.td
+++ b/stablehlo/dialect/ChloOps.td
@@ -54,7 +54,7 @@ def CHLO_Dialect : Dialect {
     dialects.
   }];
 
-  let emitAccessorPrefix = kEmitAccessorPrefix_Both;
+  let emitAccessorPrefix = kEmitAccessorPrefix_Prefixed;
 }
 
 class CHLO_Op<string mnemonic, list<Trait> traits> :


### PR DESCRIPTION
Follows up on #203 to complete the migration of the StableHLO repository to kEmitAccessorPrefix_Prefixed.