### PR TITLE
Refactor pretty printing machinery to separate files (NFC)

### DIFF
--- a/stablehlo/dialect/AssemblyFormat.cpp
+++ b/stablehlo/dialect/AssemblyFormat.cpp
@@ -14,8 +14,9 @@ limitations under the License.
 ==============================================================================*/
 
 #include "stablehlo/dialect/AssemblyFormat.h"
-#include "stablehlo/dialect/Base.h"
+
 #include "llvm/Support/Regex.h"
+#include "stablehlo/dialect/Base.h"
 
 namespace mlir {
 namespace hlo {

--- a/stablehlo/dialect/AssemblyFormat.cpp
+++ b/stablehlo/dialect/AssemblyFormat.cpp
@@ -1,0 +1,330 @@
+/* Copyright 2022 The StableHLO Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "stablehlo/dialect/AssemblyFormat.h"
+#include "stablehlo/dialect/Base.h"
+#include "llvm/Support/Regex.h"
+
+namespace mlir {
+namespace hlo {
+//===----------------------------------------------------------------------===//
+// Generic Type Printer and Parser
+//===----------------------------------------------------------------------===//
+namespace {
+// Utility function, used by printSelectOpType and
+// printSameOperandsAndResultType. Given a FunctionType, assign the types
+// to operands and results, erroring if any mismatch in number of operands
+// or results occurs.
+ParseResult assignFromFunctionType(OpAsmParser& parser, llvm::SMLoc loc,
+                                   ArrayRef<Type*> operands, Type& result,
+                                   FunctionType& fnType) {
+  assert(fnType);
+  if (fnType.getInputs().size() != operands.size()) {
+    return parser.emitError(loc)
+           << operands.size() << " operands present, but expected "
+           << fnType.getInputs().size();
+  }
+
+  // Set operand types to function input types
+  for (auto [operand, input] : llvm::zip(operands, fnType.getInputs())) {
+    *operand = input;
+  }
+
+  // Set result type
+  if (fnType.getResults().size() != 1) {
+    return parser.emitError(loc, "expected single output");
+  }
+  result = fnType.getResults()[0];
+
+  return success();
+}
+}  // namespace
+
+namespace detail {
+void printSameOperandsAndResultTypeImpl(OpAsmPrinter& p, Operation* op,
+                                        TypeRange operands, Type result) {
+  // Handle zero operand types `() -> a` prints `a`
+  if (operands.empty()) {
+    p.printType(result);
+    return;
+  }
+
+  // Handle all same type `(a,a,...) -> a` prints `a`
+  bool allSameType =
+      llvm::all_of(operands, [&result](auto t) { return t == result; });
+  if (allSameType) {
+    p.printType(result);
+    return;
+  }
+
+  // Fall back to generic
+  p.printFunctionalType(op);
+}
+
+ParseResult parseSameOperandsAndResultTypeImpl(OpAsmParser& parser,
+                                               ArrayRef<Type*> operands,
+                                               Type& result) {
+  llvm::SMLoc loc = parser.getCurrentLocation();
+
+  Type type;
+  if (parser.parseType(type)) {
+    return failure();
+  }
+
+  // Handle if function type, all operand types did not match result type.
+  if (auto fnType = type.dyn_cast<FunctionType>()) {
+    return assignFromFunctionType(parser, loc, operands, result, fnType);
+  }
+
+  // Handle bare types. ` : type` indicating all input/output types match.
+  for (Type* t : operands) {
+    *t = type;
+  }
+  result = type;
+  return success();
+}
+}  // namespace detail
+
+void printVariadicSameOperandsAndResultType(OpAsmPrinter& p, Operation* op,
+                                            OperandRange operands,
+                                            TypeRange opTypes, Type result) {
+  return detail::printSameOperandsAndResultTypeImpl(p, op, opTypes, result);
+}
+
+ParseResult parseVariadicSameOperandsAndResultType(
+    OpAsmParser& parser,
+    SmallVectorImpl<OpAsmParser::UnresolvedOperand>& operands,
+    SmallVectorImpl<Type>& opTypes, Type& result) {
+  // Insert a type for each operand. Need to do this since passing the type of
+  // a variadic op gives no indication of how many operands were provided.
+  opTypes.resize(operands.size());
+
+  // Make a pointer list to the operands
+  SmallVector<Type*> typePtrs;
+  typePtrs.reserve(opTypes.size());
+  for (Type& t : opTypes) {
+    typePtrs.push_back(&t);
+  }
+
+  return detail::parseSameOperandsAndResultTypeImpl(parser, typePtrs, result);
+}
+
+void printTupleOpType(OpAsmPrinter& p, Operation*, TypeRange operands,
+                      Type result) {
+  p.printType(result);
+}
+
+ParseResult parseTupleOpType(OpAsmParser& parser,
+                             SmallVectorImpl<Type>& operands, Type& result) {
+  // Result type must be tuple type.
+  llvm::SMLoc loc = parser.getCurrentLocation();
+  if (parser.parseType(result)) {
+    return failure();
+  }
+
+  auto tupType = result.dyn_cast<TupleType>();
+  if (!tupType) {
+    return parser.emitError(loc, "expected tuple type");
+  }
+
+  // Assign operand types to tuple types
+  llvm::append_range(operands, tupType.getTypes());
+  return success();
+}
+
+void printPairwiseOpType(OpAsmPrinter& p, Operation*, TypeRange operands,
+                         TypeRange results) {
+  llvm::interleaveComma(operands, p);
+}
+
+ParseResult parsePairwiseOpType(OpAsmParser& parser,
+                                SmallVectorImpl<Type>& operands,
+                                SmallVectorImpl<Type>& results) {
+  llvm::SMLoc loc = parser.getCurrentLocation();
+  if (parser.parseTypeList(operands)) {
+    return parser.emitError(loc, "expected type list");
+  }
+  results = operands;
+  return success();
+}
+
+void printVariadicOperandWithAttribute(OpAsmPrinter& p, Operation*,
+                                       OperandRange operands) {
+  llvm::interleaveComma(operands, p);
+  p << ",";
+}
+
+ParseResult parseVariadicOperandWithAttribute(
+    OpAsmParser& parser,
+    SmallVectorImpl<OpAsmParser::UnresolvedOperand>& operands) {
+  // Parse operands as well as trailing commas. Stops when first non-ssa value
+  // seen.
+  OpAsmParser::UnresolvedOperand operand;
+  auto resultOpt = parser.parseOptionalOperand(operand);
+  while (resultOpt.has_value() && succeeded(resultOpt.value())) {
+    operands.push_back(operand);
+    if (failed(parser.parseComma())) {
+      return failure();
+    }
+    resultOpt = parser.parseOptionalOperand(operand);
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// Operation Printers and Parsers
+//===----------------------------------------------------------------------===//
+
+// ComplexOpType - only print result type if the inferred complex type
+// matches all operand types.
+//
+// Inferring operand types for complex ops:
+//  %0 = stablehlo.complex %1, %2 : tensor<4xcomplex<f32>>
+//    %0 : tensor<4xcomplex<f32>>
+//    %1 : tensor<4xf32>
+//    %2 : tensor<4xf32>
+void printComplexOpType(OpAsmPrinter& p, Operation* op, Type lhs, Type rhs,
+                        Type result) {
+  Type realType = createRealType(result.cast<TensorType>());
+
+  if (lhs != realType || rhs != realType) {
+    p.printFunctionalType(op);
+    return;
+  }
+
+  p.printType(result);
+}
+
+ParseResult parseComplexOpType(OpAsmParser& parser, Type& lhs, Type& rhs,
+                               Type& result) {
+  llvm::SMLoc loc = parser.getCurrentLocation();
+  Type type;
+  if (failed(parser.parseType(type))) {
+    return failure();
+  }
+
+  // Handle if function type, all operand types did not match result type.
+  if (auto fnType = type.dyn_cast<FunctionType>()) {
+    return assignFromFunctionType(parser, loc, {&lhs, &rhs}, result, fnType);
+  }
+
+  // Otherwise, operand type is inferred from complex type
+  auto tensorType = type.dyn_cast<TensorType>();
+  if (!tensorType || !tensorType.getElementType().isa<ComplexType>()) {
+    return parser.emitError(loc, "expected tensor with complex element type");
+  }
+
+  // Assign LHS and RHS to inferred type
+  Type realType = createRealType(type.cast<TensorType>());
+  lhs = rhs = realType;
+  result = type;
+  return success();
+}
+
+void printSelectOpType(OpAsmPrinter& p, Operation* op, Type pred, Type onTrue,
+                       Type onFalse, Type result) {
+  // Print functional type if true/false branches don't match return type.
+  if (onTrue != result || onFalse != result) {
+    p.printFunctionalType(op);
+    return;
+  }
+
+  // Print pred type and result type
+  p << pred << ", " << result;
+}
+
+ParseResult parseSelectOpType(OpAsmParser& parser, Type& pred, Type& onTrue,
+                              Type& onFalse, Type& result) {
+  llvm::SMLoc loc = parser.getCurrentLocation();
+  SmallVector<Type> types;
+  if (parser.parseTypeList(types)) {
+    return failure();
+  }
+
+  // Error handling for invalid types
+  // Fail if not two types, or single functional type
+  bool isValidType = (types.size() == 2 ||
+                      (types.size() == 1 && types[0].isa<FunctionType>()));
+  if (!isValidType) {
+    return parser.emitError(loc,
+                            "expected functional type or list of two types");
+  }
+
+  // stablehlo.select %0, %1 : <pred_type>, <op_and_result_type>
+  if (types.size() == 2) {
+    pred = types[0];
+    onTrue = onFalse = result = types[1];
+    return success();
+  }
+
+  // stablehlo.select %0, %1 : (<op_types> ...) -> <result_type>
+  auto fnType = types[0].cast<FunctionType>();
+  return assignFromFunctionType(parser, loc, {&pred, &onTrue, &onFalse}, result,
+                                fnType);
+}
+
+//===----------------------------------------------------------------------===//
+// Attribute Printers and Parsers
+//===----------------------------------------------------------------------===//
+
+// Print attributes as e#m#
+void printExponentMantissa(AsmPrinter& p, Operation*, IntegerAttr exponent,
+                           IntegerAttr mantissa) {
+  p << 'e';
+  p.printAttributeWithoutType(exponent);
+  p << 'm';
+  p.printAttributeWithoutType(mantissa);
+}
+
+// Parse e#m# as exponent=# and mantissa=#
+ParseResult parseExponentMantissa(AsmParser& parser, IntegerAttr& exponent,
+                                  IntegerAttr& mantissa) {
+  llvm::SMLoc loc = parser.getCurrentLocation();
+  llvm::StringRef expMan;
+  if (parser.parseKeyword(&expMan)) {
+    return failure();
+  }
+
+  // Validate format e#m#
+  llvm::Regex expManRegex("^e([0-9]+)m([0-9]+)$");
+  llvm::SmallVector<llvm::StringRef> matches;
+  if (!expManRegex.match(expMan, &matches)) {
+    return parser.emitError(loc,
+                            "expected exponent mantissa in format e#m#, saw ")
+           << expMan;
+  }
+
+  // Parse off digits of exp/man
+  assert(matches.size() == 3);  // matches[0] is entire regex match.
+  llvm::StringRef expS = matches[1];
+  llvm::StringRef manS = matches[2];
+
+  // Parse as base 10 integer strings
+  int exp, mant;
+  if (expS.getAsInteger(/*radix=*/10, exp)) {
+    return parser.emitError(loc, "unable to parse exponent '")
+           << expS.str() << "'";
+  }
+  if (manS.getAsInteger(/*radix=*/10, mant)) {
+    return parser.emitError(loc, "unable to parse mantissa '")
+           << manS.str() << "'";
+  }
+
+  exponent = parser.getBuilder().getI32IntegerAttr(exp);
+  mantissa = parser.getBuilder().getI32IntegerAttr(mant);
+  return success();
+}
+}  // namespace hlo
+}  // namespace mlir

