### PR TITLE
Add spec for AllGatherOp

### DIFF
--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -570,7 +570,7 @@ The execution of the operation involves logically partitioning each execution
 instance (`ei`) of `rid`, `pid` pair, henceforth referred to as `ei(rid, pid)`
 into groups. All the execution instances within a group can participate in the
 operation without getting interfered by execution instances from other groups.
-The number of groups represents the number of `stablehlo.all_to_all` operations
+The number of groups represents the number of `stablehlo.all_gather` operations
 executed in parallel.
 
 Given,

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -539,13 +539,13 @@ Within each process group in the StableHLO grid, concatenates the values of the
 `operand` tensor from each process along `all_gather_dim` and produces a
 `result` tensor.
 
-The operation splits the StableHLO grid into process groups as follows:
+The operation splits the StableHLO grid into `process_groups` as follows:
   * `channel_id <= 0` and `use_global_device_ids = false`,
     `cross_replica(replica_groups)`.
   * `channel_id > 0` and `use_global_device_ids = false`,
     `cross_replica_and_partition(replica_groups)`.
   * `channel_id > 0` and `use_global_device_ids = true`,
-    `flattened_ids(replica_groups).
+    `flattened_ids(replica_groups)`.
 
 Afterwards, within each `process_group`:
   * `operands@receiver = [operand@sender for sender in process_group]` for all
@@ -572,17 +572,13 @@ Afterwards, within each `process_group`:
 ### Constraints
 
   * (C1) `all_gather_dim` $\in$ [0, rank(`operand`)).
-  * (C2) size(`replica_groups`) $\gt$ 0.
-  * (C3) All values in `replica_groups` are unique.
-  * (C4) `size(replica_groups)` = `num_replicas`.
-  * (C5) $0 \le$ `replica_groups`[i] $\lt$ size(`replica_groups`) $\forall i$
+  * (C2) All values in `replica_groups` are unique.
+  * (C3) `size(replica_groups)` = `num_replicas`.
+  * (C4) $0 \le$ `replica_groups`[i] $\lt$ size(`replica_groups`) $\forall i$
          from `indices(replica_groups)`.
-  * (C6) If `use_global_device_ids = true`, then `channel_id > 0`. [todo](https://github.com/openxla/stablehlo/issues/654)
-  * (C7)`type(result) = type(operand)` except that `dim(result, all_gather_dim)`
-        is given by
-    * `dim(replica_groups, 1) * number_partitions * dim(operand, all_gather_dim)`,
-       for process groups formation strategy $=$  `cross_replica_and_partition`,
-    * `dim(replica_groups, 1) * dim(operand, all_gather_dim)`, otherwise.
+  * (C5) If `use_global_device_ids = true`, then `channel_id > 0`. [todo](https://github.com/openxla/stablehlo/issues/654)
+  * (C6)`type(result) = type(operand)` except that
+    * `dim(result, all_gather_dim)` = `dim(operand, all_gather_dim) * dim(process_groups, 1)`.
 
 ### Examples
 

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -300,7 +300,7 @@ Multiple instances of a compiled StableHLO program could be running to exploit
 data parallelism. Each instance is called a replica identified uniquely using
 replica id (`rid`). In addition, several different StableHLO programs can be
 executed together to exploit "Multiple Program Multiple Data" (MPMD) style
-parallelism and these are called partitions each of which is identified uniquely
+parallelism and these are called partitions, each of which is identified uniquely
 using a partition id (`pid`).
 
 ## Errors
@@ -556,7 +556,7 @@ instruction pair or via collective instructions (e.g.
 [stablehlo.all_reduce](#stablehloall_reduce),
 [stablehlo.all_gather](#stablehloall_gather), etc.). It is represented using a
 `channel-id` and a `channel-type`. A `channel-id` is used for cross-partition
-communication: only operations with the same opcode and `channel-id` can
+communication; only operations with the same opcode and `channel-id` can
 communicate to each other. Non-positive `channel-id` is equivalent to no channel
 id. The `channel-type` is not relevant for this instruction.
 
@@ -594,7 +594,7 @@ The formation of groups is defined as follows:
      groups = []
 
      if len(replica_groups) == 0:
-       replica_groups = all_replica_ids
+       replica_groups = [all_replica_ids]
 
      for replica_group in replica_groups:
        for pid in all_partition_ids:
@@ -621,7 +621,7 @@ The formation of groups is defined as follows:
      groups = []
 
      if len(replica_groups) == 0:
-       replica_groups = all_replica_ids
+       replica_groups = [all_replica_ids]
 
      for replica_group in replica_groups:
        sub_group = []
@@ -693,18 +693,16 @@ For each group `G` $\in$ `groups`, the `result` is given by:
 ### Examples
 
 ```mlir
