### PR TITLE
Add spec for CollectivePermuteOp

### DIFF
--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -1565,7 +1565,6 @@ The operation splits the StableHLO grid into `process_groups` as follows:
 Afterwards, `result@process` is given by:
 
  * `operand@process_groups[i, 0]`, if there exists an `i` such that `process_groups[i, 1] = process`.
- * `[0, ..., 0]`, otherwise.
  * `broadcast_in_dim(0, [], shape(result))`, otherwise.
 
 ### Inputs
@@ -1587,8 +1586,8 @@ Afterwards, `result@process` is given by:
   * (C1) dim(`source_target_pairs`, 1) $=$ 2.
   * (C2) All values in `source_target_pairs[:, 0]` are unique.
   * (C3) All values in `source_target_pairs[:, 1]` are unique.
-  * (C4) $0 \ge$ source_target_pairs[i][0], source_target_pairs[i][1] $\lt N$,
-         where $N$ is given by
+  * (C4) $0 \le$ source_target_pairs[i][0], source_target_pairs[i][1] $\lt N$,
+         where $N$ depends on the process grouping strategy:
     * If `cross_replica`, `num_replicas`.
     * If `cross_partition`, `num_partitions`.
   * (C5) type(`result`) $=$ type(`operand`).

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -1555,9 +1555,9 @@ The operation splits the StableHLO grid into `process_groups` as follows:
   * `channel_id > 0`,
     `cross_partition(replica_groups)`.
 
-Afterwards, `result@receiver` is given by
- * `operand@process_groups[i][0]`, if there exist an `i` such that  `process_groups[i][1] = receiver`.
- * `result@receiver = T, otherwise, # where T is a zero valued tensor constant with type(T) = type(operand)`, otherwise.
+Afterwards, `result@target` is given by
+ * `operand@process_groups[i][0]`, if there exist an `i` such that  `process_groups[i][1] = target`.
+ * `result@target = T, otherwise, # where T is a zero valued tensor constant with type(T) = type(operand)`, otherwise.
 
 ### Inputs
 
@@ -1576,8 +1576,8 @@ Afterwards, `result@receiver` is given by
 ### Constraints
 
   * (C1) dim(`source_target_pairs`, 1) $=$ 2.