--- a/stablehlo/dialect/AssemblyFormat.h
+++ b/stablehlo/dialect/AssemblyFormat.h
@@ -1,0 +1,156 @@
+/* Copyright 2022 The StableHLO Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef STABLEHLO_DIALECT_ASSEMBLYFORMAT_H
+#define STABLEHLO_DIALECT_ASSEMBLYFORMAT_H
+
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/OpImplementation.h"
+
+namespace mlir {
+namespace hlo {
+
+//===----------------------------------------------------------------------===//
+// Generic Type Printers and Parsers
+//===----------------------------------------------------------------------===//
+
+// Declarative `custom<SameOperandsAndResultType>(...)` implementation:
+// Pretty print for ops with many operands, but one result type, simplifies
+// print if all operand types match the result type.
+//
+// Example:
+//   custom<SameOperandsAndResultType>(type($result), type($operand1),
+//   type($operand2))
+//
+//   Generic:
+//     %0 = "stablehlo.op"(%0, %1) : (tensor<i1>, tensor<i1>) -> tensor<i1>
+//   Custom:
+//     %0 = stablehlo.op(%0, %1) : tensor<i1>
+//
+// Falls back to `printFunctionalType` if all operands do not match result
+// type.
+//
+// Note that `type($result)` is the first argument, this is done because the
+// behavior of trailing parameter packs is easily understandable.
+namespace detail {
+void printSameOperandsAndResultTypeImpl(OpAsmPrinter& p, Operation* op,
+                                        TypeRange operands, Type result);
+
+ParseResult parseSameOperandsAndResultTypeImpl(OpAsmParser& parser,
+                                               ArrayRef<Type*> operands,
+                                               Type& result);
+}  // namespace detail
+
+template <class... OpTypes>
+void printSameOperandsAndResultType(OpAsmPrinter& p, Operation* op,
+                                    OpTypes... types) {
+  static_assert(sizeof...(types) > 0);  // Must be non empty, must have result
+  SmallVector<Type> typesVec{types...};
+  ArrayRef<Type> typesRef = makeArrayRef(typesVec);
+  return detail::printSameOperandsAndResultTypeImpl(
+      p, op, typesRef.drop_back(1), typesRef.back());
+}
+
+template <class... OpTypes>
+ParseResult parseSameOperandsAndResultType(OpAsmParser& parser,
+                                           OpTypes&... types) {
+  static_assert(sizeof...(types) > 0);  // Must be non empty, must have result
+  SmallVector<Type*> typesVec{&types...};
+  ArrayRef<Type*> typesRef = makeArrayRef(typesVec);
+  return detail::parseSameOperandsAndResultTypeImpl(
+      parser, typesRef.drop_back(1), *typesRef.back());
+}
+
+void printVariadicSameOperandsAndResultType(OpAsmPrinter& p, Operation* op,
+                                            OperandRange operands,
+                                            TypeRange opTypes, Type result);
+
+ParseResult parseVariadicSameOperandsAndResultType(
+    OpAsmParser& parser,
+    SmallVectorImpl<OpAsmParser::UnresolvedOperand>& operands,
+    SmallVectorImpl<Type>& opTypes, Type& result);
+
+// TuplesOp - only print result type. Operand type is trivially inferrable.
+//
+// Inferring operand types from tuple type:
+//  %3 = stablehlo.tuple %1, %2 : tuple<tensor<i1>, tensor<f32>>
+//    %1 : tensor<i1>
+//    %2 : tensor<f32>
+//    %3 : tuple<tensor<i1>, tensor<f32>>
+void printTupleOpType(OpAsmPrinter& p, Operation*, TypeRange operands,
+                      Type result);
+
+ParseResult parseTupleOpType(OpAsmParser& parser,
+                             SmallVectorImpl<Type>& operands, Type& result);
+
+// PairwiseOps - only print result type. Operand types are trivially
+// inferrable.
+//
+// Inferring operand types for pairwise ops:
+//  %3, %4 = stablehlo.operation %1, %2 : tensor<i1>, tensor<f32>
+//    %1 : tensor<i1>
+//    %2 : tensor<f32>
+//    %3 : tensor<i1>
+//    %4 : tensor<f32>
+void printPairwiseOpType(OpAsmPrinter& p, Operation*, TypeRange operands,
+                         TypeRange results);
+
+ParseResult parsePairwiseOpType(OpAsmParser& parser,
+                                SmallVectorImpl<Type>& operands,
+                                SmallVectorImpl<Type>& results);
+
+// Variadic operands with attributes - Need to provide custom parser since
+// the built-in operand list parser parses the attribute expecting an SSA value
+// and errors.
+//
+// %0 = stablehlo.operation %arg0, ..., %argN, attr = value
+void printVariadicOperandWithAttribute(OpAsmPrinter& p, Operation*,
+                                       OperandRange operands);
+
+ParseResult parseVariadicOperandWithAttribute(
+    OpAsmParser& parser,
+    SmallVectorImpl<OpAsmParser::UnresolvedOperand>& operands);
+
+//===----------------------------------------------------------------------===//
+// Operation Printers and Parsers
+//===----------------------------------------------------------------------===//
+
+void printComplexOpType(OpAsmPrinter& p, Operation* op, Type lhs, Type rhs,
+                        Type result);
+
+ParseResult parseComplexOpType(OpAsmParser& parser, Type& lhs, Type& rhs,
+                               Type& result);
+
+void printSelectOpType(OpAsmPrinter& p, Operation* op, Type pred, Type onTrue,
+                       Type onFalse, Type result);
+
+ParseResult parseSelectOpType(OpAsmParser& parser, Type& pred, Type& onTrue,
+                              Type& onFalse, Type& result);
+
+
+//===----------------------------------------------------------------------===//
+// Attribute Printers and Parsers
+//===----------------------------------------------------------------------===//
+
+void printExponentMantissa(AsmPrinter& p, Operation*, IntegerAttr exponent,
+                           IntegerAttr mantissa);
+
+ParseResult parseExponentMantissa(AsmParser& parser, IntegerAttr& exponent,
+                                  IntegerAttr& mantissa);
+
+}  // namespace hlo
+}  // namespace mlir
+
+#endif  // STABLEHLO_DIALECT_ASSEMBLYFORMAT_H

--- a/stablehlo/dialect/AssemblyFormat.h
+++ b/stablehlo/dialect/AssemblyFormat.h
@@ -16,8 +16,8 @@ limitations under the License.
 #ifndef STABLEHLO_DIALECT_ASSEMBLYFORMAT_H
 #define STABLEHLO_DIALECT_ASSEMBLYFORMAT_H
 
-#include "mlir/IR/Operation.h"
 #include "mlir/IR/OpImplementation.h"
+#include "mlir/IR/Operation.h"
 
 namespace mlir {
 namespace hlo {
@@ -138,7 +138,6 @@ void printSelectOpType(OpAsmPrinter& p, Operation* op, Type pred, Type onTrue,
 
 ParseResult parseSelectOpType(OpAsmParser& parser, Type& pred, Type& onTrue,
                               Type& onFalse, Type& result);
-
 
 //===----------------------------------------------------------------------===//
 // Attribute Printers and Parsers

--- a/stablehlo/dialect/Base.cpp
+++ b/stablehlo/dialect/Base.cpp
@@ -139,6 +139,17 @@ TensorType getSameShapeTensorType(TensorType tensorType, Type elementType) {
   llvm_unreachable("unhandled type");
 }
 
+// createRealType takes a tensor type that may have complex elements and
+// returns a type that maintains the shape, but with real numeric data types.
+//   Ex: tensor<4xcomplex<f32>>  -->  tensor<4xf32>
+Type createRealType(TensorType type) {
+  auto elementTy = type.getElementType();
+  if (auto complexTy = elementTy.dyn_cast<ComplexType>()) {
+    elementTy = complexTy.getElementType();
+  }
+  return hlo::getSameShapeTensorType(type, elementTy);
+}
+
 // TODO(hinsu): Add verification for bounds that it has the same size as rank
 // of the tensor and static dimensions don't have bounds.
 LogicalResult verifyBounds(ArrayRef<int64_t> bounds, ShapedType type,

--- a/stablehlo/dialect/Base.h
+++ b/stablehlo/dialect/Base.h
@@ -69,6 +69,11 @@ LogicalResult deriveShapeFromOperand(
 // Type derivation function that returns a tensor type with a new element type.
 TensorType getSameShapeTensorType(TensorType tensorType, Type elementType);
 
+// Takes a tensor type that may have complex elements and returns a type that
+// maintains the shape, but with real numeric data types.
+//   Ex: tensor<4xcomplex<f32>>  -->  tensor<4xf32>
+Type createRealType(TensorType type);
+
 // Verify bounds expressed by HLO_BoundedInterface against the provided type.
 // See documentation for HLO_BoundedInterface for the list of checks.
 LogicalResult verifyBounds(ArrayRef<int64_t> bounds, ShapedType type,

--- a/stablehlo/dialect/CMakeLists.txt
+++ b/stablehlo/dialect/CMakeLists.txt
@@ -90,6 +90,15 @@ add_mlir_dialect_library(StablehloRegister
   StablehloOps
 )
 
+add_mlir_dialect_library(StablehloAssemblyFormat
+  PARTIAL_SOURCES_INTENDED
+  AssemblyFormat.cpp 
+
+  LINK_LIBS PUBLIC
+  StablehloBase
+  MLIRIR
+)
+
 add_mlir_dialect_library(StablehloTypeInference
   PARTIAL_SOURCES_INTENDED
   TypeInference.cpp 
@@ -118,6 +127,7 @@ add_mlir_dialect_library(StablehloOps
   StablehloOpsIncGen
 
   LINK_LIBS PUBLIC
+  StablehloAssemblyFormat
   StablehloBase
   StablehloTypeInference
   MLIRArithDialect

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -70,10 +70,10 @@ limitations under the License.
 #include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/InliningUtils.h"
+#include "stablehlo/dialect/AssemblyFormat.h"
 #include "stablehlo/dialect/StablehloBytecode.h"
 #include "stablehlo/dialect/StablehloOps.h.inc"
 #include "stablehlo/dialect/TypeInference.h"
-#include "stablehlo/dialect/AssemblyFormat.h"
 
 // Include order matters
 #include "stablehlo/dialect/StablehloEnums.cpp.inc"
@@ -2365,7 +2365,6 @@ LogicalResult ClampOp::reifyReturnTypeShapes(
 // ComplexOp
 //===----------------------------------------------------------------------===//
 
-
 LogicalResult ComplexOp::inferReturnTypes(
     MLIRContext*, Optional<Location>, ValueRange operands, DictionaryAttr,
     RegionRange, SmallVectorImpl<Type>& inferredReturnTypes) {
@@ -4478,7 +4477,6 @@ LogicalResult UniformDequantizeOp::inferReturnTypeComponents(
   inferredReturnShapes.emplace_back(shape, quantType.getExpressedType());
   return success();
 }
-
 
 }  // namespace stablehlo
 }  // namespace mlir

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -73,6 +73,7 @@ limitations under the License.
 #include "stablehlo/dialect/StablehloBytecode.h"
 #include "stablehlo/dialect/StablehloOps.h.inc"
 #include "stablehlo/dialect/TypeInference.h"
+#include "stablehlo/dialect/AssemblyFormat.h"
 
 // Include order matters
 #include "stablehlo/dialect/StablehloEnums.cpp.inc"
@@ -667,7 +668,7 @@ ParseResult parsePrecisionConfig(OpAsmParser& parser, mlir::ArrayAttr& attr) {
   if (failed(parser.parseCommaSeparatedList(
           AsmParser::Delimiter::Square, [&]() -> ParseResult {
             attrs.push_back(PrecisionAttr::parse(parser, {}));
-            return success(/*isSuccess=*/bool(attrs.back()));
+            return success(/*isSuccess=*/static_cast<bool>(attrs.back()));
           }))) {
     return failure();
   }
