### PR TITLE
Handle bounds in the PadOp shape function

### DIFF
--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -3363,15 +3363,15 @@ LogicalResult SetDimensionSizeOp::inferReturnTypes(
 // PadOp
 //===----------------------------------------------------------------------===//
 
-LogicalResult PadOp::inferReturnTypeComponents(
-    MLIRContext*, Optional<Location> location, ValueShapeRange operands,
+LogicalResult PadOp::inferReturnTypes(
+    MLIRContext*, Optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, RegionRange regions,
-    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
+    SmallVectorImpl<Type>& inferredReturnTypes) {
   PadOp::Adaptor adaptor(operands, attributes, regions);
   return hlo::inferPadOp(location, adaptor.getOperand(),
                          adaptor.getPaddingValue(), adaptor.getEdgePaddingLow(),
                          adaptor.getEdgePaddingHigh(),
-                         adaptor.getInteriorPadding(), inferredReturnShapes);
+                         adaptor.getInteriorPadding(), inferredReturnTypes);
 }
 
 LogicalResult PadOp::reifyReturnTypeShapes(

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2413,7 +2413,8 @@ def StableHLO_ReverseOp: StableHLO_Op<"reverse",
 }
 
 def StableHLO_PadOp: StableHLO_ShapedInterfaceOp<"pad",
-      [Pure, SameOperandsAndResultElementType, InferTensorType]> {
+      [Pure, SameOperandsAndResultElementType, 
+      DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
   let summary = "Pad operator";
   let description = [{
     Expands `operand` by padding around the tensor as well as between the

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -414,6 +414,17 @@ LogicalResult verifyReducerShape(
   return success();
 }
 
+// Returns output dimension size for slice result for the given arguments.
+// Returns ShapedType::kDynamicSize if arguments are illegal.
+static int64_t inferSliceDim(int64_t inputDim, int64_t start, int64_t end,
+                             int64_t stride) {
+  if (inputDim == ShapedType::kDynamicSize || start < 0 || start > end ||
+      end > inputDim || stride == 0)
+    return ShapedType::kDynamicSize;
+
+  return llvm::divideCeil(end - start, stride);
+}
+
 //===----------------------------------------------------------------------===//
 // Shape functions for ops.
 //===----------------------------------------------------------------------===//
@@ -878,9 +889,15 @@ LogicalResult inferPadOp(Optional<Location> location, Value operand,
 
       if (!inputBounds.empty())
         resultBounds.push_back(ShapedType::kDynamicSize);
-    } else  // dynamic dim with bounds
-      resultBounds.push_back(inferPadDim(inputBounds[i], paddingLowVal,
-                                         paddingHighVal, paddingInteriorVal));
+    } else {  // dynamic dim with bounds
+      int64_t resultBound = inferPadDim(inputBounds[i], paddingLowVal,
+                                        paddingHighVal, paddingInteriorVal);
+      if (resultBound < 0 && resultBound != ShapedType::kDynamicSize)
+        return emitOptionalError(
+            location, "Padding result in negative size for bound of dimension ",
+            i);
+      resultBounds.push_back(resultBound);
+    }
   }
   inferredReturnTypes.push_back(RankedTensorType::get(
       resultShape, inputType.getElementType(),
@@ -1124,26 +1141,20 @@ LogicalResult inferSliceOp(Optional<Location> location, Value operand,
   SmallVector<int64_t, 4> shape;
   shape.reserve(rank);
   SmallVector<int64_t> resultBounds;
-
-  auto inferSliceDim = [&](int64_t inputDim, int64_t start, int64_t end,
-                           int64_t stride) {
-    return inputDim == ShapedType::kDynamicSize
-               ? ShapedType::kDynamicSize
-               : static_cast<int64_t>(llvm::divideCeil(end - start, stride));
-  };
-
   for (int64_t i = 0, e = rank; i != e; i++) {
+    if (!inputBounds.empty())
+      resultBounds.push_back(
+          inferSliceDim(inputBounds[i], start[i], limit[i], strideVals[i]));
     if (hlo::isDynamicDimSize(rankedTy.getDimSize(i))) {
       shape.push_back(ShapedType::kDynamicSize);
-      if (inputBounds.empty()) continue;  // dynamic dim without bounds
+      continue;
     }
     // P3.
     if (start[i] < 0)
       return emitOptionalError(location, "negative start index ", start[i],
                                " in dimension ", i);
     // P4.
-    if (!hlo::isDynamicDimSize(rankedTy.getDimSize(i)) &&
-        limit[i] > rankedTy.getDimSize(i))
+    if (limit[i] > rankedTy.getDimSize(i))
       return emitOptionalError(location, "limit index ", limit[i],
                                " is larger than dimension size ",
                                rankedTy.getDimSize(i), " in dimension ", i);
@@ -1157,14 +1168,8 @@ LogicalResult inferSliceOp(Optional<Location> location, Value operand,
       return emitOptionalError(location, "stride must be positive but got ",
                                strideVals[i], " in dimension ", i);
 
-    if (!hlo::isDynamicDimSize(rankedTy.getDimSize(i))) {  // static dim
-      shape.push_back(inferSliceDim(rankedTy.getDimSize(i), start[i], limit[i],
-                                    strideVals[i]));
-      if (!inputBounds.empty())
-        resultBounds.push_back(ShapedType::kDynamicSize);
-    } else  // dynamic dim with bounds
-      resultBounds.push_back(
-          inferSliceDim(inputBounds[i], start[i], limit[i], strideVals[i]));
+    shape.push_back(inferSliceDim(rankedTy.getDimSize(i), start[i], limit[i],
+                                  strideVals[i]));
   }
 
   inferredReturnTypes.push_back(RankedTensorType::get(

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -879,7 +879,7 @@ LogicalResult inferPadOp(Optional<Location> location, Value operand,
         return emitOptionalError(location, "Padding result in negative ",
                                  sizeOrBound, " for dimension ", i);
       }
-      (isStaticDim ? resultShape : resultBounds)[i] = resultSizeOrBound);
+      (isStaticDim ? resultShape : resultBounds)[i] = resultSizeOrBound;
     }
   }
   inferredReturnTypes.push_back(RankedTensorType::get(

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -127,11 +127,12 @@ LogicalResult inferMapOp(
     DenseIntElementsAttr dimensions, Region& computation,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
-LogicalResult inferPadOp(
-    Optional<Location> location, Value operand, Value paddingValue,
-    DenseIntElementsAttr edgePaddingLow, DenseIntElementsAttr edgePaddingHigh,
-    DenseIntElementsAttr interiorPadding,
-    SmallVectorImpl<Type>& inferredReturnTypes);
+LogicalResult inferPadOp(Optional<Location> location, Value operand,
+                         Value paddingValue,
+                         DenseIntElementsAttr edgePaddingLow,
+                         DenseIntElementsAttr edgePaddingHigh,
+                         DenseIntElementsAttr interiorPadding,
+                         SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferReduceOp(
     Optional<Location> location, ValueRange inputs, ValueRange initValues,

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -131,7 +131,7 @@ LogicalResult inferPadOp(
     Optional<Location> location, Value operand, Value paddingValue,
     DenseIntElementsAttr edgePaddingLow, DenseIntElementsAttr edgePaddingHigh,
     DenseIntElementsAttr interiorPadding,
-    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
+    SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferReduceOp(
     Optional<Location> location, ValueRange inputs, ValueRange initValues,

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -662,8 +662,8 @@ func.func @slice_with_bounds(%arg0: tensor<3x?x?xi32, #stablehlo.type_extensions
 // CHECK-LABEL: @pad_with_bounds
 func.func @pad_with_bounds(%arg0: tensor<3x?x?xf16, #stablehlo.type_extensions<bounds = [-1, 3, -1]>>, %arg1: tensor<f16>) -> tensor<*xindex> {
   %0 = "stablehlo.pad"(%arg0, %arg1) {
-    edge_padding_high = dense<[0, 0, 0]> : tensor<3xi64>,
     edge_padding_low = dense<[2, 2, 0]> : tensor<3xi64>,
+    edge_padding_high = dense<[0, 0, 0]> : tensor<3xi64>,
     interior_padding = dense<[1, 1, 1]> : tensor<3xi64>
   } : (tensor<3x?x?xf16, #stablehlo.type_extensions<bounds = [-1, 3, -1]>>, tensor<f16>) -> tensor<*xf16>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xf16>) -> tensor<*xindex>
@@ -676,8 +676,8 @@ func.func @pad_with_bounds(%arg0: tensor<3x?x?xf16, #stablehlo.type_extensions<b
 func.func @pad_with_negative_inferred_bounds(%arg0: tensor<3x?x?xf16, #stablehlo.type_extensions<bounds = [-1, 3, -1]>>, %arg1: tensor<f16>) -> tensor<*xindex> {
   // expected-error@+1 {{Padding result in negative bound for dimension 1}}
   %0 = "stablehlo.pad"(%arg0, %arg1) {
-    edge_padding_high = dense<[0, 0, 0]> : tensor<3xi64>,
     edge_padding_low = dense<[2, -10, 0]> : tensor<3xi64>,
+    edge_padding_high = dense<[0, 0, 0]> : tensor<3xi64>,
     interior_padding = dense<[1, 1, 1]> : tensor<3xi64>
   } : (tensor<3x?x?xf16, #stablehlo.type_extensions<bounds = [-1, 3, -1]>>, tensor<f16>) -> tensor<*xf16>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xf16>) -> tensor<*xindex>

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -674,7 +674,7 @@ func.func @pad_with_bounds(%arg0: tensor<3x?x?xf16, #stablehlo.type_extensions<b
 // -----
 
 func.func @pad_with_negative_inferred_bounds(%arg0: tensor<3x?x?xf16, #stablehlo.type_extensions<bounds = [-1, 3, -1]>>, %arg1: tensor<f16>) -> tensor<*xindex> {
-  // expected-error@+1 {{Padding result in negative size for bound of dimension 1}}
+  // expected-error@+1 {{Padding result in negative bound for dimension 1}}
   %0 = "stablehlo.pad"(%arg0, %arg1) {
     edge_padding_high = dense<[0, 0, 0]> : tensor<3xi64>,
     edge_padding_low = dense<[2, -10, 0]> : tensor<3xi64>,

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -93,9 +93,8 @@ func.func @pad(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x4x7xf16
     edge_padding_low = dense<[0, 1, 2]> : tensor<3xi64>,
     interior_padding = dense<[0, 0, 1]> : tensor<3xi64>
   } : (tensor<1x2x3xf16>, tensor<f16>) -> tensor<2x4x7xf16>
-  %1 = "hlo_test_infer.get_return_type_components"(%0)
-      : (tensor<2x4x7xf16>) -> tensor<2x4x7xindex>
-// CHECK: %1 = "hlo_test_infer.return_type_components"(%0) {dims0 = [2, 4, 7], element_type0 = f16} : (tensor<2x4x7xf16>) -> tensor<2x4x7xindex>
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<2x4x7xf16>) -> tensor<2x4x7xindex>
+  // CHECK: %1 = "hlo_test_infer.return_types"(%0) {types0 = tensor<2x4x7xf16>} : (tensor<2x4x7xf16>) -> tensor<2x4x7xindex>
   func.return %0 : tensor<2x4x7xf16>
 }
 
@@ -655,5 +654,19 @@ func.func @slice_with_bounds(%arg0: tensor<3x?x?xi32, #stablehlo.type_extensions
   %0 = "stablehlo.slice"(%arg0) {start_indices = dense<[1, 0, 0]> : tensor<3xi64>, limit_indices = dense<[2, 4, 4]> : tensor<3xi64>, strides = dense<[1, 2, 2]> : tensor<3xi64>} : (tensor<3x?x?xi32, #stablehlo.type_extensions<bounds = [-1, 4, -1]>>) -> tensor<*xi32>
   // CHECK: types0 = tensor<1x?x?xi32, #stablehlo.type_extensions<bounds = [-1, 2, -1]>> 
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xi32>) -> tensor<*xindex>
+  func.return %1 : tensor<*xindex>
+}
+
+// -----
+
+// CHECK-LABEL: @pad_with_bounds
+func.func @pad_with_bounds(%arg0: tensor<3x?x?xf16, #stablehlo.type_extensions<bounds = [-1, 3, -1]>>, %arg1: tensor<f16>) -> tensor<*xindex> {
+  %0 = "stablehlo.pad"(%arg0, %arg1) {
+    edge_padding_high = dense<[0, 0, 0]> : tensor<3xi64>,
+    edge_padding_low = dense<[2, 2, 0]> : tensor<3xi64>,
+    interior_padding = dense<[1, 1, 1]> : tensor<3xi64>
+  } : (tensor<3x?x?xf16, #stablehlo.type_extensions<bounds = [-1, 3, -1]>>, tensor<f16>) -> tensor<*xf16>
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xf16>) -> tensor<*xindex>
+  // types0 = tensor<7x?x?xf16, #stablehlo.type_extensions<bounds = [-1, 7, -1]>>
   func.return %1 : tensor<*xindex>
 }

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -667,6 +667,19 @@ func.func @pad_with_bounds(%arg0: tensor<3x?x?xf16, #stablehlo.type_extensions<b
     interior_padding = dense<[1, 1, 1]> : tensor<3xi64>
   } : (tensor<3x?x?xf16, #stablehlo.type_extensions<bounds = [-1, 3, -1]>>, tensor<f16>) -> tensor<*xf16>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xf16>) -> tensor<*xindex>
-  // types0 = tensor<7x?x?xf16, #stablehlo.type_extensions<bounds = [-1, 7, -1]>>
+  // CHECK: types0 = tensor<7x?x?xf16, #stablehlo.type_extensions<bounds = [-1, 7, -1]>>
+  func.return %1 : tensor<*xindex>
+}
+
+// -----
+
+func.func @pad_with_negative_inferred_bounds(%arg0: tensor<3x?x?xf16, #stablehlo.type_extensions<bounds = [-1, 3, -1]>>, %arg1: tensor<f16>) -> tensor<*xindex> {
+  // expected-error@+1 {{Padding result in negative size for bound of dimension 1}}
+  %0 = "stablehlo.pad"(%arg0, %arg1) {
+    edge_padding_high = dense<[0, 0, 0]> : tensor<3xi64>,
+    edge_padding_low = dense<[2, -10, 0]> : tensor<3xi64>,
+    interior_padding = dense<[1, 1, 1]> : tensor<3xi64>
+  } : (tensor<3x?x?xf16, #stablehlo.type_extensions<bounds = [-1, 3, -1]>>, tensor<f16>) -> tensor<*xf16>
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xf16>) -> tensor<*xindex>
   func.return %1 : tensor<*xindex>
 }


### PR DESCRIPTION
Add bounds support for `PadOp`
Why change the shape function interface from `inferReturnTypeComponents` to `inferReturnTypes`? Appending `inferredReturnShapes.emplace_back(..., encoding_attr)` inside `inferReturnTypeComponents` will trigger error in [upstream](https://github.com/llvm/llvm-project/blob/main/mlir/lib/Interfaces/InferTypeOpInterface.cpp#L190)
```
assert(shapeAndType.getAttribute() == nullptr && "attribute not supported");
```

This PR follow the verification of in dim loop similar to https://github.com/openxla/stablehlo/pull/378/files.

Also add @smit-hinsu as reviewer.