### PR TITLE
Add spec for DynamicUpdateSliceOp

### DIFF
--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -1610,11 +1610,11 @@ More formally, `result[i0, ..., iR-1]` is defined as:
 
 ### Inputs
 
-| Name            | Type                                                    |
-|-----------------|---------------------------------------------------------|
-| `operand`       | tensor of any supported type                            |
-| `update`        | tensor of any supported type                            |
-| `start_indices` | variadic number of 0-dimensional tensors of type `si64` |
+| Name            | Type                                                     |
+|-----------------|----------------------------------------------------------|
+| `operand`       | tensor of any supported type                             |
+| `update`        | tensor of any supported type                             |
+| `start_indices` | variadic number of 0-dimensional tensors of integer type |
 
 ### Outputs
 
@@ -1628,7 +1628,8 @@ More formally, `result[i0, ..., iR-1]` is defined as:
   * (C2) element_type(`update`) $=$ element_type(`operand`).
   * (C3) rank(`update`) $=$ rank(`operand`).
   * (C4) size(`start_indices`) $=$ rank(`operand`).
-  * (C5) dim(`update`, `k`) $\in$ [0, dim(`operand`, `k`)) for all `k` $\in$
+  * (C5) All `start_indices` have the same type.
+  * (C6) dim(`update`, `k`) $\in$ [0, dim(`operand`, `k`)) for all `k` $\in$
     [0, rank(`operand`)).
 
 
@@ -3267,8 +3268,8 @@ specification. Numeric precision is implementation-defined.
 
 ### Semantics
 
-Generate `results` which is the values of the `inputs` operand, with several
-slices at indices specified by `scatter_indices`, updated with the values in
+Produces `results` tensors which are equal to `inputs` tensors except that
+several slices specified by `scatter_indices` are updated with the values
 `updates` using `update_computation`.
 
 The following diagram shows how elements in `updates[k]` map on elements in

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -1603,10 +1603,11 @@ More formally, `result[i0, ..., iR-1] = operand[j0, ..., jR-1]` where:
 Overwrites the `operand` tensor at `start_indices` with values from `update`
 tensor and produces a `result` tensor.
 
-More formally, `result[j0, ..., jR-1] = update[i0, ..., iR-1]` if
-`jd = effective_start_indices[d] + id` where `effective_start_indices[d] = `
-`clamp(start_indices[d], 0, dim(operand, d) - dim(update, d))` and
-`result[i0, ..., iR-1] = operand[i0, ..., iR-1]` otherwise.
+More formally, `result[j0, ..., jR-1]` is defined as:
+  * `update[i0, ..., iR-1]` if `jd = effective_start_indices[d] + id` where
+    `effective_start_indices[d] = clamp(start_indices[d], 0, dim(operand, d) - `
+    `dim(update, d))`
+  * `result[i0, ..., iR-1] = operand[i0, ..., iR-1]` otherwise.
 
 ### Inputs
 

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -1601,18 +1601,20 @@ More formally, `result[i0, ..., iR-1] = operand[j0, ..., jR-1]` where:
 ### Semantics
 
 Overwrites the `operand` tensor at `start_indices` with values from `update`
-tensor and produces a `result` tensor. More formally,
-`result[start_indices0+j0, ..., start_indicesR-1+jR-1] = update[j0, ..., jR-1]`
-and `result[i0, ..., iR-1] = operand[i0, ..., iR-1]` otherwise where `R` $=$
-rank(`operand`).
+tensor and produces a `result` tensor.
+
+More formally, `result[j0, ..., jR-1] = update[i0, ..., iR-1]` if
+`jd = effective_start_indices[d] + id` where `effective_start_indices[d] = `
+`clamp(start_indices[d], 0, dim(operand, d) - dim(update, d))` and
+`result[i0, ..., iR-1] = operand[i0, ..., iR-1]` otherwise.
 
 ### Inputs
 
