### PR TITLE
Improve Python bindings for CHLO and StableHLO

### DIFF
--- a/stablehlo/integrations/c/ChloAttributes.cpp
+++ b/stablehlo/integrations/c/ChloAttributes.cpp
@@ -22,20 +22,19 @@ limitations under the License.
 //===----------------------------------------------------------------------===//
 
 MlirAttribute chloComparisonDirectionAttrGet(MlirContext ctx,
-                                             MlirStringRef direction) {
-  llvm::Optional<mlir::chlo::ComparisonDirection> compareDirection =
-      mlir::chlo::symbolizeComparisonDirection(unwrap(direction));
-  if (!compareDirection)
-    llvm_unreachable("Invalid comparison-direction specified.");
+                                             MlirStringRef value) {
+  llvm::Optional<mlir::chlo::ComparisonDirection> comparisonDirection =
+      mlir::chlo::symbolizeComparisonDirection(unwrap(value));
+  if (!comparisonDirection) llvm_unreachable("Invalid value.");
   return wrap(mlir::chlo::ComparisonDirectionAttr::get(
-      unwrap(ctx), compareDirection.value()));
+      unwrap(ctx), comparisonDirection.value()));
 }
 
 bool chloAttributeIsAComparisonDirectionAttr(MlirAttribute attr) {
   return unwrap(attr).isa<mlir::chlo::ComparisonDirectionAttr>();
 }
 
