### PR TITLE
Tweak the description of ConcatenateOp::dimension

### DIFF
--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -441,7 +441,7 @@ tensor. More formally,
 | Name        | Type                                              |
 |-------------|---------------------------------------------------|
 | `inputs`    | variadic number of tensors of any supported types |
-| `dimension` | `si64`                                            |
+| `dimension` | constant of type `si64`                           |
 
 ### Outputs
 


### PR DESCRIPTION
Instead of "`si64`", expand to "constant of type `si64`" to be in line with other places in the spec.