### PR TITLE
Change -1 to ? printing when possible

### DIFF
--- a/stablehlo/dialect/AssemblyFormat.cpp
+++ b/stablehlo/dialect/AssemblyFormat.cpp
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 #include "stablehlo/dialect/AssemblyFormat.h"
+
 #include <cstdint>
 #include <string>
 
@@ -327,7 +328,8 @@ FailureOr<SmallVector<int64_t>> parseDimensionSizes(AsmParser& parser) {
     }
     return parser.parseInteger(dims.emplace_back());
   };
-  if (failed(parser.parseCommaSeparatedList(AsmParser::Delimiter::Square, parseElt))) {
+  if (failed(parser.parseCommaSeparatedList(AsmParser::Delimiter::Square,
+                                            parseElt))) {
     return failure();
   }
   return dims;

--- a/stablehlo/dialect/AssemblyFormat.cpp
+++ b/stablehlo/dialect/AssemblyFormat.cpp
@@ -305,11 +305,11 @@ ParseResult parseDenseI64Array(OpAsmParser& parser,
   return success();
 }
 
-std::string dimSizeToString(int64_t dim) {
-  if (hlo::isDynamicDimSize(dim)) {
+std::string dimSizeToString(int64_t dimSize) {
+  if (hlo::isDynamicDimSize(dimSize)) {
     return "?";
   }
-  return std::to_string(dim);
+  return std::to_string(dimSize);
 }
 
 void printDimSizes(AsmPrinter& p, llvm::ArrayRef<int64_t> dimSizes) {

--- a/stablehlo/dialect/AssemblyFormat.h
+++ b/stablehlo/dialect/AssemblyFormat.h
@@ -16,6 +16,7 @@ limitations under the License.
 #ifndef STABLEHLO_DIALECT_ASSEMBLYFORMAT_H
 #define STABLEHLO_DIALECT_ASSEMBLYFORMAT_H
 
+#include "llvm/ADT/StringRef.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/Operation.h"
 
@@ -178,10 +179,13 @@ ParseResult parseDenseI64Array(OpAsmParser& parser, DenseIntElementsAttr& attr);
 //     [1, -1]
 //   Custom:
 //     [1, ?]
-void printDimensionSizes(AsmPrinter& p, llvm::ArrayRef<int64_t> shape);
+std::string dimensionToString(int64_t dim);
 
+void printDimensionSizes(AsmPrinter& p, llvm::ArrayRef<int64_t> dims);
+
+FailureOr<SmallVector<int64_t>> parseDimensionSizes(AsmParser& parser);
 ParseResult parseDimensionSizes(AsmParser& parser,
-                                FailureOr<SmallVector<int64_t>>& shape);
+                                FailureOr<SmallVector<int64_t>>& dims);
 
 // ExponentMantissa - Abbreviated printing of exponent and mantissa as e#m#.
 //
@@ -218,7 +222,6 @@ ParseResult parseCustomCallTarget(AsmParser& parser, StringAttr& target);
 //     [1, 2]
 void printIntArray(AsmPrinter& printer, ArrayRef<int64_t> ints);
 
-FailureOr<SmallVector<int64_t>> parseIntArray(AsmParser& parser);
 ParseResult parseIntArray(AsmParser& parser, SmallVector<int64_t>& ints);
 
 }  // namespace hlo

--- a/stablehlo/dialect/AssemblyFormat.h
+++ b/stablehlo/dialect/AssemblyFormat.h
@@ -185,7 +185,7 @@ void printDimSizes(AsmPrinter& p, llvm::ArrayRef<int64_t> dims);
 
 FailureOr<SmallVector<int64_t>> parseDimSizes(AsmParser& parser);
 ParseResult parseDimSizes(AsmParser& parser,
-                                FailureOr<SmallVector<int64_t>>& dims);
+                          FailureOr<SmallVector<int64_t>>& dims);
 
 // ExponentMantissa - Abbreviated printing of exponent and mantissa as e#m#.
 //

--- a/stablehlo/dialect/AssemblyFormat.h
+++ b/stablehlo/dialect/AssemblyFormat.h
@@ -173,18 +173,18 @@ void printDenseI64Array(OpAsmPrinter& p, Operation* op,
 
 ParseResult parseDenseI64Array(OpAsmParser& parser, DenseIntElementsAttr& attr);
 
-// DimensionSizes - Print an array of ints. Dynamic dimensions printed as `?`.
+// DimSizes - Print an array of ints. Dynamic dimensions printed as `?`.
 //
 //   Generic:
 //     [1, -1]
 //   Custom:
 //     [1, ?]
-std::string dimensionToString(int64_t dim);
+std::string dimSizeToString(int64_t dim);
 
-void printDimensionSizes(AsmPrinter& p, llvm::ArrayRef<int64_t> dims);
+void printDimSizes(AsmPrinter& p, llvm::ArrayRef<int64_t> dims);
 
-FailureOr<SmallVector<int64_t>> parseDimensionSizes(AsmParser& parser);
-ParseResult parseDimensionSizes(AsmParser& parser,
+FailureOr<SmallVector<int64_t>> parseDimSizes(AsmParser& parser);
+ParseResult parseDimSizes(AsmParser& parser,
                                 FailureOr<SmallVector<int64_t>>& dims);
 
 // ExponentMantissa - Abbreviated printing of exponent and mantissa as e#m#.
@@ -212,17 +212,6 @@ ParseResult parseExponentMantissa(AsmParser& parser, IntegerAttr& exponent,
 void printCustomCallTarget(AsmPrinter& p, Operation*, StringAttr target);
 
 ParseResult parseCustomCallTarget(AsmParser& parser, StringAttr& target);
-
-// IntArray - Print an array of ints with brackets. Unlike DimensionSizes,
-// doesn't have special handling for kDynamicSize.
-//
-//   Generic:
-//     1, 2
-//   Custom:
-//     [1, 2]
-void printIntArray(AsmPrinter& printer, ArrayRef<int64_t> ints);
-
-ParseResult parseIntArray(AsmParser& parser, SmallVector<int64_t>& ints);
 
 }  // namespace hlo
 }  // namespace mlir

--- a/stablehlo/dialect/AssemblyFormat.h
+++ b/stablehlo/dialect/AssemblyFormat.h
@@ -179,13 +179,13 @@ ParseResult parseDenseI64Array(OpAsmParser& parser, DenseIntElementsAttr& attr);
 //     [1, -1]
 //   Custom:
 //     [1, ?]
-std::string dimSizeToString(int64_t dim);
+std::string dimSizeToString(int64_t dimSize);
 
-void printDimSizes(AsmPrinter& p, llvm::ArrayRef<int64_t> dims);
+void printDimSizes(AsmPrinter& p, llvm::ArrayRef<int64_t> dimSizes);
 
 FailureOr<SmallVector<int64_t>> parseDimSizes(AsmParser& parser);
 ParseResult parseDimSizes(AsmParser& parser,
-                          FailureOr<SmallVector<int64_t>>& dims);
+                          FailureOr<SmallVector<int64_t>>& dimSizes);
 
 // ExponentMantissa - Abbreviated printing of exponent and mantissa as e#m#.
 //

--- a/stablehlo/dialect/Base.h
+++ b/stablehlo/dialect/Base.h
@@ -25,6 +25,7 @@ limitations under the License.
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypeInterfaces.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Diagnostics.h"
 #include "mlir/IR/DialectInterface.h"
@@ -46,7 +47,7 @@ namespace hlo {
 // Check if the dimension size is dynamic.
 // TODO(zhouxin) add isStaticDimSize() as well.
 inline static bool isDynamicDimSize(int64_t val) {
-  return val == ShapedType::kDynamic;
+  return ShapedType::isDynamic(val);
 }
 
 // Returns true if the given types are the same for the purposes of HLO type

--- a/stablehlo/dialect/Base.td
+++ b/stablehlo/dialect/Base.td
@@ -200,9 +200,9 @@ def HLO_BoundedAttrInterface : AttrInterface<"BoundedAttrInterface"> {
     RankedTensorType::getEncoding.
     The number of bounds is expected to be the same as the number of dimensions
     in the accompanying shaped type.
-    For a static dimension, the corresponding bound is ShapedType::kDynamicSize.
+    For a static dimension, the corresponding bound is ShapedType::kDynamic.
     For a dynamic dimension, the corresponding bound is either known and is
-    a non-negative number or unknown and is ShapedType::kDynamicSize.
+    a non-negative number or unknown and is ShapedType::kDynamic.
   }];
 
   let methods = [InterfaceMethod<

--- a/stablehlo/dialect/StablehloAttrs.td
+++ b/stablehlo/dialect/StablehloAttrs.td
@@ -21,8 +21,8 @@ include "mlir/IR/OpBase.td"
 include "mlir/IR/TensorEncoding.td"
 
 def StableHLO_Dims : ArrayRefParameter<"int64_t", "Dimension"> {
-  let parser = "mlir::hlo::parseDimensionSizes($_parser)";
-  let printer = "mlir::hlo::printDimensionSizes($_printer, $_self)";
+  let parser = "parseDimSizes($_parser)";
+  let printer = "printDimSizes($_printer, $_self)";
 }
 
 def StableHLO_ScatterDimensionNumbers : AttrDef<StableHLO_Dialect, "ScatterDimensionNumbers"> {
@@ -175,7 +175,7 @@ def StableHLO_TypeExtensions : AttrDef<StableHLO_Dialect, "TypeExtensions", [
 
     See `HLO_BoundedAttrInterface` for documentation for `bounds`.
   }];
-  let assemblyFormat = "`<` `bounds` `=` ` ` custom<DimensionSizes>($bounds) `>`";
+  let assemblyFormat = "`<` `bounds` `=` ` ` custom<DimSizes>($bounds) `>`";
 }
 
 // A layout attribute (1D tensor of index type)

--- a/stablehlo/dialect/StablehloAttrs.td
+++ b/stablehlo/dialect/StablehloAttrs.td
@@ -21,8 +21,8 @@ include "mlir/IR/OpBase.td"
 include "mlir/IR/TensorEncoding.td"
 
 def StableHLO_Dims : ArrayRefParameter<"int64_t", "Dimension"> {
-  let parser = "mlir::hlo::parseIntArray($_parser)";
-  let printer = "mlir::hlo::printIntArray($_printer, $_self)";
+  let parser = "mlir::hlo::parseDimensionSizes($_parser)";
+  let printer = "mlir::hlo::printDimensionSizes($_printer, $_self)";
 }
 
 def StableHLO_ScatterDimensionNumbers : AttrDef<StableHLO_Dialect, "ScatterDimensionNumbers"> {

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -76,10 +76,8 @@ limitations under the License.
 #include "stablehlo/dialect/TypeInference.h"
 
 // Include order matters
-using mlir::hlo::parseDimensionSizes;
-using mlir::hlo::parseIntArray;
-using mlir::hlo::printDimensionSizes;
-using mlir::hlo::printIntArray;
+using mlir::hlo::parseDimSizes;
+using mlir::hlo::printDimSizes;
 #include "stablehlo/dialect/StablehloEnums.cpp.inc"
 #define GET_ATTRDEF_CLASSES
 #include "stablehlo/dialect/StablehloAttrs.cpp.inc"
@@ -4494,19 +4492,25 @@ void StablehloDialect::printAttribute(Attribute attr,
 
 /// Helpers for attributes parsing.
 
-static ParseResult parseDims(AsmParser& parser, SmallVector<int64_t>& dims) {
-  dims.clear();
-  return parseIntArray(parser, dims);
+static ParseResult parseDims(AsmParser& parser,
+                             SmallVector<int64_t>& dimSizes) {
+  dimSizes.clear();
+  auto failOrDims = parseDimSizes(parser);
+  if (failed(failOrDims)) {
+    return failure();
+  }
+  dimSizes = std::move(*failOrDims);
+  return success();
 }
 
 static ParseResult parseDimsWithMinimumElements(AsmParser& parser,
-                                                SmallVector<int64_t>& dims,
+                                                SmallVector<int64_t>& dimSizes,
                                                 int minElements) {
-  if (failed(parseDims(parser, dims))) return failure();
-  if (static_cast<int64_t>(dims.size()) < minElements)
+  if (failed(parseDims(parser, dimSizes))) return failure();
+  if (static_cast<int64_t>(dimSizes.size()) < minElements)
     return parser.emitError(parser.getCurrentLocation())
            << "expected at least " << minElements << " element(s), found "
-           << dims.size();
+           << dimSizes.size();
   return success();
 }
 

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -53,6 +53,7 @@ limitations under the License.
 #include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
+#include "stablehlo/dialect/AssemblyFormat.h"
 #include "stablehlo/dialect/Base.h"
 
 namespace mlir {
@@ -196,7 +197,8 @@ LogicalResult verifyBatchNorm(Optional<Location> location, Value operand,
         location,
         "expects the size of scale factor to be same as the "
         "feature count, but the size of scale factor is ",
-        scaleShape, " and the feature count is ", featureCount, ".");
+        dimensionToString(scaleShape), " and the feature count is ",
+        dimensionToString(featureCount), ".");
 
   return success();
 }
@@ -557,8 +559,8 @@ LogicalResult inferConcatenateOp(Optional<Location> location, ValueRange inputs,
     auto firstShape = firstRankedType.getShape();
     auto secondShape = secondType.getShape();
     for (int d = 0; d < firstRankedType.getRank(); ++d) {
-      if (!ShapedType::isDynamic(firstShape[d]) &&
-          !ShapedType::isDynamic(secondShape[d]) &&
+      if (!isDynamicDimSize(firstShape[d]) &&
+          !isDynamicDimSize(secondShape[d]) &&
           firstShape[d] != secondShape[d] && d != dimension) {
         return emitOptionalError(
             location, "shapes of operand (", firstRankedIndex, ") and (", i,

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -197,8 +197,8 @@ LogicalResult verifyBatchNorm(Optional<Location> location, Value operand,
         location,
         "expects the size of scale factor to be same as the "
         "feature count, but the size of scale factor is ",
-        dimensionToString(scaleShape), " and the feature count is ",
-        dimensionToString(featureCount), ".");
+        dimSizeToString(scaleShape), " and the feature count is ",
+        dimSizeToString(featureCount), ".");
 
   return success();
 }

--- a/stablehlo/integrations/python/tests/stablehlo.py
+++ b/stablehlo/integrations/python/tests/stablehlo.py
@@ -20,7 +20,6 @@
 from mlir import ir
 from mlir.dialects import stablehlo
 
-
 def run(f):
   with ir.Context() as context:
     stablehlo.register_dialect(context)
@@ -196,6 +195,8 @@ def test_token_type():
 
 @run
 def test_type_extensions():
-  attr = stablehlo.TypeExtensions.get(bounds=[128, -1])
+
+  dyn_size = ir.ShapedType.get_dynamic_size()
+  attr = stablehlo.TypeExtensions.get(bounds=[128, dyn_size])
   assert attr is not None
-  assert attr.bounds == [128, -1]
+  assert attr.bounds == [128, dyn_size]

--- a/stablehlo/integrations/python/tests/stablehlo.py
+++ b/stablehlo/integrations/python/tests/stablehlo.py
@@ -20,6 +20,7 @@
 from mlir import ir
 from mlir.dialects import stablehlo
 
+
 def run(f):
   with ir.Context() as context:
     stablehlo.register_dialect(context)
@@ -195,7 +196,6 @@ def test_token_type():
 
 @run
 def test_type_extensions():
-
   dyn_size = ir.ShapedType.get_dynamic_size()
   attr = stablehlo.TypeExtensions.get(bounds=[128, dyn_size])
   assert attr is not None

--- a/stablehlo/tests/TestUtils.cpp
+++ b/stablehlo/tests/TestUtils.cpp
@@ -109,8 +109,9 @@ struct InferReturnTypeComponentsPattern : public RewritePattern {
     auto *newOp = rewriter.create(state);
     for (const auto &it : llvm::enumerate(components)) {
       if (it.value().hasRank()) {
-        newOp->setAttr((StringRef("dims") + Twine(it.index())).str(),
-                       rewriter.getI64ArrayAttr(fixDynamicDims(it.value().getDims())));
+        newOp->setAttr(
+            (StringRef("dims") + Twine(it.index())).str(),
+            rewriter.getI64ArrayAttr(fixDynamicDims(it.value().getDims())));
       }
       if (it.value().getElementType()) {
         newOp->setAttr((Twine("element_type") + Twine(it.index())).str(),

--- a/stablehlo/tests/TestUtils.cpp
+++ b/stablehlo/tests/TestUtils.cpp
@@ -44,12 +44,12 @@ namespace hlo {
 namespace {
 
 // Convert dynamic dimensions to -1 for infer tests.
-std::string dimSizesToString(ArrayRef<int64_t> const & arr) {
+std::string dimSizesToString(ArrayRef<int64_t> dimSizes) {
   std::string buffer;
   llvm::raw_string_ostream os(buffer);
   os << '[';
   llvm::interleaveComma(
-      arr, os, [&](int64_t dimSize) { os << dimSizeToString(dimSize); });
+      dimSizes, os, [&](int64_t dimSize) { os << dimSizeToString(dimSize); });
   os << ']';
   return buffer;
 }
@@ -112,8 +112,9 @@ struct InferReturnTypeComponentsPattern : public RewritePattern {
     auto *newOp = rewriter.create(state);
     for (const auto &it : llvm::enumerate(components)) {
       if (it.value().hasRank()) {
-        newOp->setAttr((StringRef("dims") + Twine(it.index())).str(),
-                       rewriter.getStringAttr(dimSizesToString(it.value().getDims())));
+        newOp->setAttr(
+            (StringRef("dims") + Twine(it.index())).str(),
+            rewriter.getStringAttr(dimSizesToString(it.value().getDims())));
       }
       if (it.value().getElementType()) {
         newOp->setAttr((Twine("element_type") + Twine(it.index())).str(),

--- a/stablehlo/tests/infer_chlo.mlir
+++ b/stablehlo/tests/infer_chlo.mlir
@@ -28,7 +28,7 @@ func.func @broadcast_add_different_operand_size(%arg1: tensor<1xi32>, %arg2: ten
 // CHECK-LABEL: @broadcast_complex_ranked_components
 func.func @broadcast_complex_ranked_components(%arg0: tensor<?xf32>, %arg1: tensor<?x?xf32>) -> tensor<?x?xcomplex<f32>> {
   %0 = chlo.broadcast_complex %arg0, %arg1 : (tensor<?xf32>, tensor<?x?xf32>) -> tensor<?x?xcomplex<f32>>
-  // CHECK: "hlo_test_infer.return_type_components"(%0) {dims0 = [-9223372036854775808, -9223372036854775808], element_type0 = complex<f32>}
+  // CHECK: "hlo_test_infer.return_type_components"(%0) {dims0 = [-1, -1], element_type0 = complex<f32>}
   %1 = "hlo_test_infer.get_return_type_components"(%0) : (tensor<?x?xcomplex<f32>>) -> tensor<?x?xcomplex<f32>>
   func.return %1 : tensor<?x?xcomplex<f32>>
 }
@@ -56,7 +56,7 @@ func.func @broadcast_complex_mismatch(%arg0: tensor<2xf64>, %arg1: tensor<2xf32>
 // CHECK-LABEL: @broadcast_compare_ranked_components
 func.func @broadcast_compare_ranked_components(%arg0: tensor<?xf32>, %arg1: tensor<?x?xf32>) -> tensor<?x?xi1> {
   %0 = chlo.broadcast_compare %arg0, %arg1 {comparison_direction = #chlo<comparison_direction EQ>} : (tensor<?xf32>, tensor<?x?xf32>) -> tensor<?x?xi1>
-  // CHECK: "hlo_test_infer.return_type_components"(%0) {dims0 = [-9223372036854775808, -9223372036854775808], element_type0 = i1}
+  // CHECK: "hlo_test_infer.return_type_components"(%0) {dims0 = [-1, -1], element_type0 = i1}
   %1 = "hlo_test_infer.get_return_type_components"(%0) : (tensor<?x?xi1>) -> tensor<?x?xi1>
   func.return %0 : tensor<?x?xi1>
 }
@@ -93,7 +93,7 @@ func.func @broadcast_add_ranked_components_r1(%arg0: tensor<?xf32>, %arg1: tenso
 // CHECK-LABEL: @broadcast_add_ranked_components_r1x2
 func.func @broadcast_add_ranked_components_r1x2(%arg0: tensor<?xf32>, %arg1: tensor<?x3xf32>) -> tensor<?x3xf32> {
   %0 = chlo.broadcast_add %arg0, %arg1 : (tensor<?xf32>, tensor<?x3xf32>) -> tensor<?x3xf32>
-  // CHECK: "hlo_test_infer.return_type_components"(%0) {dims0 = [-9223372036854775808, 3], element_type0 = f32}
+  // CHECK: "hlo_test_infer.return_type_components"(%0) {dims0 = [-1, 3], element_type0 = f32}
   %1 = "hlo_test_infer.get_return_type_components"(%0) : (tensor<?x3xf32>) -> tensor<?x3xf32>
   func.return %1 : tensor<?x3xf32>
 }
@@ -102,7 +102,7 @@ func.func @broadcast_add_ranked_components_r1x2(%arg0: tensor<?xf32>, %arg1: ten
 // CHECK-LABEL: @broadcast_add_ranked_components_with_zero_r1x2
 func.func @broadcast_add_ranked_components_with_zero_r1x2(%arg0: tensor<0xf32>, %arg1: tensor<?x1xf32>) -> tensor<?x0xf32> {
   %0 = chlo.broadcast_add %arg0, %arg1 : (tensor<0xf32>, tensor<?x1xf32>) -> tensor<?x0xf32>
-  // CHECK: "hlo_test_infer.return_type_components"(%0) {dims0 = [-9223372036854775808, 0], element_type0 = f32}
+  // CHECK: "hlo_test_infer.return_type_components"(%0) {dims0 = [-1, 0], element_type0 = f32}
   %1 = "hlo_test_infer.get_return_type_components"(%0) : (tensor<?x0xf32>) -> tensor<?x0xf32>
   func.return %1 : tensor<?x0xf32>
 }
@@ -140,7 +140,7 @@ func.func @constant_ranked() -> (tensor<i32>) {
 // CHECK-LABEL: @constant_like_ranked
 func.func @constant_like_ranked(%arg0: tensor<1x?xi64>) -> (tensor<1x?xf32>) {
   %0 = "chlo.constant_like"(%arg0) { value = 3.2 : f32 } : (tensor<1x?xi64>) -> tensor<1x?xf32>
-  // CHECK: "hlo_test_infer.return_type_components"(%0) {dims0 = [1, -9223372036854775808], element_type0 = f32}
+  // CHECK: "hlo_test_infer.return_type_components"(%0) {dims0 = [1, -1], element_type0 = f32}
   %1 = "hlo_test_infer.get_return_type_components"(%0) : (tensor<1x?xf32>) -> tensor<1x?xf32>
   func.return %1 : tensor<1x?xf32>
 }

--- a/stablehlo/tests/infer_chlo.mlir
+++ b/stablehlo/tests/infer_chlo.mlir
@@ -19,7 +19,7 @@ func.func @broadcast_add_reify(%arg0: tensor<?xf32>, %arg1: tensor<?xf32>) -> te
 // CHECK-LABEL: @broadcast_add_different_operand_size
 func.func @broadcast_add_different_operand_size(%arg1: tensor<1xi32>, %arg2: tensor<1x2xi32>) -> tensor<1x2xi32> {
   %0 = "chlo.broadcast_add"(%arg1, %arg2) {broadcast_dimensions = dense<1> : tensor<i64>} : (tensor<1xi32>, tensor<1x2xi32>) -> tensor<1x2xi32>
-  // CHECK: "hlo_test_infer.return_type_components"(%0) {dims0 = [1, 2], element_type0 = i32}
+  // CHECK: "hlo_test_infer.return_type_components"(%0) {dims0 = "[1, 2]", element_type0 = i32}
   %1 = "hlo_test_infer.get_return_type_components"(%0) : (tensor<1x2xi32>) -> tensor<1x2xi32>
   return %1: tensor<1x2xi32>
 }
@@ -28,7 +28,7 @@ func.func @broadcast_add_different_operand_size(%arg1: tensor<1xi32>, %arg2: ten
 // CHECK-LABEL: @broadcast_complex_ranked_components
 func.func @broadcast_complex_ranked_components(%arg0: tensor<?xf32>, %arg1: tensor<?x?xf32>) -> tensor<?x?xcomplex<f32>> {
   %0 = chlo.broadcast_complex %arg0, %arg1 : (tensor<?xf32>, tensor<?x?xf32>) -> tensor<?x?xcomplex<f32>>
-  // CHECK: "hlo_test_infer.return_type_components"(%0) {dims0 = [-1, -1], element_type0 = complex<f32>}
+  // CHECK: "hlo_test_infer.return_type_components"(%0) {dims0 = "[?, ?]", element_type0 = complex<f32>}
   %1 = "hlo_test_infer.get_return_type_components"(%0) : (tensor<?x?xcomplex<f32>>) -> tensor<?x?xcomplex<f32>>
   func.return %1 : tensor<?x?xcomplex<f32>>
 }
@@ -56,7 +56,7 @@ func.func @broadcast_complex_mismatch(%arg0: tensor<2xf64>, %arg1: tensor<2xf32>
 // CHECK-LABEL: @broadcast_compare_ranked_components
 func.func @broadcast_compare_ranked_components(%arg0: tensor<?xf32>, %arg1: tensor<?x?xf32>) -> tensor<?x?xi1> {
   %0 = chlo.broadcast_compare %arg0, %arg1 {comparison_direction = #chlo<comparison_direction EQ>} : (tensor<?xf32>, tensor<?x?xf32>) -> tensor<?x?xi1>
-  // CHECK: "hlo_test_infer.return_type_components"(%0) {dims0 = [-1, -1], element_type0 = i1}
+  // CHECK: "hlo_test_infer.return_type_components"(%0) {dims0 = "[?, ?]", element_type0 = i1}
   %1 = "hlo_test_infer.get_return_type_components"(%0) : (tensor<?x?xi1>) -> tensor<?x?xi1>
   func.return %0 : tensor<?x?xi1>
 }
@@ -93,7 +93,7 @@ func.func @broadcast_add_ranked_components_r1(%arg0: tensor<?xf32>, %arg1: tenso
 // CHECK-LABEL: @broadcast_add_ranked_components_r1x2
 func.func @broadcast_add_ranked_components_r1x2(%arg0: tensor<?xf32>, %arg1: tensor<?x3xf32>) -> tensor<?x3xf32> {
   %0 = chlo.broadcast_add %arg0, %arg1 : (tensor<?xf32>, tensor<?x3xf32>) -> tensor<?x3xf32>
-  // CHECK: "hlo_test_infer.return_type_components"(%0) {dims0 = [-1, 3], element_type0 = f32}
+  // CHECK: "hlo_test_infer.return_type_components"(%0) {dims0 = "[?, 3]", element_type0 = f32}
   %1 = "hlo_test_infer.get_return_type_components"(%0) : (tensor<?x3xf32>) -> tensor<?x3xf32>
   func.return %1 : tensor<?x3xf32>
 }
@@ -102,7 +102,7 @@ func.func @broadcast_add_ranked_components_r1x2(%arg0: tensor<?xf32>, %arg1: ten
 // CHECK-LABEL: @broadcast_add_ranked_components_with_zero_r1x2
 func.func @broadcast_add_ranked_components_with_zero_r1x2(%arg0: tensor<0xf32>, %arg1: tensor<?x1xf32>) -> tensor<?x0xf32> {
   %0 = chlo.broadcast_add %arg0, %arg1 : (tensor<0xf32>, tensor<?x1xf32>) -> tensor<?x0xf32>
-  // CHECK: "hlo_test_infer.return_type_components"(%0) {dims0 = [-1, 0], element_type0 = f32}
+  // CHECK: "hlo_test_infer.return_type_components"(%0) {dims0 = "[?, 0]", element_type0 = f32}
   %1 = "hlo_test_infer.get_return_type_components"(%0) : (tensor<?x0xf32>) -> tensor<?x0xf32>
   func.return %1 : tensor<?x0xf32>
 }
@@ -140,7 +140,7 @@ func.func @constant_ranked() -> (tensor<i32>) {
 // CHECK-LABEL: @constant_like_ranked
 func.func @constant_like_ranked(%arg0: tensor<1x?xi64>) -> (tensor<1x?xf32>) {
   %0 = "chlo.constant_like"(%arg0) { value = 3.2 : f32 } : (tensor<1x?xi64>) -> tensor<1x?xf32>
-  // CHECK: "hlo_test_infer.return_type_components"(%0) {dims0 = [1, -1], element_type0 = f32}
+  // CHECK: "hlo_test_infer.return_type_components"(%0) {dims0 = "[1, ?]", element_type0 = f32}
   %1 = "hlo_test_infer.get_return_type_components"(%0) : (tensor<1x?xf32>) -> tensor<1x?xf32>
   func.return %1 : tensor<1x?xf32>
 }
@@ -199,24 +199,24 @@ func.func @infer_type_components_from_operands(%arg : tensor<2xf32>) -> tensor<2
   %15 = "chlo.sinh"(%14) : (tensor<2xf32>) -> tensor<2xf32>
   %16 = "chlo.tan"(%15) : (tensor<2xf32>) -> tensor<2xf32>
   %17 = "chlo.zeta"(%16, %16) : (tensor<2xf32>, tensor<2xf32>) -> tensor<2xf32>
-  // CHECK:      "hlo_test_infer.return_type_components"(%0) {dims0 = [2], element_type0 = f32}
-  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%1) {dims0 = [2], element_type0 = f32}
-  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%2) {dims0 = [2], element_type0 = f32}
-  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%3) {dims0 = [2], element_type0 = f32}
-  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%4) {dims0 = [2], element_type0 = f32}
-  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%5) {dims0 = [2], element_type0 = f32}
-  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%6) {dims0 = [2], element_type0 = f32}
-  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%7) {dims0 = [2], element_type0 = f32}
-  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%8) {dims0 = [2], element_type0 = f32}
-  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%9) {dims0 = [2], element_type0 = f32}
-  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%10) {dims0 = [2], element_type0 = f32}
-  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%11) {dims0 = [2], element_type0 = f32}
-  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%12) {dims0 = [2], element_type0 = f32}
-  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%13) {dims0 = [2], element_type0 = f32}
-  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%14) {dims0 = [2], element_type0 = f32}
-  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%15) {dims0 = [2], element_type0 = f32}
-  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%16) {dims0 = [2], element_type0 = f32}
-  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%17) {dims0 = [2], element_type0 = f32}
+  // CHECK:      "hlo_test_infer.return_type_components"(%0) {dims0 = "[2]", element_type0 = f32}
+  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%1) {dims0 = "[2]", element_type0 = f32}
+  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%2) {dims0 = "[2]", element_type0 = f32}
+  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%3) {dims0 = "[2]", element_type0 = f32}
+  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%4) {dims0 = "[2]", element_type0 = f32}
+  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%5) {dims0 = "[2]", element_type0 = f32}
+  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%6) {dims0 = "[2]", element_type0 = f32}
+  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%7) {dims0 = "[2]", element_type0 = f32}
+  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%8) {dims0 = "[2]", element_type0 = f32}
+  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%9) {dims0 = "[2]", element_type0 = f32}
+  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%10) {dims0 = "[2]", element_type0 = f32}
+  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%11) {dims0 = "[2]", element_type0 = f32}
+  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%12) {dims0 = "[2]", element_type0 = f32}
+  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%13) {dims0 = "[2]", element_type0 = f32}
+  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%14) {dims0 = "[2]", element_type0 = f32}
+  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%15) {dims0 = "[2]", element_type0 = f32}
+  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%16) {dims0 = "[2]", element_type0 = f32}
+  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%17) {dims0 = "[2]", element_type0 = f32}
   %r0 = "hlo_test_infer.get_return_type_components"(%0) : (tensor<2xf32>) -> tensor<2xf32>
   %r1 = "hlo_test_infer.get_return_type_components"(%1) : (tensor<2xf32>) -> tensor<2xf32>
   %r2 = "hlo_test_infer.get_return_type_components"(%2) : (tensor<2xf32>) -> tensor<2xf32>

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -36,7 +36,7 @@ func.func @select(%pred : tensor<i1>, %a : tensor<2x2xf32>, %b : tensor<2x2xf32>
       : (tensor<i1>, tensor<2x2xf32>, tensor<2x2xf32>) -> tensor<2x2xf32>
   %1 = "hlo_test_infer.get_return_type_components"(%0)
       : (tensor<2x2xf32>) -> tensor<2x2xindex>
-// CHECK: %1 = "hlo_test_infer.return_type_components"(%0) {dims0 = [2, 2], element_type0 = f32} : (tensor<2x2xf32>) -> tensor<2x2xindex>
+// CHECK: %1 = "hlo_test_infer.return_type_components"(%0) {dims0 = "[2, 2]", element_type0 = f32} : (tensor<2x2xf32>) -> tensor<2x2xindex>
   func.return %1 : tensor<2x2xindex>
 }
 
