### PR TITLE
Move shape functions of pad and concatenate

### DIFF
--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1844,8 +1844,6 @@ def StableHLO_ConcatenateOp : StableHLO_ShapedInterfaceOp<"concatenate",
 
   let results = (outs HLO_Tensor);
 
-  let hasVerifier = 1;
-
   let assemblyFormat = [{
      custom<VariadicOperandWithAttribute>($inputs) `dim` `=` $dimension attr-dict `:` functional-type(operands, results)
   }];

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -123,6 +123,12 @@ LogicalResult inferMapOp(
     DenseIntElementsAttr dimensions, Region& computation,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
+LogicalResult inferPadOp(
+    Optional<Location> location, Value operand, Value paddingValue,
+    DenseIntElementsAttr edgePaddingLow, DenseIntElementsAttr edgePaddingHigh,
+    DenseIntElementsAttr interiorPadding,
+    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
+
 LogicalResult inferReduceOp(
     Optional<Location> location, ValueRange inputs, ValueRange initValues,
     DenseIntElementsAttr dimensions, Region& body,

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -108,7 +108,7 @@ LogicalResult inferCaseOp(Optional<Location> location, RegionRange branches,
                           SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferConcatenateOp(Optional<Location> location, ValueRange inputs,
-                                 uint64_t dimension,
+                                 int64_t dimension,
                                  SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferDotGeneralOp(

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -107,6 +107,10 @@ LogicalResult inferBatchNormTrainingOp(
 LogicalResult inferCaseOp(Optional<Location> location, RegionRange branches,
                           SmallVectorImpl<Type>& inferredReturnTypes);
 
+LogicalResult inferConcatenateOp(Optional<Location> location, ValueRange inputs,
+                                 uint64_t dimension,
+                                 SmallVectorImpl<Type>& inferredReturnTypes);
+
 LogicalResult inferDotGeneralOp(
     Optional<Location> location, Value lhs, Value rhs,
     ArrayRef<int64_t> lhsBatchingDimensions,

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -909,7 +909,7 @@ func.func @concat_outofbounds_dim(%arg0: tensor<1xi32>, %arg1: tensor<2xi32>)  -
 // -----
 
 func.func @concat_mismatch_rank(%arg0: tensor<1xi32>, %arg1: tensor<2x2xi32>)  -> tensor<3xi32> {
-  // expected-error@+1 {{op operands (0) and (1) do not match rank}}
+  // expected-error@+1 {{operands (0) and (1) do not match rank}}
   %0 = "stablehlo.concatenate"(%arg0, %arg1) { dimension = 0 : i64 } : (tensor<1xi32>, tensor<2x2xi32>) -> tensor<3xi32>
   func.return %0 : tensor<3xi32>
 }


### PR DESCRIPTION
Move the shape functions of 2 ops: pad and concatenate to `TypeInference.cpp`. They will add bounds support soon in later PRs. For concatenate: the old `verify()` method is removed.
This PRs include:
1. Pure code move and minimal signature change.
2. Trivial unit test change. Some code style refinement.

No included:
1. Any logical change: they are already both labeled "yes" in `status.md`. And was revisited fully in MHLO as well.