-| Name            | Type                                                     |
-|-----------------|----------------------------------------------------------|
-| `operand`       | tensor of any supported type                             |
-| `update`        | tensor of any supported type                             |
-| `start_indices` | variadic number of 0-dimensional tensors of integer type |
+| Name            | Type                                                    |
+|-----------------|---------------------------------------------------------|
+| `operand`       | tensor of any supported type                            |
+| `update`        | tensor of any supported type                            |
+| `start_indices` | variadic number of 0-dimensional tensors of type `si64` |
 
 ### Outputs
 
@@ -1626,11 +1628,8 @@ rank(`operand`).
   * (C2) element_type(`update`) $=$ element_type(`operand`).
   * (C3) rank(`update`) $=$ rank(`operand`).
   * (C4) size(`start_indices`) $=$ rank(`operand`).
-  * (C5) Each `start_indices` `dk` is in range [0, shape(`operand`)[`k`]) for
-    all `k` in range [0, rank(`operand`)).
-  * (C6) 0 $\le$ `k`th `start_indices` + shape(`update`)[`k`] $\le$
-    shape(`operand`).
-  * (C7) dim(`update`, `k`) $\ne$ 0 for all `k` in range [0, R).
+  * (C5) dim(`update`, `k`) $\in$ [0, dim(`operand`, `k`)) for all `k` in range
+    [0, rank(`operand`)).
 
 
 ### Examples

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -1628,7 +1628,7 @@ More formally, `result[j0, ..., jR-1] = update[i0, ..., iR-1]` if
   * (C2) element_type(`update`) $=$ element_type(`operand`).
   * (C3) rank(`update`) $=$ rank(`operand`).
   * (C4) size(`start_indices`) $=$ rank(`operand`).
-  * (C5) dim(`update`, `k`) $\in$ [0, dim(`operand`, `k`)) for all `k` in range
+  * (C5) dim(`update`, `k`) $\in$ [0, dim(`operand`, `k`)) for all `k` $\in$
     [0, rank(`operand`)).
 
 

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -1627,7 +1627,7 @@ rank(`operand`).
   * (C3) rank(`update`) $=$ rank(`operand`).
   * (C4) size(`start_indices`) $=$ rank(`operand`).
   * (C5) Each `start_indices` `dk` is in range [0, shape(`operand`)[`k`]) for
-    `k` in range [0, rank(`operand`)).
+    all `k` in range [0, rank(`operand`)).
   * (C6) 0 $\le$ `k`th `start_indices` + shape(`update`)[`k`] $\le$
     shape(`operand`).
   * (C7) dim(`update`, `k`) $\ne$ 0 for all `k` in range [0, R).

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -1600,14 +1600,13 @@ More formally, `result[i0, ..., iR-1] = operand[j0, ..., jR-1]` where:
 
 ### Semantics
 
-Overwrites the `operand` tensor at `start_indices` with values from `update`
-tensor and produces a `result` tensor.
+Produces a `result` tensor which is equal to the `operand` tensor except that
+the slice starting at `start_indices` is updated with the values in `update`.
 
-More formally, `result[j0, ..., jR-1]` is defined as:
-  * `update[i0, ..., iR-1]` if `jd = effective_start_indices[d] + id` where
-    `effective_start_indices[d] = clamp(start_indices[d], 0, dim(operand, d) - `
-    `dim(update, d))`
-  * `result[i0, ..., iR-1] = operand[i0, ..., iR-1]` otherwise.
+More formally, `result[i0, ..., iR-1]` is defined as:
+  * `update[j0, ..., jR-1]` if `jd = adjusted_start_indices[d][] + id` where
+    `adjusted_start_indices = clamp(0, start_indices, shape(operand) - update)`.
+  * `operand[i0, ..., iR-1]` otherwise.
 
 ### Inputs
 
