### PR TITLE
Add spec for DynamicSliceOp

### DIFF
--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -1120,11 +1120,11 @@ More formally, `result[i0, ..., iR-1] = operand[j0, ..., jR-1]` such that:
 
 ### Inputs
 
-| Name            | Type                                                     |
-|-----------------|----------------------------------------------------------|
-| `operand`       | tensor of any supported type                             |
-| `start_indices` | variadic number of 0-dimensional tensors of integer type |
-| `slice_sizes`   | 1-dimensional tensor constant of type `si64`             |
+| Name            | Type                                                    |
+|-----------------|---------------------------------------------------------|
+| `operand`       | tensor of any supported type                            |
+| `start_indices` | variadic number of 0-dimensional tensors of type `si64` |
+| `slice_sizes`   | 1-dimensional tensor constant of type `si64`            |
 
 ### Outputs
 

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -1122,11 +1122,11 @@ More formally, `result[i0, ..., iR-1] = operand[j0, ..., jR-1]` where:
 
 ### Inputs
 
-| Name            | Type                                                    |
-|-----------------|---------------------------------------------------------|
-| `operand`       | tensor of any supported type                            |
-| `start_indices` | variadic number of 0-dimensional tensors of type `si64` |
-| `slice_sizes`   | 1-dimensional tensor constant of type `si64`            |
+| Name            | Type                                                     |
+|-----------------|----------------------------------------------------------|
+| `operand`       | tensor of any supported type                             |
+| `start_indices` | variadic number of 0-dimensional tensors of integer type |
+| `slice_sizes`   | 1-dimensional tensor constant of type `si64`             |
 
 ### Outputs
 
@@ -1138,9 +1138,10 @@ More formally, `result[i0, ..., iR-1] = operand[j0, ..., jR-1]` where:
 
   * (C1) `operand` and `result` have the same element type.
   * (C2) size(`start_indices`) $=$ size(`slice_sizes`) $=$ rank(`operand`).
-  * (C3) `slice_sizes[k]` $\in$ [0, dim(`operand`, `k`)) for all `k` $\in$
-    [0, rank(`operand`)).
-  * (C4) shape(`result`) $=$ `slice_sizes`.
+  * (C3) All `start_indices` have the same type.
+  * (C4) `slice_sizes[k]` $\in$ [0, dim(`operand`, `k`)) for all `k` $\in$ [0,
+    rank(`operand`)).
+  * (C5) shape(`result`) $=$ `slice_sizes`.
 
 ### Examples
 

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -1110,13 +1110,15 @@ produces an implementation-defined value.
 
 ### Semantics
 
-Extracts a slice of shape `slice_sizes` from the `operand` tensor starting at
-`start_indices` and produces a `result` tensor.
+Extracts a slice from the `operand` using dynamically-computed starting indices
+and produces a `result` tensor. `start_indices` contain the starting indices of
+the slice for each dimension subject to potential adjustment, and `slice_sizes`
+contain the sizes of the slice for each dimension.
 
-More formally, `result[i0, ..., iR-1] = operand[j0, ..., jR-1]` such that:
-  * `jd = effective_start_indices[d] + id`.
-  * `effective_start_indices[d] = clamp(start_indices[d], 0, dim(operand, d) - `
-    `slice_sizes[d])`.
+More formally, `result[i0, ..., iR-1] = operand[j0, ..., jR-1]` where:
+  * `jd = adjusted_start_indices[d][] + id`.
+  * `adjusted_start_indices = clamp(0, start_indices, shape(operand) - `
+    `slice_sizes)`.
 
 ### Inputs
 
