### PR TITLE
Handle bounds in the ConcatenateOp shape function

### DIFF
--- a/stablehlo/dialect/Base.h
+++ b/stablehlo/dialect/Base.h
@@ -54,12 +54,12 @@ bool isCompatibleForHloTypeInference(TypeRange tp1, TypeRange tp2);
 // Infer single most specific return type from inputTypes with support for
 // bounds. (Size, bound) of each dimension of the return type will be inferred
 // from corresponding dimensions of every inputType by merging them. If
-// `concatenateDims` is set, then the dimensions in `concatenateDims` will be
+// `concatenateDim` is set other than default -1, then that dimensions will be
 // concatenated into return type instead.
-LogicalResult inferMostSpecificType(
-    Optional<Location> location, ValueTypeRange<ValueRange> inputTypes,
-    SmallVectorImpl<Type> &inferredReturnTypes,
-    const SmallVector<int64_t> &concatenateDims = {});
+LogicalResult inferMostSpecificType(Optional<Location> location,
+                                    ValueTypeRange<ValueRange> inputTypes,
+                                    SmallVectorImpl<Type> &inferredReturnTypes,
+                                    int64_t concatenateDim = -1);
 
 // Shape derivation function that computes the shape of the result based on an
 // operand. For a 2-dimensional input tensor, this produces IR of the form