@@ -48,7 +48,7 @@ func.func @compare(%a : tensor<2x2xf32>, %b : tensor<2x2xf32>) -> tensor<2x2xind
       : (tensor<2x2xf32>, tensor<2x2xf32>) -> tensor<2x2xi1>
   %1 = "hlo_test_infer.get_return_type_components"(%0)
       : (tensor<2x2xi1>) -> tensor<2x2xindex>
-// CHECK: %1 = "hlo_test_infer.return_type_components"(%0) {dims0 = [2, 2], element_type0 = i1} : (tensor<2x2xi1>) -> tensor<2x2xindex>
+// CHECK: %1 = "hlo_test_infer.return_type_components"(%0) {dims0 = "[2, 2]", element_type0 = i1} : (tensor<2x2xi1>) -> tensor<2x2xindex>
   func.return %1 : tensor<2x2xindex>
 }
 
@@ -60,7 +60,7 @@ func.func @broadcast(%a : tensor<3xi32>) -> tensor<1x2x3xindex> {
       : (tensor<3xi32>) -> tensor<1x2x3xi32>
   %1 = "hlo_test_infer.get_return_type_components"(%0)
       : (tensor<1x2x3xi32>) -> tensor<1x2x3xindex>
-// CHECK: %1 = "hlo_test_infer.return_type_components"(%0) {dims0 = [1, 2, 3], element_type0 = i32} : (tensor<1x2x3xi32>) -> tensor<1x2x3xindex>
+// CHECK: %1 = "hlo_test_infer.return_type_components"(%0) {dims0 = "[1, 2, 3]", element_type0 = i32} : (tensor<1x2x3xi32>) -> tensor<1x2x3xindex>
   func.return %1 : tensor<1x2x3xindex>
 }
 
