### PR TITLE
update spec checklist: Adding ticket link in PR

### DIFF
--- a/docs/spec_checklist.md
+++ b/docs/spec_checklist.md
@@ -20,10 +20,9 @@ reviews:
       1. Matches
          [StablehloOps.cpp](https://github.com/openxla/stablehlo/blob/main/stablehlo/dialect/StablehloOps.cpp).
       1. If there are any mismatches, check that there are corresponding
-         tickets. For all those tickets make sure to add their links to the
-         affected PRs; to keep track of all the Ops, associated with the
-         affected PRs, that need to be addressed as part of resolving those
-         tickets.
+         tickets. Link all those tickets in the spec, in locations which are
+         as specific as possible (e.g. if a ticket is about a constraint that
+         hasn't been implemented, link the ticket right in that constraint).
       1. If the corresponding parts of the ODS and StablehloOps.cpp match the
          spec, check that the "Verification" and "Type Inference" columns in
          [status.md](https://github.com/openxla/stablehlo/blob/main/docs/status.md)

--- a/docs/spec_checklist.md
+++ b/docs/spec_checklist.md
@@ -19,7 +19,11 @@ reviews:
       1. Matches the ODS.
       1. Matches
          [StablehloOps.cpp](https://github.com/openxla/stablehlo/blob/main/stablehlo/dialect/StablehloOps.cpp).
-      1. If there are any mismatches, check that there are corresponding tickets.
+      1. If there are any mismatches, check that there are corresponding
+         tickets. If the ticket happens to be a generic one, applied to multiple
+         similar mismatches, then make sure to add a link of the ticket in all
+         the affected PRs: to keep track of all the PRs linked to the common
+         ticket.
       1. If the corresponding parts of the ODS and StablehloOps.cpp match the
          spec, check that the "Verification" and "Type Inference" columns in
          [status.md](https://github.com/openxla/stablehlo/blob/main/docs/status.md)

--- a/docs/spec_checklist.md
+++ b/docs/spec_checklist.md
@@ -20,10 +20,10 @@ reviews:
       1. Matches
          [StablehloOps.cpp](https://github.com/openxla/stablehlo/blob/main/stablehlo/dialect/StablehloOps.cpp).
       1. If there are any mismatches, check that there are corresponding
-         tickets. If the ticket happens to be a generic one, applied to multiple
-         similar mismatches, then make sure to add a link of the ticket in all
-         the affected PRs: to keep track of all the PRs linked to the common
-         ticket.
+         tickets. For all those tickets make sure to add their links to the
+         affected PRs; to keep track of all the Ops, associated with the
+         affected PRs, that need to be addressed as part of resolving those
+         tickets.
       1. If the corresponding parts of the ODS and StablehloOps.cpp match the
          spec, check that the "Verification" and "Type Inference" columns in
          [status.md](https://github.com/openxla/stablehlo/blob/main/docs/status.md)


### PR DESCRIPTION
For tickets like https://github.com/openxla/stablehlo/issues/369 which is applicable to many PRs and prevents the status of one or more implementations from being a `yes`, it would be useful to track all the Ops which needs to be tracked before closing this issue. Linking the ticket in the PR could be a solution and hence the proposal.