### PR TITLE
Allow inlining StableHLO ops

### DIFF
--- a/stablehlo/tests/transform_stablehlo.mlir
+++ b/stablehlo/tests/transform_stablehlo.mlir
@@ -1,0 +1,12 @@
+// RUN: stablehlo-opt --inline %s | FileCheck %s
+
+func.func @main(%arg0: tensor<f32>) -> tensor<f32> {
+  %0 = func.call @callee(%arg0): (tensor<f32>) -> tensor<f32>
+  func.return %0 : tensor<f32>
+}
+
+// CHECK-NOT: func.func private @callee
+func.func private @callee(%arg0: tensor<f32>) -> tensor<f32> {
+  %0 = stablehlo.abs %arg0 : tensor<f32>
+  func.return %0 : tensor<f32>
+}

--- a/stablehlo/tests/transform_stablehlo.mlir
+++ b/stablehlo/tests/transform_stablehlo.mlir
@@ -1,6 +1,8 @@
 // RUN: stablehlo-opt --inline %s | FileCheck %s
 
+// CHECK: func.func @main
 func.func @main(%arg0: tensor<f32>) -> tensor<f32> {
+  // CHECK-NEXT: stablehlo.abs
   %0 = func.call @callee(%arg0): (tensor<f32>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }


### PR DESCRIPTION
This hasn't been discussed much, but as part of defining the
relationship between StableHLO and MHLO, it looks reasonable to avoid
doing transformations on StableHLO and leave that to MHLO.

This way, we don't have to duplicate stuff like constant folding,
canonicalization, etc etc.

Inlining is one of the transformations that's in a gray area because
this is something that we get for free from upstream, so I don't think
that the duplication argument applies here.