-MlirStringRef chloComparisonDirectionAttrGetDirection(MlirAttribute attr) {
+MlirStringRef chloComparisonDirectionAttrGetValue(MlirAttribute attr) {
   return wrap(mlir::chlo::stringifyComparisonDirection(
       unwrap(attr).cast<mlir::chlo::ComparisonDirectionAttr>().getValue()));
 }
@@ -44,19 +43,19 @@ MlirStringRef chloComparisonDirectionAttrGetDirection(MlirAttribute attr) {
 // ComparisonTypeAttr
 //===----------------------------------------------------------------------===//
 
-MlirAttribute chloComparisonTypeAttrGet(MlirContext ctx, MlirStringRef type) {
-  llvm::Optional<mlir::chlo::ComparisonType> compareType =
-      mlir::chlo::symbolizeComparisonType(unwrap(type));
-  if (!compareType) llvm_unreachable("Invalid comparison-type specified.");
+MlirAttribute chloComparisonTypeAttrGet(MlirContext ctx, MlirStringRef value) {
+  llvm::Optional<mlir::chlo::ComparisonType> comparisonType =
+      mlir::chlo::symbolizeComparisonType(unwrap(value));
+  if (!comparisonType) llvm_unreachable("Invalid value.");
   return wrap(
-      mlir::chlo::ComparisonTypeAttr::get(unwrap(ctx), compareType.value()));
+      mlir::chlo::ComparisonTypeAttr::get(unwrap(ctx), comparisonType.value()));
 }
 
 bool chloAttributeIsAComparisonTypeAttr(MlirAttribute attr) {
   return unwrap(attr).isa<mlir::chlo::ComparisonTypeAttr>();
 }
 
-MlirStringRef chloComparisonTypeAttrGetType(MlirAttribute attr) {
+MlirStringRef chloComparisonTypeAttrGetValue(MlirAttribute attr) {
   return wrap(mlir::chlo::stringifyComparisonType(
       unwrap(attr).cast<mlir::chlo::ComparisonTypeAttr>().getValue()));
 }

--- a/stablehlo/integrations/c/ChloAttributes.h
+++ b/stablehlo/integrations/c/ChloAttributes.h
@@ -27,25 +27,25 @@ extern "C" {
 //===----------------------------------------------------------------------===//
 
 MLIR_CAPI_EXPORTED MlirAttribute
-chloComparisonDirectionAttrGet(MlirContext ctx, MlirStringRef direction);
+chloComparisonDirectionAttrGet(MlirContext ctx, MlirStringRef value);
 
 MLIR_CAPI_EXPORTED bool chloAttributeIsAComparisonDirectionAttr(
     MlirAttribute attr);
 
 MLIR_CAPI_EXPORTED MlirStringRef
-chloComparisonDirectionAttrGetDirection(MlirAttribute attr);
+chloComparisonDirectionAttrGetValue(MlirAttribute attr);
 
 //===----------------------------------------------------------------------===//
 // ComparisonTypeAttr
 //===----------------------------------------------------------------------===//
 
 MLIR_CAPI_EXPORTED MlirAttribute chloComparisonTypeAttrGet(MlirContext ctx,
-                                                           MlirStringRef type);
+                                                           MlirStringRef value);
 
 MLIR_CAPI_EXPORTED bool chloAttributeIsAComparisonTypeAttr(MlirAttribute attr);
 
 MLIR_CAPI_EXPORTED MlirStringRef
-chloComparisonTypeAttrGetType(MlirAttribute attr);
+chloComparisonTypeAttrGetValue(MlirAttribute attr);
 
 #ifdef __cplusplus
 }

--- a/stablehlo/integrations/c/StablehloAttributes.cpp
+++ b/stablehlo/integrations/c/StablehloAttributes.cpp
@@ -356,20 +356,19 @@ int64_t stablehloConvDimensionNumbersGetOutputSpatialDimensionsElem(
 //===----------------------------------------------------------------------===//
 
 MlirAttribute stablehloComparisonDirectionAttrGet(MlirContext ctx,
-                                                  MlirStringRef direction) {
-  llvm::Optional<mlir::stablehlo::ComparisonDirection> compareDirection =
-      mlir::stablehlo::symbolizeComparisonDirection(unwrap(direction));
-  if (!compareDirection)
-    llvm_unreachable("Invalid comparison-direction specified.");
+                                                  MlirStringRef value) {
+  llvm::Optional<mlir::stablehlo::ComparisonDirection> comparisonDirection =
+      mlir::stablehlo::symbolizeComparisonDirection(unwrap(value));
+  if (!comparisonDirection) llvm_unreachable("Invalid value.");
   return wrap(mlir::stablehlo::ComparisonDirectionAttr::get(
-      unwrap(ctx), compareDirection.value()));
+      unwrap(ctx), comparisonDirection.value()));
 }
 
 bool stablehloAttributeIsAComparisonDirectionAttr(MlirAttribute attr) {
   return unwrap(attr).isa<mlir::stablehlo::ComparisonDirectionAttr>();
 }
 
-MlirStringRef stablehloComparisonDirectionAttrGetDirection(MlirAttribute attr) {
+MlirStringRef stablehloComparisonDirectionAttrGetValue(MlirAttribute attr) {
   return wrap(mlir::stablehlo::stringifyComparisonDirection(
       unwrap(attr)
           .cast<mlir::stablehlo::ComparisonDirectionAttr>()
@@ -381,19 +380,19 @@ MlirStringRef stablehloComparisonDirectionAttrGetDirection(MlirAttribute attr) {
 //===----------------------------------------------------------------------===//
 
 MlirAttribute stablehloComparisonTypeAttrGet(MlirContext ctx,
-                                             MlirStringRef type) {
-  llvm::Optional<mlir::stablehlo::ComparisonType> compareType =
-      mlir::stablehlo::symbolizeComparisonType(unwrap(type));
-  if (!compareType) llvm_unreachable("Invalid comparison-type specified.");
+                                             MlirStringRef value) {
+  llvm::Optional<mlir::stablehlo::ComparisonType> comparisonType =
+      mlir::stablehlo::symbolizeComparisonType(unwrap(value));
+  if (!comparisonType) llvm_unreachable("Invalid value.");
   return wrap(mlir::stablehlo::ComparisonTypeAttr::get(unwrap(ctx),
-                                                       compareType.value()));
+                                                       comparisonType.value()));
 }
 
 bool stablehloAttributeIsAComparisonTypeAttr(MlirAttribute attr) {
   return unwrap(attr).isa<mlir::stablehlo::ComparisonTypeAttr>();
 }
 
-MlirStringRef stablehloComparisonTypeAttrGetType(MlirAttribute attr) {
+MlirStringRef stablehloComparisonTypeAttrGetValue(MlirAttribute attr) {
   return wrap(mlir::stablehlo::stringifyComparisonType(
       unwrap(attr).cast<mlir::stablehlo::ComparisonTypeAttr>().getValue()));
 }
@@ -402,19 +401,19 @@ MlirStringRef stablehloComparisonTypeAttrGetType(MlirAttribute attr) {
 // PrecisionAttr
 //===----------------------------------------------------------------------===//
 
-MlirAttribute stablehloPrecisionAttrGet(MlirContext ctx, MlirStringRef type) {
-  llvm::Optional<mlir::stablehlo::Precision> precisionType =
-      mlir::stablehlo::symbolizePrecision(unwrap(type));
-  if (!precisionType) llvm_unreachable("Invalid precision-type specified.");
+MlirAttribute stablehloPrecisionAttrGet(MlirContext ctx, MlirStringRef value) {
+  llvm::Optional<mlir::stablehlo::Precision> precision =
+      mlir::stablehlo::symbolizePrecision(unwrap(value));
+  if (!precision) llvm_unreachable("Invalid value.");
   return wrap(
-      mlir::stablehlo::PrecisionAttr::get(unwrap(ctx), precisionType.value()));
+      mlir::stablehlo::PrecisionAttr::get(unwrap(ctx), precision.value()));
 }
 
 bool stablehloAttributeIsAPrecisionAttr(MlirAttribute attr) {
   return unwrap(attr).isa<mlir::stablehlo::PrecisionAttr>();
 }
 
-MlirStringRef stablehloPrecisionAttrGetPrecision(MlirAttribute attr) {
+MlirStringRef stablehloPrecisionAttrGetValue(MlirAttribute attr) {
   return wrap(mlir::stablehlo::stringifyPrecision(
       unwrap(attr).cast<mlir::stablehlo::PrecisionAttr>().getValue()));
 }
@@ -423,10 +422,10 @@ MlirStringRef stablehloPrecisionAttrGetPrecision(MlirAttribute attr) {
 // FftTypeAttr
 //===----------------------------------------------------------------------===//
 
-MlirAttribute stablehloFftTypeAttrGet(MlirContext ctx, MlirStringRef type) {
+MlirAttribute stablehloFftTypeAttrGet(MlirContext ctx, MlirStringRef value) {
   llvm::Optional<mlir::stablehlo::FftType> fftType =
-      mlir::stablehlo::symbolizeFftType(unwrap(type));
-  if (!fftType) llvm_unreachable("Invalid fft-type specified.");
+      mlir::stablehlo::symbolizeFftType(unwrap(value));
+  if (!fftType) llvm_unreachable("Invalid value.");
   return wrap(mlir::stablehlo::FftTypeAttr::get(unwrap(ctx), fftType.value()));
 }
 
@@ -434,7 +433,7 @@ bool stablehloAttributeIsAFftTypeAttr(MlirAttribute attr) {
   return unwrap(attr).isa<mlir::stablehlo::FftTypeAttr>();
 }
 
-MlirStringRef stablehloFftTypeAttrGetFftType(MlirAttribute attr) {
+MlirStringRef stablehloFftTypeAttrGetValue(MlirAttribute attr) {
   return wrap(mlir::stablehlo::stringifyFftType(
       unwrap(attr).cast<mlir::stablehlo::FftTypeAttr>().getValue()));
 }
@@ -443,19 +442,19 @@ MlirStringRef stablehloFftTypeAttrGetFftType(MlirAttribute attr) {
 // TransposeAttr
 //===----------------------------------------------------------------------===//
 
-MlirAttribute stablehloTransposeAttrGet(MlirContext ctx, MlirStringRef type) {
-  llvm::Optional<mlir::stablehlo::Transpose> transposeType =
-      mlir::stablehlo::symbolizeTranspose(unwrap(type));
-  if (!transposeType) llvm_unreachable("Invalid transpose-type specified.");
+MlirAttribute stablehloTransposeAttrGet(MlirContext ctx, MlirStringRef value) {
+  llvm::Optional<mlir::stablehlo::Transpose> transpose =
+      mlir::stablehlo::symbolizeTranspose(unwrap(value));
+  if (!transpose) llvm_unreachable("Invalid value.");
   return wrap(
-      mlir::stablehlo::TransposeAttr::get(unwrap(ctx), transposeType.value()));
+      mlir::stablehlo::TransposeAttr::get(unwrap(ctx), transpose.value()));
 }
 
 bool stablehloAttributeIsATransposeAttr(MlirAttribute attr) {
   return unwrap(attr).isa<mlir::stablehlo::TransposeAttr>();
 }
 
-MlirStringRef stablehloTransposeAttrGetTranspose(MlirAttribute attr) {
+MlirStringRef stablehloTransposeAttrGetValue(MlirAttribute attr) {
   return wrap(mlir::stablehlo::stringifyTranspose(
       unwrap(attr).cast<mlir::stablehlo::TransposeAttr>().getValue()));
 }
@@ -465,10 +464,10 @@ MlirStringRef stablehloTransposeAttrGetTranspose(MlirAttribute attr) {
 //===----------------------------------------------------------------------===//
 
 MlirAttribute stablehloRngDistributionAttrGet(MlirContext ctx,
-                                              MlirStringRef distribution) {
+                                              MlirStringRef value) {
   llvm::Optional<mlir::stablehlo::RngDistribution> rngDistribution =
-      mlir::stablehlo::symbolizeRngDistribution(unwrap(distribution));
-  if (!rngDistribution) llvm_unreachable("Invalid rng-distribution specified.");
+      mlir::stablehlo::symbolizeRngDistribution(unwrap(value));
+  if (!rngDistribution) llvm_unreachable("Invalid value.");
   return wrap(mlir::stablehlo::RngDistributionAttr::get(
       unwrap(ctx), rngDistribution.value()));
 }
@@ -477,8 +476,7 @@ bool stablehloAttributeIsARngDistributionAttr(MlirAttribute attr) {
   return unwrap(attr).isa<mlir::stablehlo::RngDistributionAttr>();
 }
 
-MlirStringRef stablehloRngDistributionAttrGetRngDistribution(
-    MlirAttribute attr) {
+MlirStringRef stablehloRngDistributionAttrGetValue(MlirAttribute attr) {
   return wrap(mlir::stablehlo::stringifyRngDistribution(
       unwrap(attr).cast<mlir::stablehlo::RngDistributionAttr>().getValue()));
 }
@@ -488,10 +486,10 @@ MlirStringRef stablehloRngDistributionAttrGetRngDistribution(
 //===----------------------------------------------------------------------===//
 
 MlirAttribute stablehloRngAlgorithmAttrGet(MlirContext ctx,
-                                           MlirStringRef algorithm) {
+                                           MlirStringRef value) {
   llvm::Optional<mlir::stablehlo::RngAlgorithm> rngAlgorithm =
-      mlir::stablehlo::symbolizeRngAlgorithm(unwrap(algorithm));
-  if (!rngAlgorithm) llvm_unreachable("Invalid rng-algorithm specified.");
+      mlir::stablehlo::symbolizeRngAlgorithm(unwrap(value));
+  if (!rngAlgorithm) llvm_unreachable("Invalid value.");
   return wrap(mlir::stablehlo::RngAlgorithmAttr::get(unwrap(ctx),
                                                      rngAlgorithm.value()));
 }
@@ -500,7 +498,7 @@ bool stablehloAttributeIsARngAlgorithmAttr(MlirAttribute attr) {
   return unwrap(attr).isa<mlir::stablehlo::RngAlgorithmAttr>();
 }
 
-MlirStringRef stablehloRngAlgorithmAttrGetRngAlgorithm(MlirAttribute attr) {
+MlirStringRef stablehloRngAlgorithmAttrGetValue(MlirAttribute attr) {
   return wrap(mlir::stablehlo::stringifyRngAlgorithm(
       unwrap(attr).cast<mlir::stablehlo::RngAlgorithmAttr>().getValue()));
 }

--- a/stablehlo/integrations/c/StablehloAttributes.h
+++ b/stablehlo/integrations/c/StablehloAttributes.h
@@ -174,88 +174,88 @@ stablehloConvDimensionNumbersGetOutputSpatialDimensionsElem(MlirAttribute attr,
 //===----------------------------------------------------------------------===//
 
 MLIR_CAPI_EXPORTED MlirAttribute
-stablehloComparisonDirectionAttrGet(MlirContext ctx, MlirStringRef direction);
+stablehloComparisonDirectionAttrGet(MlirContext ctx, MlirStringRef value);
 
 MLIR_CAPI_EXPORTED bool stablehloAttributeIsAComparisonDirectionAttr(
     MlirAttribute attr);
 
 MLIR_CAPI_EXPORTED MlirStringRef
-stablehloComparisonDirectionAttrGetDirection(MlirAttribute attr);
+stablehloComparisonDirectionAttrGetValue(MlirAttribute attr);
 
 //===----------------------------------------------------------------------===//
 // ComparisonTypeAttr
 //===----------------------------------------------------------------------===//
 
 MLIR_CAPI_EXPORTED MlirAttribute
-stablehloComparisonTypeAttrGet(MlirContext ctx, MlirStringRef type);
+stablehloComparisonTypeAttrGet(MlirContext ctx, MlirStringRef value);
 
 MLIR_CAPI_EXPORTED bool stablehloAttributeIsAComparisonTypeAttr(
     MlirAttribute attr);
 
 MLIR_CAPI_EXPORTED MlirStringRef
-stablehloComparisonTypeAttrGetType(MlirAttribute attr);
+stablehloComparisonTypeAttrGetValue(MlirAttribute attr);
 
 //===----------------------------------------------------------------------===//
 // PrecisionAttr
 //===----------------------------------------------------------------------===//
 
 MLIR_CAPI_EXPORTED MlirAttribute stablehloPrecisionAttrGet(MlirContext ctx,
-                                                           MlirStringRef type);
+                                                           MlirStringRef value);
 
 MLIR_CAPI_EXPORTED bool stablehloAttributeIsAPrecisionAttr(MlirAttribute attr);
 
 MLIR_CAPI_EXPORTED MlirStringRef
-stablehloPrecisionAttrGetPrecision(MlirAttribute attr);
+stablehloPrecisionAttrGetValue(MlirAttribute attr);
 
 //===----------------------------------------------------------------------===//
 // FftTypeAttr
 //===----------------------------------------------------------------------===//
 
 MLIR_CAPI_EXPORTED MlirAttribute stablehloFftTypeAttrGet(MlirContext ctx,
-                                                         MlirStringRef type);
+                                                         MlirStringRef value);
 
 MLIR_CAPI_EXPORTED bool stablehloAttributeIsAFftTypeAttr(MlirAttribute attr);
 
 MLIR_CAPI_EXPORTED MlirStringRef
-stablehloFftTypeAttrGetFftType(MlirAttribute attr);
+stablehloFftTypeAttrGetValue(MlirAttribute attr);
 
 //===----------------------------------------------------------------------===//
 // TransposeAttr
 //===----------------------------------------------------------------------===//
 
 MLIR_CAPI_EXPORTED MlirAttribute stablehloTransposeAttrGet(MlirContext ctx,
-                                                           MlirStringRef type);
+                                                           MlirStringRef value);
 
 MLIR_CAPI_EXPORTED bool stablehloAttributeIsATransposeAttr(MlirAttribute attr);
 
 MLIR_CAPI_EXPORTED MlirStringRef
-stablehloTransposeAttrGetTranspose(MlirAttribute attr);
+stablehloTransposeAttrGetValue(MlirAttribute attr);
 
 //===----------------------------------------------------------------------===//
 // RngDistributionAttr
 //===----------------------------------------------------------------------===//
 
 MLIR_CAPI_EXPORTED MlirAttribute
-stablehloRngDistributionAttrGet(MlirContext ctx, MlirStringRef distribution);
+stablehloRngDistributionAttrGet(MlirContext ctx, MlirStringRef value);
 
 MLIR_CAPI_EXPORTED bool stablehloAttributeIsARngDistributionAttr(
     MlirAttribute attr);
 
 MLIR_CAPI_EXPORTED MlirStringRef
-stablehloRngDistributionAttrGetRngDistribution(MlirAttribute attr);
+stablehloRngDistributionAttrGetValue(MlirAttribute attr);
 
 //===----------------------------------------------------------------------===//
 // RngAlgorithmAttr
 //===----------------------------------------------------------------------===//
 
 MLIR_CAPI_EXPORTED MlirAttribute
-stablehloRngAlgorithmAttrGet(MlirContext ctx, MlirStringRef algorithm);
+stablehloRngAlgorithmAttrGet(MlirContext ctx, MlirStringRef value);
 
 MLIR_CAPI_EXPORTED bool stablehloAttributeIsARngAlgorithmAttr(
     MlirAttribute attr);
 
 MLIR_CAPI_EXPORTED MlirStringRef
-stablehloRngAlgorithmAttrGetRngAlgorithm(MlirAttribute attr);
+stablehloRngAlgorithmAttrGetValue(MlirAttribute attr);
 
 //===----------------------------------------------------------------------===//
 // ChannelHandle

--- a/stablehlo/integrations/python/ChloModule.cpp
+++ b/stablehlo/integrations/python/ChloModule.cpp
@@ -52,29 +52,27 @@ PYBIND11_MODULE(_chlo, m) {
       m, "ComparisonDirectionAttr", chloAttributeIsAComparisonDirectionAttr)
       .def_classmethod(
           "get",
-          [](py::object cls, const std::string &direction, MlirContext ctx) {
+          [](py::object cls, const std::string &value, MlirContext ctx) {
             return cls(chloComparisonDirectionAttrGet(
-                ctx, mlirStringRefCreate(direction.c_str(), direction.size())));
+                ctx, mlirStringRefCreate(value.c_str(), value.size())));
           },
-          py::arg("cls"), py::arg("comparison_direction"),
-          py::arg("context") = py::none(),
-          "Creates a ComparisonDirection attribute with the given direction.")
-      .def_property_readonly("comparison_direction", [](MlirAttribute self) {
-        return toPyString(chloComparisonDirectionAttrGetDirection(self));
+          py::arg("cls"), py::arg("value"), py::arg("context") = py::none(),
+          "Creates a ComparisonDirection attribute with the given value.")
+      .def_property_readonly("value", [](MlirAttribute self) {
+        return toPyString(chloComparisonDirectionAttrGetValue(self));
       });
 
   mlir::python::adaptors::mlir_attribute_subclass(
       m, "ComparisonTypeAttr", chloAttributeIsAComparisonTypeAttr)
       .def_classmethod(
           "get",
-          [](py::object cls, const std::string &type, MlirContext ctx) {
+          [](py::object cls, const std::string &value, MlirContext ctx) {
             return cls(chloComparisonTypeAttrGet(
-                ctx, mlirStringRefCreate(type.c_str(), type.size())));
+                ctx, mlirStringRefCreate(value.c_str(), value.size())));
           },
-          py::arg("cls"), py::arg("comparison_type"),
-          py::arg("context") = py::none(),
-          "Creates a ComparisonType attribute with the given type.")
-      .def_property_readonly("comparison_type", [](MlirAttribute self) {
-        return toPyString(chloComparisonTypeAttrGetType(self));
+          py::arg("cls"), py::arg("value"), py::arg("context") = py::none(),
+          "Creates a ComparisonType attribute with the given value.")
+      .def_property_readonly("value", [](MlirAttribute self) {
+        return toPyString(chloComparisonTypeAttrGetValue(self));
       });
 }

--- a/stablehlo/integrations/python/StablehloModule.cpp
+++ b/stablehlo/integrations/python/StablehloModule.cpp
@@ -311,109 +311,98 @@ PYBIND11_MODULE(_stablehlo, m) {
       stablehloAttributeIsAComparisonDirectionAttr)
       .def_classmethod(
           "get",
-          [](py::object cls, const std::string &direction, MlirContext ctx) {
+          [](py::object cls, const std::string &value, MlirContext ctx) {
             return cls(stablehloComparisonDirectionAttrGet(
-                ctx, mlirStringRefCreate(direction.c_str(), direction.size())));
+                ctx, mlirStringRefCreate(value.c_str(), value.size())));
           },
-          py::arg("cls"), py::arg("comparison_direction"),
-          py::arg("context") = py::none(),
-          "Creates a ComparisonDirection attribute with the given direction.")
-      .def_property_readonly("comparison_direction", [](MlirAttribute self) {
-        return toPyString(stablehloComparisonDirectionAttrGetDirection(self));
+          py::arg("cls"), py::arg("value"), py::arg("context") = py::none(),
+          "Creates a ComparisonDirection attribute with the given value.")
+      .def_property_readonly("value", [](MlirAttribute self) {
+        return toPyString(stablehloComparisonDirectionAttrGetValue(self));
       });
 
   mlir::python::adaptors::mlir_attribute_subclass(
       m, "ComparisonTypeAttr", stablehloAttributeIsAComparisonTypeAttr)
       .def_classmethod(
           "get",
-          [](py::object cls, const std::string &type, MlirContext ctx) {
+          [](py::object cls, const std::string &value, MlirContext ctx) {
             return cls(stablehloComparisonTypeAttrGet(
-                ctx, mlirStringRefCreate(type.c_str(), type.size())));
+                ctx, mlirStringRefCreate(value.c_str(), value.size())));
           },
-          py::arg("cls"), py::arg("comparison_type"),
-          py::arg("context") = py::none(),
-          "Creates a ComparisonType attribute with the given type.")
-      .def_property_readonly("comparison_type", [](MlirAttribute self) {
-        return toPyString(stablehloComparisonTypeAttrGetType(self));
+          py::arg("cls"), py::arg("value"), py::arg("context") = py::none(),
+          "Creates a ComparisonType attribute with the given value.")
+      .def_property_readonly("value", [](MlirAttribute self) {
+        return toPyString(stablehloComparisonTypeAttrGetValue(self));
       });
 
   mlir::python::adaptors::mlir_attribute_subclass(
       m, "PrecisionAttr", stablehloAttributeIsAPrecisionAttr)
       .def_classmethod(
           "get",
-          [](py::object cls, const std::string &type, MlirContext ctx) {
+          [](py::object cls, const std::string &value, MlirContext ctx) {
             return cls(stablehloPrecisionAttrGet(
-                ctx, mlirStringRefCreate(type.c_str(), type.size())));
+                ctx, mlirStringRefCreate(value.c_str(), value.size())));
           },
-          py::arg("cls"), py::arg("precision_type"),
-          py::arg("context") = py::none(),
-          "Creates a Precision attribute with the given type.")
-      .def_property_readonly("precision_type", [](MlirAttribute self) {
-        return toPyString(stablehloPrecisionAttrGetPrecision(self));
+          py::arg("cls"), py::arg("value"), py::arg("context") = py::none(),
+          "Creates a Precision attribute with the given value.")
+      .def_property_readonly("value", [](MlirAttribute self) {
+        return toPyString(stablehloPrecisionAttrGetValue(self));
       });
 
   mlir::python::adaptors::mlir_attribute_subclass(
       m, "FftTypeAttr", stablehloAttributeIsAFftTypeAttr)
       .def_classmethod(
           "get",
-          [](py::object cls, const std::string &type, MlirContext ctx) {
+          [](py::object cls, const std::string &value, MlirContext ctx) {
             return cls(stablehloFftTypeAttrGet(
-                ctx, mlirStringRefCreate(type.c_str(), type.size())));
+                ctx, mlirStringRefCreate(value.c_str(), value.size())));
           },
-          py::arg("cls"), py::arg("fft_type"), py::arg("context") = py::none(),
-          "Creates a FftType attribute with the given type.")
-      .def_property_readonly("fft_type", [](MlirAttribute self) {
-        return toPyString(stablehloFftTypeAttrGetFftType(self));
+          py::arg("cls"), py::arg("value"), py::arg("context") = py::none(),
+          "Creates a FftType attribute with the given value.")
+      .def_property_readonly("value", [](MlirAttribute self) {
+        return toPyString(stablehloFftTypeAttrGetValue(self));
       });
 
   mlir::python::adaptors::mlir_attribute_subclass(
       m, "TransposeAttr", stablehloAttributeIsATransposeAttr)
       .def_classmethod(
           "get",
-          [](py::object cls, const std::string &type, MlirContext ctx) {
+          [](py::object cls, const std::string &value, MlirContext ctx) {
             return cls(stablehloTransposeAttrGet(
-                ctx, mlirStringRefCreate(type.c_str(), type.size())));
+                ctx, mlirStringRefCreate(value.c_str(), value.size())));
           },
-          py::arg("cls"), py::arg("transpose_type"),
-          py::arg("context") = py::none(),
-          "Creates a Transpose attribute with the given type.")
-      .def_property_readonly("transpose_type", [](MlirAttribute self) {
-        return toPyString(stablehloTransposeAttrGetTranspose(self));
+          py::arg("cls"), py::arg("value"), py::arg("context") = py::none(),
+          "Creates a Transpose attribute with the given value.")
+      .def_property_readonly("value", [](MlirAttribute self) {
+        return toPyString(stablehloTransposeAttrGetValue(self));
       });
 
   mlir::python::adaptors::mlir_attribute_subclass(
       m, "RngDistributionAttr", stablehloAttributeIsARngDistributionAttr)
       .def_classmethod(
           "get",
-          [](py::object cls, const std::string &distribution, MlirContext ctx) {
+          [](py::object cls, const std::string &value, MlirContext ctx) {
             return cls(stablehloRngDistributionAttrGet(
-                ctx, mlirStringRefCreate(distribution.c_str(),
-                                         distribution.size())));
+                ctx, mlirStringRefCreate(value.c_str(), value.size())));
           },
-          py::arg("cls"), py::arg("rng_distribution"),
-          py::arg("context") = py::none(),
-          "Creates a RngDistribution attribute with the given rng "
-          "distribution.")
-      .def_property_readonly("rng_distribution", [](MlirAttribute self) {
-        auto distribution =
-            stablehloRngDistributionAttrGetRngDistribution(self);
-        return py::str(distribution.data, distribution.length);
+          py::arg("cls"), py::arg("value"), py::arg("context") = py::none(),
+          "Creates a RngDistribution attribute with the given value.")
+      .def_property_readonly("value", [](MlirAttribute self) {
+        return toPyString(stablehloRngDistributionAttrGetValue(self));
       });
 
   mlir::python::adaptors::mlir_attribute_subclass(
       m, "RngAlgorithmAttr", stablehloAttributeIsARngAlgorithmAttr)
       .def_classmethod(
           "get",
-          [](py::object cls, const std::string &algorithm, MlirContext ctx) {
+          [](py::object cls, const std::string &value, MlirContext ctx) {
             return cls(stablehloRngAlgorithmAttrGet(
-                ctx, mlirStringRefCreate(algorithm.c_str(), algorithm.size())));
+                ctx, mlirStringRefCreate(value.c_str(), value.size())));
           },
-          py::arg("cls"), py::arg("rng_algorithm"),
-          py::arg("context") = py::none(),
-          "Creates a RngAlgorithm attribute with the given rng algorithm.")
-      .def_property_readonly("rng_algorithm", [](MlirAttribute self) {
-        auto algorithm = stablehloRngAlgorithmAttrGetRngAlgorithm(self);
-        return py::str(algorithm.data, algorithm.length);
+          py::arg("cls"), py::arg("value"), py::arg("context") = py::none(),
+          "Creates a RngAlgorithm attribute with the given value.")
+      .def_property_readonly("value", [](MlirAttribute self) {
+        return toPyString(stablehloRngAlgorithmAttrGetValue(self));
       });
 
   mlir::python::adaptors::mlir_attribute_subclass(
@@ -429,6 +418,8 @@ PYBIND11_MODULE(_stablehlo, m) {
                              [](MlirAttribute self) {
                                return stablehloChannelHandleGetHandle(self);
                              })
+      // We cannot call this "type" to match how this is called on the C++ side,
+      // because `type` is already defined in the superclass.
       .def_property_readonly("channel_type", [](MlirAttribute self) {
         return stablehloChannelHandleGetType(self);
       });

--- a/stablehlo/integrations/python/mlir/dialects/stablehlo.py
+++ b/stablehlo/integrations/python/mlir/dialects/stablehlo.py
@@ -16,8 +16,4 @@
 
 # pylint: disable=wildcard-import,relative-beyond-top-level,g-import-not-at-top
 from ._stablehlo_ops_gen import *
-
-
-def register_dialect(context, load=True):
-  from .._mlir_libs import _stablehlo
-  _stablehlo.register_dialect(context, load=load)
+from .._mlir_libs._stablehlo import *

--- a/stablehlo/integrations/python/tests/CMakeLists.txt
+++ b/stablehlo/integrations/python/tests/CMakeLists.txt
@@ -24,6 +24,8 @@ add_custom_target(${test_name}
 add_dependencies(check-stablehlo-python ${test_name})
 endfunction()
 
+add_stablehlo_python_test(stablehlo-python-chlo chlo.py)
 add_stablehlo_python_test(stablehlo-python-smoketest smoketest.py)
+add_stablehlo_python_test(stablehlo-python-stablehlo stablehlo.py)
 
 add_dependencies(check-stablehlo check-stablehlo-python)

--- a/stablehlo/integrations/python/tests/chlo.py
+++ b/stablehlo/integrations/python/tests/chlo.py
@@ -13,12 +13,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+"""Tests for CHLO Python APIs."""
 
-# pylint: disable=wildcard-import,relative-beyond-top-level,g-import-not-at-top
-from ._chlo_ops_gen import *
-from .._mlir_libs._chlo import *
+# pylint: disable=wildcard-import,undefined-variable
+
+from mlir import ir
+from mlir.dialects import chlo
 
 
-# Backward compatibility with the old way of registering CHLO dialect
-def register_chlo_dialect(context, load=True):
-  register_dialect(context, load)
+def run(f):
+  with ir.Context() as context:
+    chlo.register_dialect(context)
+    f()
+  return f
+
+
+@run
+def test_comparison_direction_attr():
+  attr = chlo.ComparisonDirectionAttr.get("EQ")
+  assert attr is not None
+  assert str(attr) == ("#chlo<comparison_direction EQ>")
+  assert attr.value == "EQ"
+
+
+@run
+def test_comparison_type_attr():
+  attr = chlo.ComparisonTypeAttr.get("FLOAT")
+  assert attr is not None
+  assert str(attr) == ("#chlo<comparison_type FLOAT>")
+  assert attr.value == "FLOAT"

--- a/stablehlo/integrations/python/tests/stablehlo.py
+++ b/stablehlo/integrations/python/tests/stablehlo.py
@@ -1,0 +1,186 @@
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2022 The StableHLO Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for StableHLO Python APIs."""
+
+# pylint: disable=wildcard-import,undefined-variable
+
+from mlir import ir
+from mlir.dialects import stablehlo
+
+
+def run(f):
+  with ir.Context() as context:
+    stablehlo.register_dialect(context)
+    f()
+  return f
+
+
+@run
+def test_channel_handle():
+  attr = stablehlo.ChannelHandle.get(handle=1, type=2)
+  assert attr is not None
+  assert attr.handle == 1
+  assert attr.channel_type == 2
+
+
+@run
+def test_comparison_direction_attr():
+  attr = stablehlo.ComparisonDirectionAttr.get("EQ")
+  assert attr is not None
+  assert str(attr) == ("#stablehlo<comparison_direction EQ>")
+  assert attr.value == "EQ"
+
+
+@run
+def test_comparison_type_attr():
+  attr = stablehlo.ComparisonTypeAttr.get("FLOAT")
+  assert attr is not None
+  assert str(attr) == ("#stablehlo<comparison_type FLOAT>")
+  assert attr.value == "FLOAT"
+
+
+@run
+def test_conv_dimension_numbers():
+  attr = stablehlo.ConvDimensionNumbers.get(
+      input_batch_dimension=0,
+      input_feature_dimension=1,
+      input_spatial_dimensions=[2, 3, 4],
+      kernel_input_feature_dimension=0,
+      kernel_output_feature_dimension=1,
+      kernel_spatial_dimensions=[2, 3],
+      output_batch_dimension=0,
+      output_feature_dimension=1,
+      output_spatial_dimensions=[2, 3])
+  assert str(attr) == ("#stablehlo.conv<[b, f, 0, 1, 2]x[i, o, 0, 1]->"
+                       "[b, f, 0, 1]>")
+  assert attr is not None
+  assert attr.input_batch_dimension == 0
+  assert attr.input_feature_dimension == 1
+  assert attr.input_spatial_dimensions == [2, 3, 4]
+  assert attr.kernel_input_feature_dimension == 0
+  assert attr.kernel_output_feature_dimension == 1
+  assert attr.kernel_spatial_dimensions == [2, 3]
+  assert attr.output_batch_dimension == 0
+  assert attr.output_feature_dimension == 1
+  assert attr.output_spatial_dimensions == [2, 3]
+
+
+@run
+def test_dot_dimension_numbers():
+  attr = stablehlo.DotDimensionNumbers.get(
+      lhs_batching_dimensions=[0, 1],
+      rhs_batching_dimensions=[2, 3],
+      lhs_contracting_dimensions=[4, 5],
+      rhs_contracting_dimensions=[6, 7])
+  assert attr is not None
+  assert str(attr) == ("#stablehlo.dot<lhs_batching_dimensions = [0, 1], "
+                       "rhs_batching_dimensions = [2, 3], "
+                       "lhs_contracting_dimensions = [4, 5], "
+                       "rhs_contracting_dimensions = [6, 7]>")
+  assert attr.lhs_batching_dimensions == [0, 1]
+  assert attr.rhs_batching_dimensions == [2, 3]
+  assert attr.lhs_contracting_dimensions == [4, 5]
+  assert attr.rhs_contracting_dimensions == [6, 7]
+
+
+@run
+def test_fft_type_attr():
+  attr = stablehlo.FftTypeAttr.get("FFT")
+  assert attr is not None
+  assert str(attr) == ("#stablehlo<fft_type FFT>")
+  assert attr.value == "FFT"
+
+
+@run
+def test_gather_dimension_numbers():
+  attr = stablehlo.GatherDimensionNumbers.get(
+      offset_dims=[1, 2],
+      collapsed_slice_dims=[3, 4, 5],
+      start_index_map=[6],
+      index_vector_dim=7)
+  assert attr is not None
+  assert str(attr) == ("#stablehlo.gather<offset_dims = [1, 2], "
+                       "collapsed_slice_dims = [3, 4, 5], "
+                       "start_index_map = [6], "
+                       "index_vector_dim = 7>")
+  assert attr.offset_dims == [1, 2]
+  assert attr.collapsed_slice_dims == [3, 4, 5]
+  assert attr.start_index_map == [6]
+  assert attr.index_vector_dim == 7
+
+
+@run
+def test_rng_algorithm_attr():
+  attr = stablehlo.RngAlgorithmAttr.get("DEFAULT")
+  assert attr is not None
+  assert str(attr) == ("#stablehlo<rng_algorithm DEFAULT>")
+  assert attr.value == "DEFAULT"
+
+
+@run
+def test_rng_distribution_attr():
+  attr = stablehlo.RngDistributionAttr.get("UNIFORM")
+  assert attr is not None
+  assert str(attr) == ("#stablehlo<rng_distribution UNIFORM>")
+  assert attr.value == "UNIFORM"
+
+
+@run
+def test_precision_attr():
+  attr = stablehlo.PrecisionAttr.get("DEFAULT")
+  assert attr is not None
+  assert str(attr) == ("#stablehlo<precision DEFAULT>")
+  assert attr.value == "DEFAULT"
+
+
+@run
+def test_scatter_dimension_numbers():
+  attr = stablehlo.ScatterDimensionNumbers.get(
+      update_window_dims=[1, 2, 3],
+      inserted_window_dims=[4, 5],
+      scattered_dims_to_operand_dims=[6, 7],
+      index_vector_dim=8)
+  assert attr is not None
+  assert str(attr) == ("#stablehlo.scatter<update_window_dims = [1, 2, 3], "
+                       "inserted_window_dims = [4, 5], "
+                       "scatter_dims_to_operand_dims = [6, 7], "
+                       "index_vector_dim = 8>")
+  assert attr.update_window_dims == [1, 2, 3]
+  assert attr.inserted_window_dims == [4, 5]
+  assert attr.scattered_dims_to_operand_dims == [6, 7]
+  assert attr.index_vector_dim == 8
+
+
+@run
+def test_transpose_attr():
+  attr = stablehlo.TransposeAttr.get("TRANSPOSE")
+  assert attr is not None
+  assert str(attr) == ("#stablehlo<transpose TRANSPOSE>")
+  assert attr.value == "TRANSPOSE"
+
+
+@run
+def test_token_type():
+  type = stablehlo.TokenType.get()
+  assert type is not None
+  assert str(type) == "!stablehlo.token"
+
+
+@run
+def test_type_extensions():
+  attr = stablehlo.TypeExtensions.get(bounds=[128, -1])
+  assert attr is not None
+  assert attr.bounds == [128, -1]


### PR DESCRIPTION
1) Fixes chlo.py and stablehlo.py to properly export constructors for attributes and types.

2) Aligns Python accessor names with C++ accessor names. E.g. renames `ComparisonDirectionAttr.comparison_direction` to `value`. We don't promise source compatibility for Python bindings at the moment, so no compatibility shims are introduced.

3) Adds exhaustive tests for ChloModule.cpp and StablehloModule.cpp.

(As promised in the code review which replaced MLIR-HLO's CHLO with StableHLO's CHLO).