### PR TITLE
Prettyprint CustomCallOp target using SymbolRef printing

### DIFF
--- a/stablehlo/dialect/AssemblyFormat.cpp
+++ b/stablehlo/dialect/AssemblyFormat.cpp
@@ -347,5 +347,13 @@ ParseResult parseExponentMantissa(AsmParser& parser, IntegerAttr& exponent,
   mantissa = parser.getBuilder().getI32IntegerAttr(mant);
   return success();
 }
+
+void printCustomCallTarget(AsmPrinter& p, Operation*, StringAttr target) {
+  p.printSymbolName(target.getValue());
+}
+
+ParseResult parseCustomCallTarget(AsmParser& parser, StringAttr& target) {
+  return parser.parseSymbolName(target);
+}
 }  // namespace hlo
 }  // namespace mlir

--- a/stablehlo/dialect/AssemblyFormat.h
+++ b/stablehlo/dialect/AssemblyFormat.h
@@ -184,6 +184,20 @@ void printExponentMantissa(AsmPrinter& p, Operation*, IntegerAttr exponent,
 ParseResult parseExponentMantissa(AsmParser& parser, IntegerAttr& exponent,
                                   IntegerAttr& mantissa);
 
+// CustomCallTarget - Print custom call target using upstream SymbolRef
+// printing.
+//
+// Generic:
+//    {custom_call_target = "foo"}
+//    {custom_call_target = "not-valid-id"}
+//
+// Custom:
+//    @foo
+//    @"not-valid-id"
+void printCustomCallTarget(AsmPrinter& p, Operation*, StringAttr target);
+
+ParseResult parseCustomCallTarget(AsmParser& parser, StringAttr& target);
+
 }  // namespace hlo
 }  // namespace mlir
 

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -4331,6 +4331,8 @@ using mlir::hlo::printSelectOpType;
 using mlir::hlo::parseSelectOpType;
 using mlir::hlo::printTupleOpType;
 using mlir::hlo::parseTupleOpType;
+using mlir::hlo::printCustomCallTarget;
+using mlir::hlo::parseCustomCallTarget;
 using mlir::hlo::printDenseI64Array;
 using mlir::hlo::parseDenseI64Array;
 using mlir::hlo::printExponentMantissa;

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2001,7 +2001,7 @@ def StableHLO_CustomCallOp: StableHLO_Op<"custom_call",
     Example:
 
     ```mlir
-    %1 = stablehlo.custom_call "foo"(%arg0, %arg1) {backend_config = "bar", has_side_effect = true}
+    %1 = stablehlo.custom_call @foo(%arg0, %arg1) {backend_config = "bar", has_side_effect = true}
           : (tensor<2x3xf32>, tensor<5x5xf32>) -> tensor<1x2x3xf32>
     ```
   }];
@@ -2025,8 +2025,8 @@ def StableHLO_CustomCallOp: StableHLO_Op<"custom_call",
   let hasVerifier = 1;
 
   let assemblyFormat = [{
-    $call_target_name `(` $inputs `)` attr-dict
-      `:` functional-type(operands, results)
+    custom<CustomCallTarget>($call_target_name) `(` $inputs `)` 
+      attr-dict `:` functional-type(operands, results)
   }];
 }
 

--- a/stablehlo/tests/print_stablehlo.mlir
+++ b/stablehlo/tests/print_stablehlo.mlir
@@ -154,9 +154,11 @@ func.func @no_attr_ops(%arg0 : tensor<4xf32>, %arg1 : !stablehlo.token,
 // CHECK-LABEL: func @multiple_attr_ops
 func.func @multiple_attr_ops(%arg0 : tensor<3x4xf32>) -> () {
   // CHECK:      %0 = stablehlo.reduce_precision %arg0, format = e8m10 : tensor<3x4xf32>
-  // CHECK-NEXT: %1 = stablehlo.custom_call "foo"(%arg0, %arg0) {backend_config = "bar", has_side_effect = true} : (tensor<3x4xf32>, tensor<3x4xf32>) -> tensor<1x2x3xf32>
+  // CHECK-NEXT: %1 = stablehlo.custom_call @foo(%arg0, %arg0) {backend_config = "bar", has_side_effect = true} : (tensor<3x4xf32>, tensor<3x4xf32>) -> tensor<1x2x3xf32>
+  // CHECK-NEXT: %2 = stablehlo.custom_call @"foo-not-id"(%arg0, %arg0) {backend_config = "bar", has_side_effect = true} : (tensor<3x4xf32>, tensor<3x4xf32>) -> tensor<1x2x3xf32>
   %0 = "stablehlo.reduce_precision"(%arg0) {exponent_bits = 8 : i32, mantissa_bits = 10 : i32} : (tensor<3x4xf32>) -> tensor<3x4xf32>
   %1 = "stablehlo.custom_call"(%arg0, %arg0) {backend_config = "bar", call_target_name = "foo", has_side_effect = true} : (tensor<3x4xf32>, tensor<3x4xf32>) -> tensor<1x2x3xf32>
+  %2 = "stablehlo.custom_call"(%arg0, %arg0) {backend_config = "bar", call_target_name = "foo-not-id", has_side_effect = true} : (tensor<3x4xf32>, tensor<3x4xf32>) -> tensor<1x2x3xf32>
   "stablehlo.return"() : () -> ()
 }
 

--- a/stablehlo/tests/print_types_invalid.mlir
+++ b/stablehlo/tests/print_types_invalid.mlir
@@ -61,6 +61,15 @@ func.func @complex_type_not_complex(%arg0: tensor<1xf64>) -> () {
   func.return
 }
 
+
+// -----
+
+func.func @custom_call_target_not_symbol(%arg0 : tensor<3x4xf32>) -> () {
+  // expected-error @+1 {{custom op 'stablehlo.custom_call' expected valid '@'-identifier for symbol name}}
+  %0 = stablehlo.custom_call "test"(%arg0, %arg0) {backend_config = "bar", has_side_effect = true} : (tensor<3x4xf32>, tensor<3x4xf32>) -> tensor<1x2x3xf32>
+  "stablehlo.return"() : () -> ()
+}
+
 // -----
 
 func.func @dense_array_nested(%arg0: tensor<1x2xf64>) -> () {


### PR DESCRIPTION
This is consistent with `func.call` printing, and relies entirely on upstream machinery. Using this printing is cleaner and more consistent, and if we eventually consider modifying what is permitted in CustomCallOp target names, this printing will not need to be updated.

```
%0 = stablehlo.custom_call @foo(%arg0) ...
%1 = stablehlo.custom_call @"foo-not-id"(%arg0) ...
```

This is a little messier for non-identifier target names, but there are _very_ few cases that target non-C or non-MLIR identifier names. The only ones I was able to find were in a single test file in mlir-hlo.

The implementation directly calls upstreams `AsmPrinter::printSymbolName`/`AsmParser::parseSymbolName`. These methods are able to handle identifier and non-identifier targets.

Closes #431 