-// %operand: [[1.0, 2.0], [3.0, 4.0]]
+// %operand (at ei(0, 0)): [[1.0, 2.0], [3.0, 4.0]]
+// %operand (at ei(1, 0)): [[5.0, 6.0], [7.0, 8.0]]
 %result = "stablehlo.all_gather"(%operand) {
   all_gather_dim = 1 : i64,
   replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>
 } : (tensor<2x2xf32>) -> tensor<2x4xf32>
 //
-// Assuming num_pids = 1,
-// groups formed = [[ei(0, 0), ei(1, 0))]]
-// Assuming all the execution instances to have identical operand vaue,
-// following is the result value visible in all the execution instances.
+// Assuming num_pids = 1, a single group [ei(0, 0), ei(1, 0)] is formed.
 //
-// %result: [[1.0, 2.0, 1.0, 2.0], [3.0, 4.0, 3.0, 4.0]]
+// %result (at ei(0, 0) or ei(1, 0): [[1.0, 2.0, 5.0, 6.0], [3.0, 4.0, 7.0, 8.0]]
 ```
 
 [Back to Ops](#index-of-ops)

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -651,7 +651,8 @@ The formation of groups is defined as follows:
     * For example, assuming `num_pids = 2` and `replica_groups = [[4, 5], [6, 7]]`:
       `groups` formed: `[ei(2, 0), ei(2, 1)] and [ei(3, 0), ei(3, 1)]`.
 
-For each group `G` $\in$ `groups`, the `result` is given by:
+For each group `G` $\in$ `groups`, the `result`, to be visible by each member of
+`G`, is given by:
 `concatenate(operands, all_gather_dim)`, where `operands` =
 { `operand` corresponding to the execution instances, following their order, in
 `G` }.

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -577,7 +577,7 @@ Afterwards, within each `process_group`:
   * (C4) `size(replica_groups)` = `num_replicas`.
   * (C5) $0 \le$ `replica_groups`[i] $\lt$ size(`replica_groups`) $\forall i$
          from `indices(replica_groups)`.
-  * (C6) If `use_global_device_ids = true`, then `channel_id > 0`.
+  * (C6) If `use_global_device_ids = true`, then `channel_id > 0`. [todo](https://github.com/openxla/stablehlo/issues/654)
   * (C7)`type(result) = type(operand)` except that `dim(result, all_gather_dim)`
         is given by
     * `dim(replica_groups, 1) * number_partitions * dim(operand, all_gather_dim)`,

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -698,6 +698,12 @@ For each group `G` $\in$ `groups`, the `result` is given by:
   all_gather_dim = 1 : i64,
   replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>
 } : (tensor<2x2xf32>) -> tensor<2x4xf32>
+//
+// Assuming num_pids = 1,
+// groups formed = [[ei(0, 0), ei(1, 0))]]
+// Assuming all the execution instances to have identical operand vaue,
+// following is the result value visible in all the execution instances.
+//
 // %result: [[1.0, 2.0, 1.0, 2.0], [3.0, 4.0, 3.0, 4.0]]
 ```
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -45,7 +45,7 @@ one of the following tracking labels.
 | abs                      | yes           | yes          | yes            | yes             | no          |
 | add                      | yes           | yes          | yes            | yes             | yes         |
 | after_all                | yes           | yes          | no             | yes             | no          |
