### PR TITLE
Remove ReduceOp::build() to sync with MLIR-HLO

### DIFF
--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -2759,19 +2759,6 @@ static TensorType getReduceResultType(Type operandTy,
   return RankedTensorType::get(shape, elementTy);
 }
 
-void ReduceOp::build(OpBuilder& builder, OperationState& state,
-                     ValueRange operands, ValueRange initValues,
-                     DenseIntElementsAttr dimensions) {
-  SmallVector<Type, 1> resultTy;
-  resultTy.reserve(operands.size());
-
-  for (Value operand : operands) {
-    resultTy.push_back(
-        getReduceResultType(operand.getType(), dimensions, &builder));
-  }
-  build(builder, state, resultTy, operands, initValues, dimensions);
-}
-
 bool hasSameOperandAndResultTypes(Operation& op) {
   Type expected;
   if (op.getNumResults() != 0) expected = op.getResult(0).getType();

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -2737,28 +2737,6 @@ LogicalResult ReducePrecisionOp::verify() {
 // ReduceOp
 //===----------------------------------------------------------------------===//
 
-// Returns the result type after reducing operand of the given type across the
-// specified dimensions.
-static TensorType getReduceResultType(Type operandTy,
-                                      DenseIntElementsAttr dimensions,
-                                      Builder* builder) {
-  Type elementTy = getElementTypeOrSelf(operandTy);
-
-  auto rankedTy = operandTy.dyn_cast<RankedTensorType>();
-  if (!rankedTy) return UnrankedTensorType::get(elementTy);
-
-  int64_t rank = rankedTy.getRank();
-  llvm::SmallVector<bool, 4> dimsMask(rank, false);
-  for (int64_t dim : dimensions.getValues<int64_t>()) dimsMask[dim] = true;
-
-  SmallVector<int64_t, 4> shape;
-  for (int64_t i = 0; i < rank; ++i) {
-    if (!dimsMask[i]) shape.push_back(rankedTy.getDimSize(i));
-  }
-
-  return RankedTensorType::get(shape, elementTy);
-}
-
 bool hasSameOperandAndResultTypes(Operation& op) {
   Type expected;
   if (op.getNumResults() != 0) expected = op.getResult(0).getType();

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1341,10 +1341,6 @@ def StableHLO_ReduceOp: StableHLO_ShapedInterfaceOp<"reduce", [
 
   let results = (outs Variadic<HLO_Tensor>);
 
-  let builders = [
-    OpBuilder<(ins "ValueRange":$inputs, "ValueRange":$init_values,
-      "DenseIntElementsAttr":$dimensions)>];
-
   let hasCustomAssemblyFormat = 1;
 
   // TODO(hinsu): Verify that the attached body arguments and results are


### PR DESCRIPTION
fix https://github.com/openxla/stablehlo/issues/391
Please see the detailed link in the related bug.