### PR TITLE
Migrate MHLO changes for printing dimensions

### DIFF
--- a/stablehlo/dialect/AssemblyFormat.cpp
+++ b/stablehlo/dialect/AssemblyFormat.cpp
@@ -313,7 +313,8 @@ void printDynamicShape(AsmPrinter& p, llvm::ArrayRef<int64_t> shape) {
   p << ']';
 }
 
-ParseResult parseDynamicShape(AsmParser& parser, FailureOr<SmallVector<int64_t>> & shapeResult) {
+ParseResult parseDynamicShape(AsmParser& parser,
+                              FailureOr<SmallVector<int64_t>>& shapeResult) {
   SmallVector<int64_t> shape;
   auto parseElt = [&]() -> ParseResult {
     if (!parser.parseOptionalQuestion()) {
@@ -322,7 +323,8 @@ ParseResult parseDynamicShape(AsmParser& parser, FailureOr<SmallVector<int64_t>>
     }
     return parser.parseInteger(shape.emplace_back());
   };
-  auto res = parser.parseCommaSeparatedList(AsmParser::Delimiter::Square, parseElt);
+  auto res =
+      parser.parseCommaSeparatedList(AsmParser::Delimiter::Square, parseElt);
   if (succeeded(res)) {
     shapeResult = shape;
   } else {
@@ -403,12 +405,13 @@ void printHloDim(AsmPrinter& printer, ArrayRef<int64_t> ints) {
   printer << ']';
 }
 
-ParseResult parseIntArray(AsmParser& parser, FailureOr<SmallVector<int64_t>> & ints) {
+ParseResult parseIntArray(AsmParser& parser,
+                          FailureOr<SmallVector<int64_t>>& ints) {
   ints = parseHloDim(parser);
   return success(/*isSuccess=*/succeeded(ints));
 }
 
-ParseResult parseIntArray(AsmParser& parser, SmallVector<int64_t> & ints) {
+ParseResult parseIntArray(AsmParser& parser, SmallVector<int64_t>& ints) {
   auto intsOrFail = parseHloDim(parser);
   if (failed(intsOrFail)) {
     return failure();
@@ -420,8 +423,6 @@ ParseResult parseIntArray(AsmParser& parser, SmallVector<int64_t> & ints) {
 void printIntArray(AsmPrinter& printer, ArrayRef<int64_t> ints) {
   printHloDim(printer, ints);
 }
-
-
 
 }  // namespace hlo
 }  // namespace mlir

--- a/stablehlo/dialect/AssemblyFormat.cpp
+++ b/stablehlo/dialect/AssemblyFormat.cpp
@@ -404,11 +404,16 @@ void printHloDim(AsmPrinter& printer, ArrayRef<int64_t> ints) {
 }
 
 ParseResult parseIntArray(AsmParser& parser, FailureOr<SmallVector<int64_t>> & ints) {
+  ints = parseHloDim(parser);
+  return success(/*isSuccess=*/succeeded(ints));
+}
+
+ParseResult parseIntArray(AsmParser& parser, SmallVector<int64_t> & ints) {
   auto intsOrFail = parseHloDim(parser);
   if (failed(intsOrFail)) {
     return failure();
   }
-  ints = *intsOrFail;
+  ints = std::move(*intsOrFail);
   return success();
 }
 

--- a/stablehlo/dialect/AssemblyFormat.cpp
+++ b/stablehlo/dialect/AssemblyFormat.cpp
@@ -301,19 +301,19 @@ ParseResult parseDenseI64Array(OpAsmParser& parser,
   return success();
 }
 
-void printDynamicShape(AsmPrinter& p, llvm::ArrayRef<int64_t> shape) {
+void printDimensionSizes(AsmPrinter& p, llvm::ArrayRef<int64_t> shape) {
   auto printIntOrQuestion = [&](int64_t value) {
     if (ShapedType::isDynamic(value))
       p << '?';
     else
       p << value;
   };
-  p << " [";
+  p << '[';
   llvm::interleaveComma(shape, p, printIntOrQuestion);
   p << ']';
 }
 
-ParseResult parseDynamicShape(AsmParser& parser,
+ParseResult parseDimensionSizes(AsmParser& parser,
                               FailureOr<SmallVector<int64_t>>& shapeResult) {
   SmallVector<int64_t> shape;
   auto parseElt = [&]() -> ParseResult {
@@ -389,7 +389,13 @@ ParseResult parseCustomCallTarget(AsmParser& parser, StringAttr& target) {
   return parser.parseSymbolName(target);
 }
 
-FailureOr<SmallVector<int64_t>> parseHloDim(AsmParser& parser) {
+void printIntArray(AsmPrinter& printer, ArrayRef<int64_t> ints) {
+  printer << '[';
+  llvm::interleaveComma(ints, printer);
+  printer << ']';
+}
+
+FailureOr<SmallVector<int64_t>> parseIntArray(AsmParser& parser) {
   SmallVector<int64_t> ints;
   if (failed(parser.parseCommaSeparatedList(
           AsmParser::Delimiter::Square,
@@ -399,29 +405,13 @@ FailureOr<SmallVector<int64_t>> parseHloDim(AsmParser& parser) {
   return ints;
 }
 
-void printHloDim(AsmPrinter& printer, ArrayRef<int64_t> ints) {
-  printer << '[';
-  llvm::interleaveComma(ints, printer);
-  printer << ']';
-}
-
-ParseResult parseIntArray(AsmParser& parser,
-                          FailureOr<SmallVector<int64_t>>& ints) {
-  ints = parseHloDim(parser);
-  return success(/*isSuccess=*/succeeded(ints));
-}
-
 ParseResult parseIntArray(AsmParser& parser, SmallVector<int64_t>& ints) {
-  auto intsOrFail = parseHloDim(parser);
+  auto intsOrFail = parseIntArray(parser);
   if (failed(intsOrFail)) {
     return failure();
   }
   ints = std::move(*intsOrFail);
   return success();
-}
-
-void printIntArray(AsmPrinter& printer, ArrayRef<int64_t> ints) {
-  printHloDim(printer, ints);
 }
 
 }  // namespace hlo

--- a/stablehlo/dialect/AssemblyFormat.cpp
+++ b/stablehlo/dialect/AssemblyFormat.cpp
@@ -314,7 +314,7 @@ void printDimensionSizes(AsmPrinter& p, llvm::ArrayRef<int64_t> shape) {
 }
 
 ParseResult parseDimensionSizes(AsmParser& parser,
-                              FailureOr<SmallVector<int64_t>>& shapeResult) {
+                                FailureOr<SmallVector<int64_t>>& shapeResult) {
   SmallVector<int64_t> shape;
   auto parseElt = [&]() -> ParseResult {
     if (!parser.parseOptionalQuestion()) {

--- a/stablehlo/dialect/AssemblyFormat.h
+++ b/stablehlo/dialect/AssemblyFormat.h
@@ -181,7 +181,7 @@ ParseResult parseDenseI64Array(OpAsmParser& parser, DenseIntElementsAttr& attr);
 void printDynamicShape(AsmPrinter& p, llvm::ArrayRef<int64_t> shape);
 
 ParseResult parseDynamicShape(AsmParser& parser,
-                              FailureOr<SmallVector<int64_t>> & shape);
+                              FailureOr<SmallVector<int64_t>>& shape);
 
 // ExponentMantissa - Abbreviated printing of exponent and mantissa as e#m#.
 //
@@ -216,19 +216,16 @@ ParseResult parseCustomCallTarget(AsmParser& parser, StringAttr& target);
 //   Custom:
 //     [1, 2]
 FailureOr<SmallVector<int64_t>> parseHloDim(AsmParser& parser);
-void printHloDim(AsmPrinter &printer, ArrayRef<int64_t> ints);
-
-
+void printHloDim(AsmPrinter& printer, ArrayRef<int64_t> ints);
 
 // IntArray - Calls parseHloDim, with an interface that works for
 // custom directives.
-ParseResult parseIntArray(AsmParser& parser,
-                          SmallVector<int64_t> & ints);
+ParseResult parseIntArray(AsmParser& parser, SmallVector<int64_t>& ints);
 
 ParseResult parseIntArray(AsmParser& parser,
                           FailureOr<SmallVector<int64_t>>& ints);
 
-void printIntArray(AsmPrinter &printer, ArrayRef<int64_t> ints);
+void printIntArray(AsmPrinter& printer, ArrayRef<int64_t> ints);
 
 }  // namespace hlo
 }  // namespace mlir

--- a/stablehlo/dialect/AssemblyFormat.h
+++ b/stablehlo/dialect/AssemblyFormat.h
@@ -172,16 +172,16 @@ void printDenseI64Array(OpAsmPrinter& p, Operation* op,
 
 ParseResult parseDenseI64Array(OpAsmParser& parser, DenseIntElementsAttr& attr);
 
-// DynamicShape - Print an array of ints. Dynamic dimensions printed as `?`.
+// DimensionSizes - Print an array of ints. Dynamic dimensions printed as `?`.
 //
 //   Generic:
 //     [1, -1]
 //   Custom:
 //     [1, ?]
-void printDynamicShape(AsmPrinter& p, llvm::ArrayRef<int64_t> shape);
+void printDimensionSizes(AsmPrinter& p, llvm::ArrayRef<int64_t> shape);
 
-ParseResult parseDynamicShape(AsmParser& parser,
-                              FailureOr<SmallVector<int64_t>>& shape);
+ParseResult parseDimensionSizes(AsmParser& parser,
+                                FailureOr<SmallVector<int64_t>>& shape);
 
 // ExponentMantissa - Abbreviated printing of exponent and mantissa as e#m#.
 //
@@ -209,23 +209,17 @@ void printCustomCallTarget(AsmPrinter& p, Operation*, StringAttr target);
 
 ParseResult parseCustomCallTarget(AsmParser& parser, StringAttr& target);
 
-// HloDim - Print an ArrayRef of integrer values with brackets.
+// IntArray - Print an array of ints with brackets. Unlike DimensionSizes,
+// doesn't have special handling for kDynamicSize.
 //
 //   Generic:
 //     1, 2
 //   Custom:
 //     [1, 2]
-FailureOr<SmallVector<int64_t>> parseHloDim(AsmParser& parser);
-void printHloDim(AsmPrinter& printer, ArrayRef<int64_t> ints);
-
-// IntArray - Calls parseHloDim, with an interface that works for
-// custom directives.
-ParseResult parseIntArray(AsmParser& parser, SmallVector<int64_t>& ints);
-
-ParseResult parseIntArray(AsmParser& parser,
-                          FailureOr<SmallVector<int64_t>>& ints);
-
 void printIntArray(AsmPrinter& printer, ArrayRef<int64_t> ints);
+
+FailureOr<SmallVector<int64_t>> parseIntArray(AsmParser& parser);
+ParseResult parseIntArray(AsmParser& parser, SmallVector<int64_t>& ints);
 
 }  // namespace hlo
 }  // namespace mlir

--- a/stablehlo/dialect/AssemblyFormat.h
+++ b/stablehlo/dialect/AssemblyFormat.h
@@ -219,8 +219,12 @@ FailureOr<SmallVector<int64_t>> parseHloDim(AsmParser& parser);
 void printHloDim(AsmPrinter &printer, ArrayRef<int64_t> ints);
 
 
+
 // IntArray - Calls parseHloDim, with an interface that works for
 // custom directives.
+ParseResult parseIntArray(AsmParser& parser,
+                          SmallVector<int64_t> & ints);
+
 ParseResult parseIntArray(AsmParser& parser,
                           FailureOr<SmallVector<int64_t>>& ints);
 

--- a/stablehlo/dialect/AssemblyFormat.h
+++ b/stablehlo/dialect/AssemblyFormat.h
@@ -172,6 +172,17 @@ void printDenseI64Array(OpAsmPrinter& p, Operation* op,
 
 ParseResult parseDenseI64Array(OpAsmParser& parser, DenseIntElementsAttr& attr);
 
+// DynamicShape - Print an array of ints. Dynamic dimensions printed as `?`.
+//
+//   Generic:
+//     [1, -1]
+//   Custom:
+//     [1, ?]
+void printDynamicShape(AsmPrinter& p, llvm::ArrayRef<int64_t> shape);
+
+ParseResult parseDynamicShape(AsmParser& parser,
+                              FailureOr<SmallVector<int64_t>> & shape);
+
 // ExponentMantissa - Abbreviated printing of exponent and mantissa as e#m#.
 //
 //   Generic:
@@ -197,6 +208,23 @@ ParseResult parseExponentMantissa(AsmParser& parser, IntegerAttr& exponent,
 void printCustomCallTarget(AsmPrinter& p, Operation*, StringAttr target);
 
 ParseResult parseCustomCallTarget(AsmParser& parser, StringAttr& target);
+
+// HloDim - Print an ArrayRef of integrer values with brackets.
+//
+//   Generic:
+//     1, 2
+//   Custom:
+//     [1, 2]
+FailureOr<SmallVector<int64_t>> parseHloDim(AsmParser& parser);
+void printHloDim(AsmPrinter &printer, ArrayRef<int64_t> ints);
+
+
+// IntArray - Calls parseHloDim, with an interface that works for
+// custom directives.
+ParseResult parseIntArray(AsmParser& parser,
+                          FailureOr<SmallVector<int64_t>>& ints);
+
+void printIntArray(AsmPrinter &printer, ArrayRef<int64_t> ints);
 
 }  // namespace hlo
 }  // namespace mlir

--- a/stablehlo/dialect/StablehloAttrs.td
+++ b/stablehlo/dialect/StablehloAttrs.td
@@ -21,8 +21,8 @@ include "mlir/IR/OpBase.td"
 include "mlir/IR/TensorEncoding.td"
 
 def StableHLO_Dim : ArrayRefParameter<"int64_t", "Dimension"> {
-  let parser = "mlir::stablehlo::parseIntArray($_parser)";
-  let printer = "mlir::stablehlo::printIntArray($_printer, $_self)";
+  let parser = "mlir::hlo::parseHloDim($_parser)";
+  let printer = "mlir::hlo::printHloDim($_printer, $_self)";
 }
 
 def StableHLO_ScatterDimensionNumbers : AttrDef<StableHLO_Dialect, "ScatterDimensionNumbers"> {
@@ -175,7 +175,7 @@ def StableHLO_TypeExtensions : AttrDef<StableHLO_Dialect, "TypeExtensions", [
 
     See `HLO_BoundedAttrInterface` for documentation for `bounds`.
   }];
-  let assemblyFormat = "`<` `bounds` `=` `[` $bounds `]` `>`";
+  let assemblyFormat = "`<` `bounds` `=` custom<DynamicShape>($bounds) `>`";
 }
 
 // A layout attribute (1D tensor of index type)

--- a/stablehlo/dialect/StablehloAttrs.td
+++ b/stablehlo/dialect/StablehloAttrs.td
@@ -20,9 +20,9 @@ limitations under the License.
 include "mlir/IR/OpBase.td"
 include "mlir/IR/TensorEncoding.td"
 
-def StableHLO_Dim : ArrayRefParameter<"int64_t", "Dimension"> {
-  let parser = "mlir::hlo::parseHloDim($_parser)";
-  let printer = "mlir::hlo::printHloDim($_printer, $_self)";
+def StableHLO_Dims : ArrayRefParameter<"int64_t", "Dimension"> {
+  let parser = "mlir::hlo::parseIntArray($_parser)";
+  let printer = "mlir::hlo::printIntArray($_printer, $_self)";
 }
 
 def StableHLO_ScatterDimensionNumbers : AttrDef<StableHLO_Dialect, "ScatterDimensionNumbers"> {
@@ -30,9 +30,9 @@ def StableHLO_ScatterDimensionNumbers : AttrDef<StableHLO_Dialect, "ScatterDimen
   let mnemonic = "scatter";
   let summary = "Attribute that models the dimension information for scatter";
   let parameters = (ins
-      StableHLO_Dim:$updateWindowDims,
-      StableHLO_Dim:$insertedWindowDims,
-      StableHLO_Dim:$scatterDimsToOperandDims,
+      StableHLO_Dims:$updateWindowDims,
+      StableHLO_Dims:$insertedWindowDims,
+      StableHLO_Dims:$scatterDimsToOperandDims,
       "int64_t":$indexVectorDim
   );
   let hasCustomAssemblyFormat = 1;
@@ -43,9 +43,9 @@ def StableHLO_GatherDimensionNumbers : AttrDef<StableHLO_Dialect, "GatherDimensi
   let mnemonic = "gather";
   let summary = "Attribute that models the dimension information for gather";
   let parameters = (ins
-      StableHLO_Dim:$offsetDims,
-      StableHLO_Dim:$collapsedSliceDims,
-      StableHLO_Dim:$startIndexMap,
+      StableHLO_Dims:$offsetDims,
+      StableHLO_Dims:$collapsedSliceDims,
+      StableHLO_Dims:$startIndexMap,
       "int64_t":$indexVectorDim
   );
   let hasCustomAssemblyFormat = 1;
@@ -56,10 +56,10 @@ def StableHLO_DotDimensionNumbers : AttrDef<StableHLO_Dialect, "DotDimensionNumb
   let mnemonic = "dot";
   let summary = "Attribute that models the dimension information for dot.";
   let parameters = (ins
-      StableHLO_Dim:$lhsBatchingDimensions,
-      StableHLO_Dim:$rhsBatchingDimensions,
-      StableHLO_Dim:$lhsContractingDimensions,
-      StableHLO_Dim:$rhsContractingDimensions
+      StableHLO_Dims:$lhsBatchingDimensions,
+      StableHLO_Dims:$rhsBatchingDimensions,
+      StableHLO_Dims:$lhsContractingDimensions,
+      StableHLO_Dims:$rhsContractingDimensions
   );
   let hasCustomAssemblyFormat = 1;
 }
@@ -97,9 +97,9 @@ def OutputOperandAlias : AttrDef<StableHLO_Dialect, "OutputOperandAlias"> {
     ```
   }];
   let parameters = (ins
-    StableHLO_Dim:$outputTupleIndices,
+    StableHLO_Dims:$outputTupleIndices,
     "int64_t":$operandIndex,
-    StableHLO_Dim:$operandTupleIndices
+    StableHLO_Dims:$operandTupleIndices
   );
   let assemblyFormat = [{
     `<` `output_tuple_indices` `=` $outputTupleIndices `,`
@@ -133,9 +133,9 @@ def StableHLO_ArgResultAlias : AttrDef<StableHLO_Dialect, "ArgResultAlias"> {
     ```
   }];
   let parameters = (ins
-    StableHLO_Dim:$argTupleIndices,
+    StableHLO_Dims:$argTupleIndices,
     "int64_t":$resultIndex,
-    StableHLO_Dim:$resultTupleIndices,
+    StableHLO_Dims:$resultTupleIndices,
     "bool":$isMustAlias
   );
   let hasCustomAssemblyFormat = 1;
@@ -175,7 +175,7 @@ def StableHLO_TypeExtensions : AttrDef<StableHLO_Dialect, "TypeExtensions", [
 
     See `HLO_BoundedAttrInterface` for documentation for `bounds`.
   }];
-  let assemblyFormat = "`<` `bounds` `=` custom<DynamicShape>($bounds) `>`";
+  let assemblyFormat = "`<` `bounds` `=` ` ` custom<DimensionSizes>($bounds) `>`";
 }
 
 // A layout attribute (1D tensor of index type)
@@ -218,15 +218,15 @@ def StableHLO_ConvDimensionNumbers : AttrDef<StableHLO_Dialect, "ConvDimensionNu
   let parameters = (ins
     "int64_t":$inputBatchDimension,
     "int64_t":$inputFeatureDimension,
-    StableHLO_Dim:$inputSpatialDimensions,
+    StableHLO_Dims:$inputSpatialDimensions,
 
     "int64_t":$kernelInputFeatureDimension,
     "int64_t":$kernelOutputFeatureDimension,
-    StableHLO_Dim:$kernelSpatialDimensions,
+    StableHLO_Dims:$kernelSpatialDimensions,
 
     "int64_t":$outputBatchDimension,
     "int64_t":$outputFeatureDimension,
-    StableHLO_Dim:$outputSpatialDimensions
+    StableHLO_Dims:$outputSpatialDimensions
   );
   let hasCustomAssemblyFormat = 1;
 }

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -4497,10 +4497,7 @@ void StablehloDialect::printAttribute(Attribute attr,
 
 static ParseResult parseDims(AsmParser& parser, SmallVector<int64_t>& dims) {
   dims.clear();
-  auto failOrDims = mlir::hlo::parseHloDim(parser);
-  if (failed(failOrDims)) return failure();
-  dims = *failOrDims;
-  return success();
+  return parseIntArray(parser, dims); 
 }
 
 static ParseResult parseDimsWithMinimumElements(AsmParser& parser,

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -76,9 +76,9 @@ limitations under the License.
 #include "stablehlo/dialect/TypeInference.h"
 
 // Include order matters
-using mlir::hlo::parseDynamicShape;
+using mlir::hlo::parseDimensionSizes;
 using mlir::hlo::parseIntArray;
-using mlir::hlo::printDynamicShape;
+using mlir::hlo::printDimensionSizes;
 using mlir::hlo::printIntArray;
 #include "stablehlo/dialect/StablehloEnums.cpp.inc"
 #define GET_ATTRDEF_CLASSES

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -76,10 +76,10 @@ limitations under the License.
 #include "stablehlo/dialect/TypeInference.h"
 
 // Include order matters
-using mlir::hlo::printDynamicShape;
 using mlir::hlo::parseDynamicShape;
-using mlir::hlo::printIntArray;
 using mlir::hlo::parseIntArray;
+using mlir::hlo::printDynamicShape;
+using mlir::hlo::printIntArray;
 #include "stablehlo/dialect/StablehloEnums.cpp.inc"
 #define GET_ATTRDEF_CLASSES
 #include "stablehlo/dialect/StablehloAttrs.cpp.inc"
@@ -4497,7 +4497,7 @@ void StablehloDialect::printAttribute(Attribute attr,
 
 static ParseResult parseDims(AsmParser& parser, SmallVector<int64_t>& dims) {
   dims.clear();
-  return parseIntArray(parser, dims); 
+  return parseIntArray(parser, dims);
 }
 
 static ParseResult parseDimsWithMinimumElements(AsmParser& parser,
@@ -4510,7 +4510,6 @@ static ParseResult parseDimsWithMinimumElements(AsmParser& parser,
            << dims.size();
   return success();
 }
-
 
 /// Parse a custom attribute that resembles a struct of the form
 /// <

--- a/stablehlo/dialect/StablehloOps.h
+++ b/stablehlo/dialect/StablehloOps.h
@@ -183,9 +183,6 @@ ParseResult parseWindowAttributes(OpAsmParser &parser,
                                   DenseIntElementsAttr &rhsDilation,
                                   DenseElementsAttr &windowReversal);
 
-// Print and parse IntArrays
-FailureOr<SmallVector<int64_t>> parseIntArray(AsmParser &parser);
-void printIntArray(AsmPrinter &printer, ArrayRef<int64_t> ints);
 }  // end namespace stablehlo
 }  // end namespace mlir
 

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -554,7 +554,7 @@ func.func @reduce_window(%arg0: tensor<4x2xf32>, %arg1: tensor<4x2xi32>,
 func.func @tensor_bounds(%arg0: tensor<3x5xf32>, %arg1: tensor<i32>) -> tensor<*xindex> {
   %result = "stablehlo.set_dimension_size"(%arg0, %arg1) {dimension = 0 : i64} : (tensor<3x5xf32>, tensor<i32>) -> tensor<*xf32>
 
-  // CHECK: types0 = tensor<?x5xf32, #stablehlo.type_extensions<bounds = [3, -1]>>
+  // CHECK: types0 = tensor<?x5xf32, #stablehlo.type_extensions<bounds = [3, ?]>>
   %1 = "hlo_test_infer.get_return_types"(%result) : (tensor<*xf32>) -> tensor<*xindex>
   func.return %1 : tensor<*xindex>
 }
@@ -562,9 +562,9 @@ func.func @tensor_bounds(%arg0: tensor<3x5xf32>, %arg1: tensor<i32>) -> tensor<*
 // -----
 
 // CHECK-LABEL: @static_tensor_bounds
-func.func @static_tensor_bounds(%arg0: tensor<?x5xf32, #stablehlo.type_extensions<bounds = [8, -1]>>) -> tensor<*xindex> {
+func.func @static_tensor_bounds(%arg0: tensor<?x5xf32, #stablehlo.type_extensions<bounds = [8, ?]>>) -> tensor<*xindex> {
   %bounds = stablehlo.constant dense<8> : tensor<i32>
-  %result = "stablehlo.set_dimension_size"(%arg0, %bounds) {dimension = 0 : i64} : (tensor<?x5xf32, #stablehlo.type_extensions<bounds = [8, -1]>>, tensor<i32>) -> tensor<*xf32>
+  %result = "stablehlo.set_dimension_size"(%arg0, %bounds) {dimension = 0 : i64} : (tensor<?x5xf32, #stablehlo.type_extensions<bounds = [8, ?]>>, tensor<i32>) -> tensor<*xf32>
 
   // CHECK: types0 = tensor<8x5xf32>
   %1 = "hlo_test_infer.get_return_types"(%result) : (tensor<*xf32>) -> tensor<*xindex>
@@ -574,8 +574,8 @@ func.func @static_tensor_bounds(%arg0: tensor<?x5xf32, #stablehlo.type_extension
 // -----
 
 // CHECK-LABEL: @edit_tensor_bounds
-func.func @edit_tensor_bounds(%arg0: tensor<?x5xf32, #stablehlo.type_extensions<bounds = [3, -1]>>, %arg1: tensor<i32>) -> tensor<*xindex> {
-  %result = "stablehlo.set_dimension_size"(%arg0, %arg1) {dimension = 1 : i64} : (tensor<?x5xf32, #stablehlo.type_extensions<bounds = [3, -1]>>, tensor<i32>) -> tensor<*xf32>
+func.func @edit_tensor_bounds(%arg0: tensor<?x5xf32, #stablehlo.type_extensions<bounds = [3, ?]>>, %arg1: tensor<i32>) -> tensor<*xindex> {
+  %result = "stablehlo.set_dimension_size"(%arg0, %arg1) {dimension = 1 : i64} : (tensor<?x5xf32, #stablehlo.type_extensions<bounds = [3, ?]>>, tensor<i32>) -> tensor<*xf32>
 
   // CHECK: types0 = tensor<?x?xf32, #stablehlo.type_extensions<bounds = [3, 5]>>
   %1 = "hlo_test_infer.get_return_types"(%result) : (tensor<*xf32>) -> tensor<*xindex>
@@ -585,10 +585,10 @@ func.func @edit_tensor_bounds(%arg0: tensor<?x5xf32, #stablehlo.type_extensions<
 // -----
 
 // CHECK-LABEL: @retain_tensor_bounds
-func.func @retain_tensor_bounds(%arg0: tensor<?x5xf32, #stablehlo.type_extensions<bounds = [3, -1]>>, %arg1: tensor<i32>) -> tensor<*xindex> {
-  %result = "stablehlo.set_dimension_size"(%arg0, %arg1) {dimension = 0 : i64} : (tensor<?x5xf32, #stablehlo.type_extensions<bounds = [3, -1]>>, tensor<i32>) -> tensor<*xf32>
+func.func @retain_tensor_bounds(%arg0: tensor<?x5xf32, #stablehlo.type_extensions<bounds = [3, ?]>>, %arg1: tensor<i32>) -> tensor<*xindex> {
+  %result = "stablehlo.set_dimension_size"(%arg0, %arg1) {dimension = 0 : i64} : (tensor<?x5xf32, #stablehlo.type_extensions<bounds = [3, ?]>>, tensor<i32>) -> tensor<*xf32>
 
-  // CHECK: types0 = tensor<?x5xf32, #stablehlo.type_extensions<bounds = [3, -1]>>
+  // CHECK: types0 = tensor<?x5xf32, #stablehlo.type_extensions<bounds = [3, ?]>>
   %1 = "hlo_test_infer.get_return_types"(%result) : (tensor<*xf32>) -> tensor<*xindex>
   func.return %1 : tensor<*xindex>
 }
@@ -596,10 +596,10 @@ func.func @retain_tensor_bounds(%arg0: tensor<?x5xf32, #stablehlo.type_extension
 // -----
 
 // CHECK-LABEL: @unknown_bounds
-func.func @unknown_bounds(%arg0: tensor<?x?xf32, #stablehlo.type_extensions<bounds = [3, -1]>>, %arg1: tensor<i32>) -> tensor<*xindex> {
-  %result = "stablehlo.set_dimension_size"(%arg0, %arg1) {dimension = 1 : i64} : (tensor<?x?xf32, #stablehlo.type_extensions<bounds = [3, -1]>>, tensor<i32>) -> tensor<*xf32>
+func.func @unknown_bounds(%arg0: tensor<?x?xf32, #stablehlo.type_extensions<bounds = [3, ?]>>, %arg1: tensor<i32>) -> tensor<*xindex> {
+  %result = "stablehlo.set_dimension_size"(%arg0, %arg1) {dimension = 1 : i64} : (tensor<?x?xf32, #stablehlo.type_extensions<bounds = [3, ?]>>, tensor<i32>) -> tensor<*xf32>
 
-  // CHECK: types0 = tensor<?x?xf32, #stablehlo.type_extensions<bounds = [3, -1]>>
+  // CHECK: types0 = tensor<?x?xf32, #stablehlo.type_extensions<bounds = [3, ?]>>
   %1 = "hlo_test_infer.get_return_types"(%result) : (tensor<*xf32>) -> tensor<*xindex>
   func.return %1 : tensor<*xindex>
 }
@@ -622,21 +622,21 @@ func.func @unranked_input(%arg0: tensor<*xf32>, %arg1: tensor<i32>) -> tensor<*x
 // See PairwiseSameOperandAndResultType::inferDimWithBound()
 // CHECK-LABEL: @add_bounds
 func.func @add_bounds(
-  %arg0: tensor<3x3x3x?x?x?x?xf32, #stablehlo.type_extensions<bounds = [-1, -1, -1, -1, -1, 3, 3]>>,
-  %arg1: tensor<3x?x?x?x?x?x?xf32, #stablehlo.type_extensions<bounds = [-1, -1, 4, -1, 3, 3, 4]>>) -> tensor<*xindex> {
+  %arg0: tensor<3x3x3x?x?x?x?xf32, #stablehlo.type_extensions<bounds = [?, ?, ?, ?, ?, 3, 3]>>,
+  %arg1: tensor<3x?x?x?x?x?x?xf32, #stablehlo.type_extensions<bounds = [?, ?, 4, ?, 3, 3, 4]>>) -> tensor<*xindex> {
   %result1 = "stablehlo.add"(%arg0, %arg1) : (
-    tensor<3x3x3x?x?x?x?xf32, #stablehlo.type_extensions<bounds = [-1, -1, -1, -1, -1, 3, 3]>>,
-    tensor<3x?x?x?x?x?x?xf32, #stablehlo.type_extensions<bounds = [-1, -1, 4, -1, 3, 3, 4]>>)
+    tensor<3x3x3x?x?x?x?xf32, #stablehlo.type_extensions<bounds = [?, ?, ?, ?, ?, 3, 3]>>,
+    tensor<3x?x?x?x?x?x?xf32, #stablehlo.type_extensions<bounds = [?, ?, 4, ?, 3, 3, 4]>>)
     -> tensor<?x?x?x?x?x?x?xf32>
   %result2 = "stablehlo.add"(%arg1, %arg0) : (
-    tensor<3x?x?x?x?x?x?xf32, #stablehlo.type_extensions<bounds = [-1, -1, 4, -1, 3, 3, 4]>>,
-    tensor<3x3x3x?x?x?x?xf32, #stablehlo.type_extensions<bounds = [-1, -1, -1, -1, -1, 3, 3]>>)
+    tensor<3x?x?x?x?x?x?xf32, #stablehlo.type_extensions<bounds = [?, ?, 4, ?, 3, 3, 4]>>,
+    tensor<3x3x3x?x?x?x?xf32, #stablehlo.type_extensions<bounds = [?, ?, ?, ?, ?, 3, 3]>>)
     -> tensor<?x?x?x?x?x?x?xf32>
 
-  // CHECK: types0 = tensor<3x3x3x?x?x?x?xf32, #stablehlo.type_extensions<bounds = [-1, -1, -1, -1, 3, 3, 3]>>
+  // CHECK: types0 = tensor<3x3x3x?x?x?x?xf32, #stablehlo.type_extensions<bounds = [?, ?, ?, ?, 3, 3, 3]>>
   %1 = "hlo_test_infer.get_return_types"(%result1) : (tensor<?x?x?x?x?x?x?xf32>) -> tensor<*xindex>
 
-  // CHECK: types0 = tensor<3x3x3x?x?x?x?xf32, #stablehlo.type_extensions<bounds = [-1, -1, -1, -1, 3, 3, 3]>>
+  // CHECK: types0 = tensor<3x3x3x?x?x?x?xf32, #stablehlo.type_extensions<bounds = [?, ?, ?, ?, 3, 3, 3]>>
   %2 = "hlo_test_infer.get_return_types"(%result2) : (tensor<?x?x?x?x?x?x?xf32>) -> tensor<*xindex>
   func.return %1 : tensor<*xindex>
 }
@@ -646,11 +646,11 @@ func.func @add_bounds(
 // This test covers "Error out" case for type inference of binary op with bounds
 // See PairwiseSameOperandAndResultType::inferDimWithBound()
 func.func @add_bounds_mismatch(
-  %arg0: tensor<3xf32, #stablehlo.type_extensions<bounds = [-1]>>,
+  %arg0: tensor<3xf32, #stablehlo.type_extensions<bounds = [?]>>,
   %arg1: tensor<?xf32, #stablehlo.type_extensions<bounds = [2]>>) -> tensor<*xindex> {
   // expected-error@+1 {{requires compatible types for all operands and results}}
   %result = "stablehlo.add"(%arg0, %arg1) : (
-    tensor<3xf32, #stablehlo.type_extensions<bounds = [-1]>>,
+    tensor<3xf32, #stablehlo.type_extensions<bounds = [?]>>,
     tensor<?xf32, #stablehlo.type_extensions<bounds = [2]>>) -> tensor<?xf32>
   %1 = "hlo_test_infer.get_return_types"(%result) : (tensor<?xf32>) -> tensor<*xindex>
   func.return %1 : tensor<*xindex>
@@ -682,10 +682,10 @@ func.func @transpose(%arg0: tensor<1x2x3x4xi32>) -> tensor<*xindex> {
 // -----
 
 // CHECK-LABEL: func @transpose_with_bounds
-func.func @transpose_with_bounds(%arg0: tensor<?x2x?x4xi32, #stablehlo.type_extensions<bounds = [1, -1, 3, -1]>>) -> tensor<*xindex> {
-  %0 = "stablehlo.transpose"(%arg0) {permutation = dense<[1, 0, 3, 2]> : tensor<4xi64>} : (tensor<?x2x?x4xi32, #stablehlo.type_extensions<bounds = [1, -1, 3, -1]>>) -> tensor<*xi32>
+func.func @transpose_with_bounds(%arg0: tensor<?x2x?x4xi32, #stablehlo.type_extensions<bounds = [1, ?, 3, ?]>>) -> tensor<*xindex> {
+  %0 = "stablehlo.transpose"(%arg0) {permutation = dense<[1, 0, 3, 2]> : tensor<4xi64>} : (tensor<?x2x?x4xi32, #stablehlo.type_extensions<bounds = [1, ?, 3, ?]>>) -> tensor<*xi32>
 
-  // CHECK: types0 = tensor<2x?x4x?xi32, #stablehlo.type_extensions<bounds = [-1, 1, -1, 3]>>
+  // CHECK: types0 = tensor<2x?x4x?xi32, #stablehlo.type_extensions<bounds = [?, 1, ?, 3]>>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xi32>) -> tensor<*xindex>
   func.return %1 : tensor<*xindex>
 }
@@ -693,8 +693,8 @@ func.func @transpose_with_bounds(%arg0: tensor<?x2x?x4xi32, #stablehlo.type_exte
 // -----
 
 // CHECK-LABEL: func @slice_with_bounds
-func.func @slice_with_bounds(%arg0: tensor<3x?x?xi32, #stablehlo.type_extensions<bounds = [-1, 4, -1]>>) -> tensor<*xindex> {
-  %0 = "stablehlo.slice"(%arg0) {start_indices = dense<[1, 0, 0]> : tensor<3xi64>, limit_indices = dense<[2, 4, 4]> : tensor<3xi64>, strides = dense<[1, 2, 2]> : tensor<3xi64>} : (tensor<3x?x?xi32, #stablehlo.type_extensions<bounds = [-1, 4, -1]>>) -> tensor<*xi32>
+func.func @slice_with_bounds(%arg0: tensor<3x?x?xi32, #stablehlo.type_extensions<bounds = [?, 4, ?]>>) -> tensor<*xindex> {
+  %0 = "stablehlo.slice"(%arg0) {start_indices = dense<[1, 0, 0]> : tensor<3xi64>, limit_indices = dense<[2, 4, 4]> : tensor<3xi64>, strides = dense<[1, 2, 2]> : tensor<3xi64>} : (tensor<3x?x?xi32, #stablehlo.type_extensions<bounds = [?, 4, ?]>>) -> tensor<*xi32>
   // CHECK: types0 = tensor<1x2x2xi32>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xi32>) -> tensor<*xindex>
   func.return %1 : tensor<*xindex>
@@ -702,9 +702,9 @@ func.func @slice_with_bounds(%arg0: tensor<3x?x?xi32, #stablehlo.type_extensions
 
 // -----
 
-func.func @slice_with_index_larger_than_bound_dim(%arg0: tensor<3x?x?xi32, #stablehlo.type_extensions<bounds = [-1, 4, -1]>>) -> tensor<*xindex> {
+func.func @slice_with_index_larger_than_bound_dim(%arg0: tensor<3x?x?xi32, #stablehlo.type_extensions<bounds = [?, 4, ?]>>) -> tensor<*xindex> {
   // expected-error@+1 {{limit index 5 is larger than dimension bound 4 in dimension 1}}
-  %0 = "stablehlo.slice"(%arg0) {start_indices = dense<[1, 0, 0]> : tensor<3xi64>, limit_indices = dense<[2, 5, 4]> : tensor<3xi64>, strides = dense<[1, 2, 2]> : tensor<3xi64>} : (tensor<3x?x?xi32, #stablehlo.type_extensions<bounds = [-1, 4, -1]>>) -> tensor<*xi32>
+  %0 = "stablehlo.slice"(%arg0) {start_indices = dense<[1, 0, 0]> : tensor<3xi64>, limit_indices = dense<[2, 5, 4]> : tensor<3xi64>, strides = dense<[1, 2, 2]> : tensor<3xi64>} : (tensor<3x?x?xi32, #stablehlo.type_extensions<bounds = [?, 4, ?]>>) -> tensor<*xi32>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xi32>) -> tensor<*xindex>
   func.return %1 : tensor<*xindex>
 }
@@ -712,26 +712,26 @@ func.func @slice_with_index_larger_than_bound_dim(%arg0: tensor<3x?x?xi32, #stab
 // -----
 
 // CHECK-LABEL: @pad_with_bounds
-func.func @pad_with_bounds(%arg0: tensor<3x?x?xf16, #stablehlo.type_extensions<bounds = [-1, 3, -1]>>, %arg1: tensor<f16>) -> tensor<*xindex> {
+func.func @pad_with_bounds(%arg0: tensor<3x?x?xf16, #stablehlo.type_extensions<bounds = [?, 3, ?]>>, %arg1: tensor<f16>) -> tensor<*xindex> {
   %0 = "stablehlo.pad"(%arg0, %arg1) {
     edge_padding_low = dense<[2, 2, 0]> : tensor<3xi64>,
     edge_padding_high = dense<[0, 0, 0]> : tensor<3xi64>,
     interior_padding = dense<[1, 1, 1]> : tensor<3xi64>
-  } : (tensor<3x?x?xf16, #stablehlo.type_extensions<bounds = [-1, 3, -1]>>, tensor<f16>) -> tensor<*xf16>
+  } : (tensor<3x?x?xf16, #stablehlo.type_extensions<bounds = [?, 3, ?]>>, tensor<f16>) -> tensor<*xf16>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xf16>) -> tensor<*xindex>
-  // CHECK: types0 = tensor<7x?x?xf16, #stablehlo.type_extensions<bounds = [-1, 7, -1]>>
+  // CHECK: types0 = tensor<7x?x?xf16, #stablehlo.type_extensions<bounds = [?, 7, ?]>>
   func.return %1 : tensor<*xindex>
 }
 
 // -----
 
-func.func @pad_with_negative_inferred_bounds(%arg0: tensor<3x?x?xf16, #stablehlo.type_extensions<bounds = [-1, 3, -1]>>, %arg1: tensor<f16>) -> tensor<*xindex> {
+func.func @pad_with_negative_inferred_bounds(%arg0: tensor<3x?x?xf16, #stablehlo.type_extensions<bounds = [?, 3, ?]>>, %arg1: tensor<f16>) -> tensor<*xindex> {
   // expected-error@+1 {{Padding result in negative bound for dimension 1}}
   %0 = "stablehlo.pad"(%arg0, %arg1) {
     edge_padding_low = dense<[2, -10, 0]> : tensor<3xi64>,
     edge_padding_high = dense<[0, 0, 0]> : tensor<3xi64>,
     interior_padding = dense<[1, 1, 1]> : tensor<3xi64>
-  } : (tensor<3x?x?xf16, #stablehlo.type_extensions<bounds = [-1, 3, -1]>>, tensor<f16>) -> tensor<*xf16>
+  } : (tensor<3x?x?xf16, #stablehlo.type_extensions<bounds = [?, 3, ?]>>, tensor<f16>) -> tensor<*xf16>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xf16>) -> tensor<*xindex>
   func.return %1 : tensor<*xindex>
 }
@@ -750,11 +750,11 @@ func.func @pad_with_negative_inferred_bounds(%arg0: tensor<3x?x?xf16, #stablehlo
 
 // CHECK-LABEL: @concat_bounds_c0
 func.func @concat_bounds_c0(
-  %arg0: tensor<5x1xi32, #stablehlo.type_extensions<bounds = [-1, -1]>>, 
-  %arg1: tensor<5x2xi32, #stablehlo.type_extensions<bounds = [-1, -1]>>)  -> tensor<*xindex> {
+  %arg0: tensor<5x1xi32, #stablehlo.type_extensions<bounds = [?, ?]>>, 
+  %arg1: tensor<5x2xi32, #stablehlo.type_extensions<bounds = [?, ?]>>)  -> tensor<*xindex> {
   %result = "stablehlo.concatenate"(%arg0, %arg1) { dimension = 1 : i64 } : (
-    tensor<5x1xi32, #stablehlo.type_extensions<bounds = [-1, -1]>>, 
-    tensor<5x2xi32, #stablehlo.type_extensions<bounds = [-1, -1]>>) -> tensor<?x?xi32>
+    tensor<5x1xi32, #stablehlo.type_extensions<bounds = [?, ?]>>, 
+    tensor<5x2xi32, #stablehlo.type_extensions<bounds = [?, ?]>>) -> tensor<?x?xi32>
   // CHECK: types0 = tensor<5x3xi32>
   %1 = "hlo_test_infer.get_return_types"(%result) : (tensor<?x?xi32>) -> tensor<*xindex> 
   func.return %1 : tensor<*xindex>
@@ -764,17 +764,17 @@ func.func @concat_bounds_c0(
 
 // CHECK-LABEL: @concat_bounds_c1
 func.func @concat_bounds_c1(
-  %arg0: tensor<5x2xi32, #stablehlo.type_extensions<bounds = [-1, -1]>>, 
-  %arg1: tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, -1]>>)  -> tensor<*xindex> {
+  %arg0: tensor<5x2xi32, #stablehlo.type_extensions<bounds = [?, ?]>>, 
+  %arg1: tensor<5x?xi32, #stablehlo.type_extensions<bounds = [?, ?]>>)  -> tensor<*xindex> {
   %result = "stablehlo.concatenate"(%arg0, %arg1) { dimension = 1 : i64 } : (
-    tensor<5x2xi32, #stablehlo.type_extensions<bounds = [-1, -1]>>, 
-    tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, -1]>>) -> tensor<?x?xi32>
+    tensor<5x2xi32, #stablehlo.type_extensions<bounds = [?, ?]>>, 
+    tensor<5x?xi32, #stablehlo.type_extensions<bounds = [?, ?]>>) -> tensor<?x?xi32>
   // CHECK: types0 = tensor<5x?xi32>
   %1 = "hlo_test_infer.get_return_types"(%result) : (tensor<?x?xi32>) -> tensor<*xindex> 
 
   %result_swap = "stablehlo.concatenate"(%arg1, %arg0) { dimension = 1 : i64 } : (
-    tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, -1]>>, 
-    tensor<5x2xi32, #stablehlo.type_extensions<bounds = [-1, -1]>>) -> tensor<?x?xi32>
+    tensor<5x?xi32, #stablehlo.type_extensions<bounds = [?, ?]>>, 
+    tensor<5x2xi32, #stablehlo.type_extensions<bounds = [?, ?]>>) -> tensor<?x?xi32>
   // CHECK: types0 = tensor<5x?xi32>
   %2 = "hlo_test_infer.get_return_types"(%result_swap) : (tensor<?x?xi32>) -> tensor<*xindex> 
 
@@ -785,18 +785,18 @@ func.func @concat_bounds_c1(
 
 // CHECK-LABEL: @concat_bounds_c2
 func.func @concat_bounds_c2(
-  %arg0: tensor<5x2xi32, #stablehlo.type_extensions<bounds = [-1, -1]>>, 
-  %arg1: tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, 4]>>)  -> tensor<*xindex> {
+  %arg0: tensor<5x2xi32, #stablehlo.type_extensions<bounds = [?, ?]>>, 
+  %arg1: tensor<5x?xi32, #stablehlo.type_extensions<bounds = [?, 4]>>)  -> tensor<*xindex> {
   %result = "stablehlo.concatenate"(%arg0, %arg1) { dimension = 1 : i64 } : (
-    tensor<5x2xi32, #stablehlo.type_extensions<bounds = [-1, -1]>>, 
-    tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, 4]>>) -> tensor<?x?xi32>
-  // CHECK: types0 = tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, 6]>>
+    tensor<5x2xi32, #stablehlo.type_extensions<bounds = [?, ?]>>, 
+    tensor<5x?xi32, #stablehlo.type_extensions<bounds = [?, 4]>>) -> tensor<?x?xi32>
+  // CHECK: types0 = tensor<5x?xi32, #stablehlo.type_extensions<bounds = [?, 6]>>
   %1 = "hlo_test_infer.get_return_types"(%result) : (tensor<?x?xi32>) -> tensor<*xindex> 
 
   %result_swap = "stablehlo.concatenate"(%arg1, %arg0) { dimension = 1 : i64 } : (
-    tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, 4]>>, 
-    tensor<5x2xi32, #stablehlo.type_extensions<bounds = [-1, -1]>>) -> tensor<?x?xi32>
-  // CHECK: types0 = tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, 6]>>
+    tensor<5x?xi32, #stablehlo.type_extensions<bounds = [?, 4]>>, 
+    tensor<5x2xi32, #stablehlo.type_extensions<bounds = [?, ?]>>) -> tensor<?x?xi32>
+  // CHECK: types0 = tensor<5x?xi32, #stablehlo.type_extensions<bounds = [?, 6]>>
   %2 = "hlo_test_infer.get_return_types"(%result_swap) : (tensor<?x?xi32>) -> tensor<*xindex> 
 
   func.return %1 : tensor<*xindex>
@@ -806,11 +806,11 @@ func.func @concat_bounds_c2(
 
 // CHECK-LABEL: @concat_bounds_c3
 func.func @concat_bounds_c3(
-  %arg0: tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, -1]>>, 
-  %arg1: tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, -1]>>)  -> tensor<*xindex> {
+  %arg0: tensor<5x?xi32, #stablehlo.type_extensions<bounds = [?, ?]>>, 
+  %arg1: tensor<5x?xi32, #stablehlo.type_extensions<bounds = [?, ?]>>)  -> tensor<*xindex> {
   %result = "stablehlo.concatenate"(%arg0, %arg1) { dimension = 1 : i64 } : (
-    tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, -1]>>, 
-    tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, -1]>>) -> tensor<?x?xi32>
+    tensor<5x?xi32, #stablehlo.type_extensions<bounds = [?, ?]>>, 
+    tensor<5x?xi32, #stablehlo.type_extensions<bounds = [?, ?]>>) -> tensor<?x?xi32>
   // CHECK: types0 = tensor<5x?xi32>
   %1 = "hlo_test_infer.get_return_types"(%result) : (tensor<?x?xi32>) -> tensor<*xindex> 
   func.return %1 : tensor<*xindex>
@@ -820,17 +820,17 @@ func.func @concat_bounds_c3(
 
 // CHECK-LABEL: @concat_bounds_c4
 func.func @concat_bounds_c4(
-  %arg0: tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, -1]>>, 
-  %arg1: tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, 4]>>)  -> tensor<*xindex> {
+  %arg0: tensor<5x?xi32, #stablehlo.type_extensions<bounds = [?, ?]>>, 
+  %arg1: tensor<5x?xi32, #stablehlo.type_extensions<bounds = [?, 4]>>)  -> tensor<*xindex> {
   %result = "stablehlo.concatenate"(%arg0, %arg1) { dimension = 1 : i64 } : (
-    tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, -1]>>, 
-    tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, 4]>>) -> tensor<?x?xi32>
+    tensor<5x?xi32, #stablehlo.type_extensions<bounds = [?, ?]>>, 
+    tensor<5x?xi32, #stablehlo.type_extensions<bounds = [?, 4]>>) -> tensor<?x?xi32>
   // CHECK: types0 = tensor<5x?xi32>
   %1 = "hlo_test_infer.get_return_types"(%result) : (tensor<?x?xi32>) -> tensor<*xindex> 
 
   %result_swap = "stablehlo.concatenate"(%arg1, %arg0) { dimension = 1 : i64 } : (
-    tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, 4]>>, 
-    tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, -1]>>) -> tensor<?x?xi32>
+    tensor<5x?xi32, #stablehlo.type_extensions<bounds = [?, 4]>>, 
+    tensor<5x?xi32, #stablehlo.type_extensions<bounds = [?, ?]>>) -> tensor<?x?xi32>
   // CHECK: types0 = tensor<5x?xi32>
   %2 = "hlo_test_infer.get_return_types"(%result_swap) : (tensor<?x?xi32>) -> tensor<*xindex> 
 
@@ -841,12 +841,12 @@ func.func @concat_bounds_c4(
 
 // CHECK-LABEL: @concat_bounds_c5
 func.func @concat_bounds_c5(
-  %arg0: tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, 3]>>, 
-  %arg1: tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, 4]>>)  -> tensor<*xindex> {
+  %arg0: tensor<5x?xi32, #stablehlo.type_extensions<bounds = [?, 3]>>, 
+  %arg1: tensor<5x?xi32, #stablehlo.type_extensions<bounds = [?, 4]>>)  -> tensor<*xindex> {
   %result = "stablehlo.concatenate"(%arg0, %arg1) { dimension = 1 : i64 } : (
-    tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, 3]>>, 
-    tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, 4]>>) -> tensor<?x?xi32>
-  // CHECK: types0 = tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, 7]>>
+    tensor<5x?xi32, #stablehlo.type_extensions<bounds = [?, 3]>>, 
+    tensor<5x?xi32, #stablehlo.type_extensions<bounds = [?, 4]>>) -> tensor<?x?xi32>
+  // CHECK: types0 = tensor<5x?xi32, #stablehlo.type_extensions<bounds = [?, 7]>>
   %1 = "hlo_test_infer.get_return_types"(%result) : (tensor<?x?xi32>) -> tensor<*xindex> 
   func.return %1 : tensor<*xindex>
 }
@@ -861,11 +861,11 @@ func.func @concat_bounds_c5(
 // CHECK-LABEL: @concat_bounds_unranked_c0
 func.func @concat_bounds_unranked_c0(
   %arg0: tensor<*xi32>, 
-  %arg1: tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, 4]>>)  -> tensor<*xindex> {
+  %arg1: tensor<5x?xi32, #stablehlo.type_extensions<bounds = [?, 4]>>)  -> tensor<*xindex> {
   %result = "stablehlo.concatenate"(%arg0, %arg1) { dimension = 0 : i64 } : (
     tensor<*xi32>, 
-    tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, 4]>>) -> tensor<5x?xi32>
-  // CHECK: types0 = tensor<?x?xi32, #stablehlo.type_extensions<bounds = [-1, 4]>>
+    tensor<5x?xi32, #stablehlo.type_extensions<bounds = [?, 4]>>) -> tensor<5x?xi32>
+  // CHECK: types0 = tensor<?x?xi32, #stablehlo.type_extensions<bounds = [?, 4]>>
   %1 = "hlo_test_infer.get_return_types"(%result) : (tensor<5x?xi32>) -> tensor<*xindex> 
   func.return %1 : tensor<*xindex>
 }
@@ -875,10 +875,10 @@ func.func @concat_bounds_unranked_c0(
 // CHECK-LABEL: @concat_bounds_unranked_c1
 func.func @concat_bounds_unranked_c1(
   %arg0: tensor<*xi32>, 
-  %arg1: tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, 4]>>)  -> tensor<*xindex> {
+  %arg1: tensor<5x?xi32, #stablehlo.type_extensions<bounds = [?, 4]>>)  -> tensor<*xindex> {
   %result = "stablehlo.concatenate"(%arg0, %arg1) { dimension = 1 : i64 } : (
     tensor<*xi32>, 
-    tensor<5x?xi32, #stablehlo.type_extensions<bounds = [-1, 4]>>) -> tensor<5x?xi32>
+    tensor<5x?xi32, #stablehlo.type_extensions<bounds = [?, 4]>>) -> tensor<5x?xi32>
   // CHECK: types0 = tensor<5x?xi32>
   %1 = "hlo_test_infer.get_return_types"(%result) : (tensor<5x?xi32>) -> tensor<*xindex> 
   func.return %1 : tensor<*xindex>

--- a/stablehlo/tests/print_stablehlo.mlir
+++ b/stablehlo/tests/print_stablehlo.mlir
@@ -268,10 +268,10 @@ func.func @fft_op(%arg0: tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>> {
 }
 
 // CHECK-LABEL: func @extensions
-func.func @extensions(%arg0 : tensor<?x?xf32, #stablehlo.type_extensions<bounds = [3, -1]>>,
+func.func @extensions(%arg0 : tensor<?x?xf32, #stablehlo.type_extensions<bounds = [3, ?]>>,
                 %arg1 : tensor<i32>) -> () {
-  // CHECK:      %0 = stablehlo.set_dimension_size %arg0, %arg1, dim = 1 : (tensor<?x?xf32, #stablehlo.type_extensions<bounds = [3, -1]>>, tensor<i32>) -> tensor<*xf32>
-  %0 = "stablehlo.set_dimension_size"(%arg0, %arg1) {dimension = 1 : i64} : (tensor<?x?xf32, #stablehlo.type_extensions<bounds = [3, -1]>>, tensor<i32>) -> tensor<*xf32>
+  // CHECK:      %0 = stablehlo.set_dimension_size %arg0, %arg1, dim = 1 : (tensor<?x?xf32, #stablehlo.type_extensions<bounds = [3, ?]>>, tensor<i32>) -> tensor<*xf32>
+  %0 = "stablehlo.set_dimension_size"(%arg0, %arg1) {dimension = 1 : i64} : (tensor<?x?xf32, #stablehlo.type_extensions<bounds = [3, ?]>>, tensor<i32>) -> tensor<*xf32>
   "stablehlo.return"() : () -> ()
 }
 


### PR DESCRIPTION
- Migrate unknown dimension printing `printDimensionSizes`.
- Move `parseIntArray` to `AssemblyFormat.h` to be shared.

This unblocks work to make a few other attributes declarative. Also opens the door to make some printing infrastructure communal between MHLO/StableHLO. Will look into removing `parseDims` today.