-| all_gather               | no            | revisit      | no             | no              | no          |
+| all_gather               | yes           | yes          | infeasible     | no              | no          |
 | all_reduce               | no            | revisit      | revisit        | no              | no          |
 | all_to_all               | no            | yes*         | yes*           | no              | no          |
 | and                      | yes           | yes          | yes            | yes             | yes         |

--- a/docs/status.md
+++ b/docs/status.md
@@ -45,7 +45,7 @@ one of the following tracking labels.
 | abs                      | yes           | yes          | yes            | yes             | no          |
 | add                      | yes           | yes          | yes            | yes             | yes         |
 | after_all                | yes           | yes          | no             | yes             | no          |
-| all_gather               | yes           | yes          | infeasible     | no              | no          |
+| all_gather               | yes           | resivit      | revisit        | no              | no          |
 | all_reduce               | no            | revisit      | revisit        | no              | no          |
 | all_to_all               | no            | yes*         | yes*           | no              | no          |
 | and                      | yes           | yes          | yes            | yes             | yes         |

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -256,7 +256,6 @@ LogicalResult verifyReduceScatter(Operation* op, TypeRange operandTypes,
 
 LogicalResult ReduceScatterOp::verify() {
   if (failed(hlo::verifyReplicaGroups(getLoc(), getReplicaGroups(),
-                                      getUseGlobalDeviceIds(),
                                       /*allGroupsMustHaveSameSize=*/true)))
     return failure();
   auto operandType = getOperand().getType().cast<TensorType>();
@@ -1969,7 +1968,6 @@ LogicalResult AllToAllOp::inferReturnTypeComponents(
 
 LogicalResult AllGatherOp::verify() {
   if (failed(hlo::verifyReplicaGroups(getLoc(), getReplicaGroups(),
-                                      getUseGlobalDeviceIds(),
                                       /*allGroupsMustHaveSameSize=*/true)))
     return failure();
 

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -1978,7 +1978,7 @@ LogicalResult AllGatherOp::verify() {
   int64_t allGatherDimIndex = getAllGatherDim();
 
   if (allGatherDimIndex < 0)
-    return emitOpError() << "all_gather_dim must be a valid index of operand";
+    return emitOpError() << "all_gather_dim cannot be negative";
 
   if (operandType) {
     if (allGatherDimIndex >= operandType.getRank())

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -1993,9 +1993,8 @@ LogicalResult AllGatherOp::verify() {
       return emitOpError() << "operand and return must have the same rank";
 
     for (int64_t index = 0; index < operandType.getRank(); index++) {
-      if (index == allGatherDimIndex) continue;
-
-      if (operandType.isDynamicDim(index) || resultType.isDynamicDim(index))
+      if (index == allGatherDimIndex || operandType.isDynamicDim(index) ||
+          resultType.isDynamicDim(index))
         continue;
 
       if (resultType.getDimSize(index) != operandType.getDimSize(index))

--- a/stablehlo/dialect/StablehloOps.h
+++ b/stablehlo/dialect/StablehloOps.h
@@ -19,7 +19,6 @@ limitations under the License.
 
 #include <algorithm>
 
-#include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/StringRef.h"
 #include "mlir/Dialect/Quant/QuantTypes.h"
 #include "mlir/Dialect/Shape/IR/Shape.h"

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1252,9 +1252,21 @@ def StableHLO_AllGatherOp : StableHLO_Op<"all_gather", [SameOperandsAndResultEle
   string summary = "AllGather operator";
 
   string description = [{
-    Performs concatenation across replicas.
+    For each replica sub-group in `replica_groups`, the operation
+    concatenates the replicas of `input` tensor formed using the sub-group along
+    `all_gather_dim` dimension following the order of the replicas in the
+    sub-group and produces a `result` tensor.
 
-    See https://www.tensorflow.org/xla/operation_semantics#allgather
+    See:
+    https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehloall_gather
+
+    Example:
+    ```mlir
+    %result = "stablehlo.all_gather"(%operand) {
+      all_gather_dim = 1 : i64,
+      replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>
+    } : (tensor<2x2xf32>) -> tensor<2x4xf32>
+    ```
   }];
 
   let arguments = (ins

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1252,10 +1252,9 @@ def StableHLO_AllGatherOp : StableHLO_Op<"all_gather", [SameOperandsAndResultEle
   string summary = "AllGather operator";
 
   string description = [{
-    For each replica subgroup in `replica_groups`, the operation
-    concatenates the replicas of `input` tensor formed using the subgroup along
-    `all_gather_dim` dimension following the order of the replicas in the
-    subgroup and produces a `result` tensor.
+    Within each process group in the StableHLO grid, concatenates the values of the
+    `operand` tensor from each process along `all_gather_dim` and produces a
+    `result` tensor.
 
     See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehloall_gather
@@ -1265,6 +1264,7 @@ def StableHLO_AllGatherOp : StableHLO_Op<"all_gather", [SameOperandsAndResultEle
     %result = "stablehlo.all_gather"(%operand) {
       all_gather_dim = 1 : i64,
       replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>
+      // use_global_device_ids = false
     } : (tensor<2x2xf32>) -> tensor<2x4xf32>
     ```
   }];

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1252,10 +1252,10 @@ def StableHLO_AllGatherOp : StableHLO_Op<"all_gather", [SameOperandsAndResultEle
   string summary = "AllGather operator";
 
   string description = [{
-    For each replica sub-group in `replica_groups`, the operation
-    concatenates the replicas of `input` tensor formed using the sub-group along
+    For each replica subgroup in `replica_groups`, the operation
+    concatenates the replicas of `input` tensor formed using the subgroup along
     `all_gather_dim` dimension following the order of the replicas in the
-    sub-group and produces a `result` tensor.
+    subgroup and produces a `result` tensor.
 
     See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehloall_gather

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -350,11 +350,11 @@ LogicalResult verifyReplicaGroups(Optional<Location> location,
     }
   }
 
-  if (isUniformSized && expectedSubgroupSize)
-    if (ids.size() / replicaGroupType.getShape()[0] != *expectedSubgroupSize)
-      return emitOptionalError(location,
-                               "subgroup size of replica_groups must be ",
-                               *expectedSubgroupSize);
+  if (isUniformSized && expectedSubgroupSize &&
+      (ids.size() / replicaGroupType.getShape()[0] != *expectedSubgroupSize))
+    return emitOptionalError(location,
+                             "subgroup size of replica_groups must be ",
+                             *expectedSubgroupSize);
 
   return success();
 }

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -305,7 +305,6 @@ unsigned potentiallyComplexBitwidth(Type type) {
 
 LogicalResult verifyReplicaGroups(Optional<Location> location,
                                   DenseIntElementsAttr replicaGroups,
-                                  bool useGlobalDeviceIds,
                                   bool allGroupsMustHaveSameSize) {
   auto replicaGroupType = replicaGroups.getType().cast<RankedTensorType>();
 

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -312,7 +312,7 @@ LogicalResult verifyReplicaGroups(Optional<Location> location,
     return emitOptionalError(location,
                              "replica groups should be a rank 2 tensor");
 
-  // Revisit the following check in light of #652.
+  // Revisit the following check in light of #498.
   if (replicaGroupType.getShape()[0] * replicaGroupType.getShape()[1] == 0) {
     return emitOptionalError(location, "replica groups cannot be empty");
   }

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -76,6 +76,17 @@ LogicalResult verifyReducerShape(
     ArrayRef<int64_t> allowedDimensions, bool allInputsUnranked,
     SmallVectorImpl<TensorType>& accumulatorSubShapes);
 
+// Verifies replica groups attached to collective communication operations.
+// If the attribute is not empty, it must be a rank 2 tensor, and each replica
+// should appear exactly once. If `is_uniform_sized` is true, then we also check
+// that each group is of the same size. If the operation has
+// `use_global_device_ids` set, then replica group cannot be empty.
+LogicalResult verifyReplicaGroups(Optional<Location> location,
+                                  DenseIntElementsAttr attr,
+                                  bool useGlobalDeviceIdsAvailableAndTrue,
+                                  bool isUniformSized,
+                                  Optional<size_t> expectedSubgroupSize);
+
 //===----------------------------------------------------------------------===//
 // Shape functions for ops.
 //===----------------------------------------------------------------------===//

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -78,14 +78,13 @@ LogicalResult verifyReducerShape(
 
 // Verifies replica groups attached to collective communication operations.
 // P1. 'replicaGroups' must be a 2-D tensor.
-// P2. If `useGlobalDeviceIds` is true, then 'replicaGroups' cannot be empty.
+// P2. replicaGroups' cannot be empty.
 // P3. If `allGroupsMustHaveSameSize` is true, then each group is of the same
 //     size.
 // P4. All values in `replica_groups` are unique and covers all the values in
 //     the interval [0, N-1], where N is the total number of replica ids.
 LogicalResult verifyReplicaGroups(Optional<Location> location,
                                   DenseIntElementsAttr replicaGroups,
-                                  bool useGlobalDeviceIds,
                                   bool allGroupsMustHaveSameSize);
 
 //===----------------------------------------------------------------------===//

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -77,15 +77,16 @@ LogicalResult verifyReducerShape(
     SmallVectorImpl<TensorType>& accumulatorSubShapes);
 
 // Verifies replica groups attached to collective communication operations.
-// If the attribute is not empty, it must be a rank 2 tensor, and each replica
-// should appear exactly once. If `is_uniform_sized` is true, then we also check
-// that each group is of the same size. If the operation has
-// `use_global_device_ids` set, then replica group cannot be empty.
+// P1. 'replicaGroups' must be a 2-D tensor.
+// P2. If `useGlobalDeviceIds` is true, then 'replicaGroups' cannot be empty.
+// P3. If `allGroupsMustHaveSameSize` is true, then each group is of the same
+//     size.
+// P4. All values in `replica_groups` are unique and covers all the values in
+//     the interval [0, N-1], where N is the total number of replica ids.
 LogicalResult verifyReplicaGroups(Optional<Location> location,
-                                  DenseIntElementsAttr attr,
-                                  bool useGlobalDeviceIdsAvailableAndTrue,
-                                  bool isUniformSized,
-                                  Optional<size_t> expectedSubgroupSize);
+                                  DenseIntElementsAttr replicaGroups,
+                                  bool useGlobalDeviceIds,
+                                  bool allGroupsMustHaveSameSize);
 
 //===----------------------------------------------------------------------===//
 // Shape functions for ops.

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -313,13 +313,13 @@ func.func @allgather_incompatible_types(%arg0: tensor<128x32xf32>) -> tensor<128
 
 // -----
 
-func.func @allgather_gather_along_zero_dimension(%arg0: tensor<128x0x32xf32>) -> tensor<128x100xf32> {
+func.func @allgather_gather_along_zero_dimension(%arg0: tensor<128x0xf32>) -> tensor<128x100xf32> {
   // expected-error@+1 {{operand gather dimension cannot be zero}}
   %0 = "stablehlo.all_gather"(%arg0) {
     all_gather_dim = 1 : i64,
     channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
     replica_groups = dense<[[0, 2, 4, 6], [1, 3, 5, 7]]> : tensor<2x4xi64>
-  } : (tensor<128x0x32xf32>) -> tensor<128x100xf32>
+  } : (tensor<128x0xf32>) -> tensor<128x100xf32>
   func.return %0 : tensor<128x100xf32>
 }
 
@@ -334,6 +334,115 @@ func.func @allgather_dynamic_gather_dim(%arg0: tensor<128x32xf32>) -> tensor<128
     use_global_device_ids
   } : (tensor<128x32xf32>) -> tensor<128x?xf32>
   func.return %0 : tensor<128x?xf32>
+}
+
+// -----
+
+func.func @all_gather_invalid_dim(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
+  // expected-error@+1 {{all_gather_dim must be a valid index of operand.}}
+  %0 = "stablehlo.all_gather"(%arg0) {
+    all_gather_dim = 2 : i64,
+    channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
+    replica_groups = dense<[[0, 2, 4, 6], [1, 3, 5, 7]]> : tensor<2x4xi64>
+  } : (tensor<8x2xf32>) -> tensor<8x8xf32>
+  func.return %0 : tensor<8x8xf32>
+}
+
+// -----
+
+func.func @all_gather_invalid_dim(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
+  // expected-error@+1 {{all_gather_dim must be a valid index of operand.}}
+  %0 = "stablehlo.all_gather"(%arg0) {
+    all_gather_dim = -1 : i64,
+    channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
+    replica_groups = dense<[[0, 2, 4, 6], [1, 3, 5, 7]]> : tensor<2x4xi64>
+  } : (tensor<8x2xf32>) -> tensor<8x8xf32>
+  func.return %0 : tensor<8x8xf32>
+}
+
+// -----
+
+func.func @all_gather_invalid_result_shape(%arg0: tensor<8x2x32xf32>) -> tensor<8x8xf32> {
+  // expected-error@+1 {{operand and return must have the same rank.}}
+  %0 = "stablehlo.all_gather"(%arg0) {
+    all_gather_dim = -1 : i64,
+    channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
+    replica_groups = dense<[[0, 2, 4, 6], [1, 3, 5, 7]]> : tensor<2x4xi64>
+  } : (tensor<8x2x32xf32>) -> tensor<8x8xf32>
+  func.return %0 : tensor<8x8xf32>
+}
+
+// -----
+
+func.func @all_gather_invalid_result_shape(%arg0: tensor<8x2xf32>) -> tensor<4x8xf32> {
+  // expected-error@+1 {{operand and result should have the same shape except for the dimension size at 'all_gather_dim'.}}
+  %0 = "stablehlo.all_gather"(%arg0) {
+    all_gather_dim = 1 : i64,
+    channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
+    replica_groups = dense<[[0, 2, 4, 6], [1, 3, 5, 7]]> : tensor<2x4xi64>
+  } : (tensor<8x2xf32>) -> tensor<4x8xf32>
+  func.return %0 : tensor<4x8xf32>
+}
+
+// -----
+
+func.func @all_gather_invalid_replica_group_shape(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
+  // expected-error@+1 {{replica groups should be a rank 2 tensor of 64 bit integers}}
+  %0 = "stablehlo.all_gather"(%arg0) {
+    all_gather_dim = 1 : i64,
+    channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
+    replica_groups = dense<[[[0], [1], [2], [3]]]> : tensor<1x4x1xi64>
+  } : (tensor<8x2xf32>) -> tensor<8x8xf32>
+  func.return %0 : tensor<8x8xf32>
+}
+
+// -----
+
+func.func @all_gather_invalid_replica_group_shape(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
+  // expected-error@+1 {{if `use_global_device_ids` is set, the replica groups cannot be empty}}
+  %0 = "stablehlo.all_gather"(%arg0) {
+    all_gather_dim = 1 : i64,
+    channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
+    replica_groups = dense<0> : tensor<0x2xi64>,
+    use_global_device_ids
+  } : (tensor<8x2xf32>) -> tensor<8x8xf32>
+  func.return %0 : tensor<8x8xf32>
+}
+
+// -----
+
+func.func @all_gather_invalid_replica_group(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
+  // expected-error@+1 {{replica id #1 not seen in replica groups}}
+  %0 = "stablehlo.all_gather"(%arg0) {
+    all_gather_dim = 1 : i64,
+    channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
+    replica_groups = dense<[[-5, -4, -3, 0]]> : tensor<1x4xi64>
+  } : (tensor<8x2xf32>) -> tensor<8x8xf32>
+  func.return %0 : tensor<8x8xf32>
+}
+
+// -----
+
+func.func @all_gather_invalid_replica_group(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
+  // expected-error@+1 {{replica id #2 seen more than once}}
+  %0 = "stablehlo.all_gather"(%arg0) {
+    all_gather_dim = 1 : i64,
+    channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
+    replica_groups = dense<[[0, 2, 4, 6], [1, 3, 5, 2]]> : tensor<2x4xi64>
+  } : (tensor<8x2xf32>) -> tensor<8x8xf32>
+  func.return %0 : tensor<8x8xf32>
+}
+
+// -----
+
+func.func @all_gather_invalid_replica_group(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
+  // expected-error@+1 {{replica id #4 not seen in replica groups}}
+  %0 = "stablehlo.all_gather"(%arg0) {
+    all_gather_dim = 1 : i64,
+    channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
+    replica_groups = dense<[[0, 2, 6, 8], [1, 3, 5, 7]]> : tensor<2x4xi64>
+  } : (tensor<8x2xf32>) -> tensor<8x8xf32>
+  func.return %0 : tensor<8x8xf32>
 }
 
 // -----

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -314,7 +314,7 @@ func.func @allgather_incompatible_types(%arg0: tensor<128x32xf32>) -> tensor<128
 // -----
 
 func.func @allgather_gather_along_zero_dimension(%arg0: tensor<128x0xf32>) -> tensor<128x100xf32> {
-  // expected-error@+1 {{operand gather dimension cannot be zero}}
+  // expected-error@+1 {{dimension size of operand at 'all_gather_dim' cannot be zero}}
   %0 = "stablehlo.all_gather"(%arg0) {
     all_gather_dim = 1 : i64,
     channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
@@ -338,8 +338,21 @@ func.func @allgather_dynamic_gather_dim(%arg0: tensor<128x32xf32>) -> tensor<128
 
 // -----
 
+// CHECK-LABEL: func @allgather_dynamic_non_gather_dim
+func.func @allgather_dynamic_non_gather_dim(%arg0: tensor<128x32xf32>) -> tensor<?x64xf32> {
+  %0 = "stablehlo.all_gather"(%arg0) {
+    all_gather_dim = 1 : i64,
+    channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
+    replica_groups = dense<[[0, 2, 4, 6], [1, 3, 5, 7]]> : tensor<2x4xi64>,
+    use_global_device_ids
+  } : (tensor<128x32xf32>) -> tensor<?x64xf32>
+  func.return %0 : tensor<?x64xf32>
+}
+
+// -----
+
 func.func @all_gather_invalid_dim(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
-  // expected-error@+1 {{all_gather_dim must be a valid index of operand.}}
+  // expected-error@+1 {{all_gather_dim must be a valid index of operand}}
   %0 = "stablehlo.all_gather"(%arg0) {
     all_gather_dim = 2 : i64,
     channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
@@ -351,7 +364,7 @@ func.func @all_gather_invalid_dim(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
 // -----
 
 func.func @all_gather_invalid_dim(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
-  // expected-error@+1 {{all_gather_dim must be a valid index of operand.}}
+  // expected-error@+1 {{all_gather_dim must be a valid index of operand}}
   %0 = "stablehlo.all_gather"(%arg0) {
     all_gather_dim = -1 : i64,
     channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
@@ -363,9 +376,9 @@ func.func @all_gather_invalid_dim(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
 // -----
 
 func.func @all_gather_invalid_result_shape(%arg0: tensor<8x2x32xf32>) -> tensor<8x8xf32> {
-  // expected-error@+1 {{operand and return must have the same rank.}}
+  // expected-error@+1 {{operand and return must have the same rank}}
   %0 = "stablehlo.all_gather"(%arg0) {
-    all_gather_dim = -1 : i64,
+    all_gather_dim = 1 : i64,
     channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
     replica_groups = dense<[[0, 2, 4, 6], [1, 3, 5, 7]]> : tensor<2x4xi64>
   } : (tensor<8x2x32xf32>) -> tensor<8x8xf32>
@@ -375,7 +388,7 @@ func.func @all_gather_invalid_result_shape(%arg0: tensor<8x2x32xf32>) -> tensor<
 // -----
 
 func.func @all_gather_invalid_result_shape(%arg0: tensor<8x2xf32>) -> tensor<4x8xf32> {
-  // expected-error@+1 {{operand and result should have the same shape except for the dimension size at 'all_gather_dim'.}}
+  // expected-error@+1 {{operand and result should have the same shape except for the dimension size at 'all_gather_dim'}}
   %0 = "stablehlo.all_gather"(%arg0) {
     all_gather_dim = 1 : i64,
     channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -364,7 +364,7 @@ func.func @all_gather_invalid_dim(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
 // -----
 
 func.func @all_gather_invalid_dim(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
-  // expected-error@+1 {{all_gather_dim must be a valid index of operand}}
+  // expected-error@+1 {{all_gather_dim cannot be negative}}
   %0 = "stablehlo.all_gather"(%arg0) {
     all_gather_dim = -1 : i64,
     channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -133,7 +133,7 @@ func.func @invalid_reduce_scatter(%data: tensor<4x16xf32>) -> tensor<3x4xf32> {
 // -----
 
 func.func @reduce_scatter(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
-  // expected-error@+1 {{replica groups should be a rank 2 tensor of 64 bit integers}}
+  // expected-error@+1 {{replica groups should be a rank 2 tensor}}
   %0 = "stablehlo.reduce_scatter"(%data) ({
     ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
     %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
@@ -400,7 +400,7 @@ func.func @all_gather_invalid_result_shape(%arg0: tensor<8x2xf32>) -> tensor<4x8
 // -----
 
 func.func @all_gather_invalid_replica_group_shape(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
-  // expected-error@+1 {{replica groups should be a rank 2 tensor of 64 bit integers}}
+  // expected-error@+1 {{replica groups should be a rank 2 tensor}}
   %0 = "stablehlo.all_gather"(%arg0) {
     all_gather_dim = 1 : i64,
     channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
@@ -412,7 +412,7 @@ func.func @all_gather_invalid_replica_group_shape(%arg0: tensor<8x2xf32>) -> ten
 // -----
 
 func.func @all_gather_invalid_replica_group_shape(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
-  // expected-error@+1 {{if `use_global_device_ids` is set, the replica groups cannot be empty}}
+  // expected-error@+1 {{replica groups cannot be empty}}
   %0 = "stablehlo.all_gather"(%arg0) {
     all_gather_dim = 1 : i64,
     channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,


### PR DESCRIPTION
fixes #462 

Address the followings:
1. Adds verification checks for AllGather w.r.t. https://github.com/openxla/stablehlo/issues/498
2. fixes https://github.com/openxla/stablehlo/issues/491

A few points
  - Type Inference is marked `infeasible` as the return type of the op depends upon the [shard_count](https://github.com/tensorflow/tensorflow/blob/20c6943d3cd7e07da162f7778a0af5d3776274b4/tensorflow/compiler/xla/service/hlo_verifier.cc#L452) which [depends on the result type](https://github.com/tensorflow/tensorflow/blob/20c6943d3cd7e07da162f7778a0af5d3776274b4/tensorflow/compiler/xla/service/hlo_verifier.cc#L426). Note that the `shard_count` is a parameter in HLO spec, where as in MHLO it is [derived](https://github.com/tensorflow/tensorflow/blob/a1acd6a6466f58ed4197b7beaa2f3e0b6fcfc32a/tensorflow/compiler/xla/translate/mhlo_to_hlo/mlir_hlo_to_hlo.cc#L766) using result type before exporting to HLO.
  - With (1) and (2), the Verifier is a `yes`.  Note that we still do not have the [check](https://github.com/tensorflow/tensorflow/blob/20c6943d3cd7e07da162f7778a0af5d3776274b4/tensorflow/compiler/xla/service/hlo_verifier.cc#L436) for  `shard_count == subgroup_size`. The `subgroup_size` depends on [module configuration](https://github.com/tensorflow/tensorflow/blob/20c6943d3cd7e07da162f7778a0af5d3776274b4/tensorflow/compiler/xla/service/hlo_verifier.cc#L95)  which manages the settings and values which affect the compiled executable outside of the HLO code itself and I am not sure if that info is available in StableHLO IR.

upd:
 - With https://github.com/openxla/stablehlo/issues/650, the type inference should be made feasible. Marked it `revisit` until that is fixed. 
 - The verifier should be `revisit` based on https://github.com/openxla/stablehlo/issues/652