--- a/stablehlo/dialect/Base.h
+++ b/stablehlo/dialect/Base.h
@@ -42,6 +42,12 @@ limitations under the License.
 namespace mlir {
 namespace hlo {
 
+// TODO(zhouxin) change to a better name as it's used by both of size and bound
+// Check if the dimension size is dynamic.
+inline static bool isDynamicDimSize(int64_t val) {
+  return val == ShapedType::kDynamicSize;
+}
+
 // Returns true if the given types are the same for the purposes of HLO type
 // inference, accounting for special properties of quantization and sparsity.
 bool isCompatibleForHloTypeInference(Type tp1, Type tp2);

--- a/stablehlo/dialect/Base.h
+++ b/stablehlo/dialect/Base.h
@@ -58,15 +58,22 @@ bool isCompatibleForHloTypeInference(Type tp1, Type tp2);
 // sparsity.
 bool isCompatibleForHloTypeInference(TypeRange tp1, TypeRange tp2);
 
+// TODO(zhouxin) Move type inference related methods to TypeInference.cpp
+
+std::pair<int64_t, int64_t> inferConcatenatedDimAndBound(
+    int64_t leftSize, int64_t rightSize, int64_t leftBound,
+    int64_t rightBound);
+
+FailureOr<std::pair<int64_t, int64_t>> inferMergedDimAndBound(
+    Optional<Location> location, int64_t dim, int64_t leftSize,
+    int64_t rightSize, int64_t leftBound, int64_t rightBound);
+
 // Infer single most specific return type from inputTypes with support for
-// bounds. (Size, bound) of each dimension of the return type will be inferred
-// from corresponding dimensions of every inputType by merging them. If
-// `concatenateDim` is set other than default -1, then that dimensions will be
-// concatenated into return type instead.
+// bounds. (Size, bound) of each dimension of the return type will be merged 
+// from corresponding dimensions of every inputType by merging them. 
 LogicalResult inferMostSpecificType(Optional<Location> location,
                                     TypeRange inputTypes,
-                                    SmallVectorImpl<Type> &inferredReturnTypes,
-                                    int64_t concatenateDim = -1);
+                                    SmallVectorImpl<Type> &inferredReturnTypes);
 
 // Shape derivation function that computes the shape of the result based on an
 // operand. For a 2-dimensional input tensor, this produces IR of the form

--- a/stablehlo/dialect/Base.h
+++ b/stablehlo/dialect/Base.h
@@ -60,17 +60,18 @@ bool isCompatibleForHloTypeInference(TypeRange tp1, TypeRange tp2);
 
 // TODO(zhouxin) Move type inference related methods to TypeInference.cpp
 
-std::pair<int64_t, int64_t> inferConcatenatedDimAndBound(
-    int64_t leftSize, int64_t rightSize, int64_t leftBound,
-    int64_t rightBound);
+std::pair<int64_t, int64_t> inferConcatenatedDimAndBound(int64_t leftSize,
+                                                         int64_t rightSize,
+                                                         int64_t leftBound,
+                                                         int64_t rightBound);
 
 FailureOr<std::pair<int64_t, int64_t>> inferMergedDimAndBound(
     Optional<Location> location, int64_t dim, int64_t leftSize,
     int64_t rightSize, int64_t leftBound, int64_t rightBound);
 
 // Infer single most specific return type from inputTypes with support for
-// bounds. (Size, bound) of each dimension of the return type will be merged 
-// from corresponding dimensions of every inputType by merging them. 
+// bounds. (Size, bound) of each dimension of the return type will be merged
+// from corresponding dimensions of every inputType by merging them.
 LogicalResult inferMostSpecificType(Optional<Location> location,
                                     TypeRange inputTypes,
                                     SmallVectorImpl<Type> &inferredReturnTypes);

--- a/stablehlo/dialect/Base.h
+++ b/stablehlo/dialect/Base.h
@@ -51,6 +51,16 @@ bool isCompatibleForHloTypeInference(Type tp1, Type tp2);
 // sparsity.
 bool isCompatibleForHloTypeInference(TypeRange tp1, TypeRange tp2);
 
+// Infer single most specific return type from inputTypes with support for
+// bounds. (Size, bound) of each dimension of the return type will be inferred
+// from corresponding dimensions of every inputType by merging them. If
+// `concatenateDims` is set, then the dimensions in `concatenateDims` will be
+// concatenated into return type instead.
+LogicalResult inferMostSpecificType(
+    Optional<Location> location, ValueTypeRange<ValueRange> inputTypes,
+    SmallVectorImpl<Type> &inferredReturnTypes,
+    const SmallVector<int64_t> &concatenateDims = {});
+
 // Shape derivation function that computes the shape of the result based on an
 // operand. For a 2-dimensional input tensor, this produces IR of the form
 //
@@ -213,92 +223,6 @@ class CompatibleOperandsAndResultType
       return failure();
     auto inferredReturnType = inferredReturnTypes[0].cast<ShapedType>();
     inferredReturnShapes.push_back(inferredReturnType);
-    return success();
-  }
-
- private:
-  // Cases of infer return shape with bounds (lhs and rhs are commutative):
-  //       Dim of lhs     Dim of rhs      Infer
-  //  c0:  3              3               3
-  //  c1:  3              ?               3
-  //  c2:  3              ?, bound=4      3
-  //  c3:  3              ?, bound=2      Error out
-  //  c4:  ?              ?               ?
-  //  c5:  ?              ?, bound=3      ?, bound=3
-  //  c6:  ?, bound=3     ?, bound=3      ?, bound=3
-  //  c7:  ?, bound=3     ?, bound=4      ?, bound=3
-  // This method generalizes it to multiple inputs: 1) get the static input dims
-  // (if any) as infer dim, and 2) get min of input bounds as infer bound
-  static LogicalResult inferMostSpecificType(
-      Optional<Location> location, ValueTypeRange<ValueRange> inputTypes,
-      SmallVectorImpl<Type> &inferredReturnTypes) {
-    SmallVector<RankedTensorType> rankedTypes;
-    for (auto inputType : inputTypes)
-      if (auto rankedType = inputType.dyn_cast<RankedTensorType>())
-        rankedTypes.push_back(rankedType);
-    if (rankedTypes.empty()) {
-      inferredReturnTypes.push_back(inputTypes[0]);
-      return success();
-    }
-
-    auto rank = rankedTypes[0].getRank();
-    BoundedDialectInterface *dialect = nullptr;
-    SmallVector<int64_t> inferredDimSizes(rank, ShapedType::kDynamicSize);
-    SmallVector<int64_t> inferredBounds(rank, ShapedType::kDynamicSize);
-    for (auto rankedType : rankedTypes) {
-      ArrayRef<int64_t> bounds;
-      if (auto boundedAttr = rankedType.getEncoding()
-                                 .dyn_cast_or_null<BoundedAttrInterface>()) {
-        dialect = cast<BoundedDialectInterface>(&boundedAttr.getDialect());
-        bounds = boundedAttr.getBounds();
-      } else if (rankedType.getEncoding()) {
-        // TODO(zhouxin) infer sparsity encoding after b/238903065 is fixed.
-        inferredReturnTypes.push_back(inputTypes[0]);
-        return success();
-      }
-
-      for (int dim = 0; dim < rank; ++dim) {
-        // Dimensions
-        auto dimSize = rankedType.getShape()[dim];
-        if (inferredDimSizes[dim] != ShapedType::kDynamicSize &&
-            dimSize != ShapedType::kDynamicSize &&
-            inferredDimSizes[dim] != dimSize)
-          return emitOptionalError(location, "Mismatch dimension size ",
-                                   inferredDimSizes[dim], " and ", dimSize,
-                                   " in dimension ", dim);
-        if (inferredDimSizes[dim] == ShapedType::kDynamicSize)
-          inferredDimSizes[dim] = dimSize;
-
-        // Bounds
-        if (!bounds.empty() && bounds[dim] != ShapedType::kDynamicSize) {
-          if (inferredBounds[dim] == ShapedType::kDynamicSize) {
-            inferredBounds[dim] = bounds[dim];
-          } else {
-            inferredBounds[dim] = std::min(inferredBounds[dim], bounds[dim]);
-          }
-        }
-        // Error out case that the inferred bound is smaller than inferred dim
-        if (inferredBounds[dim] != ShapedType::kDynamicSize &&
-            inferredBounds[dim] < inferredDimSizes[dim])
-          return emitOptionalError(location,
-                                   "bound must not be less than static "
-                                   "dimension size but has bound ",
-                                   inferredBounds[dim], " vs static size ",
-                                   inferredDimSizes[dim], " in dimension ",
-                                   dim);
-        if (inferredDimSizes[dim] != ShapedType::kDynamicSize)
-          inferredBounds[dim] = ShapedType::kDynamicSize;
-      }
-    }
-
-    Attribute encoding = nullptr;
-    if (llvm::any_of(inferredBounds,
-                     [](auto el) { return el != ShapedType::kDynamicSize; })) {
-      encoding = dialect->createBoundedAttr(inferredBounds);
-    }
-    inferredReturnTypes.push_back(RankedTensorType::get(
-        inferredDimSizes, rankedTypes[0].getElementType(), encoding));
-
     return success();
   }
 };

