### PR TITLE
Expand the checklist to include HloInstruction::CreateFromProto

### DIFF
--- a/docs/spec_checklist.md
+++ b/docs/spec_checklist.md
@@ -5,12 +5,15 @@ specification. At the moment, these changes typically involve checking multiple
 things in multiple sources, so this document summarizes them all to simplify
 reviews:
 
+  1. Check that the "Specification" column in status.md says "yes".
   1. Check if the section title matches the op's mnemonic in
      [the ODS](https://github.com/openxla/stablehlo/blob/main/stablehlo/dialect/StablehloOps.td).
   1. Check if the "Semantics" section matches XLA's
      [Operation Semantics](https://www.tensorflow.org/xla/operation_semantics).
-  1. Check if the "Inputs" and "Outputs" sections list items in the same order
-     as the ODS.
+  1. Check whether the "Inputs" and "Outputs" sections:
+      1. List the same items as the ODS.
+      1. List the same items as [HloInstruction::CreateFromProto](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/xla/hlo/ir/hlo_instruction.cc).
+      1. Are ordered exactly like ODS.
   1. Check whether the "Constraints" section:
       1. Matches XLA's
          [shape_inference.cc](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/xla/service/shape_inference.cc).
@@ -34,7 +37,6 @@ reviews:
       1. Uses generic MLIR syntax which can be obtained by running
          `stablehlo-opt -mlir-print-op-generic` (we stick to generic syntax in
          the spec to avoid having to change the spec on prettyprinter changes).
-  1. Check that the "Specification" column in status.md says "yes".
   1. Check that the `description` in op's ODS:
       1. Includes the first sentence of the spec.
       1. Then links to the corresponding section of the spec.

--- a/docs/spec_checklist.md
+++ b/docs/spec_checklist.md
@@ -14,6 +14,8 @@ reviews:
       1. List the same items as the ODS.
       1. List the same items as [HloInstruction::CreateFromProto](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/xla/hlo/ir/hlo_instruction.cc).
       1. Are ordered exactly like ODS.
+      1. If there are any mismatches, check that there are corresponding
+         tickets.
   1. Check whether the "Constraints" section:
       1. Matches XLA's
          [shape_inference.cc](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/xla/service/shape_inference.cc).

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -162,18 +162,6 @@ syntax.
   following mapping from indices to elements: `{0, 0} => 1`, `{0, 1} => 2`,
   `{0, 2} => 3`, `{1, 0} => 4`, `{1, 1} => 5`, `{1, 2} => 6`.
 
-## Structure of an Op’s Specification
-
-The specification of an op comprises of the following components (in the order
-described below)
-
-  * **Semantics** Semantics of the operation.
-  * **Inputs** Meaning of input(s) and their type(s).
-  * **Outputs** Meaning of the output(s) and the type(s).
-  * **Constraints** Constraints on the input(s) and the output(s).
-  * **Examples** Examples demonstrating the working of the op using
-    [MLIR generic syntax](https://mlir.llvm.org/docs/LangRef/#operations).
-
 ## Index of Ops
    * [abs](#stablehloabs)
    * [add](#stablehloadd)


### PR DESCRIPTION
This is really useful (see #565 for details).

Also remove the "Structure of an Op’s Specification" section of the spec since it has been superseded by the checklist a while ago.