### PR TITLE
Change shape function interface for branch ops

### DIFF
--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -3954,24 +3954,24 @@ LogicalResult ReplicaIdOp::inferReturnTypes(
 // If Op
 //===----------------------------------------------------------------------===//
 
-LogicalResult IfOp::inferReturnTypeComponents(
-    MLIRContext*, Optional<Location> location, ValueShapeRange operands,
+LogicalResult IfOp::inferReturnTypes(
+    MLIRContext*, Optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, RegionRange regions,
-    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
+    SmallVectorImpl<Type>& inferredReturnTypes) {
   IfOp::Adaptor adaptor(operands, attributes, regions);
-  return hlo::inferIfOp(location, adaptor.getRegions(), inferredReturnShapes);
+  return hlo::inferIfOp(location, adaptor.getRegions(), inferredReturnTypes);
 }
 
 //===----------------------------------------------------------------------===//
 // Case Op
 //===----------------------------------------------------------------------===//
 
-LogicalResult CaseOp::inferReturnTypeComponents(
-    MLIRContext*, Optional<Location> location, ValueShapeRange operands,
+LogicalResult CaseOp::inferReturnTypes(
+    MLIRContext*, Optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, RegionRange regions,
-    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
+    SmallVectorImpl<Type>& inferredReturnTypes) {
   CaseOp::Adaptor adaptor(operands, attributes, regions);
-  return hlo::inferCaseOp(location, adaptor.getRegions(), inferredReturnShapes);
+  return hlo::inferCaseOp(location, adaptor.getRegions(), inferredReturnTypes);
 }
 
 //===----------------------------------------------------------------------===//
@@ -4577,13 +4577,13 @@ LogicalResult ScatterOp::verify() {
 // WhileOp
 //===----------------------------------------------------------------------===//
 
-LogicalResult WhileOp::inferReturnTypeComponents(
-    MLIRContext*, Optional<Location> location, ValueShapeRange operands,
+LogicalResult WhileOp::inferReturnTypes(
+    MLIRContext*, Optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, RegionRange regions,
-    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
+    SmallVectorImpl<Type>& inferredReturnTypes) {
   WhileOp::Adaptor adaptor(operands, attributes, regions);
   return hlo::inferWhileOp(location, adaptor.getOperand(), adaptor.getCond(),
-                           adaptor.getBody(), inferredReturnShapes);
+                           adaptor.getBody(), inferredReturnTypes);
 }
 
 /// Print a `while` op.

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1138,7 +1138,7 @@ def StableHLO_AfterAllOp : StableHLO_Op<"after_all", [NoSideEffect]> {
 def StableHLO_IfOp: StableHLO_Op<"if", [
     RecursiveSideEffects,
     SingleBlockImplicitTerminator<"ReturnOp">,
-    InferTensorType]> {
+    DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
   let summary = "If operator";
 
   let description = [{
@@ -1169,7 +1169,7 @@ def StableHLO_IfOp: StableHLO_Op<"if", [
 def StableHLO_CaseOp: StableHLO_Op<"case", [
       RecursiveSideEffects,
       SingleBlockImplicitTerminator<"ReturnOp">,
-      InferTensorType
+      DeclareOpInterfaceMethods<InferTypeOpInterface>
     ]> {
   let summary = "Switch-Case operator";
   let description = [{
@@ -1196,7 +1196,7 @@ def StableHLO_CaseOp: StableHLO_Op<"case", [
 def StableHLO_WhileOp: StableHLO_Op<"while", [
       RecursiveSideEffects,
       SingleBlockImplicitTerminator<"ReturnOp">,
-      InferTensorType,
+      DeclareOpInterfaceMethods<InferTypeOpInterface>,
       OpAsmOpInterface
     ]> {
   let summary = "While operator";

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -463,9 +463,9 @@ LogicalResult inferBatchNormTrainingOp(
   return success();
 }
 
-LogicalResult inferConditionalOp(
-    Optional<Location> location, RegionRange branches,
-    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
+LogicalResult inferConditionalOp(Optional<Location> location,
+                                 RegionRange branches,
+                                 SmallVectorImpl<Type>& inferredReturnTypes) {
   if (branches.empty())
     return emitOptionalError(location, "expect at least one branch");
 
@@ -487,14 +487,13 @@ LogicalResult inferConditionalOp(
                                branch0ResultTypes, " vs ", branchResultTypes);
   }
   for (auto resultType : branch0ResultTypes)
-    inferredReturnShapes.emplace_back(resultType.cast<ShapedType>());
+    inferredReturnTypes.push_back(resultType);
   return success();
 }
 
-LogicalResult inferCaseOp(
-    Optional<Location> location, RegionRange branches,
-    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
-  return inferConditionalOp(location, branches, inferredReturnShapes);
+LogicalResult inferCaseOp(Optional<Location> location, RegionRange branches,
+                          SmallVectorImpl<Type>& inferredReturnTypes) {
+  return inferConditionalOp(location, branches, inferredReturnTypes);
 }
 
 LogicalResult inferDotGeneralOp(
@@ -617,10 +616,9 @@ LogicalResult inferDotGeneralOp(
   return success();
 }
 
-LogicalResult inferIfOp(
-    Optional<Location> location, RegionRange branches,
-    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
-  return inferConditionalOp(location, branches, inferredReturnShapes);
+LogicalResult inferIfOp(Optional<Location> location, RegionRange branches,
+                        SmallVectorImpl<Type>& inferredReturnTypes) {
+  return inferConditionalOp(location, branches, inferredReturnTypes);
 }
 
 LogicalResult inferMapOp(
@@ -1154,9 +1152,9 @@ LogicalResult inferTriangularSolveOp(
   return success();
 }
 
-LogicalResult inferWhileOp(
-    Optional<Location> location, ValueRange operand, Region& cond, Region& body,
-    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
+LogicalResult inferWhileOp(Optional<Location> location, ValueRange operand,
+                           Region& cond, Region& body,
+                           SmallVectorImpl<Type>& inferredReturnTypes) {
   auto operandTypes = operand.getTypes();
   auto condArgsTypes = cond.front().getArgumentTypes();
   auto bodyArgsTypes = body.front().getArgumentTypes();
@@ -1192,7 +1190,7 @@ LogicalResult inferWhileOp(
         condReturnTypes[0]);
 
   for (const auto& resultType : operand.getType())
-    inferredReturnShapes.emplace_back(resultType.cast<ShapedType>());
+    inferredReturnTypes.push_back(resultType);
   return success();
 }
 

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -104,9 +104,8 @@ LogicalResult inferBatchNormTrainingOp(
     Value operand, uint64_t featureIndex,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
-LogicalResult inferCaseOp(
-    Optional<Location> location, RegionRange branches,
-    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
+LogicalResult inferCaseOp(Optional<Location> location, RegionRange branches,
+                          SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferDotGeneralOp(
     Optional<Location> location, Value lhs, Value rhs,
@@ -116,9 +115,8 @@ LogicalResult inferDotGeneralOp(
     ArrayRef<int64_t> rhsContractingDimensions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
-LogicalResult inferIfOp(
-    Optional<Location> location, RegionRange branches,
-    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
+LogicalResult inferIfOp(Optional<Location> location, RegionRange branches,
+                        SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferMapOp(
     Optional<Location> location, ValueRange inputs,
@@ -159,9 +157,9 @@ LogicalResult inferTriangularSolveOp(
     bool isTransposeAInvalid,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
-LogicalResult inferWhileOp(
-    Optional<Location> location, ValueRange operand, Region& cond, Region& body,
-    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
+LogicalResult inferWhileOp(Optional<Location> location, ValueRange operand,
+                           Region& cond, Region& body,
+                           SmallVectorImpl<Type>& inferredReturnTypes);
 
 }  // end namespace hlo
 }  // end namespace mlir


### PR DESCRIPTION
For shape functions, the interface`inferReturnTypeComponents()` infers `SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes` while `inferReturnTypes()` inferes`SmallVectorImpl<Type>& inferredReturnShapes`.  However `ShapedTypeComponents` dose not fit for the Token case for the result type `HLO_TensorOrToken` for if/case/while ops. Thus, we need use the `Type` as inferred type: choose `inferReturnTypes()`.

Besides, these functions will be called by with MHLO, so this PR is expected to check in before shared with MHLO.