### PR TITLE
Fix error handling and add testing for printDenseI64Array

### DIFF
--- a/stablehlo/dialect/AssemblyFormat.cpp
+++ b/stablehlo/dialect/AssemblyFormat.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/Regex.h"
+#include "mlir/IR/BuiltinAttributes.h"
 #include "stablehlo/dialect/Base.h"
 
 namespace mlir {
@@ -286,12 +287,12 @@ void printDenseI64Array(OpAsmPrinter& p, Operation* op,
 
 ParseResult parseDenseI64Array(OpAsmParser& parser,
                                DenseIntElementsAttr& attr) {
-  Attribute parsedAttr = DenseI64ArrayAttr::parse(parser, Type{});
-  if (!parsedAttr) {
+  DenseI64ArrayAttr arrayAttr = DenseI64ArrayAttr::parse(parser, Type{})
+                                    .dyn_cast_or_null<DenseI64ArrayAttr>();
+  if (!arrayAttr) {
     return failure();
   }
 
-  auto arrayAttr = parsedAttr.dyn_cast<DenseI64ArrayAttr>();
   ArrayRef<int64_t> data = arrayAttr.asArrayRef();
   RankedTensorType type =
       RankedTensorType::get(data.size(), parser.getBuilder().getI64Type());

--- a/stablehlo/dialect/AssemblyFormat.cpp
+++ b/stablehlo/dialect/AssemblyFormat.cpp
@@ -286,12 +286,12 @@ void printDenseI64Array(OpAsmPrinter& p, Operation* op,
 
 ParseResult parseDenseI64Array(OpAsmParser& parser,
                                DenseIntElementsAttr& attr) {
-  DenseI64ArrayAttr arrayAttr =
-      DenseI64ArrayAttr::parse(parser, Type{}).dyn_cast<DenseI64ArrayAttr>();
-  if (!arrayAttr) {
+  Attribute parsedAttr = DenseI64ArrayAttr::parse(parser, Type{});
+  if (!parsedAttr) {
     return failure();
   }
 
+  auto arrayAttr = parsedAttr.dyn_cast<DenseI64ArrayAttr>();
   ArrayRef<int64_t> data = arrayAttr.asArrayRef();
   RankedTensorType type =
       RankedTensorType::get(data.size(), parser.getBuilder().getI64Type());

--- a/stablehlo/tests/print_types_invalid.mlir
+++ b/stablehlo/tests/print_types_invalid.mlir
@@ -63,6 +63,15 @@ func.func @complex_type_not_complex(%arg0: tensor<1xf64>) -> () {
 
 // -----
 
+func.func @dense_array_nested(%arg0: tensor<1x2xf64>) -> () {
+  // expected-error @+2 {{custom op 'stablehlo.transpose' expected integer value}}
+  // expected-error @+1 {{expected ']'}}
+  %0 = stablehlo.transpose %arg0, dims = [1, [0]] : tensor<1xf64>
+  func.return
+}
+
+// -----
+
 func.func @select_type_wrong_type(%arg0: tensor<2x3xi1>, %arg1: tensor<2x3xi32>) -> () {
   // expected-error @+1 {{custom op 'stablehlo.select' expected functional type or list of two types}}
   %0 = stablehlo.select %arg0, %arg1, %arg1 : tensor<2x3xi1>


### PR DESCRIPTION
The code `DenseI64ArrayAttr::parse(parser, Type{}).dyn_cast<DenseI64ArrayAttr>();` is problematic since if parsing fails, the null attribute will crash on `dyn_cast`.

Move the `dyn_cast` to after error handling. Add test case.