### PR TITLE
Rename Operands/Results to Inputs/Outputs

### DIFF
--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -143,8 +143,8 @@ described below)
 
   * **Semantics** Semantics of the operation.
   * **Inputs** Meaning of input(s) and their type(s).
-  * **Outputs** Meaning of the outputs(s) and the type(s).
-  * **Constraints** Constraints on the input(s) and the outputs(s).
+  * **Outputs** Meaning of the output(s) and the type(s).
+  * **Constraints** Constraints on the input(s) and the output(s).
   * **Examples** Examples demonstrating the working of the op using
     [MLIR generic syntax](https://mlir.llvm.org/docs/LangRef/#operations).
 

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -76,10 +76,10 @@ are aligned, whether they are stored contiguously, etc).
 
 ## Programs
 
-StableHLO programs consist of functions. Each function has operands and results
+StableHLO programs consist of functions. Each function has inputs and outputs
 of supported types and a list of ops in static single-assignment (SSA) form
-which is terminated by a return op which produces the results of the function.
-StableHLO ops take operands and produce results.
+which is terminated by a return op which produces the outputs of the function.
+StableHLO ops take inputs and produce outputs.
 
 ```mlir
 ml_program.func @example_func(%arg: tensor<2x3xf32>) -> tensor<2x3xf32> {
@@ -91,7 +91,7 @@ ml_program.func @example_func(%arg: tensor<2x3xf32>) -> tensor<2x3xf32> {
 ```
 
 A program is executed by passing argument values to a given function and
-computing result values. Result values of a function are computed by evaluating
+computing output values. Output values of a function are computed by evaluating
 the graph of ops rooted in the corresponding return op. The evaluation order is
 implementation-defined, as long as ops are evaluated before their uses. Possible
 execution orders of the above example program are `%0` → `%1` → `%2` → `return`
@@ -142,9 +142,9 @@ The specification of an op comprises of the following components (in the order
 described below)
 
   * **Semantics** Semantics of the operation.
