### PR TITLE
Use new github actions output environment files

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -49,7 +49,7 @@ jobs:
       id: llvm-version
       shell: bash
       run: |
-        echo "::set-output name=version::$(cat ${{ github.workspace }}/build_tools/llvm_version.txt)"
+        echo "version=$(cat ${{ github.workspace }}/build_tools/llvm_version.txt)" >> $GITHUB_OUTPUT
 
     # Check out LLVM, and install tools for compilation 
     - name: Setup workspace


### PR DESCRIPTION
GitHub Actions is deprecating save-state and set-output commands, need to update to use new Environment Files:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

I made a PR on my forked repo to test, and it had the following in the logs:

```
Run ./.github/actions/setup-build
  with:
    llvm-version: d4c61314420ca8794ad6d2588566c64109482505
  env:
    LLVM_PROJECT_DIR: llvm-project
    LLVM_BUILD_DIR: llvm-build
    STABLEHLO_BUILD_DIR: stablehlo-build
    STABLEHLO_PYTHON_BUILD_DIR: stablehlo-python-build
```

This confirms that the new syntax is working. The `llvm-version` is set by the output of the previous command.