### PR TITLE
(abs..constant) Align examples in spec/ODS with spec_checklist.md

### DIFF
--- a/docs/spec_checklist.md
+++ b/docs/spec_checklist.md
@@ -25,12 +25,15 @@ reviews:
          [status.md](https://github.com/openxla/stablehlo/blob/main/docs/status.md)
          say "yes".
   1. Check whether the "Examples" section:
+      1. Only has one example. (In the future, we'll link to more examples from
+         the StableHLO interpreter test suite).
       1. Uses valid MLIR syntax by running `stablehlo-opt` on code examples.
       1. Uses generic MLIR syntax which can be obtained by running
          `stablehlo-opt -mlir-print-op-generic` (we stick to generic syntax in
          the spec to avoid having to change the spec on prettyprinter changes).
   1. Check that the "Specification" column in status.md says "yes".
   1. Check that the `description` in op's ODS:
-      1. Links to the corresponding section of the spec.
-      1. Uses the same example as the spec but via pretty syntax which can be
-         obtaining by running `stablehlo-opt`.
+      1. Includes the first sentence of the spec.
+      1. Then links to the corresponding section of the spec.
+      1. Then uses the same example as the spec but via pretty syntax which can
+         be obtaining by running `stablehlo-opt`.

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -241,20 +241,9 @@ defined and one of the following:
 ### Examples
 
 ```mlir
-// integers
 // %operand: [-2, 0, 2]
 %result = "stablehlo.abs"(%operand) : (tensor<3xi32>) -> tensor<3xi32>
 // %result: [2, 0, 2]
-
-// floats
-// %operand: [-2.2, 0.0, 2.2]
-%result = "stablehlo.abs"(%operand) : (tensor<3xf32>) -> tensor<3xf32>
-// %result = [2.2, 0.0, 2.2]
-
-// complex
-// %operand: [(0.0, 1.0), (4.0, -3.0)]
-%result = "stablehlo.abs"(%operand) : (tensor<2xcomplex<f64>>) -> tensor<2xf64>
-// %result = [1, 5.0]
 ```
 
 [Back to Ops](#index-of-ops)
@@ -300,7 +289,7 @@ the IEEE-754 specification. For boolean element type, the behavior is same as
 ```mlir
 // %lhs: [[1, 2], [3, 4]]
 // %rhs: [[5, 6], [7, 8]]
-%result = "stablehlo.add"(%lhs, %rhs) : (tensor<2x2xf32>, tensor<2x2xf32>) -> tensor<2x2xf32>
+%result = "stablehlo.add"(%lhs, %rhs) : (tensor<2x2xi32>, tensor<2x2xi32>) -> tensor<2x2xi32>
 // %result: [[6, 8], [10, 12]]
 ```
 
@@ -312,9 +301,9 @@ the IEEE-754 specification. For boolean element type, the behavior is same as
 
 ### Semantics
 
-Performs element-wise bitwise AND of two tensors `lhs` and `rhs` of integer
-types and produces a `result` tensor. For boolean tensors, it computes the
-logical operation.
+Performs element-wise bitwise or logical AND of two tensors `lhs` and `rhs` and
+produces a `result` tensor. For integer tensors, computes the bitwise operation.
+For boolean tensors, computes the logical operation.
 
 ### Inputs
 
@@ -336,17 +325,10 @@ logical operation.
 ### Examples
 
 ```mlir
-// Bitwise operation with with integer tensors
 // %lhs: [[1, 2], [3, 4]]
 // %rhs: [[5, 6], [7, 8]]
 %result = "stablehlo.and"(%lhs, %rhs) : (tensor<2x2xi32>, tensor<2x2xi32>) -> tensor<2x2xi32>
 // %result: [[1, 2], [3, 0]]
-
-// Logical operation with with boolean tensors
-// %lhs: [[false, false], [true, true]]
-// %rhs: [[false, true], [false, true]]
-%result = "stablehlo.and"(%lhs, %rhs) : (tensor<2x2xi1>, tensor<2x2xi1>) -> tensor<2x2xi1>
-// %result: [[false, false], [false, true]]
 ```
 
 [Back to Ops](#index-of-ops)
@@ -666,23 +648,11 @@ tensor. More formally,
 ### Examples
 
 ```mlir
-// 1-dimensional concatenate
-
-// %input0 = [1, 2]
-// %input1 = [3, 4]
-// %input2 = [5, 6]
-%result = "stablehlo.concatenate"(%input0, %input1, %input2) {
-  dimension = 0 : i64
-} : (tensor<2xi32>, tensor<2xi32>, tensor<2xi32>) -> tensor<6xi32>
-// %result: [1, 2, 3, 4, 5, 6]
-
-// 2-dimensional concatenate
-
 // %input0: [[1, 2], [3, 4], [5, 6]]
 // %input1: [[7, 8]]
 %result = "stablehlo.concatenate"(%input0, %input1) {
   dimension = 0 : i64
-} : (tensor<3x2xi32>, tensor<1x2xi32>, i64) -> tensor<4x2xi32>
+} : (tensor<3x2xi32>, tensor<1x2xi32>) -> tensor<4x2xi32>
 // %result: [[1, 2], [3, 4], [5, 6], [7, 8]]
 ```
 

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -243,7 +243,7 @@ def StableHLO_CeilOp: StableHLO_UnaryElementwiseOp<"ceil",
 
     Example:
     ```mlir
-    %result = stablehlo.ceil %operand : tensor<2xf32>
+    %result = stablehlo.ceil %operand : tensor<5xf32>
     ```
   }];
 }
