### PR TITLE
Handle bounds in the Transpose op shape function

### DIFF
--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -4138,7 +4138,7 @@ LogicalResult TransposeOp::reifyReturnTypeShapes(
 // Method for InferTypeOpInterface: infer the return type from the operand type
 // and the permutation.
 LogicalResult TransposeOp::inferReturnTypes(
-    MLIRContext* /*context*/, Optional<Location> loc, ValueRange operands,
+    MLIRContext* context, Optional<Location> loc, ValueRange operands,
     DictionaryAttr attributes, RegionRange,
     SmallVectorImpl<Type>& inferredReturnTypes) {
   auto type = operands[0].getType();
@@ -4168,13 +4168,31 @@ LogicalResult TransposeOp::inferReturnTypes(
                              " of [",
                              range, "] but got ", permutation);
 
+  llvm::SmallVector<int64_t, 4> inputBounds(rank, ShapedType::kDynamicSize);
+  bool hasBounds = false;
+  if (auto encoding =
+          rankedTy.getEncoding().dyn_cast_or_null<TypeExtensionsAttr>()) {
+    inputBounds = llvm::to_vector<4>(encoding.getBounds());
+    hasBounds = true;
+  }
+
   SmallVector<int64_t> resultShape;
+  SmallVector<int64_t> resultBounds;
   ArrayRef<int64_t> inputShape = rankedTy.getShape();
   for (int64_t dim : permutation.getValues<int64_t>()) {
     resultShape.push_back(inputShape[dim]);
+    if (hasBounds) {
+      resultBounds.push_back(inputBounds[dim]);
+    }
   }
-  inferredReturnTypes.emplace_back(RankedTensorType::get(
-      resultShape, rankedTy.getElementType(), rankedTy.getEncoding()));
+
+  // If the input type doesn't have bounds, propagate the input type's encoding
+  // to handle sparse tensor encoding.
+  Attribute encoding = hasBounds
+                           ? TypeExtensionsAttr::get(context, resultBounds)
+                           : rankedTy.getEncoding();
+  inferredReturnTypes.emplace_back(
+      RankedTensorType::get(resultShape, rankedTy.getElementType(), encoding));
   return success();
 }
 

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -622,3 +622,25 @@ func.func @add_bounds_unranked(
   %1 = "hlo_test_infer.get_return_types"(%result) : (tensor<*xf32>) -> tensor<*xindex>
   func.return %1 : tensor<*xindex>
 }
+
+// -----
+
+// CHECK-LABEL: func @transpose
+func.func @transpose(%arg0: tensor<1x2x3x4xi32>) -> tensor<*xindex> {
+  %0 = "mhlo.transpose"(%arg0) {permutation = dense<[1, 0, 3, 2]> : tensor<4xi64>} : (tensor<1x2x3x4xi32>) -> tensor<*xi32>
+
+  // CHECK: types0 = tensor<2x1x4x3xi32>
+  %1 = "mhlo_test.get_return_types"(%0) : (tensor<*xi32>) -> tensor<*xindex>
+  func.return %1 : tensor<*xindex>
+}
+
+// -----
+
+// CHECK-LABEL: func @transpose_with_bounds
+func.func @transpose_with_bounds(%arg0: tensor<?x2x?x4xi32, #mhlo.type_extensions<bounds = [1, -1, 3, -1]>>) -> tensor<*xindex> {
+  %0 = "mhlo.transpose"(%arg0) {permutation = dense<[1, 0, 3, 2]> : tensor<4xi64>} : (tensor<?x2x?x4xi32, #mhlo.type_extensions<bounds = [1, -1, 3, -1]>>) -> tensor<*xi32>
+
+  // CHECK: types0 = tensor<2x?x4x?xi32, #mhlo.type_extensions<bounds = [-1, 1, -1, 3]>>
+  %1 = "mhlo_test.get_return_types"(%0) : (tensor<*xi32>) -> tensor<*xindex>
+  func.return %1 : tensor<*xindex>
+}

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -627,10 +627,10 @@ func.func @add_bounds_unranked(
 
 // CHECK-LABEL: func @transpose
 func.func @transpose(%arg0: tensor<1x2x3x4xi32>) -> tensor<*xindex> {
-  %0 = "mhlo.transpose"(%arg0) {permutation = dense<[1, 0, 3, 2]> : tensor<4xi64>} : (tensor<1x2x3x4xi32>) -> tensor<*xi32>
+  %0 = "stablehlo.transpose"(%arg0) {permutation = dense<[1, 0, 3, 2]> : tensor<4xi64>} : (tensor<1x2x3x4xi32>) -> tensor<*xi32>
 
   // CHECK: types0 = tensor<2x1x4x3xi32>
-  %1 = "mhlo_test.get_return_types"(%0) : (tensor<*xi32>) -> tensor<*xindex>
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xi32>) -> tensor<*xindex>
   func.return %1 : tensor<*xindex>
 }
 
@@ -638,9 +638,9 @@ func.func @transpose(%arg0: tensor<1x2x3x4xi32>) -> tensor<*xindex> {
 
 // CHECK-LABEL: func @transpose_with_bounds
 func.func @transpose_with_bounds(%arg0: tensor<?x2x?x4xi32, #mhlo.type_extensions<bounds = [1, -1, 3, -1]>>) -> tensor<*xindex> {
-  %0 = "mhlo.transpose"(%arg0) {permutation = dense<[1, 0, 3, 2]> : tensor<4xi64>} : (tensor<?x2x?x4xi32, #mhlo.type_extensions<bounds = [1, -1, 3, -1]>>) -> tensor<*xi32>
+  %0 = "stablehlo.transpose"(%arg0) {permutation = dense<[1, 0, 3, 2]> : tensor<4xi64>} : (tensor<?x2x?x4xi32, #mhlo.type_extensions<bounds = [1, -1, 3, -1]>>) -> tensor<*xi32>
 
   // CHECK: types0 = tensor<2x?x4x?xi32, #mhlo.type_extensions<bounds = [-1, 1, -1, 3]>>
-  %1 = "mhlo_test.get_return_types"(%0) : (tensor<*xi32>) -> tensor<*xindex>
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xi32>) -> tensor<*xindex>
   func.return %1 : tensor<*xindex>
 }

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -637,10 +637,10 @@ func.func @transpose(%arg0: tensor<1x2x3x4xi32>) -> tensor<*xindex> {
 // -----
 
 // CHECK-LABEL: func @transpose_with_bounds
-func.func @transpose_with_bounds(%arg0: tensor<?x2x?x4xi32, #mhlo.type_extensions<bounds = [1, -1, 3, -1]>>) -> tensor<*xindex> {
-  %0 = "stablehlo.transpose"(%arg0) {permutation = dense<[1, 0, 3, 2]> : tensor<4xi64>} : (tensor<?x2x?x4xi32, #mhlo.type_extensions<bounds = [1, -1, 3, -1]>>) -> tensor<*xi32>
+func.func @transpose_with_bounds(%arg0: tensor<?x2x?x4xi32, #stablehlo.type_extensions<bounds = [1, -1, 3, -1]>>) -> tensor<*xindex> {
+  %0 = "stablehlo.transpose"(%arg0) {permutation = dense<[1, 0, 3, 2]> : tensor<4xi64>} : (tensor<?x2x?x4xi32, #stablehlo.type_extensions<bounds = [1, -1, 3, -1]>>) -> tensor<*xi32>
 
-  // CHECK: types0 = tensor<2x?x4x?xi32, #mhlo.type_extensions<bounds = [-1, 1, -1, 3]>>
+  // CHECK: types0 = tensor<2x?x4x?xi32, #stablehlo.type_extensions<bounds = [-1, 1, -1, 3]>>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xi32>) -> tensor<*xindex>
   func.return %1 : tensor<*xindex>
 }


### PR DESCRIPTION
This makes it possible to propagate the input bounds while creating the Transpose op. 