### PR TITLE
Move SliceOp to shared file before we add bounds to it

### DIFF
--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -3980,93 +3980,14 @@ LogicalResult CaseOp::inferReturnTypeComponents(
 // SliceOp
 //===----------------------------------------------------------------------===//
 
-// Returns output dimension size for slice result for the given arguments.
-// Returns -1 if arguments are illegal.
-static int64_t inferSliceDim(int64_t inputDim, int64_t start, int64_t end,
-                             int64_t stride) {
-  if (inputDim == -1 || start < 0 || start > end || end > inputDim ||
-      stride == 0)
-    return -1;
-
-  return llvm::divideCeil(end - start, stride);
-}
-
-// The following properties are already enforced by the ODS:
-//  type(start_indices) == type(limit_indices) == type(strides).
-// Verify the following properties:
-//  P1. Verify rank(start_indices) == 1.
-//  P2. Verify size(start_indices) == rank(operand).
-//  P3~5. Verify 0 <= start_indices[i] <= limit_indices[i] <= shape(operand)[i].
-//  P6. Verify stride[i] > 0.
 LogicalResult SliceOp::inferReturnTypes(
     MLIRContext* context, Optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<Type>& inferredReturnTypes) {
-  SliceOpAdaptor slice(operands, attributes);
-  Type ty = slice.getOperand().getType();
-  RankedTensorType rankedTy = ty.dyn_cast<RankedTensorType>();
-  if (!rankedTy) {
-    // The operand type is unranked, so the best we can infer for the result
-    // type is an unranked tensor with the same element type as the operand
-    // type.
-    inferredReturnTypes.assign({ty});
-    return success();
-  }
-
-  ShapedType attrTy = slice.getStartIndices().getType();
-  // P1.
-  // Note: ODS has type(start_indices) == type(limit_indices) == type(strides)
-  // So this implies rank(limit_indices) == rank(strides) == 1 also.
-  if (attrTy.getRank() != 1) {
-    return emitOptionalError(location, "start_indices has rank ",
-                             attrTy.getRank(), " instead of required rank 1");
-  }
-
-  // P2.
-  int64_t rank = rankedTy.getRank();
-  if (attrTy.getNumElements() != rank) {
-    return emitOptionalError(
-        location, "the number of elements in start_indices (",
-        attrTy.getNumElements(), ") does not match the rank of the operand (",
-        rank, ")");
-  }
-
-  SmallVector<int64_t, 4> start(slice.getStartIndices().getValues<int64_t>());
-  SmallVector<int64_t, 4> limit(slice.getLimitIndices().getValues<int64_t>());
-  SmallVector<int64_t, 4> strideVals(slice.getStrides().getValues<int64_t>());
-
-  SmallVector<int64_t, 4> shape;
-  shape.reserve(rank);
-  for (int64_t i = 0, e = rank; i != e; i++) {
-    if (hlo::isDynamicDimSize(rankedTy.getDimSize(i))) {
-      shape.push_back(ShapedType::kDynamicSize);
-      continue;
-    }
-    // P3.
-    if (start[i] < 0)
-      return emitOptionalError(location, "negative start index ", start[i],
-                               " in dimension ", i);
-    // P4.
-    if (limit[i] > rankedTy.getDimSize(i))
-      return emitOptionalError(location, "limit index ", limit[i],
-                               " is larger than dimension size ",
-                               rankedTy.getDimSize(i), " in dimension ", i);
-    // P5.
-    if (start[i] > limit[i])
-      return emitOptionalError(location, "start index ", start[i],
-                               " is larger than limit index ", limit[i],
-                               " in dimension ", i);
-    // P6.
-    if (strideVals[i] <= 0)
-      return emitOptionalError(location, "stride must be positive but got ",
-                               strideVals[i], " in dimension ", i);
-
-    shape.push_back(inferSliceDim(rankedTy.getDimSize(i), start[i], limit[i],
-                                  strideVals[i]));
-  }
-  inferredReturnTypes.assign(
-      {RankedTensorType::get(shape, rankedTy.getElementType())});
-  return success();
+  SliceOpAdaptor adaptor(operands, attributes);
+  return hlo::inferSliceOp(location, adaptor.getOperand(),
+                           adaptor.getStartIndices(), adaptor.getLimitIndices(),
+                           adaptor.getStrides(), inferredReturnTypes);
 }
 
 //===----------------------------------------------------------------------===//

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -1037,8 +1037,6 @@ LogicalResult inferSortOp(
   return success();
 }
 
-
-
 LogicalResult inferTriangularSolveOp(
     Optional<Location> location, Value a, Value b, bool leftSide,
     bool isTransposeAInvalid,

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -414,6 +414,17 @@ LogicalResult verifyReducerShape(
   return success();
 }
 
+// Returns output dimension size for slice result for the given arguments.
+// Returns -1 if arguments are illegal.
+static int64_t inferSliceDim(int64_t inputDim, int64_t start, int64_t end,
+                             int64_t stride) {
+  if (inputDim == -1 || start < 0 || start > end || end > inputDim ||
+      stride == 0)
+    return -1;
+
+  return llvm::divideCeil(end - start, stride);
+}
+
 //===----------------------------------------------------------------------===//
 // Shape functions for ops.
 //===----------------------------------------------------------------------===//
@@ -891,6 +902,84 @@ LogicalResult inferReduceWindowOp(
   return success();
 }
 
+// The following properties are already enforced by the ODS:
+//  type(start_indices) == type(limit_indices) == type(strides).
+// Verify the following properties:
+//  P1. Verify rank(start_indices) == 1.
+//  P2. Verify size(start_indices) == rank(operand).
+//  P3~5. Verify 0 <= start_indices[i] <= limit_indices[i] <= shape(operand)[i].
+//  P6. Verify stride[i] > 0.
+LogicalResult inferSliceOp(Optional<Location> location, Value operand,
+                           DenseIntElementsAttr startIndices,
+                           DenseIntElementsAttr limitIndices,
+                           DenseIntElementsAttr strides,
+                           SmallVectorImpl<Type>& inferredReturnTypes) {
+  Type ty = operand.getType();
+  RankedTensorType rankedTy = ty.dyn_cast<RankedTensorType>();
+  if (!rankedTy) {
+    // The operand type is unranked, so the best we can infer for the result
+    // type is an unranked tensor with the same element type as the operand
+    // type.
+    inferredReturnTypes.assign({ty});
+    return success();
+  }
+
+  ShapedType attrTy = startIndices.getType();
+  // P1.
+  // Note: ODS has type(start_indices) == type(limit_indices) == type(strides)
+  // So this implies rank(limit_indices) == rank(strides) == 1 also.
+  if (attrTy.getRank() != 1) {
+    return emitOptionalError(location, "start_indices has rank ",
+                             attrTy.getRank(), " instead of required rank 1");
+  }
+
+  // P2.
+  int64_t rank = rankedTy.getRank();
+  if (attrTy.getNumElements() != rank) {
+    return emitOptionalError(
+        location, "the number of elements in start_indices (",
+        attrTy.getNumElements(), ") does not match the rank of the operand (",
+        rank, ")");
+  }
+
+  SmallVector<int64_t, 4> start(startIndices.getValues<int64_t>());
+  SmallVector<int64_t, 4> limit(limitIndices.getValues<int64_t>());
+  SmallVector<int64_t, 4> strideVals(strides.getValues<int64_t>());
+
+  SmallVector<int64_t, 4> shape;
+  shape.reserve(rank);
+  for (int64_t i = 0, e = rank; i != e; i++) {
+    if (hlo::isDynamicDimSize(rankedTy.getDimSize(i))) {
+      shape.push_back(ShapedType::kDynamicSize);
+      continue;
+    }
+    // P3.
+    if (start[i] < 0)
+      return emitOptionalError(location, "negative start index ", start[i],
+                               " in dimension ", i);
+    // P4.
+    if (limit[i] > rankedTy.getDimSize(i))
+      return emitOptionalError(location, "limit index ", limit[i],
+                               " is larger than dimension size ",
+                               rankedTy.getDimSize(i), " in dimension ", i);
+    // P5.
+    if (start[i] > limit[i])
+      return emitOptionalError(location, "start index ", start[i],
+                               " is larger than limit index ", limit[i],
+                               " in dimension ", i);
+    // P6.
+    if (strideVals[i] <= 0)
+      return emitOptionalError(location, "stride must be positive but got ",
+                               strideVals[i], " in dimension ", i);
+
+    shape.push_back(inferSliceDim(rankedTy.getDimSize(i), start[i], limit[i],
+                                  strideVals[i]));
+  }
+  inferredReturnTypes.assign(
+      {RankedTensorType::get(shape, rankedTy.getElementType())});
+  return success();
+}
+
 LogicalResult inferSortOp(
     Optional<Location> location, ValueRange inputs, uint64_t dimension,
     Region& comparator,
@@ -947,6 +1036,8 @@ LogicalResult inferSortOp(
     inferredReturnShapes.emplace_back(resultType.cast<ShapedType>());
   return success();
 }
+
+
 
 LogicalResult inferTriangularSolveOp(
     Optional<Location> location, Value a, Value b, bool leftSide,

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -139,6 +139,12 @@ LogicalResult inferReduceWindowOp(
     Optional<DenseIntElementsAttr> padding, Region& body,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
+LogicalResult inferSliceOp(Optional<Location> location, Value operand,
+                           DenseIntElementsAttr startIndices,
+                           DenseIntElementsAttr limitIndices,
+                           DenseIntElementsAttr strides,
+                           SmallVectorImpl<Type>& inferredReturnTypes);
+
 LogicalResult inferSortOp(
     Optional<Location> location, ValueRange inputs, uint64_t dimension,
     Region& comparator,


### PR DESCRIPTION
This PR purely move the code without change, I expect to add the bounds to the it directly in the shared file. @smit-hinsu 

Following PRs will move more ops for which we will add bounds soon, but more refactoring code needed, so let's keep this PR simple to review. 