@@ -80,7 +80,7 @@ func.func @dynamic_slice(%arg0: tensor<3x4xi32>, %arg1: tensor<i64>, %arg2: tens
   %0 = "stablehlo.dynamic_slice"(%arg0, %arg1, %arg2) {slice_sizes = dense<[1, 4]> : tensor<2xi64>} : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xi32>
   %1 = "hlo_test_infer.get_return_type_components"(%0)
       : (tensor<1x4xi32>) -> tensor<1x4xindex>
-// CHECK: %1 = "hlo_test_infer.return_type_components"(%0) {dims0 = [1, 4], element_type0 = i32} : (tensor<1x4xi32>) -> tensor<1x4xindex>
+// CHECK: %1 = "hlo_test_infer.return_type_components"(%0) {dims0 = "[1, 4]", element_type0 = i32} : (tensor<1x4xi32>) -> tensor<1x4xindex>
   func.return %1 : tensor<1x4xindex>
 }
 
@@ -105,7 +105,7 @@ func.func @cholesky(%arg0: tensor<1x2x2xf32>) -> tensor<1x2x2xindex> {
   %0 = "stablehlo.cholesky"(%arg0) { lower = true } : (tensor<1x2x2xf32>) -> tensor<1x2x2xf32>
   %1 = "hlo_test_infer.get_return_type_components"(%0)
       : (tensor<1x2x2xf32>) -> tensor<1x2x2xindex>
-// CHECK: %1 = "hlo_test_infer.return_type_components"(%0) {dims0 = [1, 2, 2], element_type0 = f32} : (tensor<1x2x2xf32>) -> tensor<1x2x2xindex>
+// CHECK: %1 = "hlo_test_infer.return_type_components"(%0) {dims0 = "[1, 2, 2]", element_type0 = f32} : (tensor<1x2x2xf32>) -> tensor<1x2x2xindex>
   func.return %1: tensor<1x2x2xindex>
 }
 