-  * **Operands** Meaning of operand(s) and their type(s).
-  * **Results** Meaning of the result(s) and the type(s).
-  * **Constraints** Constraints on the operand(s) and the result(s).
+  * **Inputs** Meaning of input(s) and their type(s).
+  * **Outputs** Meaning of the outputs(s) and the type(s).
+  * **Constraints** Constraints on the input(s) and the outputs(s).
   * **Examples** Examples demonstrating the working of the op using
     [MLIR generic syntax](https://mlir.llvm.org/docs/LangRef/#operations).
 
@@ -194,13 +194,13 @@ defined and one of the following:
   * Saturation to $2^{n-1}-1$
   * $-2^{n-1}$
 
-### Operands
+### Inputs
 
 | Name      | Type                                                               |
 |-----------|--------------------------------------------------------------------|
 | `operand` | tensor of signed integer, floating-point, or complex element types |
 
-### Results
+### Outputs
 
 | Name     | Type                                                               |
 |----------|--------------------------------------------------------------------|
@@ -254,14 +254,14 @@ For floating-point element types, it implements the `addition` operation from
 the IEEE-754 specification. For boolean element types, the behavior is same as
 [stablehlo.or](#stablehloor).
 
-### Operands
+### Inputs
 
 | Name  | Type                                                        |
 |-------|-------------------------------------------------------------|
 | `lhs` | tensor of all supported element types |
 | `rhs` | tensor of all supported element types |
 
-### Results
+### Outputs
 
 | Name     | Type                                                        |
 |----------|-------------------------------------------------------------|
@@ -292,14 +292,14 @@ Performs element-wise bitwise AND of two tensors `lhs` and `rhs` of integer
 types and produces a `result` tensor. For boolean tensors, it computes the
 logical operation.
 
-### Operands
+### Inputs
 
 | Name  | Type                                       |
 |-------|--------------------------------------------|
 | `lhs` | tensor of integer or boolean element types |
 | `rhs` | tensor of integer or boolean element types |
 
-### Results
+### Outputs
 
 | Name     | Type                                       |
 |----------|--------------------------------------------|
@@ -335,13 +335,13 @@ Performs element-wise ceil of `operand` tensor and produces a `result` tensor.
 Implements the rounding to integral towards positive infinity operation from the
 IEEE-754 specification.
 
-### Operands
+### Inputs
 
 | Name      | Type                                   |
 |-----------|----------------------------------------|
 | `operand` | tensor of floating-point element types |
 
-### Results
+### Outputs
 
 | Name     | Type                                   |
 |----------|----------------------------------------|
@@ -375,14 +375,14 @@ tensor. More formally,
   1. `d` is equal to `dimension`, and `d0`, ... are `d`th dimension sizes
      of `inputs`.
 
-### Operands
+### Inputs
 
 | Name        | Type                                              |
 |-------------|---------------------------------------------------|
 | `inputs`    | variadic number of tensors of any supported types |
 | `dimension` | `si64`                                            |
 
-### Results
+### Outputs
 
 | Name     | Type                          |
 |----------|-------------------------------|
@@ -431,13 +431,13 @@ tensor. More formally,
 
 Produces a `result` tensor from a constant `value`.
 
-### Operands
+### Inputs
 
 | Name    | Type                            |
 |---------|---------------------------------|
 | `value` | constant of any supported types |
 
-### Results
+### Outputs
 
 | Name     | Type                          |
 |----------|-------------------------------|
@@ -468,13 +468,13 @@ Performs element-wise cosine operation on `operand` tensor and produces a
 `result` tensor, implementing the `cos` operation from the IEEE-754
 specification. Numeric precision is implementation-defined.
 
-### Operands
+### Inputs
 
 | Name      | Type                                              |
 |-----------|---------------------------------------------------|
 | `operand` | tensor of floating-point or complex element types |
 
-### Results
+### Outputs
 
 | Name     | Type                                              |
 |----------|---------------------------------------------------|
@@ -510,14 +510,14 @@ implements integer division truncating any fractional part. For n-bit integer
 types, division overflow (division by zero or division of $-2^{n-1}$ with $-1$)
 produces an implementation-defined value.
 
-### Operands
+### Inputs
 
 | Name  | Type                                                       |
 |-------|------------------------------------------------------------|
 | `lhs` | tensor of integer, floating-point or complex element types |
 | `rhs` | tensor of integer, floating-point or complex element types |
 
-### Results
+### Outputs
 
 | Name     | Type                                                       |
 |----------|------------------------------------------------------------|
@@ -553,13 +553,13 @@ operation from the IEEE-754 specification. For complex element types, it
 computes a complex exponential, with corner cases TBD. Numeric precision is
 implementation-defined.
 
-### Operands
+### Inputs
 
 | Name      | Type                                              |
 |-----------|---------------------------------------------------|
 | `operand` | tensor of floating-point or complex element types |
 
-### Results
+### Outputs
 
 | Name     | Type                                              |
 |----------|---------------------------------------------------|
@@ -591,13 +591,13 @@ Performs element-wise floor of `operand` tensor and produces a `result` tensor.
 Implements the rounding to integral towards negative infinity operation from the
 IEEE-754 specification.
 
-### Operands
+### Inputs
 
 | Name      | Type                                   |
 |-----------|----------------------------------------|
 | `operand` | tensor of floating-point element types |
 
-### Results
+### Outputs
 
 | Name     | Type                                   |
 |----------|----------------------------------------|
@@ -636,13 +636,13 @@ defined and one of the following:
   * saturation to $2^{n-1} - 1$ for signed overflow and saturation to $2^n - 1$
   for unsigned overflow.
 
-### Operands
+### Inputs
 
 | Name             | Type   |
 |------------------|--------|
 | `iota_dimension` | `si64` |
 
-### Results
+### Outputs
 
 | Name     | Type                                                       |
 |----------|------------------------------------------------------------|
@@ -691,13 +691,13 @@ operation from the IEEE-754 specification. For complex element types, it
 computes a complex logarithm, with corner cases TBD. Numeric precision is
 implementation-defined.
 
-### Operands
+### Inputs
 
 | Name      | Type                                              |
 |-----------|---------------------------------------------------|
 | `operand` | tensor of floating-point or complex element types |
 
-### Results
+### Outputs
 
 | Name     | Type                                              |
 |----------|---------------------------------------------------|
@@ -732,13 +732,13 @@ where `addition`, `division`, and `exp` are operations from IEEE-754
 specification. For complex element types, it computes a complex logistic
 function, with corner cases TBD. Numeric precision is implementation-defined.
 
-### Operands
+### Inputs
 
 | Name      | Type                                              |
 |-----------|---------------------------------------------------|
 | `operand` | tensor of floating-point or complex element types |
 
-### Results
+### Outputs
 
 | Name     | Type                                              |
 |----------|---------------------------------------------------|
@@ -772,14 +772,14 @@ operation from the IEEE-754 specification. For complex element type, it performs
 lexicographic comparison on the (real, imaginary) pairs with corner cases TBD.
 For boolean element types, the behavior is same as [stablehlo.or](#stablehloor).
 
-### Operands
+### Inputs
 
 | Name  | Type                                                        |
 |-------|-------------------------------------------------------------|
 | `lhs` | tensor of all supported element types |
 | `rhs` | tensor of all supported element types |
 
-### Results
+### Outputs
 
 | Name     | Type                                                        |
 |----------|-------------------------------------------------------------|
@@ -813,14 +813,14 @@ lexicographic comparison on the (real, imaginary) pairs with corner cases TBD.
 For boolean element types, the behavior is same as
 [stablehlo.and](#stablehloand).
 
-### Operands
+### Inputs
 
 | Name  | Type                                                        |
 |-------|-------------------------------------------------------------|
 | `lhs` | tensor of all supported element types |
 | `rhs` | tensor of all supported element types |
 
-### Results
+### Outputs
 
 | Name     | Type                                                        |
 |----------|-------------------------------------------------------------|
@@ -867,14 +867,14 @@ cases TBD.
 For boolean element types, the behavior is same as
 [stablehlo.and](#stablehloand).
 
-### Operands
+### Inputs
 
 | Name  | Type                                  |
 |-------|---------------------------------------|
 | `lhs` | tensor of all supported element types |
 | `rhs` | tensor of all supported element types |
 
-### Results
+### Outputs
 
 | Name     | Type                                  |
 |----------|---------------------------------------|
@@ -914,13 +914,13 @@ For unsigned integer types, it bitcasts to the corresponding signed integer type
 performs the regular negation operation and bitcasts back to the original
 unsigned integer type.
 
-### Operands
+### Inputs
 
 | Name      | Type                                                        |
 |-----------|-------------------------------------------------------------|
 | `operand` | tensor of integer, floating-point, or complex element types |
 
-### Results
+### Outputs
 
 | Name     | Type                                                        |
 |----------|-------------------------------------------------------------|
@@ -961,7 +961,7 @@ produces a `result` tensor. For boolean tensors, it computes the logical NOT.
 |-----------|--------------------------------------------|
 | `operand` | tensor of integer or boolean element types |
 
-### Results
+### Outputs
 
 | Name     | Type                                       |
 |----------|--------------------------------------------|
@@ -995,14 +995,14 @@ Performs element-wise bitwise OR of two tensors `lhs` and `rhs` of integer types
 and produces a `result` tensor. For boolean tensors, it computes the logical
 operation.
 
-### Operands
+### Inputs
 
 | Name  | Type                                       |
 |-------|--------------------------------------------|
 | `lhs` | tensor of integer or boolean element types |
 | `rhs` | tensor of integer or boolean element types |
 
-### Results
+### Outputs
 
 | Name     | Type                                       |
 |----------|--------------------------------------------|
@@ -1052,7 +1052,7 @@ More formally, `result[i0, ..., iR-1]` is equal to:
   * `operand[j0, ..., jR-1]` if `id = edge_padding_low[d] + jd * (interior_padding[d] + 1)`.
   * `padding_value[]` otherwise.
 
-### Operands
+### Inputs
 
 | Name                | Type                                        |
 |---------------------|---------------------------------------------|
@@ -1062,7 +1062,7 @@ More formally, `result[i0, ..., iR-1]` is equal to:
 | `edge_padding_high` | 1-dimensional array of type `si64`          |
 | `interior_padding`  | 1-dimensional array of type `si64`          |
 
-### Results
+### Outputs
 
 | Name     | Type                          |
 |----------|-------------------------------|
@@ -1117,14 +1117,14 @@ floating-point types, the corner cases are TBD. For n-bit integer, division
 overflow (remainder by zero or remainder of $-2^{n-1}$ with $-1$) produces an
 implementation-defined value.
 
-### Operands
+### Inputs
 
 | Name  | Type                                                       |
 |-------|------------------------------------------------------------|
 | `lhs` | tensor of integer, floating-point or complex element types |
 | `rhs` | tensor of integer, floating-point or complex element types |
 
-### Results
+### Outputs
 
 | Name     | Type                                                       |
 |----------|------------------------------------------------------------|
@@ -1162,13 +1162,13 @@ More formally, `result[i0, ..., iR-1] = operand[j0, ..., jR'-1]` where
 `i` and `j` have the same position in the lexicographic ordering of the index
 spaces of `result` and `operand`.
 
-### Operands
+### Inputs
 
 | Name      | Type                          |
 |-----------|-------------------------------|
 | `operand` | tensor of any supported types |
 
-### Results
+### Outputs
 
 | Name     | Type                          |
 |----------|-------------------------------|
@@ -1199,14 +1199,14 @@ and produces a `result` tensor. More formally,
 `result[i0, ..., ik,..., iR-1] = operand[i0, ..., ik',..., iR-1]` where
 `ik + ik' = dk - 1` for all dimensions `k` in `dimensions`.
 
-### Operands
+### Inputs
 
 | Name         | Type                               |
 |--------------|------------------------------------|
 | `operand`    | tensor of any supported types      |
 | `dimensions` | 1-dimensional array of type `si64` |
 
-### Results
+### Outputs
 
 | Name     | Type                          |
 |----------|-------------------------------|
@@ -1248,13 +1248,13 @@ Performs element-wise reciprocal square root operation on `operand` tensor and
 produces a `result` tensor, implementing the `rSqrt` operation from the IEEE-754
 specification. Numeric precision is implementation-defined.
 
-### Operands
+### Inputs
 
 | Name      | Type                                              |
 |-----------|---------------------------------------------------|
 | `operand` | tensor of floating-point or complex element types |
 
-### Results
+### Outputs
 
 | Name     | Type                                              |
 |----------|---------------------------------------------------|
@@ -1286,13 +1286,13 @@ Performs element-wise sine operation on `operand` tensor and produces a `result`
 tensor, implementing the `sin` operation from the IEEE-754 specification.
 Numeric precision is implementation-defined.
 
-### Operands
+### Inputs
 
 | Name      | Type                                              |
 |-----------|---------------------------------------------------|
 | `operand` | tensor of floating-point or complex element types |
 
-### Results
+### Outputs
 
 | Name     | Type                                              |
 |----------|---------------------------------------------------|
@@ -1325,13 +1325,13 @@ Performs element-wise square root operation on `operand` tensor and produces a
 `result` tensor, implementing the `squareRoot` operation from the IEEE-754
 specification.
 
-### Operands
+### Inputs
 
 | Name      | Type                                              |
 |-----------|---------------------------------------------------|
 | `operand` | tensor of floating-point or complex element types |
 
-### Results
+### Outputs
 
 | Name     | Type                                              |
 |----------|---------------------------------------------------|
@@ -1373,14 +1373,14 @@ following:
 For floating-point element types, it implements the `subtraction` operation from
 the IEEE-754 specification.
 
-### Operands
+### Inputs
 
 | Name  | Type                                                        |
 |-------|-------------------------------------------------------------|
 | `lhs` | tensor of integer, floating-point, or complex element types |
 | `rhs` | tensor of integer, floating-point, or complex element types |
 
-### Results
+### Outputs
 
 | Name     | Type                                                        |
 |----------|-------------------------------------------------------------|
@@ -1411,13 +1411,13 @@ Performs element-wise tanh operation on `operand` tensor and produces a `result`
 tensor, implementing the `tanh` operation from the IEEE-754 specification.
 Numeric precision is implementation-defined.
 
-### Operands
+### Inputs
 
 | Name      | Type                                              |
 |-----------|---------------------------------------------------|
 | `operand` | tensor of floating-point or complex element types |
 
-### Results
+### Outputs
 
 | Name     | Type                                              |
 |----------|---------------------------------------------------|
@@ -1447,14 +1447,14 @@ Permutes the dimensions of `operand` tensor using `permutation` and produces a
 `result` tensor. More formally, `result[i0, ..., iR-1] = operand[j0, ..., jR-1]`
 where `i[d] = j[permutation[d]]`.
 
-### Operands
+### Inputs
 
 | Name          | Type                               |
 |---------------|------------------------------------|
 | `operand`     | tensor of any supported types      |
 | `permutation` | 1-dimensional array of type `si64` |
 
-### Results
+### Outputs
 
 | Name     | Type                          |
 |----------|-------------------------------|
@@ -1495,14 +1495,14 @@ Performs element-wise bitwise XOR of two tensors `lhs` and `rhs` of integer
 types and produces a `result` tensor. For boolean tensors, it computes the
 logical operation.
 
-### Operands
+### Inputs
 
 | Name  | Type                                       |
 |-------|--------------------------------------------|
 | `lhs` | tensor of integer or boolean element types |
 | `rhs` | tensor of integer or boolean element types |
 
-### Results
+### Outputs
 
 | Name     | Type                                       |
 |----------|--------------------------------------------|


### PR DESCRIPTION
This allows us to avoid thinking about whether something is an operand, an attribute or a region. See #310 for an inspiration.