@@ -2364,93 +2365,6 @@ LogicalResult ClampOp::reifyReturnTypeShapes(
 // ComplexOp
 //===----------------------------------------------------------------------===//
 
-namespace {
-// Utility function, used by printSelectOpType and
-// printSameOperandsAndResultType. Given a FunctionType, assign the types
-// to operands and results, erroring if any mismatch in number of operands
-// or results occurs.
-ParseResult assignFromFunctionType(OpAsmParser& parser, llvm::SMLoc loc,
-                                   ArrayRef<Type*> operands, Type& result,
-                                   FunctionType& fnType) {
-  assert(fnType);
-  if (fnType.getInputs().size() != operands.size()) {
-    return parser.emitError(loc)
-           << operands.size() << " operands present, but expected "
-           << fnType.getInputs().size();
-  }
-
-  // Set operand types to function input types
-  for (auto [operand, input] : llvm::zip(operands, fnType.getInputs())) {
-    *operand = input;
-  }
-
-  // Set result type
-  if (fnType.getResults().size() != 1) {
-    return parser.emitError(loc, "expected single output");
-  }
-  result = fnType.getResults()[0];
-
-  return success();
-}
-
-// createRealType takes a tensor type that may have complex elements and
-// returns a type that maintains the shape, but with real numeric data types.
-//   Ex: tensor<4xcomplex<f32>>  -->  tensor<4xf32>
-Type createRealType(TensorType type) {
-  auto elementTy = type.getElementType();
-  if (auto complexTy = elementTy.dyn_cast<ComplexType>()) {
-    elementTy = complexTy.getElementType();
-  }
-  return hlo::getSameShapeTensorType(type, elementTy);
-}
-
-// ComplexOpType - only print result type if the inferred complex type
-// matches all operand types.
-//
-// Inferring operand types for complex ops:
-//  %0 = stablehlo.complex %1, %2 : tensor<4xcomplex<f32>>
-//    %0 : tensor<4xcomplex<f32>>
-//    %1 : tensor<4xf32>
-//    %2 : tensor<4xf32>
-void printComplexOpType(OpAsmPrinter& p, Operation* op, Type lhs, Type rhs,
-                        Type result) {
-  Type realType = createRealType(result.cast<TensorType>());
-
-  if (lhs != realType || rhs != realType) {
-    p.printFunctionalType(op);
-    return;
-  }
-
-  p.printType(result);
-}
-
-ParseResult parseComplexOpType(OpAsmParser& parser, Type& lhs, Type& rhs,
-                               Type& result) {
-  llvm::SMLoc loc = parser.getCurrentLocation();
-  Type type;
-  if (failed(parser.parseType(type))) {
-    return failure();
-  }
-
-  // Handle if function type, all operand types did not match result type.
-  if (auto fnType = type.dyn_cast<FunctionType>()) {
-    return assignFromFunctionType(parser, loc, {&lhs, &rhs}, result, fnType);
-  }
-
-  // Otherwise, operand type is inferred from complex type
-  auto tensorType = type.dyn_cast<TensorType>();
-  if (!tensorType || !tensorType.getElementType().isa<ComplexType>()) {
-    return parser.emitError(loc, "expected tensor with complex element type");
-  }
-
-  // Assign LHS and RHS to inferred type
-  Type realType = createRealType(type.cast<TensorType>());
-  lhs = rhs = realType;
-  result = type;
-  return success();
-}
-
-}  // namespace
 
 LogicalResult ComplexOp::inferReturnTypes(
     MLIRContext*, Optional<Location>, ValueRange operands, DictionaryAttr,
@@ -2470,7 +2384,7 @@ LogicalResult ImagOp::inferReturnTypes(
     MLIRContext*, Optional<Location>, ValueRange operands, DictionaryAttr,
     RegionRange, SmallVectorImpl<Type>& inferredReturnTypes) {
   inferredReturnTypes.push_back(
-      createRealType(operands[0].getType().cast<TensorType>()));
+      hlo::createRealType(operands[0].getType().cast<TensorType>()));
   return success();
 }
 
@@ -2496,7 +2410,7 @@ LogicalResult RealOp::inferReturnTypes(
     MLIRContext*, Optional<Location>, ValueRange operands, DictionaryAttr,
     RegionRange, SmallVectorImpl<Type>& inferredReturnTypes) {
   inferredReturnTypes.push_back(
-      createRealType(operands[0].getType().cast<TensorType>()));
+      hlo::createRealType(operands[0].getType().cast<TensorType>()));
   return success();
 }
 
