### PR TITLE
Move shape function of TransposeOp to shared file

### DIFF
--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -948,6 +948,52 @@ LogicalResult inferSortOp(
   return success();
 }
 
+LogicalResult inferTransposeOp(MLIRContext* context, Optional<Location> loc,
+                               Value operand,
+                               llvm::SmallVector<int64_t>& operandBounds,
+                               DenseIntElementsAttr permutation,
+                               SmallVectorImpl<Type>& inferredReturnTypes,
+                               llvm::SmallVector<int64_t>& resultBounds) {
+  auto type = operand.getType();
+  auto rankedTy = type.dyn_cast<RankedTensorType>();
+  if (!rankedTy) {
+    auto shapedTy = type.dyn_cast<ShapedType>();
+    inferredReturnTypes.emplace_back(shapedTy);
+    return success();
+  }
+  int64_t rank = rankedTy.getRank();
+  if (permutation.getType().getRank() != 1)
+    return emitOptionalError(loc, "TransposeOp permutation has rank ",
+                             permutation.getType().getRank(),
+                             " instead of rank 1");
+
+  if (permutation.size() != rank)
+    return emitOptionalError(loc, "TransposeOp operand rank ", rank,
+                             " does not match permutation size ",
+                             permutation.size());
+
+  std::vector<int64_t> range(rank);
+  std::iota(range.begin(), range.end(), 0);
+  if (!std::is_permutation(range.begin(), range.end(), permutation.begin()))
+    return emitOptionalError(loc,
+                             "attribute permutation must be a permutation"
+                             " of [",
+                             range, "] but got ", permutation);
+
+  SmallVector<int64_t> resultShape;
+  ArrayRef<int64_t> inputShape = rankedTy.getShape();
+  for (int64_t dim : permutation.getValues<int64_t>()) {
+    resultShape.push_back(inputShape[dim]);
+    if (!operandBounds.empty()) {
+      resultBounds.push_back(operandBounds[dim]);
+    }
+  }
+
+  inferredReturnTypes.emplace_back(RankedTensorType::get(
+      resultShape, rankedTy.getElementType(), rankedTy.getEncoding()));
+  return success();
+}
+
 LogicalResult inferTriangularSolveOp(
     Optional<Location> location, Value a, Value b, bool leftSide,
     bool isTransposeAInvalid,

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -144,6 +144,13 @@ LogicalResult inferSortOp(
     Region& comparator,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
+LogicalResult inferTransposeOp(MLIRContext* context, Optional<Location> loc,
+                               Value operand,
+                               llvm::SmallVector<int64_t>& inputBounds,
+                               DenseIntElementsAttr permutation,
+                               SmallVectorImpl<Type>& inferredReturnTypes,
+                               llvm::SmallVector<int64_t>& resultBounds);
+
 LogicalResult inferTriangularSolveOp(
     Optional<Location> location, Value a, Value b, bool leftSide,
     bool isTransposeAInvalid,


### PR DESCRIPTION
The bounded dynamism parts of the shape function of TransposeOp can't be moved directly: `TypeInference.h/cpp` is designed to be shared for both StableHLO and MHLO, thus they can't involve anything about the custom Attributes like `TypeExtensionsAttr`. So this PR prepares the bounds for the `operand` before calling the new shared `inferTransposeOp()` and later add the resultBounds on top of the result Type. MHLO is expected to follow the same pattern to call this shared method as well.

A few things open to discussion:
1. Does the existing code https://github.com/openxla/stablehlo/blob/main/stablehlo/dialect/StablehloOps.cpp#L4189 mean that we can't have bounds and sparse tensor encoding at the same time?
2. Is there any specific reason we prefer `inferReturnTypes` over `inferReturnTypeComponents`:
`inferReturnTypes` has arg`SmallVectorImpl<Type>& inferredReturnTypes` while `inferReturnTypeComponents` has `SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes`: AFAIK, `ShapedTypeComponents` also supports attribute: https://github.com/llvm/llvm-project/blob/main/mlir/include/mlir/Interfaces/InferTypeOpInterface.h#L101. If OK, I would consider use `inferReturnTypeComponents` instead, like other ops.