### PR TITLE
Add spec for RngBitGeneratorOp

### DIFF
--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -3127,17 +3127,11 @@ deterministic between implementations.
 
 ### Constraints
 
-  * (C1) shape(`initial_state`) $=$ shape(`output_state`).
-  * (C2) For `initial_state`, `output_state`, and `output`:
-    * If `rng_algorithm = DEFAULT`:
-      * `initial_state`, `output_state`, and `output` have backend-specific type
-        requirements.
-    * If `rng_algorithm = THREE_FRY`:
-      * type(`initial_state`) $=$ type(`output_state`) $=$ `tensor<2xui64>`.
-      * element_type(`output`) $\in$ {`ui32`, `ui64`}.
-    * If `rng_algorithm = PHILOX`:
-      * type(`initial_state`) $=$ type(`output_state`) $=$ `tensor<3xui64>`.
-      * element_type(`output`) $\in$ {`ui32`, `ui64`}.
+  * (C1) type(`initial_state`) $=$ type(`output_state`).
+  * (C2) size(`initial_state`) depends on `rng_algorithm`:
+    * `DEFAULT`: implementation-defined.
+    * `THREE_FRY`: `2`.
+    * `PHILOX`: `2` or `3`.
 
 ### Examples
 

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -3103,10 +3103,6 @@ number generator algorithm `rng_algorithm`. The output is guaranteed to be
 deterministic function of `initial_state`, but it is not guaranteed to be
 deterministic between backends and different compiler versions.
 
-`initial_state` is the initial state of the current random number generation.
-The initial state, supported element type, and valid values are dependent on the
-algorithm used.
-
 `rng_algorithm` is one of the following, different variants of the algorithm is
 implementation-defined:
   * `DEFAULT`: Backend specific algorithm.
@@ -3138,10 +3134,10 @@ implementation-defined:
       * `initial_state`, `output_state`, and `output` have backend-specific type
         requirements.
     * If `rng_algorithm = THREE_FRY`:
-      * type(`initial_state`) $=$ type(`output_state`) $=$ `2xui64`.
+      * type(`initial_state`) $=$ type(`output_state`) $=$ `tensor<2xui64>`.
       * element_type(`output`) $\in$ {`ui32`, `ui64`}.
     * If `rng_algorithm = PHILOX`:
-      * type(`initial_state`) $=$ type(`output_state`) $=$ `3xui64`.
+      * type(`initial_state`) $=$ type(`output_state`) $=$ `tensor<3xui64>`.
       * element_type(`output`) $\in$ {`ui32`, `ui64`}.
 
 ### Examples

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -382,6 +382,7 @@ syntax.
    * [reshape](#stablehloreshape)
    * [reverse](#stablehloreverse)
    * [rng](#stablehlorng)
+   * [rng_bit_generator](#stablehlorng_bit_generator)
    * [round_nearest_afz](#stablehloround_nearest_afz)
    * [round_nearest_even](#stablehloround_nearest_even)
    * [rsqrt](#stablehlorsqrt)
@@ -3088,6 +3089,60 @@ hidden state.
 //           [1, 1, 1],
 //           [0, 0, 0]
 //          ]
+```
+
+[Back to Ops](#index-of-ops)
+
+## stablehlo.rng_bit_generator
+
+### Semantics
+
+Returns an `output` filled with uniform random data and an updated
+`output_state` using the `rng_algorithm` given `initial_state`. The output is
+guaranteed to be deterministic from the initial state, but it is not guaranteed
+to be deterministic between backends and different compiler versions.
+
+`initial_state` is the initial state of the current random number generation.
+The initial state, required shape, and valid values are dependent on the
+algorithm used.
+
+`rng_algorithm` is one of the following:
+  * `DEFAULT`: Backend specific algorithm.
+  * `THREE_FRY`: ThreeFry counter-based PRNG algorithm.
+  * `PHILOX`: Philox algorithm to generate random numbers in parallel.
+
+### Inputs
+
+| Name            | Type                                                 |
+|-----------------|------------------------------------------------------|
+| `initial_state` | tensor of integer or floating-point type             |
+| `rng_algorithm` | constant of type `enum {DEFAULT, THREE_FRY, PHILOX}` |
+
+### Outputs
+
+| Name           | Type                                     |
+|----------------|------------------------------------------|
+| `output_state` | tensor of integer or floating-point type |
+| `output`       | tensor of integer or floating-point type |
+
+### Constraints
+
+  * (C1) Shape of `initial_state` vary depending on the `rng_algorithm`:
+    * If `rng_algorithm = DEFAULT`, `initial_state` has backend-specific
+      requirements.
+    * If `rng_algorithm = THREE_FRY`, `initial_state` is 2-dimensional.
+    * If `rng_algorithm = PHILOX`, `initial_state` is 3-dimensional.
+  * (C2) `output_state` has the same shape as `initial_state`.
+
+### Examples
+
+```mlir
+// %initial_state: [1, 2, 3]
+%output_state, %output = "stablehlo.rng_bit_generator"(%initial_state) {
+  rng_algorithm = #stablehlo.rng_algorithm<DEFAULT>
+} : (tensor<3xi32>) -> (tensor<3xi32>, tensor<2x2xf64>)
+// %output_state: []
+// %output: [[], []]
 ```
 
 [Back to Ops](#index-of-ops)

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -3104,7 +3104,7 @@ deterministic function of `initial_state`, but it is not guaranteed to be
 deterministic between implementations.
 
 `rng_algorithm` is one of the following:
-  * `DEFAULT`: Backend specific algorithm.
+  * `DEFAULT`: Implementation-defined algorithm.
   * `THREE_FRY`: Implementation-defined variant of the Threefry algorithm.*
   * `PHILOX`: Implementation-defined variant of the Philox algorithm.*
 
@@ -3115,14 +3115,14 @@ deterministic between implementations.
 
 | Name            | Type                                         |
 |-----------------|----------------------------------------------|
-| `initial_state` | tensor of integer or floating-point type     |
+| `initial_state` | 1-dimensional tensor of type `ui64`          |
 | `rng_algorithm` | enum of `DEFAULT`, `THREE_FRY`, and `PHILOX` |
 
 ### Outputs
 
 | Name           | Type                                     |
 |----------------|------------------------------------------|
-| `output_state` | tensor of integer or floating-point type |
+| `output_state` | 1-dimensional tensor of type `ui64`      |
 | `output`       | tensor of integer or floating-point type |
 
 ### Constraints

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -3101,13 +3101,12 @@ Returns an `output` filled with uniform random bits and an updated output state
 `output_state` given an initial state `initial_state` using the pseudorandom
 number generator algorithm `rng_algorithm`. The output is guaranteed to be
 deterministic function of `initial_state`, but it is not guaranteed to be
-deterministic between backends and different compiler versions.
+deterministic between implementations.
 
-`rng_algorithm` is one of the following, different variants of the algorithm is
-implementation-defined:
+`rng_algorithm` is one of the following:
   * `DEFAULT`: Backend specific algorithm.
-  * `THREE_FRY`: Threefry counter-based PRNG algorithm.*
-  * `PHILOX`: Philox algorithm to generate random numbers in parallel.*
+  * `THREE_FRY`: Implementation-defined variant of the Threefry algorithm.*
+  * `PHILOX`: Implementation-defined variant of the Philox algorithm.*
 
 \* See: [Salmon et al. SC 2011. Parallel random numbers: as easy as 1, 2, 3.
 ](http://www.thesalmons.org/john/random123/papers/random123sc11.pdf)
@@ -3145,7 +3144,7 @@ implementation-defined:
 ```mlir
 // %initial_state: [1, 2]
 %output_state, %output = "stablehlo.rng_bit_generator"(%initial_state) {
-  rng_algorithm = #stablehlo.rng_algorithm<THREE_FRY>
+  rng_algorithm = #stablehlo<rng_algorithm THREE_FRY>
 } : (tensor<2xui64>) -> (tensor<2xui64>, tensor<2x2xui64>)
 // %output_state: [1, 6]
 // %output: [

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -3111,6 +3111,11 @@ algorithm used.
   * `THREE_FRY`: ThreeFry counter-based PRNG algorithm.
   * `PHILOX`: Philox algorithm to generate random numbers in parallel.
 
+More formally, given the function `rng_algorithm` which takes an
+`initial_state` as input, the `output` with uniform random data is generated
+given `initial_state`:
+  * `output_state, output = rng(initial_state)`
+
 ### Inputs
 
 | Name            | Type                                                 |

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -3104,7 +3104,7 @@ deterministic function of `initial_state`, but it is not guaranteed to be
 deterministic between backends and different compiler versions.
 
 `initial_state` is the initial state of the current random number generation.
-The initial state, required shape, and valid values are dependent on the
+The initial state, supported element type, and valid values are dependent on the
 algorithm used.
 
 `rng_algorithm` is one of the following, different variants of the algorithm is
@@ -3133,10 +3133,9 @@ implementation-defined:
 ### Constraints
 
   * (C1) shape(`initial_state`) $=$ shape(`output_state`).
-  * (C2) The relationship between `initial_state`, `output_state`, and `output`
-      varies:
+  * (C2) For `initial_state`, `output_state`, and `output`:
     * If `rng_algorithm = DEFAULT`:
-      * `initial_state`, `output_state`, and `output` have backend-specific
+      * `initial_state`, `output_state`, and `output` have backend-specific type
         requirements.
     * If `rng_algorithm = THREE_FRY`:
       * type(`initial_state`) $=$ type(`output_state`) $=$ `2xui64`.

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -3108,8 +3108,11 @@ algorithm used.
 
 `rng_algorithm` is one of the following:
   * `DEFAULT`: Backend specific algorithm.
-  * `THREE_FRY`: ThreeFry counter-based PRNG algorithm.
-  * `PHILOX`: Philox algorithm to generate random numbers in parallel.
+  * `THREE_FRY`: Threefry counter-based PRNG algorithm.*
+  * `PHILOX`: Philox algorithm to generate random numbers in parallel.*
+
+\* See: [Salmon et al. SC 2011. Parallel random numbers: as easy as 1, 2, 3.
+](http://www.thesalmons.org/john/random123/papers/random123sc11.pdf)
 
 More formally, given the function `rng_algorithm` which takes an
 `initial_state` as input, the `output` with uniform random data is generated

--- a/docs/status.md
+++ b/docs/status.md
@@ -127,7 +127,7 @@ one of the following tracking labels.
 | return                   | no            | revisit      | no             | yes             | no          |
 | reverse                  | yes           | revisit      | yes            | yes             | no          |
 | rng                      | yes           | yes          | yes            | yes             | no          |
-| rng_bit_generator        | yes           | yes          | infeasible     | yes             | no          |
+| rng_bit_generator        | yes           | revisit      | infeasible     | yes             | no          |
 | round_nearest_afz        | yes           | yes          | yes            | yes             | no          |
 | round_nearest_even       | yes           | yes          | yes            | yes             | no          |
 | rsqrt                    | yes           | yes          | yes            | yes             | no          |

--- a/docs/status.md
+++ b/docs/status.md
@@ -127,7 +127,7 @@ one of the following tracking labels.
 | return                   | no            | revisit      | no             | yes             | no          |
 | reverse                  | yes           | revisit      | yes            | yes             | no          |
 | rng                      | yes           | yes          | yes            | yes             | no          |
-| rng_bit_generator        | no            | yes*         | infeasible     | yes             | no          |
+| rng_bit_generator        | yes           | yes          | infeasible     | yes             | no          |
 | round_nearest_afz        | yes           | yes          | yes            | yes             | no          |
 | round_nearest_even       | yes           | yes          | yes            | yes             | no          |
 | rsqrt                    | yes           | yes          | yes            | yes             | no          |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2819,27 +2819,26 @@ def StableHLO_RngOp : StableHLO_Op<"rng", [InferTensorTypeWithReify, AllElementT
 def StableHLO_RngBitGeneratorOp : StableHLO_Op<"rng_bit_generator", [Pure]> {
   let summary = "Uniform random number generator operator";
   let description = [{
-    Returns an output with a given shape filled with uniform random bits using
-    the specified algorithm (or backend default) and returns an updated state
-    (with the same shape as initial state) and the generated random data.
+    Returns an `output` filled with uniform random data and an updated
+    `output_state` using the `rng_algorithm` given `initial_state`.
 
-    See https://www.tensorflow.org/xla/operation_semantics#rngbitgenerator.
+    See:
+    https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlorng_bit_generator
 
     Example:
-
     ```mlir
-    %0, %1 = stablehlo.rng_bit_generator %arg0, algorithm = PHILOX : (tensor<3xui64>) -> (tensor<3xui64>, tensor<2x2xui32>)
+    %output_state, %output = stablehlo.rng_bit_generator %initial_state, algorithm = DEFAULT : (tensor<3xi32>) -> (tensor<3xi32>, tensor<2x2xf64>)
     ```
   }];
   let arguments = (ins
-    StableHLO_RngAlgorithmAttr:$rng_algorithm,
-    HLO_IntOrFpTensor:$initial_state
+    HLO_IntOrFpTensor:$initial_state,
+    StableHLO_RngAlgorithmAttr:$rng_algorithm
   );
 
   let results = (outs
-      HLO_IntOrFpTensor:$output_state,
-      HLO_IntOrFpTensor:$output
-      );
+    HLO_IntOrFpTensor:$output_state,
+    HLO_IntOrFpTensor:$output
+  );
 
   let hasVerifier = 1;
 

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2832,8 +2832,8 @@ def StableHLO_RngBitGeneratorOp : StableHLO_Op<"rng_bit_generator", [Pure]> {
     ```
   }];
   let arguments = (ins
-    HLO_IntOrFpTensor:$initial_state,
-    StableHLO_RngAlgorithmAttr:$rng_algorithm
+    StableHLO_RngAlgorithmAttr:$rng_algorithm,
+    HLO_IntOrFpTensor:$initial_state
   );
 
   let results = (outs

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2817,17 +2817,18 @@ def StableHLO_RngOp : StableHLO_Op<"rng", [InferTensorTypeWithReify, AllElementT
 }
 
 def StableHLO_RngBitGeneratorOp : StableHLO_Op<"rng_bit_generator", [Pure]> {
-  let summary = "Uniform random number generator operator";
+  let summary = "Uniform pseudo random number generator operator";
   let description = [{
-    Returns an `output` filled with uniform random data and an updated
-    `output_state` using the `rng_algorithm` given `initial_state`.
+    Returns an `output` filled with uniform random data and an updated output
+    state `output_state` given an initial state `initial_state` using the
+    pseudorandom number generator algorithm `rng_algorithm`.
 
     See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlorng_bit_generator
 
     Example:
     ```mlir
-    %output_state, %output = stablehlo.rng_bit_generator %initial_state, algorithm = DEFAULT : (tensor<3xi32>) -> (tensor<3xi32>, tensor<2x2xf64>)
+    %output_state, %output = stablehlo.rng_bit_generator %initial_state, algorithm = DEFAULT : (tensor<2xui64>) -> (tensor<2xui64>, tensor<2x2xui64>)
     ```
   }];
   let arguments = (ins

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2828,7 +2828,7 @@ def StableHLO_RngBitGeneratorOp : StableHLO_Op<"rng_bit_generator", [Pure]> {
 
     Example:
     ```mlir
-    %output_state, %output = stablehlo.rng_bit_generator %initial_state, algorithm = DEFAULT : (tensor<2xui64>) -> (tensor<2xui64>, tensor<2x2xui64>)
+    %output_state, %output = stablehlo.rng_bit_generator %initial_state, algorithm = THREE_FRY : (tensor<2xui64>) -> (tensor<2xui64>, tensor<2x2xui64>)
     ```
   }];
   let arguments = (ins


### PR DESCRIPTION
Raised issue #643 to track which types are supported for the inputs/outputs.
Verification is set to `revisit` due to #486.
closes #414 