@@ -2977,61 +2891,6 @@ Operation* ReduceWindowOp::getReductionOp(int resultIndex) {
 // ReducePrecisionOp
 //===----------------------------------------------------------------------===//
 
-namespace {
-// Print attributes as e#m#
-void printExponentMantissa(AsmPrinter& p, IntegerAttr exponent,
-                           IntegerAttr mantissa) {
-  p << 'e';
-  p.printAttributeWithoutType(exponent);
-  p << 'm';
-  p.printAttributeWithoutType(mantissa);
-}
-
-void printExponentMantissa(AsmPrinter& p, Operation*, IntegerAttr exponent,
-                           IntegerAttr mantissa) {
-  printExponentMantissa(p, exponent, mantissa);
-}
-
-// Parse e#m# as exponent=# and mantissa=#
-ParseResult parseExponentMantissa(AsmParser& parser, IntegerAttr& exponent,
-                                  IntegerAttr& mantissa) {
-  llvm::SMLoc loc = parser.getCurrentLocation();
-  llvm::StringRef expMan;
-  if (parser.parseKeyword(&expMan)) {
-    return failure();
-  }
-
-  // Validate format e#m#
-  llvm::Regex expManRegex("^e([0-9]+)m([0-9]+)$");
-  llvm::SmallVector<llvm::StringRef> matches;
-  if (!expManRegex.match(expMan, &matches)) {
-    return parser.emitError(loc,
-                            "expected exponent mantissa in format e#m#, saw ")
-           << expMan;
-  }
-
-  // Parse off digits of exp/man
-  assert(matches.size() == 3);  // matches[0] is entire regex match.
-  llvm::StringRef expS = matches[1];
-  llvm::StringRef manS = matches[2];
-
-  // Parse as base 10 integer strings
-  int exp, mant;
-  if (expS.getAsInteger(/*radix=*/10, exp)) {
-    return parser.emitError(loc, "unable to parse exponent '")
-           << expS.str() << "'";
-  }
-  if (manS.getAsInteger(/*radix=*/10, mant)) {
-    return parser.emitError(loc, "unable to parse mantissa '")
-           << manS.str() << "'";
-  }
-
-  exponent = parser.getBuilder().getI32IntegerAttr(exp);
-  mantissa = parser.getBuilder().getI32IntegerAttr(mant);
-  return success();
-}
-}  // namespace
-
 // The following property is already enforced by the ODS:
 //  P0. operand element type is float
 //  P1. mantissa_bits >= 0
@@ -3498,51 +3357,6 @@ LogicalResult RngOp::reifyReturnTypeShapes(
 //===----------------------------------------------------------------------===//
 // SelectOp
 //===----------------------------------------------------------------------===//
-
-namespace {
-void printSelectOpType(OpAsmPrinter& p, Operation* op, Type pred, Type onTrue,
-                       Type onFalse, Type result) {
-  // Print functional type if true/false branches don't match return type.
-  if (onTrue != result || onFalse != result) {
-    p.printFunctionalType(op);
-    return;
-  }
-
-  // Print pred type and result type
-  p << pred << ", " << result;
-}
-
-ParseResult parseSelectOpType(OpAsmParser& parser, Type& pred, Type& onTrue,
-                              Type& onFalse, Type& result) {
-  llvm::SMLoc loc = parser.getCurrentLocation();
-  SmallVector<Type> types;
-  if (parser.parseTypeList(types)) {
-    return failure();
-  }
-
-  // Error handling for invalid types
-  // Fail if not two types, or single functional type
-  bool isValidType = (types.size() == 2 ||
-                      (types.size() == 1 && types[0].isa<FunctionType>()));
-  if (!isValidType) {
-    return parser.emitError(loc,
-                            "expected functional type or list of two types");
-  }
-
-  // stablehlo.select %0, %1 : <pred_type>, <op_and_result_type>
-  if (types.size() == 2) {
-    pred = types[0];
-    onTrue = onFalse = result = types[1];
-    return success();
-  }
-
-  // stablehlo.select %0, %1 : (<op_types> ...) -> <result_type>
-  auto fnType = types[0].cast<FunctionType>();
-  return assignFromFunctionType(parser, loc, {&pred, &onTrue, &onFalse}, result,
-                                fnType);
-}
-
-}  // namespace
 
 LogicalResult SelectOp::verify() {
   // The operands 'on_true' and 'on_false' should have compatible types, i.e.,
@@ -4665,195 +4479,28 @@ LogicalResult UniformDequantizeOp::inferReturnTypeComponents(
   return success();
 }
 
-//===----------------------------------------------------------------------===//
-// Assembly - Custom Type Directives
-//===----------------------------------------------------------------------===//
-
-// Declarative `custom<SameOperandsAndResultType>(...)` implementation:
-// Pretty print for ops with many operands, but one result type, simplifies
-// print if all operand types match the result type. Based on `printOneResultOp`
-// and `parseOneResultSameOperandTypeOp` from tfl_ops.cc and SPIRVOps.cpp.
-//
-// Example:
-//   custom<SameOperandsAndResultType>(type($result), type($operand1),
-//   type($operand2))
-//
-//   Generic:
-//     %0 = "stablehlo.op"(%0, %1) : (tensor<i1>, tensor<i1>) -> tensor<i1>
-//   Custom:
-//     %0 = stablehlo.op(%0, %1) : tensor<i1>
-//
-// Falls back to `printFunctionalType` if all operands do not match result type.
-//
-// Note that `type($result)` is the first argument, this is done because the
-// behavior of trailing parameter packs is easily understandable.
-void printSameOperandsAndResultTypeImpl(OpAsmPrinter& p, Operation* op,
-                                        TypeRange operands, Type result) {
-  // Handle zero operand types `() -> a` prints `a`
-  if (operands.empty()) {
-    p.printType(result);
-    return;
-  }
-
-  // Handle all same type `(a,a,...) -> a` prints `a`
-  bool allSameType =
-      llvm::all_of(operands, [&result](auto t) { return t == result; });
-  if (allSameType) {
-    p.printType(result);
-    return;
-  }
-
-  // Fall back to generic
-  p.printFunctionalType(op);
-}
-
-ParseResult parseSameOperandsAndResultTypeImpl(OpAsmParser& parser,
-                                               ArrayRef<Type*> operands,
-                                               Type& result) {
-  llvm::SMLoc loc = parser.getCurrentLocation();
-
-  Type type;
-  if (parser.parseType(type)) {
-    return failure();
-  }
-
-  // Handle if function type, all operand types did not match result type.
-  if (auto fnType = type.dyn_cast<FunctionType>()) {
-    return assignFromFunctionType(parser, loc, operands, result, fnType);
-  }
-
-  // Handle bare types. ` : type` indicating all input/output types match.
-  for (Type* t : operands) {
-    *t = type;
-  }
-  result = type;
-  return success();
-}
-
-template <class... OpTypes>
-void printSameOperandsAndResultType(OpAsmPrinter& p, Operation* op,
-                                    OpTypes... types) {
-  static_assert(sizeof...(types) > 0);  // Must be non empty, must have result
-  SmallVector<Type> typesVec{types...};
-  ArrayRef<Type> typesRef = makeArrayRef(typesVec);
-  return printSameOperandsAndResultTypeImpl(p, op, typesRef.drop_back(1),
-                                            typesRef.back());
-}
-
-template <class... OpTypes>
-ParseResult parseSameOperandsAndResultType(OpAsmParser& parser,
-                                           OpTypes&... types) {
-  static_assert(sizeof...(types) > 0);  // Must be non empty, must have result
-  SmallVector<Type*> typesVec{&types...};
-  ArrayRef<Type*> typesRef = makeArrayRef(typesVec);
-  return parseSameOperandsAndResultTypeImpl(parser, typesRef.drop_back(1),
-                                            *typesRef.back());
-}
-
-void printVariadicSameOperandsAndResultType(OpAsmPrinter& p, Operation* op,
-                                            OperandRange operands,
-                                            TypeRange opTypes, Type result) {
-  return printSameOperandsAndResultTypeImpl(p, op, opTypes, result);
-}
-
-ParseResult parseVariadicSameOperandsAndResultType(
-    OpAsmParser& parser,
-    SmallVectorImpl<OpAsmParser::UnresolvedOperand>& operands,
-    SmallVectorImpl<Type>& opTypes, Type& result) {
-  // Insert a type for each operand. Need to do this since passing the type of
-  // a variadic op gives no indication of how many operands were provided.
-  opTypes.resize(operands.size());
-
-  // Make a pointer list to the operands
-  SmallVector<Type*> typePtrs;
-  typePtrs.reserve(opTypes.size());
-  for (Type& t : opTypes) {
-    typePtrs.push_back(&t);
-  }
-
-  return parseSameOperandsAndResultTypeImpl(parser, typePtrs, result);
-}
-
-// TuplesOp - only print result type. Operand type is trivially inferrable.
-//
-// Inferring operand types from tuple type:
-//  %3 = stablehlo.tuple %1, %2 : tuple<tensor<i1>, tensor<f32>>
-//    %1 : tensor<i1>
-//    %2 : tensor<f32>
-//    %3 : tuple<tensor<i1>, tensor<f32>>
-void printTupleOpType(OpAsmPrinter& p, Operation*, TypeRange operands,
-                      Type result) {
-  p.printType(result);
-}
-
-ParseResult parseTupleOpType(OpAsmParser& parser,
-                             SmallVectorImpl<Type>& operands, Type& result) {
-  // Result type must be tuple type.
-  llvm::SMLoc loc = parser.getCurrentLocation();
-  if (parser.parseType(result)) {
-    return failure();
-  }
-
-  auto tupType = result.dyn_cast<TupleType>();
-  if (!tupType) {
-    return parser.emitError(loc, "expected tuple type");
-  }
-
-  // Assign operand types to tuple types
-  llvm::append_range(operands, tupType.getTypes());
-  return success();
-}
-
-// PairwiseOps - only print result type. Operand types are trivially
-// inferrable.
-//
-// Inferring operand types for pairwise ops:
-//  %3, %4 = stablehlo.operation %1, %2 : tensor<i1>, tensor<f32>
-//    %1 : tensor<i1>
-//    %2 : tensor<f32>
-//    %3 : tensor<i1>
-//    %4 : tensor<f32>
-void printPairwiseOpType(OpAsmPrinter& p, Operation*, TypeRange operands,
-                         TypeRange results) {
-  llvm::interleaveComma(operands, p);
-}
-
-ParseResult parsePairwiseOpType(OpAsmParser& parser,
-                                SmallVectorImpl<Type>& operands,
-                                SmallVectorImpl<Type>& results) {
-  llvm::SMLoc loc = parser.getCurrentLocation();
-  if (parser.parseTypeList(operands)) {
-    return parser.emitError(loc, "expected type list");
-  }
-  results = operands;
-  return success();
-}
-
-void printVariadicOperandWithAttribute(OpAsmPrinter& p, Operation*,
-                                       OperandRange operands) {
-  llvm::interleaveComma(operands, p);
-  p << ",";
-}
-
-ParseResult parseVariadicOperandWithAttribute(
-    OpAsmParser& parser,
-    SmallVectorImpl<OpAsmParser::UnresolvedOperand>& operands) {
-  // Parse operands as well as trailing commas. Stops when first non-ssa value
-  // seen.
-  OpAsmParser::UnresolvedOperand operand;
-  auto resultOpt = parser.parseOptionalOperand(operand);
-  while (resultOpt.has_value() && succeeded(resultOpt.value())) {
-    operands.push_back(operand);
-    if (failed(parser.parseComma())) {
-      return failure();
-    }
-    resultOpt = parser.parseOptionalOperand(operand);
-  }
-  return success();
-}
 
 }  // namespace stablehlo
 }  // namespace mlir
+
+// clang-format off
+using mlir::hlo::printSameOperandsAndResultType;
+using mlir::hlo::parseSameOperandsAndResultType;
+using mlir::hlo::printVariadicSameOperandsAndResultType;
+using mlir::hlo::parseVariadicSameOperandsAndResultType;
+using mlir::hlo::printVariadicOperandWithAttribute;
+using mlir::hlo::parseVariadicOperandWithAttribute;
+using mlir::hlo::printComplexOpType;
+using mlir::hlo::parseComplexOpType;
+using mlir::hlo::printPairwiseOpType;
+using mlir::hlo::parsePairwiseOpType;
+using mlir::hlo::printSelectOpType;
+using mlir::hlo::parseSelectOpType;
+using mlir::hlo::printTupleOpType;
+using mlir::hlo::parseTupleOpType;
+using mlir::hlo::printExponentMantissa;
+using mlir::hlo::parseExponentMantissa;
+// clang-format on
 
 #define GET_OP_CLASSES
 #include "stablehlo/dialect/StablehloOps.cpp.inc"


### PR DESCRIPTION
Created `stablehlo/dialect/AssemblyFormat.h` with shared code for pretty printing. This only depends on `StablehloBase` and upstream MLIR.

Skipping the move of print operations that rely on specific attribute types. Will reconsider these in a later PR. Custom printer machinery requires functions to have a certain signature, so there is a good change these will need to be templated.
`StablehloOps.cpp` has many `using mlir::hlo::print*` declarations. An alternative is to `using namespace mlir::hlo` in the file scope, but that is not super desirable and clang tidy complains.