### PR TITLE
Add spec for MapOp

### DIFF
--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -182,6 +182,7 @@ described below)
    * [iota](#stablehloiota)
    * [log](#stablehlolog)
    * [logistic](#stablehlologistic)
+   * [map](#stablehlomap)
    * [maximum](#stablehlomaximum)
    * [minimum](#stablehlominimum)
    * [multiply](#stablehlomultiply)
@@ -1455,6 +1456,57 @@ For boolean element type, the behavior is same as [stablehlo.or](#stablehloor).
 ```
 
 &nbsp;[More Examples](../stablehlo/tests/interpret_maximum.mlir)
+
+[Back to Ops](#index-of-ops)
+
+## stablehlo.map
+
+### Semantics
+
+Performs a map function `computation` over the `inputs` along the `dimensions`
+and produces a `result` tensor where each element is the result of `computation`
+applied to the corresponding elements in `inputs`.
+
+More formally, `result[i0, ..., iR-1] = computation(inputs0[i0, ..., iR-1], `
+`..., inputsN-1[i0, ..., iR-1])`.
+
+### Inputs
+
+| Name          | Type                                             |
+|---------------|--------------------------------------------------|
+| `inputs`      | variadic number of tensors of any supported type |
+| `dimensions`  | 1-dimensional tensor constant of type `si64`     |
+| `computation` | `function`                                       |
+
+### Outputs
+
+| Name     | Type                         |
+|----------|------------------------------|
+| `result` | tensor of any supported type |
+
+### Constraints
+
+  * (C1) `inputs` and `result` have the same shape.
+  * (C2) size(`dimensions`) $=$ size(`inputs`).
+  * (C3) `dimensions[i]` $\lt$ `dimensions[i+1]` for all `i` $\in$ [0, `R`-2].
+  * (C3) `computation` has type `(tensor<E0>, ..., tensor<EN-1>, tensor<E0>,`
+    `..., tensor<EN-1>) -> tensor<E'>` where `Ek = element_type(inputs[k])`
+    and `E' = element_type(result)`.
+
+### Examples
+
+```mlir
+// %input0: [[0, 1], [2, 3]]
+// %input1: [[4, 5], [6, 7]]
+%result = "stablehlo.map"(%input0, %input1) ({
+  ^bb0(%arg0: tensor<i32>, %arg1: tensor<i32>):
+    %0 = "stablehlo.multiply"(%arg0, %arg1) : (tensor<i32>, tensor<i32>) -> tensor<i32>
+    "stablehlo.return"(%0) : (tensor<i32>) -> ()
+}) {
+  dimensions = dense<[0, 1]> : tensor<2xi64>
+} : (tensor<2x2xi32>, tensor<2x2xi32>) -> tensor<2x2xi32>
+// %result: [[0, 5], [12, 21]]
+```
 
 [Back to Ops](#index-of-ops)
 

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -1487,11 +1487,12 @@ More formally, `result[i0, ..., iR-1] = computation(inputs0[i0, ..., iR-1], `
 ### Constraints
 
   * (C1) `inputs` and `result` have the same shape.
-  * (C2) size(`dimensions`) $=$ size(`inputs`).
-  * (C3) `dimensions[i]` $\lt$ `dimensions[i+1]` for all `i` $\in$ [0, `R`-2].
-  * (C3) `computation` has type `(tensor<E0>, ..., tensor<EN-1>, tensor<E0>,`
-    `..., tensor<EN-1>) -> tensor<E'>` where `Ek = element_type(inputs[k])`
-    and `E' = element_type(result)`.
+  * (C2) size(`inputs`) $=$ N $\ge$ 1.
+  * (C3) size(`dimensions`) $=$ rank(`inputs[k]`) for all `k` $\in$ [0, N).
+  * (C4) `dimensions[i]` $\lt$ `dimensions[i+1]` for all `i` $\in$ [0, `R`-2].
+  * (C5) `computation` has type `(tensor<E0>, ..., tensor<EN-1>) -> tensor<E'>`
+    where `Ek` $=$ element_type(`inputs[k]`) and `E'` $=$
+    element_type(`result`).
 
 ### Examples
 

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -1463,12 +1463,11 @@ For boolean element type, the behavior is same as [stablehlo.or](#stablehloor).
 
 ### Semantics
 
-Performs a map function `computation` over the `inputs` along the `dimensions`
-and produces a `result` tensor where each element is the result of `computation`
-applied to the corresponding elements in `inputs`.
+Applies a map function `computation` to `inputs` along the `dimensions` and
+produces a `result` tensor.
 
-More formally, `result[i0, ..., iR-1] = computation(inputs0[i0, ..., iR-1], `
-`..., inputsN-1[i0, ..., iR-1])`.
+More formally, `result[i0, ..., iR-1] = computation(inputs[0][i0, ..., iR-1], `
+`..., inputs[N-1][i0, ..., iR-1])`.
 
 ### Inputs
 
@@ -1486,11 +1485,10 @@ More formally, `result[i0, ..., iR-1] = computation(inputs0[i0, ..., iR-1], `
 
 ### Constraints
 
-  * (C1) `inputs` and `result` have the same shape.
+  * (C1) All `inputs` and `result` have the same shape.
   * (C2) size(`inputs`) $=$ N $\ge$ 1.
-  * (C3) size(`dimensions`) $=$ rank(`inputs[k]`) for all `k` $\in$ [0, N).
-  * (C4) `dimensions[i]` $\lt$ `dimensions[i+1]` for all `i` $\in$ [0, `R`-2].
-  * (C5) `computation` has type `(tensor<E0>, ..., tensor<EN-1>) -> tensor<E'>`
+  * (C3) `dimensions = [0, ..., R-1]`, where `R` $=$ rank(`inputs[0]`).
+  * (C4) `computation` has type `(tensor<E0>, ..., tensor<EN-1>) -> tensor<E'>`
     where `Ek` $=$ element_type(`inputs[k]`) and `E'` $=$
     element_type(`result`).
 
@@ -1501,8 +1499,8 @@ More formally, `result[i0, ..., iR-1] = computation(inputs0[i0, ..., iR-1], `
 // %input1: [[4, 5], [6, 7]]
 %result = "stablehlo.map"(%input0, %input1) ({
   ^bb0(%arg0: tensor<i32>, %arg1: tensor<i32>):
-    %0 = "stablehlo.multiply"(%arg0, %arg1) : (tensor<i32>, tensor<i32>) -> tensor<i32>
-    "stablehlo.return"(%0) : (tensor<i32>) -> ()
+    %0 = stablehlo.multiply %arg0, %arg1 : tensor<i32>
+    stablehlo.return %0 : tensor<i32>
 }) {
   dimensions = dense<[0, 1]> : tensor<2xi64>
 } : (tensor<2x2xi32>, tensor<2x2xi32>) -> tensor<2x2xi32>
@@ -1848,8 +1846,8 @@ and produces a `result` tensor.
 
 ### Semantics
 
-Applies a function `body` to `inputs` and `init_values` along the `dimensions`
-and produces a `result` tensor.
+Applies a reduction function `body` to `inputs` and `init_values` along the
+`dimensions` and produces a `result` tensor.
 
 The order of reductions is implementation-defined, which means that `body` and
 `init_values` must form a monoid to guarantee that the operation produces the

--- a/docs/status.md
+++ b/docs/status.md
@@ -102,7 +102,7 @@ one of the following tracking labels.
 | log                      | yes           | yes          | yes            | yes             | no          |
 | log_plus_one             | no            | yes*         | yes*           | yes             | no          |
 | logistic                 | yes           | yes          | yes            | yes             | no          |
-| map                      | no            | yes*         | yes*           | no              | no          |
+| map                      | yes           | yes          | yes            | no              | no          |
 | maximum                  | yes           | yes          | yes            | yes             | yes         |
 | minimum                  | yes           | yes          | yes            | yes             | yes         |
 | multiply                 | yes           | yes          | yes            | yes             | yes         |

--- a/docs/status.md
+++ b/docs/status.md
@@ -102,7 +102,7 @@ one of the following tracking labels.
 | log                      | yes           | yes          | yes            | yes             | no          |
 | log_plus_one             | no            | yes*         | yes*           | yes             | no          |
 | logistic                 | yes           | yes          | yes            | yes             | no          |
-| map                      | yes           | yes          | yes            | no              | no          |
+| map                      | yes           | revisit      | yes            | no              | no          |
 | maximum                  | yes           | yes          | yes            | yes             | yes         |
 | minimum                  | yes           | yes          | yes            | yes             | yes         |
 | multiply                 | yes           | yes          | yes            | yes             | yes         |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1344,7 +1344,7 @@ def StableHLO_ReduceOp: StableHLO_ShapedInterfaceOp<"reduce", [
     ]> {
   let summary = "Reduce operator";
   let description = [{
-    Applies a function `body` to `inputs` and `init_values` along the
+    Applies a reduction function `body` to `inputs` and `init_values` along the
     `dimensions` and produces a `result` tensor.
 
     See:
@@ -2261,22 +2261,21 @@ def StableHLO_MapOp: StableHLO_ShapedInterfaceOp<"map",
        SingleBlockImplicitTerminator<"ReturnOp">, InferTensorTypeWithReify]> {
   let summary = "Map operator";
   let description = [{
-  Performs a map function `computation` over the `inputs` along the `dimensions`
-  and produces a `result` tensor where each element is the result of
-  `computation` applied to the corresponding elements in `inputs`.
+    Applies a map function `computation` to `inputs` along the `dimensions` and
+    produces a `result` tensor.
 
-  See:
-  https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlomap
+    See:
+    https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlomap
 
-  Example:
-  ```mlir
-  %result = "stablehlo.map"(%input0, %input1) ({
-    ^bb0(%arg0: tensor<i32>, %arg1: tensor<i32>):
-      %0 = "stablehlo.multiply"(%arg0, %arg1) : (tensor<i32>, tensor<i32>) -> tensor<i32>
-      "stablehlo.return"(%0) : (tensor<i32>) -> ()
-  }) {
-    dimensions = dense<[0, 1]> : tensor<2xi64>
-  } : (tensor<2x2xi32>, tensor<2x2xi32>) -> tensor<2x2xi32>
+    Example:
+    ```mlir
+    %result = "stablehlo.map"(%input0, %input1) ({
+      ^bb0(%arg0: tensor<i32>, %arg1: tensor<i32>):
+        %0 = stablehlo.multiply %arg0, %arg1 : tensor<i32>
+        stablehlo.return %0 : tensor<i32>
+    }) {
+      dimensions = dense<[0, 1]> : tensor<2xi64>
+    } : (tensor<2x2xi32>, tensor<2x2xi32>) -> tensor<2x2xi32>
   ```
   }];
   let arguments = (ins

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2261,16 +2261,23 @@ def StableHLO_MapOp: StableHLO_ShapedInterfaceOp<"map",
        SingleBlockImplicitTerminator<"ReturnOp">, InferTensorTypeWithReify]> {
   let summary = "Map operator";
   let description = [{
-  Applies a scalar function over the given operands arrays, producing an array
-  of the same dimensions where each element is the result of the mapped function
-  applied to the corresponding elements in the input arrays.
+  Performs a map function `computation` over the `inputs` along the `dimensions`
+  and produces a `result` tensor where each element is the result of
+  `computation` applied to the corresponding elements in `inputs`.
 
-  The mapped function is an arbitrary computation with the restriction that it
-  has N inputs of scalar type T and a single output with type S. The output has
-  the same dimensions as the operands except that the element type T is replaced
-  with S.
+  See:
+  https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlomap
 
-  See https://www.tensorflow.org/xla/operation_semantics#map.
+  Example:
+  ```mlir
+  %result = "stablehlo.map"(%input0, %input1) ({
+    ^bb0(%arg0: tensor<i32>, %arg1: tensor<i32>):
+      %0 = "stablehlo.multiply"(%arg0, %arg1) : (tensor<i32>, tensor<i32>) -> tensor<i32>
+      "stablehlo.return"(%0) : (tensor<i32>) -> ()
+  }) {
+    dimensions = dense<[0, 1]> : tensor<2xi64>
+  } : (tensor<2x2xi32>, tensor<2x2xi32>) -> tensor<2x2xi32>
+  ```
   }];
   let arguments = (ins
     Variadic<HLO_Tensor>:$inputs,


### PR DESCRIPTION
Update semantics of ReduceOp to align with MapOp semantics.
closes #437 