### PR TITLE
Add spec for RoundOp

### DIFF
--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -736,8 +736,8 @@ corner cases TBD. Numeric precision is implementation-defined.
 ### Semantics
 
 Performs element-wise ceil of `operand` tensor and produces a `result` tensor.
-Implements the rounding to integral towards positive infinity operation from the
-IEEE-754 specification.
+Implements the `roundToIntegralTowardPositive` operation from the IEEE-754
+specification.
 
 ### Inputs
 
@@ -1299,8 +1299,8 @@ for `fft_type = RFFT`. For example, for `L = 3`:
 ### Semantics
 
 Performs element-wise floor of `operand` tensor and produces a `result` tensor.
-Implements the rounding to integral towards negative infinity operation from the
-IEEE-754 specification.
+Implements the `roundToIntegralTowardNegative` operation from the IEEE-754
+specification.
 
 ### Inputs
 
@@ -2532,7 +2532,8 @@ hidden state.
 ### Semantics
 
 Performs element-wise rounding towards the nearest integer, breaking ties away
-from zero, on the `operand` tensor and produces a `result` tensor.
+from zero, on the `operand` tensor and produces a `result` tensor. Implements
+the `roundToIntegralTiesToAway` operation from the IEEE-754 specification.
 
 ### Inputs
 

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -2548,7 +2548,7 @@ from zero, on the `operand` tensor and produces a `result` tensor.
 
 ### Constraints
 
-  * (C1) `opernad` and `result` have the same type.
+  * (C1) `operand` and `result` have the same type.
 
 ### Examples
 

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -2567,7 +2567,8 @@ the `roundToIntegralTiesToAway` operation from the IEEE-754 specification.
 
 Performs element-wise rounding towards the nearest integer, breaking ties
 towards the even integer, on the `operand` tensor and produces a `result`
-tensor. Implements the `roundToIntegralTiesToEven` operation from the IEEE-754 specification.
+tensor. Implements the `roundToIntegralTiesToEven` operation from the IEEE-754
+specification.
 
 ### Inputs
 

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -2531,8 +2531,8 @@ hidden state.
 
 ### Semantics
 
-Performs element-wise round, rounding to nearest integer with ties away from
-zero, on `operand` tensor and produces a `result` tensor.
+Performs element-wise rounding towards the nearest integer, breaking ties away
+from zero, on the `operand` tensor and produces a `result` tensor.
 
 ### Inputs
 
@@ -2553,9 +2553,9 @@ zero, on `operand` tensor and produces a `result` tensor.
 ### Examples
 
 ```mlir
-// %operand = [-2.5, 0.5, 2.5]
-%result = "stablehlo.round_nearest_afz"(%operand) : (tensor<3xf32>) -> tensor<3xf32>
-// %result: [-3.0, 1.0, 3.0]
+// %operand = [-2.5, 0.4, 0.5, 0.6, 2.5]
+%result = "stablehlo.round_nearest_afz"(%operand) : (tensor<5xf32>) -> tensor<5xf32>
+// %result: [-3.0, 0.0, 1.0, 1.0, 3.0]
 ```
 
 [Back to Ops](#index-of-ops)

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -210,6 +210,7 @@ syntax.
    * [reshape](#stablehloreshape)
    * [reverse](#stablehloreverse)
    * [rng](#stablehlorng)
+   * [round_nearest_afz](#stablehloround_nearest_afz)
    * [round_nearest_even](#stablehloround_nearest_even)
    * [rsqrt](#stablehlorsqrt)
    * [scatter](#stablehloscatter)
@@ -2522,6 +2523,39 @@ hidden state.
 //           [1, 1, 1],
 //           [0, 0, 0]
 //          ]
+```
+
+[Back to Ops](#index-of-ops)
+
+## stablehlo.round_nearest_afz
+
+### Semantics
+
+Performs element-wise round, rounding to nearest integer with ties away from
+zero, on `operand` tensor and produces a `result` tensor.
+
+### Inputs
+
+| Name      | Type                          |
+|-----------|-------------------------------|
+| `operand` | tensor of floating-point type |
+
+### Outputs
+
+| Name     | Type                          |
+|----------|-------------------------------|
+| `result` | tensor of floating-point type |
+
+### Constraints
+
+  * (C1) `opernad` and `result` have the same type.
+
+### Examples
+
+```mlir
+// %operand = [-2.5, 0.5, 2.5]
+%result = "stablehlo.round_nearest_afz"(%operand) : (tensor<3xf32>) -> tensor<3xf32>
+// %result: [-3.0, 1.0, 3.0]
 ```
 
 [Back to Ops](#index-of-ops)

--- a/docs/status.md
+++ b/docs/status.md
@@ -128,7 +128,7 @@ one of the following tracking labels.
 | reverse                  | yes           | revisit      | yes            | yes             | no          |
 | rng                      | yes           | yes          | yes            | yes             | no          |
 | rng_bit_generator        | no            | yes*         | infeasible     | yes             | no          |
-| round_nearest_afz        | no            | yes*         | yes*           | yes             | no          |
+| round_nearest_afz        | yes           | yes          | yes            | yes             | no          |
 | round_nearest_even       | yes           | yes          | yes            | yes             | no          |
 | rsqrt                    | yes           | yes          | yes            | yes             | no          |
 | scatter                  | yes           | revisit      | no             | no              | no          |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -519,16 +519,15 @@ def StableHLO_RoundOp: StableHLO_UnaryElementwiseOp<"round_nearest_afz",
     [Pure, HLO_CompatibleOperandsAndResultType], HLO_FpTensor> {
   let summary = "Round operator, ties away from zero";
   let description = [{
-    Returns `Round(operand)` element-wise, rounding to nearest integer with
-    half-way cases rounding away from zero.
+    Performs element-wise round, rounding to nearest integer with ties away from
+    zero, on `operand` tensor and produces a `result` tensor.
 
-    See
-    https://www.tensorflow.org/xla/operation_semantics#element-wise_unary_functions.
+    See:
+    https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehloround_nearest_afz
 
     Example:
-
     ```mlir
-    %0 = stablehlo.round_nearest_afz %11 : tensor<10x10xbf16>
+    %result = stablehlo.round_nearest_afz %operand : tensor<3xf32>
     ```
   }];
 }

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -519,8 +519,8 @@ def StableHLO_RoundOp: StableHLO_UnaryElementwiseOp<"round_nearest_afz",
     [Pure, HLO_CompatibleOperandsAndResultType], HLO_FpTensor> {
   let summary = "Round operator, ties away from zero";
   let description = [{
-    Performs element-wise round, rounding to nearest integer with ties away from
-    zero, on `operand` tensor and produces a `result` tensor.
+    Performs element-wise rounding towards the nearest integer, breaking ties
+    away from zero, on the `operand` tensor and produces a `result` tensor.
 
     See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehloround_nearest_afz

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -527,7 +527,7 @@ def StableHLO_RoundOp: StableHLO_UnaryElementwiseOp<"round_nearest_afz",
 
     Example:
     ```mlir
-    %result = stablehlo.round_nearest_afz %operand : tensor<3xf32>
+    %result = stablehlo.round_nearest_afz %operand : tensor<5xf32>
     ```
   }];
 }


### PR DESCRIPTION
Updates the description of ceil and floor op to call out IEEE-754 operation names.
closes #475