@@ -1144,15 +1146,15 @@ More formally, `result[i0, ..., iR-1] = operand[j0, ..., jR-1]` such that:
 
 ```mlir
 // %operand: [
+//            [0, 0, 1, 1],
+//            [0, 0, 1, 1],
 //            [0, 0, 0, 0],
-//            [0, 0, 1, 1],
-//            [0, 0, 1, 1],
 //            [0, 0, 0, 0]
 //           ]
-// %start_indices0: 1
-// %start_indices1: 2
+// %start_indices0: -1
+// %start_indices1: 3
 %result = "stablehlo.dynamic_slice"(%operand, %start_indices0, %start_indices1) {
-  slice_sizes = [2, 2]
+  slice_sizes = dense<[2, 2]> : tensor<2xi64>
 } : (tensor<4x4xi32>, tensor<i64>, tensor<i64>) -> tensor<2x2xi32>
 // %result: [
 //           [1, 1],
@@ -3031,10 +3033,11 @@ Numeric precision is implementation-defined.
 
 ### Semantics
 
-Extracts a sub-tensor from the `operand` and produces a `result` tensor.
-`start_indices` contain the starting indices of the slice for each dimension,
-`limit_indices` contain the ending indices (exclusive) for the slice for each
-dimension, and `strides` contain the strides for each dimension.
+Extracts a slice from the `operand` using statically-computed starting indices
+and produces a `result` tensor. `start_indices` contain the starting indices of
+the slice for each dimension, `limit_indices` contain the ending indices
+(exclusive) for the slice for each dimension, and `strides` contain the strides
+for each dimension.
 
 More formally, `result[i0, ..., iR-1] = operand[j0, ..., jR-1]` where
 `jd = start_indices[d] + id * strides[d]`.

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -1110,10 +1110,13 @@ produces an implementation-defined value.
 
 ### Semantics
 
-Extracts a subtensor of the shape in `slice_sizes` from the `operand` tensor
-starting from `start_indices` and produces a `result` tensor. More formally,
-`result[i0, ..., iR-1] = operand[j0, ..., jR-1]` where
-`jd = start_indices[d] + id`.
+Extracts a slice of shape `slice_sizes` from the `operand` tensor starting from
+`start_indices` and produces a `result` tensor.
+
+More formally, `result[i0, ..., iR-1] = operand[j0, ..., jR-1]` such that:
+  * `jd = effective_start_indices[d] + id`.
+  * `effective_start_indices[d] = clamp(start_indices[d], 0, dim(operand, d) - `
+    `slice_sizes[d])`.
 
 ### Inputs
 
@@ -1121,7 +1124,7 @@ starting from `start_indices` and produces a `result` tensor. More formally,
 |-----------------|----------------------------------------------------------|
 | `operand`       | tensor of any supported type                             |
 | `start_indices` | variadic number of 0-dimensional tensors of integer type |
-| `slice_sizes`   | 1-dimensional tensor of type `si64`                      |
+| `slice_sizes`   | 1-dimensional tensor constant of type `si64`             |
 
 ### Outputs
 
@@ -1133,13 +1136,9 @@ starting from `start_indices` and produces a `result` tensor. More formally,
 
   * (C1) `operand` and `result` have the same element type.
   * (C2) size(`start_indices`) $=$ size(`slice_sizes`) $=$ rank(`operand`).
-  * (C3) Each `start_indices` `dk` is in range [0, shape(`operand`)[`k`]) for
-    all `k` in range [0, rank(`operand`)).
-  * (C4) `slice_sizes[k]` is in range [0, shape(`operand`)[`k`]) for all `k` in
-    range [0, rank(`operand`)).
-  * (C5) 0 $\le$ `k`th `start_indices` + `slice_sizes[k]` $\le$
-    shape(`operand`)[`k`] for all `k` in range [0, rank(`operand`)).
-  * (C6) shape(`result`) $=$ `slice_sizes`.
+  * (C3) `slice_sizes[k]` $\in$ [0, dim(`operand`, `k`) for all `k` $\in$
+    [0, rank(`operand`)).
+  * (C4) shape(`result`) $=$ `slice_sizes`.
 
 ### Examples
 

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -182,6 +182,7 @@ syntax.
    * [cosine](#stablehlocosine)
    * [count_leading_zeros](#stablehlocount_leading_zeros)
    * [divide](#stablehlodivide)
+   * [dynamic_slice](#stablehlodynamic_slice)
    * [exponential](#stablehloexponential)
    * [exponential_minus_one](#stablehloexponential_minus_one)
    * [fft](#stablehlofft)
@@ -1101,6 +1102,63 @@ produces an implementation-defined value.
 // %rhs: [3, 3, -3, -3]
 %result = "stablehlo.divide"(%lhs, %rhs) : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi32>
 // %result: [5, -5, -5, 5]
+```
+
+[Back to Ops](#index-of-ops)
+
+## stablehlo.dynamic_slice
+
+### Semantics
+
+Extracts a subtensor of the shape in `slice_sizes` from the `operand` tensor
+starting from `start_indices` and produces a `result` tensor. More formally,
+`result[i0, ..., iR-1] = operand[j0, ..., jR-1]` where
+`jd = start_indices[d] + id`.
+
+### Inputs
+
+| Name            | Type                                                     |
+|-----------------|----------------------------------------------------------|
+| `operand`       | tensor of any supported type                             |
+| `start_indices` | variadic number of 0-dimensional tensors of integer type |
+| `slice_sizes`   | 1-dimensional tensor of type `si64`                      |
+
+### Outputs
+
+| Name     | Type                         |
+|----------|------------------------------|
+| `result` | tensor of any supported type |
+
+### Constraints
+
+  * (C1) `operand` and `result` have the same element type.
+  * (C2) size(`start_indices`) $=$ size(`slice_sizes`) $=$ rank(`operand`).
+  * (C3) Each `start_indices` `dk` is in range [0, shape(`operand`)[`k`]) for
+    all `k` in range [0, rank(`operand`)).
+  * (C4) `slice_sizes[k]` is in range [0, shape(`operand`)[`k`]) for all `k` in
+    range [0, rank(`operand`)).
+  * (C5) 0 $\le$ `k`th `start_indices` + `slice_sizes[k]` $\le$
+    shape(`operand`)[`k`] for all `k` in range [0, rank(`operand`)).
+  * (C6) shape(`result`) $=$ `slice_sizes`.
+
+### Examples
+
+```mlir
+// %operand: [
+//            [0, 0, 0, 0],
+//            [0, 0, 1, 1],
+//            [0, 0, 1, 1],
+//            [0, 0, 0, 0]
+//           ]
+// %start_indices0: 1
+// %start_indices1: 2
+%result = "stablehlo.dynamic_slice"(%operand, %start_indices0, %start_indices1) {
+  slice_sizes = [2, 2]
+} : (tensor<4x4xi32>, tensor<i64>, tensor<i64>) -> tensor<2x2xi32>
+// %result: [
+//           [1, 1],
+//           [1, 1]
+//          ]
 ```
 
 [Back to Ops](#index-of-ops)

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -1136,7 +1136,7 @@ More formally, `result[i0, ..., iR-1] = operand[j0, ..., jR-1]` such that:
 
   * (C1) `operand` and `result` have the same element type.
   * (C2) size(`start_indices`) $=$ size(`slice_sizes`) $=$ rank(`operand`).
-  * (C3) `slice_sizes[k]` $\in$ [0, dim(`operand`, `k`) for all `k` $\in$
+  * (C3) `slice_sizes[k]` $\in$ [0, dim(`operand`, `k`)) for all `k` $\in$
     [0, rank(`operand`)).
   * (C4) shape(`result`) $=$ `slice_sizes`.
 

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -1110,7 +1110,7 @@ produces an implementation-defined value.
 
 ### Semantics
 
-Extracts a slice of shape `slice_sizes` from the `operand` tensor starting from
+Extracts a slice of shape `slice_sizes` from the `operand` tensor starting at
 `start_indices` and produces a `result` tensor.
 
 More formally, `result[i0, ..., iR-1] = operand[j0, ..., jR-1]` such that:

--- a/docs/status.md
+++ b/docs/status.md
@@ -84,7 +84,7 @@ one of the following tracking labels.
 | dynamic_iota             | no            | revisit      | infeasible     | yes             | no          |
 | dynamic_pad              | no            | revisit      | no             | yes             | no          |
 | dynamic_reshape          | no            | revisit      | infeasible     | yes             | no          |
-| dynamic_slice            | no            | yes*         | yes*           | yes             | no          |
+| dynamic_slice            | yes           | revisit      | yes            | yes             | no          |
 | dynamic_update_slice     | no            | revisit      | no             | yes             | no          |
 | einsum                   | no            | revisit      | no             | no              | no          |
 | exponential              | yes           | yes          | yes            | yes             | no          |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1520,15 +1520,16 @@ def StableHLO_DynamicSliceOp: StableHLO_Op<"dynamic_slice",
        InferTensorType]> {
   let summary = "Dynamic Slice operator";
   let description = [{
-    Extracts a sub-array from the input array at dynamic start_indices.
+    Extracts a subtensor of the shape in `slice_sizes` from the `operand` tensor
+    starting from `start_indices` and produces a `result` tensor.
 
-    See https://www.tensorflow.org/xla/operation_semantics#dynamicslice.
+    See:
+    https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlodynamic_slice
 
     Example:
-
     ```mlir
-    %0 = stablehlo.dynamic_slice %arg2, %arg3, %arg3, sizes = [1, 4]
-      : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xi32>
+    %result = stablehlo.dynamic_slice %operand, %start_indices0, %start_indices1, sizes = [2, 2]
+      : (tensor<4x4xi32>, tensor<i64>, tensor<i64>) -> tensor<2x2xi32>
     ```
   }];
   let arguments = (ins

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1520,8 +1520,8 @@ def StableHLO_DynamicSliceOp: StableHLO_Op<"dynamic_slice",
        InferTensorType]> {
   let summary = "Dynamic Slice operator";
   let description = [{
-    Extracts a subtensor of the shape in `slice_sizes` from the `operand` tensor
-    starting from `start_indices` and produces a `result` tensor.
+    Extracts a slice of shape `slice_sizes` from the `operand` tensor starting
+    from `start_indices` and produces a `result` tensor.
 
     See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlodynamic_slice

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1490,7 +1490,8 @@ def StableHLO_SliceOp: StableHLO_Op<
        DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
   let summary = "Slice operator";
   let description = [{
-    Extracts a sub-tensor from the `operand` and produces a `result` tensor.
+    Extracts a slice from the `operand` using statically-computed starting
+    indices and produces a `result` tensor.
 
     See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehloslice
@@ -1520,8 +1521,8 @@ def StableHLO_DynamicSliceOp: StableHLO_Op<"dynamic_slice",
        InferTensorType]> {
   let summary = "Dynamic Slice operator";
   let description = [{
-    Extracts a slice of shape `slice_sizes` from the `operand` tensor starting
-    from `start_indices` and produces a `result` tensor.
+    Extracts a slice from the `operand` using dynamically-computed starting
+    indices and produces a `result` tensor.
 
     See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlodynamic_slice


### PR DESCRIPTION
Verification is set to `revisit` due to #557
Updates semantics of SliceOp to match DynamicSliceOp
closes #519 