### PR TITLE
Anchor evals to result's index space iterator

### DIFF
--- a/docs/interpreter.md
+++ b/docs/interpreter.md
@@ -50,7 +50,7 @@ an `Element` object, is stored in the final `result` tensor.
 Tensor eval(AddOp op, const Tensor &lhs, const Tensor &rhs) {
   Tensor result(op.getType());
 
-  for (auto it = lhs.index_begin(); it != lhs.index_end(); ++it)
+  for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, lhs.get(*it) + rhs.get(*it));
 
   return result;

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -47,7 +47,7 @@ std::vector<int64_t> permute(ArrayRef<int64_t> array, ArrayRef<int64_t> perm) {
 
 Tensor eval(AddOp op, const Tensor &lhs, const Tensor &rhs) {
   Tensor result(op.getType());
-  for (auto it = lhs.index_begin(); it != lhs.index_end(); ++it) {
+  for (auto it = result.index_begin(); it != result.index_end(); ++it) {
     result.set(*it, lhs.get(*it) + rhs.get(*it));
   }
   return result;
@@ -55,7 +55,7 @@ Tensor eval(AddOp op, const Tensor &lhs, const Tensor &rhs) {
 
 Tensor eval(CeilOp op, const Tensor &operand) {
   Tensor result(op.getType());
-  for (auto it = operand.index_begin(); it != operand.index_end(); ++it) {
+  for (auto it = result.index_begin(); it != result.index_end(); ++it) {
     result.set(*it, ceil(operand.get(*it)));
   }
   return result;
@@ -67,7 +67,7 @@ Tensor eval(ConstantOp op) {
 
 Tensor eval(CosineOp op, const Tensor &operand) {
   Tensor result(op.getType());
-  for (auto it = operand.index_begin(); it != operand.index_end(); ++it) {
+  for (auto it = result.index_begin(); it != result.index_end(); ++it) {
     result.set(*it, cosine(operand.get(*it)));
   }
   return result;
@@ -75,7 +75,7 @@ Tensor eval(CosineOp op, const Tensor &operand) {
 
 Tensor eval(FloorOp op, const Tensor &operand) {
   Tensor result(op.getType());
-  for (auto it = operand.index_begin(); it != operand.index_end(); ++it) {
+  for (auto it = result.index_begin(); it != result.index_end(); ++it) {
     result.set(*it, floor(operand.get(*it)));
   }
   return result;
@@ -120,7 +120,7 @@ Tensor eval(IotaOp op) {
 
 Tensor eval(NegOp op, const Tensor &operand) {
   Tensor result(op.getType());
-  for (auto it = operand.index_begin(); it != operand.index_end(); ++it) {
+  for (auto it = result.index_begin(); it != result.index_end(); ++it) {
     result.set(*it, -operand.get(*it));
   }
   return result;
@@ -128,8 +128,8 @@ Tensor eval(NegOp op, const Tensor &operand) {
 
 Tensor eval(ReshapeOp op, const Tensor &operand) {
   Tensor result(op.getType());
-  for (auto operandIt = operand.index_begin(), resultIt = result.index_begin();
-       operandIt != operand.index_end(); ++operandIt, ++resultIt) {
+  for (auto resultIt = result.index_begin(), operandIt = operand.index_begin();
+       resultIt != result.index_end(); ++resultIt, ++operandIt) {
     result.set(*resultIt, operand.get(*operandIt));
   }
   return result;
@@ -137,7 +137,7 @@ Tensor eval(ReshapeOp op, const Tensor &operand) {
 
 Tensor eval(MaxOp op, const Tensor &lhs, const Tensor &rhs) {
   Tensor result(op.getType());
-  for (auto it = lhs.index_begin(); it != lhs.index_end(); ++it) {
+  for (auto it = result.index_begin(); it != result.index_end(); ++it) {
     result.set(*it, max(lhs.get(*it), rhs.get(*it)));
   }
   return result;
@@ -145,7 +145,7 @@ Tensor eval(MaxOp op, const Tensor &lhs, const Tensor &rhs) {
 
 Tensor eval(MinOp op, const Tensor &lhs, const Tensor &rhs) {
   Tensor result(op.getType());
-  for (auto it = lhs.index_begin(); it != lhs.index_end(); ++it) {
+  for (auto it = result.index_begin(); it != result.index_end(); ++it) {
     result.set(*it, min(lhs.get(*it), rhs.get(*it)));
   }
   return result;
@@ -153,7 +153,7 @@ Tensor eval(MinOp op, const Tensor &lhs, const Tensor &rhs) {
 
 Tensor eval(SineOp op, const Tensor &operand) {
   Tensor result(op.getType());
-  for (auto it = operand.index_begin(); it != operand.index_end(); ++it) {
+  for (auto it = result.index_begin(); it != result.index_end(); ++it) {
     result.set(*it, sine(operand.get(*it)));
   }
   return result;
@@ -161,7 +161,7 @@ Tensor eval(SineOp op, const Tensor &operand) {
 
 Tensor eval(SubtractOp op, const Tensor &lhs, const Tensor &rhs) {
   Tensor result(op.getType());
-  for (auto it = lhs.index_begin(); it != lhs.index_end(); ++it) {
+  for (auto it = result.index_begin(); it != result.index_end(); ++it) {
     result.set(*it, lhs.get(*it) - rhs.get(*it));
   }
   return result;
@@ -169,7 +169,7 @@ Tensor eval(SubtractOp op, const Tensor &lhs, const Tensor &rhs) {
 
 Tensor eval(TanhOp op, const Tensor &operand) {
   Tensor result(op.getType());
-  for (auto it = operand.index_begin(); it != operand.index_end(); ++it) {
+  for (auto it = result.index_begin(); it != result.index_end(); ++it) {
     result.set(*it, tanh(operand.get(*it)));
   }
   return result;


### PR DESCRIPTION
This better matches the spec, where our formal notation always says `result[...] = operand[...]`. The only exception so far is transpose where the spec derives result index from operand index.