@@ -121,7 +121,7 @@ func.func @alltoall(%data: tensor<4x16xf32>) -> tensor<16x4xindex> {
   } : (tensor<4x16xf32>) -> tensor<16x4xf32>
   %1 = "hlo_test_infer.get_return_type_components"(%0)
       : (tensor<16x4xf32>) -> tensor<16x4xindex>
-// CHECK: %1 = "hlo_test_infer.return_type_components"(%0) {dims0 = [16, 4], element_type0 = f32} : (tensor<16x4xf32>) -> tensor<16x4xindex>
+// CHECK: %1 = "hlo_test_infer.return_type_components"(%0) {dims0 = "[16, 4]", element_type0 = f32} : (tensor<16x4xf32>) -> tensor<16x4xindex>
   func.return %1 : tensor<16x4xindex>
 }
 
@@ -163,7 +163,7 @@ func.func @gather(%operand : tensor<2x4x9xi32>, %start_indices : tensor<1x5x2xi3
   } : (tensor<2x4x9xi32>, tensor<1x5x2xi32>) -> tensor<1x5x8xi32>
   %1 = "hlo_test_infer.get_return_type_components"(%res)
       : (tensor<1x5x8xi32>) -> tensor<1x5x8xindex>
-// CHECK: %1 = "hlo_test_infer.return_type_components"(%0) {dims0 = [1, 5, 8], element_type0 = i32} : (tensor<1x5x8xi32>) -> tensor<1x5x8xindex>
+// CHECK: %1 = "hlo_test_infer.return_type_components"(%0) {dims0 = "[1, 5, 8]", element_type0 = i32} : (tensor<1x5x8xi32>) -> tensor<1x5x8xindex>
   func.return %1 : tensor<1x5x8xindex>
 }
 
