### PR TITLE
Migrate all uses of -1 to kDynamicSize

### DIFF
--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -4797,7 +4797,7 @@ ParseResult parseConvolutionDimensions(AsmParser& parser,
     }
 
     llvm::SmallDenseMap<int64_t, int64_t> spatialDimsMap;
-    constexpr int64_t kInvalidDimension = -1;
+    constexpr int64_t kInvalidDimension = ShapedType::kDynamicSize;
     // Keep track of the maximum spatial dimension parsed as we expect to see
     // all the dimensions from 0 to maximum dimension parsed.
     int64_t maxParsedSpatialDim = kInvalidDimension;

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -898,7 +898,7 @@ LogicalResult inferReduceOp(
   uint64_t numInputs = inputs.size();
 
   // Check for unranked tensors in input operands.
-  int64_t rankedInputIdx = -1;
+  int64_t rankedInputIdx = ShapedType::kDynamicSize;
   for (uint64_t inputIdx = 0; inputIdx < numInputs; ++inputIdx) {
     if (inputArgTypes[inputIdx].hasRank()) {
       rankedInputIdx = inputIdx;
@@ -906,7 +906,7 @@ LogicalResult inferReduceOp(
     }
   }
 
-  bool allInputsUnranked = (rankedInputIdx == -1);
+  bool allInputsUnranked = (rankedInputIdx == ShapedType::kDynamicSize);
 
   // P1.
   if (!allInputsUnranked) {
@@ -991,7 +991,7 @@ LogicalResult inferReduceWindowOp(
   uint64_t numInputs = inputs.size();
 
   // Check for unranked tensors in input operands.
-  int64_t rankedInputIdx = -1;
+  int64_t rankedInputIdx = ShapedType::kDynamicSize;
   for (uint64_t inputIdx = 0; inputIdx < numInputs; ++inputIdx) {
     if (inputArgTypes[inputIdx].hasRank()) {
       rankedInputIdx = inputIdx;
@@ -999,7 +999,7 @@ LogicalResult inferReduceWindowOp(
     }
   }
 
-  bool allInputsUnranked = (rankedInputIdx == -1);
+  bool allInputsUnranked = (rankedInputIdx == ShapedType::kDynamicSize);
 
   // P2.
   if (!allInputsUnranked) {


### PR DESCRIPTION
The process for replacing uses of -1 was:

1. Find all occurrences of `-1` (and `- 1`).
2. Read the context of the code to determine whether the use of `-1` (or `- 1`) is appropriate.
3. Replace `-1` with `ShapedType::kDynamicSize` where appropriate.

closes #327 