### PR TITLE
Fix typo in spec_draft.md

### DIFF
--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -25,7 +25,7 @@ Following are the supported element types in StableHLO:
     are `complex<f32>` (represents a par of `f32`) and `complex<f64>`
     (represents a pair of `f64`). Exact representation of complex types
     (e.g. whether the real part or the imaginary part comes first in memory)
-    is implementation-dependent.
+    is implementation-defined.
 
 **Tensor types** are the cornerstone of the StableHLO type system. They model
 immutable n-dimensional arrays and are referred to in the document as


### PR DESCRIPTION
"implementation-dependent" => "implementation-defined".

As we're making our language around implementation-defined and undefined behavior stricter, rewording this looked appropriate.