@@ -175,7 +175,7 @@ func.func @rng_normal(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<7xindex>
   %1 = "stablehlo.rng"(%arg0, %arg1, %0) {rng_distribution = #stablehlo<rng_distribution NORMAL>} : (tensor<f32>, tensor<f32>, tensor<1xi64>) -> tensor<7xf32>
   %2 = "hlo_test_infer.get_return_type_components"(%1)
       : (tensor<7xf32>) -> tensor<7xindex>
-// CHECK: %2 = "hlo_test_infer.return_type_components"(%1) {dims0 = [7], element_type0 = f32} : (tensor<7xf32>) -> tensor<7xindex>
+// CHECK: %2 = "hlo_test_infer.return_type_components"(%1) {dims0 = "[7]", element_type0 = f32} : (tensor<7xf32>) -> tensor<7xindex>
   func.return %2 : tensor<7xindex>
 }
 
@@ -187,7 +187,7 @@ func.func @rng_uniform(%a: tensor<f32>, %b: tensor<f32>) -> tensor<2x3x5xindex> 
   %1 = "stablehlo.rng"(%a, %b, %0) {rng_distribution = #stablehlo<rng_distribution UNIFORM>} : (tensor<f32>, tensor<f32>, tensor<3xi64>) -> tensor<2x3x5xf32>
   %2 = "hlo_test_infer.get_return_type_components"(%1)
       : (tensor<2x3x5xf32>) -> tensor<2x3x5xindex>
-// CHECK: %2 = "hlo_test_infer.return_type_components"(%1) {dims0 = [2, 3, 5], element_type0 = f32} : (tensor<2x3x5xf32>) -> tensor<2x3x5xindex>
+// CHECK: %2 = "hlo_test_infer.return_type_components"(%1) {dims0 = "[2, 3, 5]", element_type0 = f32} : (tensor<2x3x5xf32>) -> tensor<2x3x5xindex>
   func.return %2 : tensor<2x3x5xindex>
 }
 
@@ -209,7 +209,7 @@ func.func @clamp(%arg0: tensor<1xi32>) -> tensor<1xindex> {
   %0 = "stablehlo.clamp"(%arg0, %arg0, %arg0) : (tensor<1xi32>, tensor<1xi32>, tensor<1xi32>) -> tensor<1xi32>
   %1 = "hlo_test_infer.get_return_type_components"(%0)
       : (tensor<1xi32>) -> tensor<1xindex>
-// CHECK: %1 = "hlo_test_infer.return_type_components"(%0) {dims0 = [1], element_type0 = i32} : (tensor<1xi32>) -> tensor<1xindex>
+// CHECK: %1 = "hlo_test_infer.return_type_components"(%0) {dims0 = "[1]", element_type0 = i32} : (tensor<1xi32>) -> tensor<1xindex>
   func.return %1 : tensor<1xindex>
 }
 
@@ -220,7 +220,7 @@ func.func @uniform_dequantize(%arg: tensor<16x16x!quant.uniform<i8:f32, 34.0:16>
   %0 = stablehlo.uniform_dequantize %arg : (tensor<16x16x!quant.uniform<i8:f32, 34.0:16>>) -> tensor<16x16xf32>
   %1 = "hlo_test_infer.get_return_type_components"(%0)
       : (tensor<16x16xf32>) -> tensor<16x16xindex>
-// CHECK: %1 = "hlo_test_infer.return_type_components"(%0) {dims0 = [16, 16], element_type0 = f32} : (tensor<16x16xf32>) -> tensor<16x16xindex>
+// CHECK: %1 = "hlo_test_infer.return_type_components"(%0) {dims0 = "[16, 16]", element_type0 = f32} : (tensor<16x16xf32>) -> tensor<16x16xindex>
   func.return %1 : tensor<16x16xindex>
 }
 
@@ -231,7 +231,7 @@ func.func @fft(%arg0: tensor<3x9xcomplex<f32>>) -> tensor<3x9xindex> {
   %0 = "stablehlo.fft"(%arg0) { fft_length = dense<9> : tensor<1xi64>, fft_type = #stablehlo<fft_type FFT> } : (tensor<3x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>>
   %1 = "hlo_test_infer.get_return_type_components"(%0)
       : (tensor<3x9xcomplex<f32>>) -> tensor<3x9xindex>
-// CHECK: %1 = "hlo_test_infer.return_type_components"(%0) {dims0 = [3, 9], element_type0 = complex<f32>} : (tensor<3x9xcomplex<f32>>) -> tensor<3x9xindex>
+// CHECK: %1 = "hlo_test_infer.return_type_components"(%0) {dims0 = "[3, 9]", element_type0 = complex<f32>} : (tensor<3x9xcomplex<f32>>) -> tensor<3x9xindex>
   func.return %1 : tensor<3x9xindex>
 }
 
@@ -340,7 +340,7 @@ func.func @dot_general(%arg0: tensor<2x3x4xf32>, %arg1: tensor<2x3x5xf32>) -> te
     >
   } : (tensor<2x3x4xf32>, tensor<2x3x5xf32>) -> tensor<2x4x5xf32>
   %1 = "hlo_test_infer.get_return_type_components"(%0) : (tensor<2x4x5xf32>) -> tensor<2x4x5xindex>
-  // CHECK: %1 = "hlo_test_infer.return_type_components"(%0) {dims0 = [2, 4, 5], element_type0 = f32} : (tensor<2x4x5xf32>) -> tensor<2x4x5xindex>
+  // CHECK: %1 = "hlo_test_infer.return_type_components"(%0) {dims0 = "[2, 4, 5]", element_type0 = f32} : (tensor<2x4x5xf32>) -> tensor<2x4x5xindex>
   func.return %1 : tensor<2x4x5xindex>
 }
 