-  * (C2) All memmbers of { `source_target_pairs`[i][0] : i $\in$ [0, dim(`source_target_pairs`, 0)) } are unique.
-  * (C3) All memmbers of { `source_target_pairs`[i][1] : i $\in$ [0, dim(`source_target_pairs`, 0)) } are unique.
+  * (C2) All members of { `source_target_pairs`[i][0] : i $\in$ [0, dim(`source_target_pairs`, 0)) } are unique.
+  * (C3) All members of { `source_target_pairs`[i][1] : i $\in$ [0, dim(`source_target_pairs`, 0)) } are unique.
   * (C4) $0 \gt$ source_target_pairs[i][0], source_target_pairs[i][1] $\lt N$,
          where $N$ is given by
     * `num_replicas`, if `cross_replica`.

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -1546,94 +1546,26 @@ operations correspond to [stablehlo.minimum](#stablehlominimum) and
 
 ### Semantics
 
-Sends and receives data between source and target replica pairs mentioned in
-`source_target_pairs`.
+Within each process group in the StableHLO grid, sends and receives data between
+processes in the group.
 
-`channel_handle`, an optional input, is a handle given to a user to represent a
-communication channel between two computations via a
-[stablehlo.send](#stablehlosend) and [stablehlo.recv](#stablehlorecv)
-instruction pair or via collective instructions (e.g.
-[stablehlo.all_reduce](#stablehloall_reduce),
-[stablehlo.all_gather](#stablehloall_gather), etc.). It is represented using a
-`channel-id` and a `channel-type`. A `channel-id` is used for cross-partition
-communication: only operations with the same opcode and `channel-id` can
-communicate to each other. Non-positive `channel-id` is equivalent to no channel
-id. The `channel-type` is not relevant for this instruction.
+The operation splits the StableHLO grid into `process_groups` as follows:
+  * `channel_id <= 0`,
+    `cross_replica(replica_groups)`.
+  * `channel_id > 0`,
+    `cross_partition(replica_groups)`.
 
-In the instruction syntax, multiple pairs of source and target replica ids
-are grouped to form `source_target_pairs`.
-
-The execution of the operation involves logically partitioning each execution
-instance (`ei`) of `rid`, `pid` pair, henceforth referred to as `ei(rid, pid)`
-into groups. All the execution instances within a group can participate in the
-operation without getting interfered by execution instances from other groups.
-The number of groups represents the number of `stablehlo.collective_permute`
-operations executed in parallel.
-
-Given,
-  * `num_pids`: Number of partition ids
-  * `num_rids`: Number of replica ids
-  * `all_partions_ids`: { pid : pid $\in$ [0, `num_pids`) }
-  * `all_replica_ids`: { rid : rid $\in$ [0, `num_rids`) }
-  * `num_subgroup`: number of (source, target) pairs in `source_target_pairs`.
-
-The formation of groups is defined as follows:
-
-1. If `channel_handle` is not provided
-   * Number of groups formed: `num_subgroup` * `num_pids`.
-   * The formation of `groups` can be demonstrated, using Python-like syntax, as
-     follows:
-     ```python
-     all_partition_ids = [pid for pid in range(num_pids)]
-     groups = []
-
-     if len(source_target_pairs) != 0:
-       for source_target_pair in source_target_pairs:
-         for pid in all_partition_ids:
-           sub_group = []
-           for rid in source_target_pair:
-             sub_group.append(ei(rid, pid))
-           groups.append(sub_group)
-       return groups
-     ```
-    * For example, assuming `num_pids = 2` and `source_target_pairs = [[0, 2], [1, 3]]`:
-      `groups` formed: `[ei(0, 0), ei(2, 0)], [ei(0, 1), ei(2, 1)], [ei(1, 0), ei(3, 0)], and [ei(1, 1), ei(3, 1)]`.
-
-2. If `channel_handle` is provided
-   * Number of groups formed: num_rids * `num_subgroup`.
-   * The formation of `groups` can be demonstrated, using Python-like syntax, as
-     follows:
-     ```python
-
-     all_replica_ids = [rid for rid in range(num_rids)]
-     groups = []
-
-     if len(source_target_pairs) != 0:
-       for source_target_pair in source_target_pairs:
-         sub_group = []
-         for rid in all_replica_ids
-           # ids in the `source_target_pairs groups` are interpreted as partition ids.
-           for pid in source_target_pair:
-             sub_group.append(ei(rid, pid))
-           groups.append(sub_group)
-       return groups
-     ```
-    * For example, assuming `all_replica_ids = [0, 1]` and `partition_groups = [[0, 2], [1, 3]]`:
-      `groups` formed: `[ei(0, 0), ei(0, 2)], [ei(0, 1), ei(0, 3)], [ei(1, 0), ei(1, 2)], [ei(1, 1), ei(1, 3)]`
-
-For each group `[ei(rid1, pid1), ei(rid2, pid2)]` $\in$ `groups`, the `result`
-at `ei(rid2', pid2')` is given by `operand` at `ei(rid1, pid1)`. If an `ei(rid,
-pid)` is not a target in any group in `groups`, then the `result` on that
-execution isnatnce is a tensor consists of 0(s) with the same shape as the
-`operand`.
+Afterwards, `result@receiver` is given by
+ * `operand@process_groups[i][0]`, if there exist an `i` such that  `process_groups[i][1] = receiver`.
+ * `result@receiver = T, otherwise, # where T is a zero valued tensor constant with type(T) = type(operand)`, otherwise.
 
 ### Inputs
 
-| Name                  | Type                                                                                                                                                     |
-|-----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `operand`             | tensor of any supported type                                                                                                                             |
-| `source_target_pairs` | 2-dimensional tensor constant of type `si64`                                                                                                             |
-| `channel_handle`      | constant of type struct { `channel-id`: `si64`, `channel-type`: enum of `CHANNEL_TYPE_INVALID`, `DEVICE_TO_DEVICE`, `DEVICE_TO_HOST`, `HOST_TO_DEVICE` } |
+| Name                  | Type                                         |
+|-----------------------|----------------------------------------------|
+| `operand`             | tensor of any supported type                 |
+| `source_target_pairs` | 2-dimensional tensor constant of type `si64` |
+| `channel_id`          | constant of type `si64`                      |
 
 ### Outputs
 
@@ -1646,29 +1578,24 @@ execution isnatnce is a tensor consists of 0(s) with the same shape as the
   * (C1) dim(`source_target_pairs`, 1) $=$ 2.
   * (C2) All memmbers of { `source_target_pairs`[i][0] : i $\in$ [0, dim(`source_target_pairs`, 0)) } are unique.
   * (C3) All memmbers of { `source_target_pairs`[i][1] : i $\in$ [0, dim(`source_target_pairs`, 0)) } are unique.
-  * (C4) type(`result`) $=$ type(`operand`).
+  * (C4) $0 \gt$ source_target_pairs[i][0], source_target_pairs[i][1] $\lt N$,
+         where $N$ is given by
+    * `num_replicas`, if `cross_replica`.
+    * `num_partitions`, if `cross_partition`.
+  * (C5) type(`result`) $=$ type(`operand`).
 
 ### Examples
 
 ```mlir
-// %operand (at ei(0, 0)): [
-//                          [1, 2],
-//                          [5, 6]
-//                         ]
+// num_replicas: 2
+// num_partitions: 1
+// %operand@(0, 0): [[1, 2], [5, 6]]
 %result = "stablehlo.collective_permute"(%operand) {
   source_target_pairs = dense<[[0, 1]]> : tensor<2x2xi64>,
 } : (tensor<2x2xf32>) -> tensor<2x2xf32>
 //
-// Assuming num_pids = 1, a single group [ei(0, 0), ei(1, 0)] is formed.
-//
-// %result (at ei(0, 0)): [
-//                         [0, 0],
-//                         [0, 0]
-//                        ]
-// %result (at ei(1, 0)): [
-//                         [1, 2],
-//                         [5, 6]
-//                        ]
+// %result@(0, 0): [[0, 0], [0, 0]]
+// %result@(1, 0): [[1, 2], [5, 6]]
 ```
 
 [Back to Ops](#index-of-ops)

--- a/docs/status.md
+++ b/docs/status.md
@@ -61,7 +61,7 @@ one of the following tracking labels.
 | ceil                     | yes           | yes          | yes            | yes             | yes         |
 | cholesky                 | yes           | yes          | yes            | yes             | no          |
 | clamp                    | yes           | revisit      | yes            | yes             | no          |
-| collective_permute       | yes           | yes          | yes            | no              | no          |
+| collective_permute       | yes           | revisit      | yes            | no              | no          |
 | compare                  | yes           | yes          | yes            | yes             | no          |
 | complex                  | yes           | yes          | yes            | yes             | no          |
 | compute_reshape_shape    | no            | revisit      | no             | yes             | no          |

--- a/docs/status.md
+++ b/docs/status.md
@@ -61,7 +61,7 @@ one of the following tracking labels.
 | ceil                     | yes           | yes          | yes            | yes             | yes         |
 | cholesky                 | yes           | yes          | yes            | yes             | no          |
 | clamp                    | yes           | revisit      | yes            | yes             | no          |
-| collective_permute       | no            | revisit      | revisit        | no              | no          |
+| collective_permute       | yes           | yes          | yes            | no              | no          |
 | compare                  | yes           | yes          | yes            | yes             | no          |
 | complex                  | yes           | yes          | yes            | yes             | no          |
 | compute_reshape_shape    | no            | revisit      | no             | yes             | no          |

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -1470,6 +1470,10 @@ LogicalResult verifyCollectivePermuteSourceTargetPairs(
   llvm::DenseSet<int64_t> targets;
   for (auto i = attr.begin(), e = attr.end(); i != e; ++i) {
     auto val = (*i).getSExtValue();
+    if (val < 0)
+      return op->emitError()
+             << "replica ids in source_target_pairs must be >= 0.";
+
     if (i.getIndex() % 2 == 0) {
       bool isUnique = sources.insert(val).second;
       if (!isUnique) return op->emitError() << "duplicate sources not allowed.";

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -1456,7 +1456,7 @@ LogicalResult AbsOp::inferReturnTypes(
 // Verifies the source target pairs attached to collective permute.
 LogicalResult verifyCollectivePermuteSourceTargetPairs(
     Operation* op, DenseIntElementsAttr attr) {
-  auto type = attr.getType().dyn_cast<RankedTensorType>();
+  auto type = attr.getType().cast<RankedTensorType>();
   if (type.getRank() != 2)
     return op->emitError() << "expect source_target_pairs attribute to be of "
                               "rank 2, but got rank "

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1308,6 +1308,8 @@ def StableHLO_AllGatherOp : StableHLO_Op<"all_gather", [SameOperandsAndResultEle
     %result = "stablehlo.all_gather"(%operand) {
       all_gather_dim = 1 : i64,
       replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>
+      // channel_id = 0
+      channel_handle = #stablehlo.channel_handle<handle = 0, type = 0>,
       // use_global_device_ids = false
     } : (tensor<2x2xf32>) -> tensor<2x4xf32>
     ```
@@ -1343,6 +1345,9 @@ def StableHLO_AllReduceOp : StableHLO_Op<"all_reduce",
         stablehlo.return %0 : tensor<f32>
     }) {
       replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>
+      // channel_id = 0
+      channel_handle = #stablehlo.channel_handle<handle = 0, type = 0>
+      // use_global_device_ids = false
     } : (tensor<4xf32>) -> tensor<4xf32>
     ```
   }];
@@ -2000,8 +2005,9 @@ def StableHLO_CollectivePermuteOp: StableHLO_Op<"collective_permute",
     [HLO_CompatibleOperandsAndResultType]> {
   let summary = "CollectivePermute operator";
   let description = [{
-    Within each process group in the StableHLO grid, sends and receives data
-    between processes in the group.
+    Within each process group in the StableHLO grid, sends the value of the
+    `operand` tensor from the source process to the target process and produces
+    a `result` tensor.
 
     See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlocollective_permute
@@ -2010,6 +2016,8 @@ def StableHLO_CollectivePermuteOp: StableHLO_Op<"collective_permute",
     ```mlir
     %result = "stablehlo.collective_permute"(%operand) {
       source_target_pairs = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>,
+      // channel_id = 0
+      channel_handle = #stablehlo.channel_handle<handle = 0, type = 0>
     } : (tensor<4x2xf32>) -> tensor<4x2xf32>
     ```
 

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1997,10 +1997,11 @@ def StableHLO_ConcatenateOp : StableHLO_ShapedInterfaceOp<"concatenate",
 }
 
 def StableHLO_CollectivePermuteOp: StableHLO_Op<"collective_permute",
-    [Pure, HLO_CompatibleOperandsAndResultType]> {
+    [HLO_CompatibleOperandsAndResultType]> {
   let summary = "CollectivePermute operator";
   let description = [{
-    Sends and receives data between source and target replicas mentioned in `source_target_pairs`.
+    Within each process group in the StableHLO grid, sends and receives data
+    between processes in the group.
 
     See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlocollective_permute

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2000,15 +2000,17 @@ def StableHLO_CollectivePermuteOp: StableHLO_Op<"collective_permute",
     [Pure, HLO_CompatibleOperandsAndResultType]> {
   let summary = "CollectivePermute operator";
   let description = [{
-    CollectivePermute is a collective operation that sends and receives data
-    cross replicas.
-    Note that there are the following restrictions on the source_target_pair:
-    - Any two pairs should not have the same target replica id, and they should
-    not have the same source replica id.
-    - If a replica id is not a target in any pair, then the output on that
-    replica is a tensor consists of 0(s) with the same shape as the input.
+    Sends and receives data between source and target replicas mentioned in `source_target_pairs`.
 
-    See https://www.tensorflow.org/xla/operation_semantics#collectivepermute.
+    See:
+    https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlocollective_permute
+
+    Example:
+    ```mlir
+    %result = "stablehlo.collective_permute"(%operand) {
+      source_target_pairs = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>,
+    } : (tensor<4x2xf32>) -> tensor<4x2xf32>
+    ```
 
   }];
 

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -1250,6 +1250,16 @@ func.func @collective_permute_duplicate_sources(%arg0: tensor<128x32xf32>) -> te
 
 // -----
 
+func.func @collective_permute_duplicate_sources(%arg0: tensor<128x32xf32>) -> tensor<128x32xf32> {
+  // expected-error@+1 {{replica ids in source_target_pairs must be >= 0}}
+  %0 = "stablehlo.collective_permute"(%arg0) {
+    source_target_pairs = dense<[[0, 1], [-1, 0]]> : tensor<2x2xi64>
+  } : (tensor<128x32xf32>) -> tensor<128x32xf32>
+  func.return %0 : tensor<128x32xf32>
+}
+
+// -----
+
 func.func @concat_0D(%arg0: tensor<i32>, %arg1: tensor<i32>)  -> tensor<2xi32> {
   // expected-error@+1 {{rank-0 values cannot be concatenated}}
   %0 = "stablehlo.concatenate"(%arg0, %arg1) { dimension = 0 : i64 } : (tensor<i32>, tensor<i32>) -> tensor<2xi32>

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -1210,7 +1210,7 @@ func.func @collective_permute(%arg0: tensor<128x32xf32>) -> tensor<128x32xf32> {
 
 // -----
 
-func.func @collective_permute_duplicate_sources(%arg0: tensor<128x32xf32>) -> tensor<128x32xf32> {
+func.func @collective_permute_invalid_sources(%arg0: tensor<128x32xf32>) -> tensor<128x32xf32> {
   // expected-error@+1 {{duplicate sources not allowed}}
   %0 = "stablehlo.collective_permute"(%arg0) {
     source_target_pairs = dense<[[0, 1], [0, 2], [2, 3]]> : tensor<3x2xi64>
@@ -1220,7 +1220,7 @@ func.func @collective_permute_duplicate_sources(%arg0: tensor<128x32xf32>) -> te
 
 // -----
 
-func.func @collective_permute_duplicate_targets(%arg0: tensor<128x32xf32>) -> tensor<128x32xf32> {
+func.func @collective_permute_invalid_destinations(%arg0: tensor<128x32xf32>) -> tensor<128x32xf32> {
   // expected-error@+1 {{duplicate targets not allowed}}
   %0 = "stablehlo.collective_permute"(%arg0) {
     source_target_pairs = dense<[[0, 1], [1, 2], [2, 1]]> : tensor<3x2xi64>
@@ -1230,7 +1230,7 @@ func.func @collective_permute_duplicate_targets(%arg0: tensor<128x32xf32>) -> te
 
 // -----
 
-func.func @collective_permute_duplicate_sources(%arg0: tensor<128x32xf32>) -> tensor<128x32xf32> {
+func.func @collective_permute_invalid_source_target_pairs(%arg0: tensor<128x32xf32>) -> tensor<128x32xf32> {
   // expected-error@+1 {{expect source_target_pairs attribute to be of rank 2, but got rank 1}}
   %0 = "stablehlo.collective_permute"(%arg0) {
     source_target_pairs = dense<[0, 1]> : tensor<2xi64>
@@ -1240,7 +1240,7 @@ func.func @collective_permute_duplicate_sources(%arg0: tensor<128x32xf32>) -> te
 
 // -----
 
-func.func @collective_permute_duplicate_sources(%arg0: tensor<128x32xf32>) -> tensor<128x32xf32> {
+func.func @collective_permute_invalid_source_target_pairs(%arg0: tensor<128x32xf32>) -> tensor<128x32xf32> {
   // expected-error@+1 {{expect source_target_pairs attribute of shape (N, 2), but got (2, 3)}}
   %0 = "stablehlo.collective_permute"(%arg0) {
     source_target_pairs = dense<[[0, 1, 2], [3, 4, 5]]> : tensor<2x3xi64>
@@ -1250,7 +1250,7 @@ func.func @collective_permute_duplicate_sources(%arg0: tensor<128x32xf32>) -> te
 
 // -----
 
-func.func @collective_permute_duplicate_sources(%arg0: tensor<128x32xf32>) -> tensor<128x32xf32> {
+func.func @collective_permute_invalid_source_target_pairs(%arg0: tensor<128x32xf32>) -> tensor<128x32xf32> {
   // expected-error@+1 {{replica ids in source_target_pairs must be >= 0}}
   %0 = "stablehlo.collective_permute"(%arg0) {
     source_target_pairs = dense<[[0, 1], [-1, 0]]> : tensor<2x2xi64>


### PR DESCRIPTION
fixes #523

A few points

1. adds verification checks for ColllectivePermute w.r.t. https://github.com/openxla/stablehlo/issues/498 
2. We do not have the upper bound check for replica ids in `source_target_pairs` as in https://github.com/tensorflow/tensorflow/blob/54926b8320184c2f07066d84b798e52ba6a74675/tensorflow/compiler/xla/service/hlo_verifier.cc#L714 because those checks [depends on](https://github.com/tensorflow/tensorflow/blob/54926b8320184c2f07066d84b798e52ba6a74675/tensorflow/compiler/xla/service/hlo_verifier.cc#L694) HloModuleConfig which not exposed in StableHLO. 


upd:
1. verification is `revisit` based on https://github.com/openxla/stablehlo/issues/498 (check empty replicas) and (2) above