### PR TITLE
Fix the LINK_LIBS of StablehloTypeInference

### DIFF
--- a/stablehlo/dialect/CMakeLists.txt
+++ b/stablehlo/dialect/CMakeLists.txt
@@ -106,6 +106,7 @@ add_mlir_dialect_library(StablehloTypeInference
   LINK_LIBS PUBLIC
   MLIRInferTypeOpInterface
   MLIRIR
+  StablehloBase
 )
 
 set(LLVM_TARGET_DEFINITIONS StablehloOps.td)


### PR DESCRIPTION
Found it in an [onnx-mlir pr](https://github.com/onnx/onnx-mlir/pull/1829)