@@ -508,7 +508,7 @@ func.func @reduce(%arg0: tensor<4x4xf32>, %arg1 : tensor<4xf32>)
 
   }) {dimensions = dense<[0]> : tensor<1xi64>} : (tensor<4x4xf32>, tensor<4xf32>) -> tensor<4xf32>
 
-  // CHECK: %1 = "hlo_test_infer.return_type_components"(%0) {dims0 = [4], element_type0 = f32} : (tensor<4xf32>) -> tensor<4xindex>
+  // CHECK: %1 = "hlo_test_infer.return_type_components"(%0) {dims0 = "[4]", element_type0 = f32} : (tensor<4xf32>) -> tensor<4xindex>
   %2 = "hlo_test_infer.get_return_type_components"(%0)
       : (tensor<4xf32>) -> tensor<4xindex>
 
@@ -534,10 +534,10 @@ func.func @reduce_window(%arg0: tensor<4x2xf32>, %arg1: tensor<4x2xi32>,
          : (tensor<4x2xf32>, tensor<4x2xi32>, tensor<f32>, tensor<i32>) ->
               (tensor<2x2xf32>, tensor<2x2xi32>)
 
-  // CHECK: %1 = "hlo_test_infer.return_type_components"(%0#0) {dims0 = [2, 2], dims1 = [2, 2], element_type0 = f32, element_type1 = i32} : (tensor<2x2xf32>) -> tensor<2x2xindex>
+  // CHECK: %1 = "hlo_test_infer.return_type_components"(%0#0) {dims0 = "[2, 2]", dims1 = "[2, 2]", element_type0 = f32, element_type1 = i32} : (tensor<2x2xf32>) -> tensor<2x2xindex>
   %1 = "hlo_test_infer.get_return_type_components"(%0#0)
       : (tensor<2x2xf32>) -> tensor<2x2xindex>
-  // CHECK: %2 = "hlo_test_infer.return_type_components"(%0#1) {dims0 = [2, 2], dims1 = [2, 2], element_type0 = f32, element_type1 = i32} : (tensor<2x2xi32>) -> tensor<2x2xindex>
+  // CHECK: %2 = "hlo_test_infer.return_type_components"(%0#1) {dims0 = "[2, 2]", dims1 = "[2, 2]", element_type0 = f32, element_type1 = i32} : (tensor<2x2xi32>) -> tensor<2x2xindex>
   %2 = "hlo_test_infer.get_return_type_components"(%0#1)
       : (tensor<2x2xi32>) -> tensor<2x2xindex>
 

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -4266,7 +4266,7 @@ func.func @error_batch_norm_grad(%input: tensor<*xf32>, %scale: tensor<2xf32>, %
 // -----
 
 func.func @error_batch_norm_grad(%input: tensor<?x2x2x2xf32>, %scale: tensor<2xf32>, %mean: tensor<2xf32>, %variance: tensor<2xf32>, %grad_output: tensor<?x2x2x2xf32>) -> tensor<?x2x2x2xf32> {
-  // expected-error@+1 {{expects the size of scale factor to be same as the feature count, but the size of scale factor is 2 and the feature count is -9223372036854775808.}}
+  // expected-error@+1 {{expects the size of scale factor to be same as the feature count, but the size of scale factor is 2 and the feature count is ?.}}
   %0:3 = "stablehlo.batch_norm_grad" (%input, %scale, %mean, %variance, %grad_output) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<?x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<?x2x2x2xf32>) -> (tensor<?x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>)
   func.return %0#0 : tensor<?x2x2x2xf32>
 }


### PR DESCRIPTION
Prepare for dynamic dim size to be changed from -1 to INTMIN.

This is a first step at removing the reliance on upstream `kDynamicSize`. There is more refactoring that can be done, but this change will at least make it so that some of our error messages will display `?` instead of the value, and our infer tests will continue to display `-1` regardless of what the underlying dynamic size is.