### PR TITLE
Split verifiers and shape functions for ops with regions

### DIFF
--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -2939,9 +2939,10 @@ LogicalResult ReduceWindowOp::inferReturnTypeComponents(
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   ReduceWindowOp::Adaptor adaptor(operands, attributes, regions);
   return hlo::inferReduceWindowOp(
-      location, adaptor.getInputs(), adaptor.getWindowDimensions(),
-      adaptor.getWindowStrides(), adaptor.getBaseDilations(),
-      adaptor.getWindowDilations(), adaptor.getPadding(), inferredReturnShapes);
+      location, adaptor.getInputs(), adaptor.getInitValues(),
+      adaptor.getWindowDimensions(), adaptor.getWindowStrides(),
+      adaptor.getBaseDilations(), adaptor.getWindowDilations(),
+      adaptor.getPadding(), inferredReturnShapes);
 }
 
 LogicalResult ReduceWindowOp::verify() {
@@ -3307,7 +3308,8 @@ LogicalResult ReduceOp::inferReturnTypeComponents(
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   ReduceOp::Adaptor adaptor(operands, attributes, regions);
   return hlo::inferReduceOp(location, adaptor.getInputs(),
-                            adaptor.getDimensions(), inferredReturnShapes);
+                            adaptor.getInitValues(), adaptor.getDimensions(),
+                            inferredReturnShapes);
 }
 
 LogicalResult ReduceOp::verify() {

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -2942,7 +2942,14 @@ LogicalResult ReduceWindowOp::inferReturnTypeComponents(
       location, adaptor.getInputs(), adaptor.getInitValues(),
       adaptor.getWindowDimensions(), adaptor.getWindowStrides(),
       adaptor.getBaseDilations(), adaptor.getWindowDilations(),
-      adaptor.getPadding(), adaptor.getBody(), inferredReturnShapes);
+      adaptor.getPadding(), inferredReturnShapes);
+}
+
+LogicalResult ReduceWindowOp::verify() {
+  return hlo::verifyReduceWindowOp(getLoc(), getInputs(), getInitValues(),
+                                   getWindowDimensions(), getWindowStrides(),
+                                   getBaseDilations(), getWindowDilations(),
+                                   getPadding(), getBody());
 }
 
 // Get the operation used for reduction applied to `result_index`th result. Its
@@ -4372,8 +4379,11 @@ LogicalResult WhileOp::inferReturnTypes(
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<Type>& inferredReturnTypes) {
   WhileOp::Adaptor adaptor(operands, attributes, regions);
-  return hlo::inferWhileOp(location, adaptor.getOperand(), adaptor.getCond(),
-                           adaptor.getBody(), inferredReturnTypes);
+  return hlo::inferWhileOp(location, adaptor.getOperand(), inferredReturnTypes);
+}
+
+LogicalResult WhileOp::verify() {
+  return hlo::verifyWhileOp(getLoc(), getOperand(), getCond(), getBody());
 }
 
 /// Print a `while` op.

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -3305,6 +3305,11 @@ LogicalResult ReduceOp::inferReturnTypeComponents(
                             adaptor.getBody(), inferredReturnShapes);
 }
 