@@ -1637,17 +1636,17 @@ More formally, `result[j0, ..., jR-1]` is defined as:
 
 ```mlir
 // %operand: [
+//            [1, 1, 0, 0],
+//            [1, 1, 0, 0],
 //            [1, 1, 1, 1],
-//            [1, 1, 0, 0],
-//            [1, 1, 0, 0],
 //            [1, 1, 1, 1]
 //           ]
 // %update: [
 //           [1, 1],
 //           [1, 1]
 //          ]
-// %start_indices0: 1
-// %start_indices1: 2
+// %start_indices0: -1
+// %start_indices1: 3
 %result = "stablehlo.dynamic_update_slice"(%operand, %update, %start_indices0, %start_indices1)
   : (tensor<4x4xi32>, tensor<2x2xi32>, tensor<i64>, tensor<i64>) -> tensor<4x4xi32>
 // %result: [

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -352,6 +352,7 @@ syntax.
    * [count_leading_zeros](#stablehlocount_leading_zeros)
    * [divide](#stablehlodivide)
    * [dynamic_slice](#stablehlodynamic_slice)
+   * [dynamic_update_slice](#stablehlodynamic_update_slice)
    * [exponential](#stablehloexponential)
    * [exponential_minus_one](#stablehloexponential_minus_one)
    * [fft](#stablehlofft)
@@ -1590,6 +1591,70 @@ More formally, `result[i0, ..., iR-1] = operand[j0, ..., jR-1]` where:
 // %result: [
 //           [1, 1],
 //           [1, 1]
+//          ]
+```
+
+[Back to Ops](#index-of-ops)
+
+## stablehlo.dynamic_update_slice
+
+### Semantics
+
+Overwrites the `operand` tensor at `start_indices` with values from `update`
+tensor and produces a `result` tensor. More formally,
+`result[start_indices0+j0, ..., start_indicesR-1+jR-1] = update[j0, ..., jR-1]`
+and `result[i0, ..., iR-1] = operand[i0, ..., iR-1]` otherwise where `R` $=$
+rank(`operand`).
+
+### Inputs
+
+| Name            | Type                                                     |
+|-----------------|----------------------------------------------------------|
+| `operand`       | tensor of any supported type                             |
+| `update`        | tensor of any supported type                             |
+| `start_indices` | variadic number of 0-dimensional tensors of integer type |
+
+### Outputs
+
+| Name     | Type                         |
+|----------|------------------------------|
+| `result` | tensor of any supported type |
+
+### Constraints
+
+  * (C1) `operand` and `result` have the same type.
+  * (C2) element_type(`update`) $=$ element_type(`operand`).
+  * (C3) rank(`update`) $=$ rank(`operand`).
+  * (C4) size(`start_indices`) $=$ rank(`operand`).
+  * (C5) Each `start_indices` `dk` is in range [0, shape(`operand`)[`k`]) for
+    `k` in range [0, rank(`operand`)).
+  * (C6) 0 $\le$ `k`th `start_indices` + shape(`update`)[`k`] $\le$
+    shape(`operand`).
+  * (C7) dim(`update`, `k`) $\ne$ 0 for all `k` in range [0, R).
+
+
+### Examples
+
+```mlir
+// %operand: [
+//            [1, 1, 1, 1],
+//            [1, 1, 0, 0],
+//            [1, 1, 0, 0],
+//            [1, 1, 1, 1]
+//           ]
+// %update: [
+//           [1, 1],
+//           [1, 1]
+//          ]
+// %start_indices0: 1
+// %start_indices1: 2
+%result = "stablehlo.dynamic_update_slice"(%operand, %update, %start_indices0, %start_indices1)
+  : (tensor<4x4xi32>, tensor<2x2xi32>, tensor<i64>, tensor<i64>) -> tensor<4x4xi32>
+// %result: [
+//           [1, 1, 1, 1],
+//           [1, 1, 1, 1],
+//           [1, 1, 1, 1],
+//           [1, 1, 1, 1]
 //          ]
 ```
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -85,7 +85,7 @@ one of the following tracking labels.
 | dynamic_pad              | no            | revisit      | no             | yes             | no          |
 | dynamic_reshape          | no            | revisit      | infeasible     | yes             | no          |
 | dynamic_slice            | yes           | revisit      | yes            | yes             | no          |
-| dynamic_update_slice     | yes           | revisit      | no             | yes             | no          |
+| dynamic_update_slice     | yes           | yes          | no             | yes             | no          |
 | einsum                   | no            | revisit      | no             | no              | no          |
 | exponential              | yes           | yes          | yes            | yes             | no          |
 | exponential_minus_one    | yes           | yes          | yes            | yes             | no          |

--- a/docs/status.md
+++ b/docs/status.md
@@ -85,7 +85,7 @@ one of the following tracking labels.
 | dynamic_pad              | no            | revisit      | no             | yes             | no          |
 | dynamic_reshape          | no            | revisit      | infeasible     | yes             | no          |
 | dynamic_slice            | yes           | revisit      | yes            | yes             | no          |
-| dynamic_update_slice     | no            | revisit      | no             | yes             | no          |
+| dynamic_update_slice     | yes           | revisit      | no             | yes             | no          |
 | einsum                   | no            | revisit      | no             | no              | no          |
 | exponential              | yes           | yes          | yes            | yes             | no          |
 | exponential_minus_one    | yes           | yes          | yes            | yes             | no          |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1537,16 +1537,16 @@ def StableHLO_DynamicUpdateSliceOp: StableHLO_Op<"dynamic_update_slice",
        AllShapesMatch<["operand", "result"]>]> {
   let summary = "Dynamic Update Slice operator";
   let description = [{
-    DynamicUpdateSlice generates a result which is the value of the input array
-    operand, with a slice update overwritten at start_indices.
+    Overwrites the `operand` tensor at `start_indices` with values from `update`
+    tensor and produces a `result` tensor.
 
-    See https://www.tensorflow.org/xla/operation_semantics#dynamicupdateslice.
+    See:
+    https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehloslice
 
     Example:
-
     ```mlir
-    %0 = stablehlo.dynamic_update_slice %arg0, %arg1, %arg2
-           : (tensor<4xf32>, tensor<2xf32>, tensor<i32>) -> tensor<4xf32>
+    %result = stablehlo.dynamic_update_slice %operand, %update, %start_indices0, %start_indices1
+      : (tensor<4x4xi32>, tensor<2x2xi32>, tensor<i64>, tensor<i64>) -> tensor<4x4xi32>
     ```
   }];
   let arguments = (ins

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1537,8 +1537,9 @@ def StableHLO_DynamicUpdateSliceOp: StableHLO_Op<"dynamic_update_slice",
        AllShapesMatch<["operand", "result"]>]> {
   let summary = "Dynamic Update Slice operator";
   let description = [{
-    Overwrites the `operand` tensor at `start_indices` with values from `update`
-    tensor and produces a `result` tensor.
+    Produces a `result` tensor which is equal to the `operand` tensor except
+    that the slice starting at `start_indices` is updated with the values in
+    `update`.
 
     See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehloslice

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2338,8 +2338,8 @@ def StableHLO_DynamicReshapeOp: StableHLO_ShapedInterfaceOp<"dynamic_reshape", [
 def StableHLO_ScatterOp: StableHLO_Op<"scatter", [SameVariadicOperandSize, RecursiveMemoryEffects]> {
   let summary = "Scatter operator";
   let description = [{
-    Generate `results` which is the values of the `inputs` operand, with several
-    slices at indices specified by `scatter_indices`, updated with the values in
+    Produces `results` tensors which are equal to `inputs` tensors except that
+    several slices specified by `scatter_indices` are updated with the values
     `updates` using `update_computation`.
 
     See:


### PR DESCRIPTION
Verification is left `revisit` due to #554.
Type Inference is left `no` since no type inference exists currently and added issue #656.
Updates spec of ScatterOp to mirror this op.
closes #520 