### PR TITLE
Update inference test to use stablehlo dialect instead of mhlo

### DIFF
--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -195,15 +195,15 @@ defined and one of the following:
 
 ### Operands
 
-| Name      | Type                                                        |
-|-----------|-------------------------------------------------------------|
-| `operand` | tensor of integer, floating-point, or complex element types |
+| Name      | Type                                                               |
+|-----------|--------------------------------------------------------------------|
+| `operand` | tensor of signed integer, floating-point, or complex element types |
 
 ### Results
 
-| Name     | Type                                                        |
-|----------|-------------------------------------------------------------|
-| `result` | tensor of integer, floating-point, or complex element types |
+| Name     | Type                                                               |
+|----------|--------------------------------------------------------------------|
+| `result` | tensor of signed integer, floating-point, or complex element types |
 
 ### Constraints
 

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -990,6 +990,10 @@ elements in each dimension which may not be negative. Interior padding occurs
 before edge padding such that negative edge padding will remove elements from
 the interior-padded operand.
 
+More formally, `result[i0, ..., iR-1]` is equal to:
+  * `operand[j0, ..., jR-1]` if `id = edge_padding_low[d] + jd * (interior_padding[d] + 1)`.
+  * `padding_value[]` otherwise.
+
 ### Operands
 
 | Name                | Type                                        |

--- a/docs/status.md
+++ b/docs/status.md
@@ -29,7 +29,7 @@ one of the following tracking labels.
 
 | StableHLO Op             | Specification | Verification |  Type Inference   |  Pretty Printing  | Interpreter |
 |:-------------------------|:-------------:|:------------:|:-----------------:|:-----------------:|:-----------:|
-| abs                      |      no       |     yes*     |       yes*        |        yes        |     no      |
+| abs                      |      yes      |     yes      |       yes         |        yes        |     no      |
 | add                      |      no       |     yes*     |       yes*        |        yes        |     yes     |
 | after_all                |      no       |      no      |        no         |        yes        |     no      |
 | all_gather               |      no       |     yes*     |        no         |        no         |     no      |

--- a/stablehlo/dialect/Base.cpp
+++ b/stablehlo/dialect/Base.cpp
@@ -108,9 +108,9 @@ bool isCompatibleForHloTypeInference(Type tp1, Type tp2) {
   return etp1 == etp2;
 }
 
-bool isCompatibleForHloTypeInference(TypeRange l, TypeRange r) {
-  if (l.size() != r.size()) return false;
-  for (auto [lt, rt] : llvm::zip(l, r))
+bool isCompatibleForHloTypeInference(TypeRange tp1, TypeRange tp2) {
+  if (tp1.size() != tp2.size()) return false;
+  for (auto [lt, rt] : llvm::zip(tp1, tp2))
     if (!isCompatibleForHloTypeInference(lt, rt)) return false;
   return true;
 }

--- a/stablehlo/dialect/ChloOps.td
+++ b/stablehlo/dialect/ChloOps.td
@@ -54,7 +54,7 @@ def CHLO_Dialect : Dialect {
     dialects.
   }];
 
-  let emitAccessorPrefix = kEmitAccessorPrefix_Both;
+  let emitAccessorPrefix = kEmitAccessorPrefix_Prefixed;
 }
 
 class CHLO_Op<string mnemonic, list<Trait> traits> :

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -253,9 +253,9 @@ LogicalResult ReduceScatterOp::verify() {
     return failure();
 
   return verifyReduceScatter(*this,
-                             /*operand_types=*/{getOperand().getType()},
-                             /*result_types=*/{getType()},
-                             /*scatter_dimension=*/getScatterDimension());
+                             /*operandTypes=*/{getOperand().getType()},
+                             /*resultTypes=*/{getType()},
+                             /*scatterDimension=*/getScatterDimension());
 }
 
 //===----------------------------------------------------------------------===//
@@ -4361,7 +4361,7 @@ LogicalResult SelectAndScatterOp::verify() {
   if (failed(windowStridesOrErr)) return failure();
   auto windowOrErr = hlo::verifyWindowAttributesAndInferWindowDimensions(
       *windowDimsOrErr, *windowStridesOrErr, *paddingOrErr,
-      /*lhs_dilation=*/{}, /*rhs_dilation=*/{}, getLoc());
+      /*lhsDilation=*/{}, /*rhsDilation=*/{}, getLoc());
   if (failed(windowOrErr)) return failure();
 
   // P5.

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -867,8 +867,8 @@ LogicalResult inferReduceWindowOp(
   if (failed(windowDilationsOrErr)) return failure();
   auto windowOrErr = verifyWindowAttributesAndInferWindowDimensions(
       *windowDimsOrErr, *windowStridesOrErr, *paddingOrErr,
-      /*lhs_dilation=*/*baseDilationsOrErr,
-      /*rhs_dilation=*/*windowDilationsOrErr, location);
+      /*lhsDilation=*/*baseDilationsOrErr,
+      /*rhsDilation=*/*windowDilationsOrErr, location);
   if (failed(windowOrErr)) return failure();
 
   // P5.


### PR DESCRIPTION
This seems to have escaped update during bootstrap and therefore it doesn't do the intended testing.