+LogicalResult ReduceOp::verify() {
+  return hlo::verifyReduceOp(getLoc(), getInputs(), getInitValues(),
+                             getDimensions(), getBody());
+}
+
 LogicalResult ReduceOp::reifyReturnTypeShapes(
     OpBuilder& builder, ValueRange operands,
     SmallVectorImpl<Value>& reifiedReturnShapes) {
@@ -3788,12 +3793,18 @@ void SortOp::build(OpBuilder& builder, OperationState& state,
 }
 
 LogicalResult SortOp::inferReturnTypeComponents(
-    MLIRContext*, Optional<Location> location, ValueShapeRange operands,
+    MLIRContext*, Optional<Location>, ValueShapeRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   SortOp::Adaptor adaptor(operands, attributes, regions);
-  return hlo::inferSortOp(location, adaptor.getInputs(), adaptor.getDimension(),
-                          adaptor.getComparator(), inferredReturnShapes);
+  for (auto resultType : adaptor.getInputs().getTypes())
+    inferredReturnShapes.emplace_back(resultType.cast<ShapedType>());
+  return success();
+}
+
+LogicalResult SortOp::verify() {
+  return hlo::verifySortOp(getLoc(), getInputs(), getDimension(),
+                           getComparator());
 }
 
 //===----------------------------------------------------------------------===//

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -2939,10 +2939,9 @@ LogicalResult ReduceWindowOp::inferReturnTypeComponents(
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   ReduceWindowOp::Adaptor adaptor(operands, attributes, regions);
   return hlo::inferReduceWindowOp(
-      location, adaptor.getInputs(), adaptor.getInitValues(),
-      adaptor.getWindowDimensions(), adaptor.getWindowStrides(),
-      adaptor.getBaseDilations(), adaptor.getWindowDilations(),
-      adaptor.getPadding(), inferredReturnShapes);
+      location, adaptor.getInputs(), adaptor.getWindowDimensions(),
+      adaptor.getWindowStrides(), adaptor.getBaseDilations(),
+      adaptor.getWindowDilations(), adaptor.getPadding(), inferredReturnShapes);
 }
 
 LogicalResult ReduceWindowOp::verify() {
@@ -3308,8 +3307,7 @@ LogicalResult ReduceOp::inferReturnTypeComponents(
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   ReduceOp::Adaptor adaptor(operands, attributes, regions);
   return hlo::inferReduceOp(location, adaptor.getInputs(),
-                            adaptor.getInitValues(), adaptor.getDimensions(),
-                            adaptor.getBody(), inferredReturnShapes);
+                            adaptor.getDimensions(), inferredReturnShapes);
 }
 
 LogicalResult ReduceOp::verify() {
@@ -3804,8 +3802,7 @@ LogicalResult SortOp::inferReturnTypeComponents(
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   SortOp::Adaptor adaptor(operands, attributes, regions);
-  return hlo::inferSortOp(location, adaptor.getInputs(), adaptor.getDimension(),
-                          adaptor.getComparator(), inferredReturnShapes);
+  return hlo::inferSortOp(location, adaptor.getInputs(), inferredReturnShapes);
 }
 
 LogicalResult SortOp::verify() {

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -3793,13 +3793,12 @@ void SortOp::build(OpBuilder& builder, OperationState& state,
 }
 
 LogicalResult SortOp::inferReturnTypeComponents(
-    MLIRContext*, Optional<Location>, ValueShapeRange operands,
+    MLIRContext*, Optional<Location> location, ValueShapeRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   SortOp::Adaptor adaptor(operands, attributes, regions);
-  for (auto resultType : adaptor.getInputs().getTypes())
-    inferredReturnShapes.emplace_back(resultType.cast<ShapedType>());
-  return success();
+  return hlo::inferSortOp(location, adaptor.getInputs(), adaptor.getDimension(),
+                          adaptor.getComparator(), inferredReturnShapes);
 }
 
 LogicalResult SortOp::verify() {

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1432,6 +1432,7 @@ def StableHLO_ReduceOp: StableHLO_ShapedInterfaceOp<"reduce", [
   let results = (outs Variadic<HLO_Tensor>);
 
   let hasCustomAssemblyFormat = 1;
+  let hasVerifier = 1;
 
   // TODO(hinsu): Verify that the attached body arguments and results are
   // compatible with reduce op's operands.
@@ -2593,6 +2594,8 @@ def StableHLO_SortOp : StableHLO_Op<"sort",
   let builders = [
     OpBuilder<(ins "ValueRange":$inputs, CArg<"int64_t", "-1">:$dimension,
       CArg<"bool", "false">:$is_stable)>];
+
+  let hasVerifier = 1;
 }
 
 def StableHLO_ReverseOp: StableHLO_Op<"reverse",

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1434,6 +1434,7 @@ def StableHLO_ReduceOp: StableHLO_ShapedInterfaceOp<"reduce", [
   let results = (outs Variadic<HLO_Tensor>);
 
   let hasCustomAssemblyFormat = 1;
+
   let hasVerifier = 1;
 
   // TODO(hinsu): Verify that the attached body arguments and results are

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1251,6 +1251,8 @@ def StableHLO_WhileOp: StableHLO_Op<"while", [
 
   let results = (outs Variadic<HLO_TensorOrToken>);
 
+  let hasVerifier = 1;
+
   let extraClassDeclaration = [{
     // Method of OpAsmOpInterface used during custom printing to name the block
     // arguments in the nested regions. We name both the condition and the body
@@ -2785,6 +2787,8 @@ def StableHLO_ReduceWindowOp: StableHLO_Op<"reduce_window", [
   let results = (outs Variadic<HLO_Tensor>);
 
   let regions = (region SizedRegion<1>:$body);
+
+  let hasVerifier = 1;
 
   // Builder for non-variadic version of the operation.
   let builders = [

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -1070,8 +1070,7 @@ LogicalResult inferOutfeedOp(MLIRContext* context, Optional<Location> location,
 }
 
 LogicalResult inferReduceOp(
-    Optional<Location>, ValueRange inputs,
-    DenseIntElementsAttr dimensions,
+    Optional<Location>, ValueRange inputs, DenseIntElementsAttr dimensions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   for (auto input : inputs) {
     Type elementTy = getElementTypeOrSelf(input.getType());

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -1070,8 +1070,8 @@ LogicalResult inferOutfeedOp(MLIRContext* context, Optional<Location> location,
 }
 
 LogicalResult inferReduceOp(
-    Optional<Location> location, ValueRange inputs, ValueRange initValues,
-    DenseIntElementsAttr dimensions, Region& body,
+    Optional<Location>, ValueRange inputs,
+    DenseIntElementsAttr dimensions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   for (auto input : inputs) {
     Type elementTy = getElementTypeOrSelf(input.getType());
@@ -1093,7 +1093,7 @@ LogicalResult inferReduceOp(
 }
 
 LogicalResult inferReduceWindowOp(
-    Optional<Location> location, ValueRange inputs, ValueRange initValues,
+    Optional<Location> location, ValueRange inputs,
     DenseIntElementsAttr windowDimensions,
     Optional<DenseIntElementsAttr> windowStrides,
     Optional<DenseIntElementsAttr> baseDilations,
@@ -1102,9 +1102,6 @@ LogicalResult inferReduceWindowOp(
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   SmallVector<TensorType> inputArgTypes{llvm::map_range(
       inputs.getTypes(),
-      [](Type t) -> TensorType { return t.cast<TensorType>(); })};
-  SmallVector<TensorType> initValueTypes{llvm::map_range(
-      initValues.getTypes(),
       [](Type t) -> TensorType { return t.cast<TensorType>(); })};
 
   auto windowDimsOrErr =
@@ -1124,11 +1121,11 @@ LogicalResult inferReduceWindowOp(
 
   for (size_t i = 0; i < inputArgTypes.size(); ++i) {
     if (!inputArgTypes[i].hasRank())
-      inferredReturnShapes.emplace_back(initValueTypes[i].getElementType());
+      inferredReturnShapes.emplace_back(inputArgTypes[i].getElementType());
     else
       inferredReturnShapes.emplace_back(
           inferWindowOutputShape(inputArgTypes[i].getShape(), *windowOrErr),
-          initValueTypes[i].getElementType());
+          inputArgTypes[i].getElementType());
   }
 
   return success();
@@ -1270,11 +1267,9 @@ LogicalResult inferSliceOp(Optional<Location> location, Value operand,
 }
 
 LogicalResult inferSortOp(
-    Optional<Location> location, ValueRange inputs, uint64_t dimension,
-    Region& comparator,
+    Optional<Location>, ValueRange inputs,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
-  auto operandTypes = inputs.getTypes();
-  for (auto resultType : operandTypes)
+  for (auto resultType : inputs.getTypes())
     inferredReturnShapes.emplace_back(resultType.cast<ShapedType>());
   return success();
 }

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -170,6 +170,7 @@ LogicalResult inferOptimizationBarrierOp(
 LogicalResult inferOutfeedOp(MLIRContext* context, Optional<Location> location,
                              SmallVectorImpl<Type>& inferredReturnTypes);
 
+
 LogicalResult inferReduceOp(
     Optional<Location> location, ValueRange inputs, ValueRange initValues,
     DenseIntElementsAttr dimensions, Region& body,
@@ -208,6 +209,9 @@ LogicalResult inferSortOp(
     Region& comparator,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
+LogicalResult verifySortOp(Optional<Location> location, ValueRange inputs,
+                           uint64_t dimension, Region& comparator);
+
 LogicalResult inferTransposeOp(Optional<Location> loc, Value operand,
                                DenseIntElementsAttr permutation,
                                SmallVectorImpl<Type>& inferredReturnTypes);
@@ -221,6 +225,9 @@ LogicalResult inferWhileOp(Optional<Location> location, ValueRange operand,
                            Region& cond, Region& body,
                            SmallVectorImpl<Type>& inferredReturnTypes);
 
+LogicalResult verifyReduceOp(Optional<Location> location, ValueRange inputs,
+                             ValueRange initValues,
+                             DenseIntElementsAttr dimensions, Region& body);
 }  // end namespace hlo
 }  // end namespace mlir
 

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -171,12 +171,12 @@ LogicalResult inferOutfeedOp(MLIRContext* context, Optional<Location> location,
                              SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferReduceOp(
-    Optional<Location> location, ValueRange inputs, ValueRange initValues,
-    DenseIntElementsAttr dimensions, Region& body,
+    Optional<Location> location, ValueRange inputs,
+    DenseIntElementsAttr dimensions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferReduceWindowOp(
-    Optional<Location> location, ValueRange inputs, ValueRange initValues,
+    Optional<Location> location, ValueRange inputs,
     DenseIntElementsAttr windowDimensions,
     Optional<DenseIntElementsAttr> windowStrides,
     Optional<DenseIntElementsAttr> baseDilations,
@@ -204,8 +204,7 @@ LogicalResult inferSliceOp(Optional<Location> location, Value operand,
                            SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferSortOp(
-    Optional<Location> location, ValueRange inputs, uint64_t dimension,
-    Region& comparator,
+    Optional<Location> location, ValueRange inputs,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferTransposeOp(Optional<Location> loc, Value operand,

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -171,12 +171,12 @@ LogicalResult inferOutfeedOp(MLIRContext* context, Optional<Location> location,
                              SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferReduceOp(
-    Optional<Location> location, ValueRange inputs,
+    Optional<Location> location, ValueRange inputs, ValueRange initValues,
     DenseIntElementsAttr dimensions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferReduceWindowOp(
-    Optional<Location> location, ValueRange inputs,
+    Optional<Location> location, ValueRange inputs, ValueRange initValues,
     DenseIntElementsAttr windowDimensions,
     Optional<DenseIntElementsAttr> windowStrides,
     Optional<DenseIntElementsAttr> baseDilations,

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -170,7 +170,6 @@ LogicalResult inferOptimizationBarrierOp(
 LogicalResult inferOutfeedOp(MLIRContext* context, Optional<Location> location,
                              SmallVectorImpl<Type>& inferredReturnTypes);
 
-
 LogicalResult inferReduceOp(
     Optional<Location> location, ValueRange inputs, ValueRange initValues,
     DenseIntElementsAttr dimensions, Region& body,
@@ -209,9 +208,6 @@ LogicalResult inferSortOp(
     Region& comparator,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
-LogicalResult verifySortOp(Optional<Location> location, ValueRange inputs,
-                           uint64_t dimension, Region& comparator);
-
 LogicalResult inferTransposeOp(Optional<Location> loc, Value operand,
                                DenseIntElementsAttr permutation,
                                SmallVectorImpl<Type>& inferredReturnTypes);
@@ -228,6 +224,9 @@ LogicalResult inferWhileOp(Optional<Location> location, ValueRange operand,
 LogicalResult verifyReduceOp(Optional<Location> location, ValueRange inputs,
                              ValueRange initValues,
                              DenseIntElementsAttr dimensions, Region& body);
+
+LogicalResult verifySortOp(Optional<Location> location, ValueRange inputs,
+                           uint64_t dimension, Region& comparator);
 }  // end namespace hlo
 }  // end namespace mlir
 

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -181,7 +181,7 @@ LogicalResult inferReduceWindowOp(
     Optional<DenseIntElementsAttr> windowStrides,
     Optional<DenseIntElementsAttr> baseDilations,
     Optional<DenseIntElementsAttr> windowDilations,
-    Optional<DenseIntElementsAttr> padding, Region& body,
+    Optional<DenseIntElementsAttr> padding,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferReturnOp(Optional<Location> location,
@@ -218,15 +218,25 @@ LogicalResult inferTriangularSolveOp(
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferWhileOp(Optional<Location> location, ValueRange operand,
-                           Region& cond, Region& body,
                            SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult verifyReduceOp(Optional<Location> location, ValueRange inputs,
                              ValueRange initValues,
                              DenseIntElementsAttr dimensions, Region& body);
 
+LogicalResult verifyReduceWindowOp(
+    Optional<Location> location, ValueRange inputs, ValueRange initValues,
+    DenseIntElementsAttr windowDimensions,
+    Optional<DenseIntElementsAttr> windowStrides,
+    Optional<DenseIntElementsAttr> baseDilations,
+    Optional<DenseIntElementsAttr> windowDilations,
+    Optional<DenseIntElementsAttr> padding, Region& body);
+
 LogicalResult verifySortOp(Optional<Location> location, ValueRange inputs,
                            uint64_t dimension, Region& comparator);
+
+LogicalResult verifyWhileOp(Optional<Location> location, ValueRange operand,
+                            Region& cond, Region& body);
 }  // end namespace hlo
 }  // end namespace mlir
 


### PR DESCRIPTION
This is a pure refactor PR which fixes https://github.com/openxla/stablehlo/issues/400 (deprecated) and https://github.com/openxla/stablehlo/issues/623 (new)

As in the https://github.com/openxla/stablehlo/issues/623 , "we only need this for ops with regions", a full list of ops with region extract from https://github.com/openxla/stablehlo/blob/main/stablehlo/dialect/StablehloOps.td includes **11 ops** in total:

| Op | what's done |
| --- | --- |
| AllReduceOp | No change (already split) |
| CaseOp |  No change (region is indispensable for type inference)  |
| IfOp |  No change (region is indispensable for type inference)  |
| MapOp |  No change (region is indispensable for type inference)  |
| ReduceOp |  Split |
| ReduceScatterOp |  No change (Type Inference implementation on hold see https://github.com/openxla/stablehlo/issues/725) |
| ReduceWindowOp |  Split |
| ScatterOp | No change (already split) |
| SelectAndScatterOp |  No change (already split) |
| SortOp |  Split |
| WhileOp |  Split |

The ideal split is that verifiers contain as almost all verifications, and the shape functions are simple as possible, but note: 
1. `IfOp/CaseOp/MapOp`: We need info from region(s) to infer the return type, so an init function without regions is always invalid and should not exist. No change for them in this PR.
2. As both verifier & shape function need verification of the inputs/attrs, so we need put them in a separate utils functions.
`ReduceOp`: introduce new util `verifyReduceOpInputsAndInferShape()`
`ReduceWindow`: introduce new util `verifyReduceWindowOpInputsAndInferWindow()`
In each op, verifier does (1) call this new util function (2) verify region
shape function:  (1) call this new util function (2) generate inferred type from the intermediate result from (1)
3. Besides, the verification logic needs further fix see https://github.com/openxla/stablehlo/issues/394, but this is out of scope of this PR.