@@ -692,7 +692,7 @@ def StableHLO_AddOp : StableHLO_BinaryElementwiseOp<"add",
 
     Example:
     ```mlir
-    %result = stablehlo.add %lhs, %rhs : tensor<4xf32>
+    %result = stablehlo.add %lhs, %rhs : tensor<2x2xi32>
     ```
   }];
 }
@@ -923,15 +923,15 @@ class StableHLO_BinaryBiwiseOrLogicalElementwiseOp<string mnemonic> :
 def StableHLO_AndOp: StableHLO_BinaryBiwiseOrLogicalElementwiseOp<"and"> {
   let summary = "And operator";
   let description = [{
-    Performs element-wise bitwise AND of two tensors `lhs` and `rhs` of integer
-    types and produces a `result` tensor.
+    Performs element-wise bitwise or logical AND of two tensors `lhs` and `rhs`
+    and produces a `result` tensor
 
     See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehloand
 
     Example:
     ```mlir
-    %result = stablehlo.and %lhs, %rhs : tensor<i1>
+    %result = stablehlo.and %lhs, %rhs : tensor<2x2xi32>
     ```
   }];
 }
@@ -1183,11 +1183,13 @@ def StableHLO_CaseOp: StableHLO_Op<"case", [
     https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlocase
 
     Example:
+    ```mlir
     %result = "stablehlo.case"(%index) ({
-      "stablehlo.return"(%result_branch0) : (tensor<i32>) -> ()
+      stablehlo.return %result_branch0 : tensor<i32>
     }, {
-      "stablehlo.return"(%result_branch1) : (tensor<i32>) -> ()
+      stablehlo.return %result_branch1 : tensor<i32>
     }) : (tensor<i32>) -> tensor<i32>
+    ```
   }];
 
   let arguments = (ins
@@ -1607,9 +1609,8 @@ def StableHLO_BatchNormInferenceOp : StableHLO_Op<"batch_norm_inference",
     InferTensorType]> {
   let summary = "Batch Normalization for Inference";
   let description = [{
-    Normalizes the `operand` tensor across batch and spatial dimensions, for
-    each feature in the `feature_index` dimension and produces a `result`
-    tensor.
+    Normalizes the `operand` tensor across all dimensions except for the
+    `feature_index` dimension and produces a `result` tensor.
 
     See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlobatch_norm_inference
@@ -1736,7 +1737,7 @@ def StableHLO_BroadcastInDimOp : StableHLO_Op<"broadcast_in_dim",
     Example:
 
     ```mlir
-    %0 = stablehlo.broadcast_in_dim %arg0, dims = [1, 2] : (tensor<1x2xi32>) -> tensor<1x2x2xi32>
+    %result = stablehlo.broadcast_in_dim %operand, dims = [2, 1] : (tensor<1x3xi32>) -> tensor<2x3x2xi32>
     ```
   }];
   let arguments = (ins
@@ -1877,7 +1878,7 @@ def StableHLO_ConcatenateOp : StableHLO_ShapedInterfaceOp<"concatenate",
 
     Example:
     ```mlir
-     %result = stablehlo.concatenate %input0, %input1, dim = 1 : (tensor<4x1xf32>, tensor<4x2xf32>) -> tensor<4x3xf32>
+     %result = stablehlo.concatenate %input0, %input1, dim = 1 : (tensor<3x2xi32>, tensor<1x2xi32>) -> tensor<4x2xi32>
     ```
    }];
 


### PR DESCRIPTION
In #439, we documented the conventions for examples in spec/ODS, and I went to check how closely the previous work on the spec follows these conventions.

I discovered quite a few divergencies, so I started going through the spec fixing things. This PR covers 10 out of the currently specced 43 ops.