### PR TITLE
Remove explicit references to kEmitAccessors_Prefixed

### DIFF
--- a/stablehlo/dialect/ChloOps.td
+++ b/stablehlo/dialect/ChloOps.td
@@ -53,8 +53,6 @@ def CHLO_Dialect : Dialect {
     and provide conversion patterns to fully materialize into lower level
     dialects.
   }];
-
-  let emitAccessorPrefix = kEmitAccessorPrefix_Prefixed;
 }
 
 class CHLO_Op<string mnemonic, list<Trait> traits> :

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -35,7 +35,6 @@ def StableHLO_Dialect : Dialect {
     a portability layer between ML frameworks and ML compilers.
   }];
 
-  let emitAccessorPrefix = kEmitAccessorPrefix_Prefixed;
   let useDefaultAttributePrinterParser = 0;
   let useDefaultTypePrinterParser = 0;
 }
@@ -2025,7 +2024,7 @@ def StableHLO_CustomCallOp: StableHLO_Op<"custom_call",
   let hasVerifier = 1;
 
   let assemblyFormat = [{
-    custom<CustomCallTarget>($call_target_name) `(` $inputs `)` 
+    custom<CustomCallTarget>($call_target_name) `(` $inputs `)`
       attr-dict `:` functional-type(operands, results)
   }];
 }


### PR DESCRIPTION
This is the default and the option will be removed by https://reviews.llvm.org/D136727