### PR TITLE
Add spec for FftOp

### DIFF
--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -773,7 +773,7 @@ for `fft_type = RFFT`. For example, for `L = 3`:
 | Name         | Type                                         |
 |--------------|----------------------------------------------|
 | `operand`    | tensor of floating-point or complex type     |
-| `fft_type`   | constant of type `si64`                      |
+| `fft_type`   | enum of `FFT`, `IFFT`, `RFFT`, and `IRFFT`   |
 | `fft_length` | 1-dimensional tensor constant of type `si64` |
 
 ### Outputs

--- a/docs/status.md
+++ b/docs/status.md
@@ -79,7 +79,7 @@ one of the following tracking labels.
 | einsum                   | no            | revisit      | no             | no              | no          |
 | exponential              | yes           | yes          | yes            | yes             | no          |
 | exponential_minus_one    | no            | yes*         | yes*           | yes             | no          |
-| fft                      | no            | yes*         | yes*           | yes             | no          |
+| fft                      | yes           | revisit      | yes            | yes             | no          |
 | floor                    | yes           | yes          | yes            | yes             | yes         |
 | gather                   | no            | yes*         | yes*           | no              | no          |
 | get_dimension_size       | no            | revisit      | no             | yes             | no          |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2142,7 +2142,7 @@ def StableHLO_UnaryEinsumOp: StableHLO_Op<"unary_einsum", [Pure]>, BASE_EinsumOp
 def StableHLO_FftOp: StableHLO_Op<"fft", [InferTensorType, Pure]> {
   let summary = "Fast fourier transform operator";
   let description = [{
-    Performs the forward and inverse Fourier Transforms for real and complex
+    Performs the forward and inverse Fourier transforms for real and complex
     inputs/outputs.
 
     See:

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1507,8 +1507,8 @@ def StableHLO_DynamicSliceOp: StableHLO_Op<"dynamic_slice",
     Example:
 
     ```mlir
-    %0 = stablehlo.dynamic_slice %arg2, %arg3, %arg3, sizes = [1, 4] 
-      : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xi32> 
+    %0 = stablehlo.dynamic_slice %arg2, %arg3, %arg3, sizes = [1, 4]
+      : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xi32>
     ```
   }];
   let arguments = (ins
@@ -1521,7 +1521,7 @@ def StableHLO_DynamicSliceOp: StableHLO_Op<"dynamic_slice",
   let hasVerifier = 1;
 
   let assemblyFormat = [{
-    $operand `,` custom<VariadicOperandWithAttribute>($start_indices) 
+    $operand `,` custom<VariadicOperandWithAttribute>($start_indices)
       `sizes` `=` custom<DenseI64Array>($slice_sizes)
       attr-dict `:` functional-type(operands, results)
   }];
@@ -1727,7 +1727,7 @@ def StableHLO_BroadcastInDimOp : StableHLO_Op<"broadcast_in_dim",
   let hasVerifier = 1;
 
   let assemblyFormat = [{
-    $operand `,` `dims` `=` custom<DenseI64Array>($broadcast_dimensions) 
+    $operand `,` `dims` `=` custom<DenseI64Array>($broadcast_dimensions)
       attr-dict `:` functional-type(operands, results)
   }];
 }
@@ -2142,19 +2142,19 @@ def StableHLO_UnaryEinsumOp: StableHLO_Op<"unary_einsum", [Pure]>, BASE_EinsumOp
 def StableHLO_FftOp: StableHLO_Op<"fft", [InferTensorType, Pure]> {
   let summary = "Fast fourier transform operator";
   let description = [{
-    Returns the fast-fourier-transform of the input array.
+    Performs the forward and inverse Fourier Transforms for real and complex
+    inputs/outputs.
 
-    See
-    https://www.tensorflow.org/xla/operation_semantics#fft.
+    See:
+    https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlofft
 
     Example:
-
     ```mlir
-    %0 = stablehlo.fft %arg0, type = RFFT, length = [9] : (tensor<3x9xf32>) -> tensor<3x5xcomplex<f32>>
+    %result = stablehlo.fft %operand, type = FFT, length = [4] : (tensor<4xcomplex<f32>>) -> tensor<4xcomplex<f32>>
     ```
   }];
   let arguments = (ins
-    HLO_Tensor:$operand,
+    HLO_FpOrComplexTensor:$operand,
     StableHLO_FftTypeAttr:$fft_type,
     I64ElementsAttr:$fft_length
   );
@@ -2503,7 +2503,7 @@ def StableHLO_PadOp: StableHLO_ShapedInterfaceOp<"pad",
   let results = (outs HLO_Tensor);
 
   let assemblyFormat = [{
-    $operand `,` $padding_value `,` 
+    $operand `,` $padding_value `,`
       `low` `=` custom<DenseI64Array>($edge_padding_low) `,`
       `high` `=` custom<DenseI64Array>($edge_padding_high) `,`
       `interior` `=` custom<DenseI64Array>($interior_padding)


### PR DESCRIPTION
Updates ODS to use `HLO_FpOrComplexTensor` instead of `HLO_Tensor` for `operand`.
closes #357