--- a/stablehlo/dialect/Base.h
+++ b/stablehlo/dialect/Base.h
@@ -44,6 +44,7 @@ namespace hlo {
 
 // TODO(zhouxin) change to a better name as it's used by both of size and bound
 // Check if the dimension size is dynamic.
+// TODO(zhouxin) add isStaticDimSize() as well.
 inline static bool isDynamicDimSize(int64_t val) {
   return val == ShapedType::kDynamicSize;
 }
@@ -63,7 +64,7 @@ bool isCompatibleForHloTypeInference(TypeRange tp1, TypeRange tp2);
 // `concatenateDim` is set other than default -1, then that dimensions will be
 // concatenated into return type instead.
 LogicalResult inferMostSpecificType(Optional<Location> location,
-                                    ValueTypeRange<ValueRange> inputTypes,
+                                    TypeRange inputTypes,
                                     SmallVectorImpl<Type> &inferredReturnTypes,
                                     int64_t concatenateDim = -1);
 

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -577,11 +577,11 @@ LogicalResult inferConcatenateOp(Optional<Location> location, ValueRange inputs,
     return success();
   }
 
-  // Infer the most specific (size, bound) of all dimenstions of the return type
+  // Infer the most specific (size, bound) of all dimensions of the return type
   auto rank = firstRankedType.getRank();
   SmallVector<int64_t> inferredSizes(rank, ShapedType::kDynamicSize);
   SmallVector<int64_t> inferredBounds(rank, ShapedType::kDynamicSize);
-  // Note: for the concatenate dimension, 0 should be the identical element:
+  // Note: for the concatenate dimension, 0 should be the identity element:
   // Any dim size can keep unchanged when concatenated with 0
   inferredSizes[dimension] = 0;
   bool anyInputHaveBounds = false;
@@ -597,7 +597,6 @@ LogicalResult inferConcatenateOp(Optional<Location> location, ValueRange inputs,
       bounds = to_vector(encodingToBounds(rankedType.getEncoding()));
     if (!bounds.empty()) anyInputHaveBounds = true;
 
-    // Infer each dim for current rankedType (from inputTypes[1:end])
     for (int dim = 0; dim < rank; ++dim) {
       std::pair<int64_t, int64_t> inferredDimAndBound;
 

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -583,7 +583,7 @@ LogicalResult inferConcatenateOp(Optional<Location> location, ValueRange inputs,
   }
 
   return inferMostSpecificType(location, inputs.getTypes(), inferredReturnTypes,
-                               {dimension});
+                               dimension);
 }
 
 LogicalResult inferDotGeneralOp(

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -32,11 +32,6 @@ namespace hlo {
 //===----------------------------------------------------------------------===//
 // TODO(#270): Remove them when all shape functions are moved to this file.
 
-// Check if the dimension size is dynamic.
-inline static bool isDynamicDimSize(int64_t val) {
-  return val == ShapedType::kDynamicSize;
-}
-
 bool compatibleShapeAndElementType(Type type1, Type type2,
                                    bool ignoreFpPrecision = false);
 

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -696,6 +696,15 @@ func.func @pad_with_negative_inferred_bounds(%arg0: tensor<3x?x?xf16, #stablehlo
 
 // -----
 
+// Alse see this in Base.cpp
+// Inference rules to concat dimensions with bounds (lhs/rhs are commutative):
+//       Dim of lhs     Dim of rhs      Infer
+//  c0:  X              Y               X+Y
+//  c1:  X              ?               ?
+//  c2:  X              ?, B            ?, X+B
+//  c3:  ?              ?               ?
+//  c4:  ?              ?, B            ?
+//  c5:  ?, B           ?, C            ?, B+C
 // CHECK-LABEL: @concat_bounds_c0
 func.func @concat_bounds_c0(
   %arg0: tensor<5x1xi32, #stablehlo.type_extensions<bounds = [-1, -1]>>, 

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -693,3 +693,108 @@ func.func @pad_with_negative_inferred_bounds(%arg0: tensor<3x?x?xf16, #stablehlo
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xf16>) -> tensor<*xindex>
   func.return %1 : tensor<*xindex>
 }
+
+// -----
+
+// CHECK-LABEL: @concat_bounds_c0
+func.func @concat_bounds_c0(
+  %arg0: tensor<5x1xi32, #stablehlo.type_extensions<bounds = [-1, -1]>>, 
+  %arg1: tensor<5x2xi32, #stablehlo.type_extensions<bounds = [-1, -1]>>)  -> tensor<*xindex> {
+  %result = "stablehlo.concatenate"(%arg0, %arg1) { dimension = 1 : i64 } : (
+    tensor<5x1xi32, #stablehlo.type_extensions<bounds = [-1, -1]>>, 
+    tensor<5x2xi32, #stablehlo.type_extensions<bounds = [-1, -1]>>) -> tensor<?x?xi32>
+  // CHECK: types0 = tensor<5x3xi32>
+  %1 = "hlo_test_infer.get_return_types"(%result) : (tensor<?x?xi32>) -> tensor<*xindex> 
+  func.return %1 : tensor<*xindex>
+}
+
+// -----
+
+// CHECK-LABEL: @concat_bounds_c1
+func.func @concat_bounds_c1(
+  %arg0: tensor<5x2xi32, #stablehlo.type_extensions<bounds = [-1, -1]>>, 
+  %arg1: tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, -1]>>)  -> tensor<*xindex> {
+  %result = "stablehlo.concatenate"(%arg0, %arg1) { dimension = 1 : i64 } : (
+    tensor<5x2xi32, #stablehlo.type_extensions<bounds = [-1, -1]>>, 
+    tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, -1]>>) -> tensor<?x?xi32>
+  // CHECK: types0 = tensor<5x?xi32>
+  %1 = "hlo_test_infer.get_return_types"(%result) : (tensor<?x?xi32>) -> tensor<*xindex> 
+
+  %result_swap = "stablehlo.concatenate"(%arg1, %arg0) { dimension = 1 : i64 } : (
+    tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, -1]>>, 
+    tensor<5x2xi32, #stablehlo.type_extensions<bounds = [-1, -1]>>) -> tensor<?x?xi32>
+  // CHECK: types0 = tensor<5x?xi32>
+  %2 = "hlo_test_infer.get_return_types"(%result_swap) : (tensor<?x?xi32>) -> tensor<*xindex> 
+
+  func.return %1 : tensor<*xindex>
+}
+
+// -----
+
+// CHECK-LABEL: @concat_bounds_c2
+func.func @concat_bounds_c2(
+  %arg0: tensor<5x2xi32, #stablehlo.type_extensions<bounds = [-1, -1]>>, 
+  %arg1: tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, 4]>>)  -> tensor<*xindex> {
+  %result = "stablehlo.concatenate"(%arg0, %arg1) { dimension = 1 : i64 } : (
+    tensor<5x2xi32, #stablehlo.type_extensions<bounds = [-1, -1]>>, 
+    tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, 4]>>) -> tensor<?x?xi32>
+  // CHECK: types0 = tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, 6]>>
+  %1 = "hlo_test_infer.get_return_types"(%result) : (tensor<?x?xi32>) -> tensor<*xindex> 
+
+  %result_swap = "stablehlo.concatenate"(%arg1, %arg0) { dimension = 1 : i64 } : (
+    tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, 4]>>, 
+    tensor<5x2xi32, #stablehlo.type_extensions<bounds = [-1, -1]>>) -> tensor<?x?xi32>
+  // CHECK: types0 = tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, 6]>>
+  %2 = "hlo_test_infer.get_return_types"(%result_swap) : (tensor<?x?xi32>) -> tensor<*xindex> 
+
+  func.return %1 : tensor<*xindex>
+}
+
+// -----
+
+// CHECK-LABEL: @concat_bounds_c3
+func.func @concat_bounds_c3(
+  %arg0: tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, -1]>>, 
+  %arg1: tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, -1]>>)  -> tensor<*xindex> {
+  %result = "stablehlo.concatenate"(%arg0, %arg1) { dimension = 1 : i64 } : (
+    tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, -1]>>, 
+    tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, -1]>>) -> tensor<?x?xi32>
+  // CHECK: types0 = tensor<5x?xi32>
+  %1 = "hlo_test_infer.get_return_types"(%result) : (tensor<?x?xi32>) -> tensor<*xindex> 
+  func.return %1 : tensor<*xindex>
+}
+
+// -----
+
+// CHECK-LABEL: @concat_bounds_c4
+func.func @concat_bounds_c4(
+  %arg0: tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, -1]>>, 
+  %arg1: tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, 4]>>)  -> tensor<*xindex> {
+  %result = "stablehlo.concatenate"(%arg0, %arg1) { dimension = 1 : i64 } : (
+    tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, -1]>>, 
+    tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, 4]>>) -> tensor<?x?xi32>
+  // CHECK: types0 = tensor<5x?xi32>
+  %1 = "hlo_test_infer.get_return_types"(%result) : (tensor<?x?xi32>) -> tensor<*xindex> 
+
+  %result_swap = "stablehlo.concatenate"(%arg1, %arg0) { dimension = 1 : i64 } : (
+    tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, 4]>>, 
+    tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, -1]>>) -> tensor<?x?xi32>
+  // CHECK: types0 = tensor<5x?xi32>
+  %2 = "hlo_test_infer.get_return_types"(%result_swap) : (tensor<?x?xi32>) -> tensor<*xindex> 
+
+  func.return %1 : tensor<*xindex>
+}
+
+// -----
+
+// CHECK-LABEL: @concat_bounds_c5
+func.func @concat_bounds_c5(
+  %arg0: tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, 3]>>, 
+  %arg1: tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, 4]>>)  -> tensor<*xindex> {
+  %result = "stablehlo.concatenate"(%arg0, %arg1) { dimension = 1 : i64 } : (
+    tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, 3]>>, 
+    tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, 4]>>) -> tensor<?x?xi32>
+  // CHECK: types0 = tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, 7]>>
+  %1 = "hlo_test_infer.get_return_types"(%result) : (tensor<?x?xi32>) -> tensor<*xindex> 
+  func.return %1 : tensor<*xindex>
+}

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -705,6 +705,7 @@ func.func @pad_with_negative_inferred_bounds(%arg0: tensor<3x?x?xf16, #stablehlo
 //  c3:  ?              ?               ?
 //  c4:  ?              ?, B            ?
 //  c5:  ?, B           ?, C            ?, B+C
+
 // CHECK-LABEL: @concat_bounds_c0
 func.func @concat_bounds_c0(
   %arg0: tensor<5x1xi32, #stablehlo.type_extensions<bounds = [-1, -1]>>, 


### PR DESCRIPTION
`ConcatenateOp` has variadic inputs, so `inferMostSpecificType` need to be used to infer multiple dims (size, bound) from multiple input tensors, which set the rules of how to infer the return bounds for binary ops like `AddOp`.
However, `ConcatenateOp` is more complicated:
1. For the dim that will be concatenated, we need a new set of different rules to infer the dimension sizes and bounds.
2. For the rest N-1 dimension, the existing rules used by binary ops can be re-used.
More details for (1) from the new code comment:
```
// Inference rules to concat dimensions with bounds (lhs/rhs are commutative):
//       Dim of lhs     Dim of rhs      Infer
//  c0:  X              Y               X+Y
//  c1:  X              ?               ?
//  c2:  X              ?, B            ?, X+B
//  c3:  ?              ?               ?
//  c4:  ?              ?, B            ?
//  c5:  ?, B1          ?, B2           ?, B1+B2
```
So, in the PR, `inferMostSpecificType` become large but refactored to be more easy to follow:
1. `inferMergedDimAndBound()`: The old kernel part of how to handle each dim for binary ops is moved to this separate util function. NO logic change but rewrite with more readability.
2. `inferConcatenatedDimAndBound()`: The new rules are implemented by this new dedicated method.
3. `inferMostSpecificType()` is still the public entry point: with a new argument `concatenateDims` which indicates which dims will be concatenated instead of merged.

I would expect that in the future more categories of inference rules will be introduced for interface `inferMostSpecificType()`, and it makes sense to me to refactor further when that happens.
I prefer not to split the (1) and (2) to two different PRs, as (1) is more meaningful when staying with (2) (3). 

Add reviewer @smit-hinsu .