### PR TITLE
Add code comments for print functions (NFC)

### DIFF
--- a/stablehlo/dialect/AssemblyFormat.cpp
+++ b/stablehlo/dialect/AssemblyFormat.cpp
@@ -188,14 +188,6 @@ ParseResult parseVariadicOperandWithAttribute(
 // Operation Printers and Parsers
 //===----------------------------------------------------------------------===//
 
-// ComplexOpType - only print result type if the inferred complex type
-// matches all operand types.
-//
-// Inferring operand types for complex ops:
-//  %0 = stablehlo.complex %1, %2 : tensor<4xcomplex<f32>>
-//    %0 : tensor<4xcomplex<f32>>
-//    %1 : tensor<4xf32>
-//    %2 : tensor<4xf32>
 void printComplexOpType(OpAsmPrinter& p, Operation* op, Type lhs, Type rhs,
                         Type result) {
   Type realType = createRealType(result.cast<TensorType>());

--- a/stablehlo/dialect/AssemblyFormat.h
+++ b/stablehlo/dialect/AssemblyFormat.h
@@ -127,12 +127,29 @@ ParseResult parseVariadicOperandWithAttribute(
 // Operation Printers and Parsers
 //===----------------------------------------------------------------------===//
 
+// ComplexOpType - only print result type if the inferred complex type
+// matches all operand types.
+//
+// Inferring operand types for complex ops:
+//  %0 = stablehlo.complex %1, %2 : tensor<4xcomplex<f32>>
+//    %0 : tensor<4xcomplex<f32>>
+//    %1 : tensor<4xf32>
+//    %2 : tensor<4xf32>
 void printComplexOpType(OpAsmPrinter& p, Operation* op, Type lhs, Type rhs,
                         Type result);
 
 ParseResult parseComplexOpType(OpAsmParser& parser, Type& lhs, Type& rhs,
                                Type& result);
 
+// SelectOpType - only print the condition and result type when branch types
+// match the result type.
+//
+// Inferring operand types for select ops:
+//  %3 = stablehlo.select %0, %1, %2 : tensor<2xi1>, tensor<2xi32>
+//    %0 : tensor<2xi1>
+//    %1 : tensor<2xi32>
+//    %2 : tensor<2xi32>
+//    %3 : tensor<2xi32>
 void printSelectOpType(OpAsmPrinter& p, Operation* op, Type pred, Type onTrue,
                        Type onFalse, Type result);
 


### PR DESCRIPTION
Move code comments for `printComplexOpType` to header file. Add description for `printSelectOpType`.

Noticed during MHLO integration work.