### PR TITLE
Add spec for parallel execution semantics

### DIFF
--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -213,7 +213,7 @@ lists of replica ids - and computes a Cartesian product of `replica_groups` by
 `replica_ids`. More formally:
 
 ```Python
-def cross_replica(replica_groups: List[List[ui32]]) -> List[List[Tuple[ui32, ui32]]]:
+def cross_replica(replica_groups: List[List[ReplicaId]]) -> List[List[ProcessId]]:
   for replica_group in replica_groups:
     for partition_id in partition_ids:
       process_group = []
@@ -233,7 +233,7 @@ a list of lists of partition ids - and computes a Cartesian product of
 elements and cover all `partition_ids`. More formally:
 
 ```Python
-def cross_partition(partition_groups: List[List[ui32]]) -> List[List[Tuple[ui32, ui32]]]:
+def cross_partition(partition_groups: List[List[PartitionId]]) -> List[List[ProcessId]]:
   for partition_group in partition_groups:
     for replica_id in replica_ids:
       process_group = []
@@ -254,7 +254,7 @@ computes Cartesian products of each `replica_group` by `partition_ids`.
 More formally:
 
 ```Python
-def cross_replica_and_partition(replica_groups: List[List[ui32]]) -> List[List[Tuple[ui32, ui32]]]:
+def cross_replica_and_partition(replica_groups: List[List[ReplicaId]]) -> List[List[ProcessId]]:
   for replica_group in replica_groups:
     process_group = []
     for partition_id in partition_ids:
@@ -274,7 +274,7 @@ process ids. `flattened_id_groups` must have unique elements and cover all
 `process_ids`. More formally:
 
 ```Python
-def flattened_ids(flattened_id_groups: List[List[ui32]]) -> List[List[Tuple[ui32, ui32]]]:
+def flattened_ids(flattened_id_groups: List[List[ui32]]) -> List[List[ProcessId]]:
   for flattened_id_group in flattened_id_groups:
     process_group = []
     for flattened_id in flattened_id_group:

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -111,6 +111,7 @@ Here is an example of a program that consists of a function `@main` which takes
 three inputs (`%image`, `%weights` and `%bias`) and produces one output (`%4`).
 Below we describe how this program can be executed.
 
+```mlir
 stablehlo.func @main(
   %image: tensor<28x28xf32>,
   %weights: tensor<784x10xf32>,
@@ -123,6 +124,7 @@ stablehlo.func @main(
   %4 = "stablehlo.maximum"(%2, %3) : (tensor<1x10xf32>, tensor<1x10xf32>) -> tensor<1x10xf32>
   "stablehlo.return"(%4): (tensor<1x10xf32>) -> ()
 }
+```
 
 ## Execution
 

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -248,7 +248,7 @@ For example, for `partition_groups = [[0, 1]]` and `num_replicas = 4`,
 `[[(0, 0), (0, 1)], [(1, 0), (1, 1)], [(2, 0), (2, 1)], [(3, 0), (3, 1)]]`.
 
 3) **cross_replica_and_partition** (as in "both cross-replica and
-cross-partition communications will be happening within each process group").
+cross-partition communications may be happening within each process group").
 This strategy takes `replica_groups` - a list of lists of replica ids - and
 computes Cartesian products of each `replica_group` by `partition_ids`.
 `replica_groups` must have unique elements and cover all `replica_ids`.

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -174,7 +174,7 @@ it is usually unambiguous to refer to these values by their names. However, when
 describing semantics of collective ops, that is insufficient, and we use the
 notation `name<run_id>` to refer to the value `name` within a particular
 `run_id`. (From what perspective, unqualified `name` can be viewed as a
-shorthand for `name<(replica_id(), partition_id())>`).
+shorthand for `name<replica_id(), partition_id()>`).
 
 The execution order across runs is implementation-defined, except for the
 synchronization introduced by collective ops as described below.

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -172,9 +172,9 @@ a small number of collective ops described below.
 Given that execution of most of the ops is only using values from the same
 process, it is usually unambiguous to refer to these values by their names.
 However, when describing semantics of collective ops, that is insufficient, and
-we use the notation `name<process_id>` to refer to the value `name` within a
+we use the notation `name@process_id` to refer to the value `name` within a
 particular process. (From what perspective, unqualified `name` can be viewed as
-a shorthand for `name<replica_id(), partition_id()>`).
+a shorthand for `name@(replica_id(), partition_id())`).
 
 The execution order across processes is implementation-defined, except for the
 synchronization introduced by collective ops as described below.

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -156,13 +156,15 @@ processes are executing at the same time. Each process has a unique
 `process_id = (replica_id, partition_id)`, where
 `replica_id ∊ replica_ids = [0, ..., num_replicas-1]` and
 `partition_id ∊ partition_ids = [0, ..., num_partitions-1]` which both have
-type `ui32`. The size of the grid is known statically for every program, and
-the position within the grid is known statically for every process.
+type `ui32`.
+
+The size of the grid is known statically for every program, and the position
+within the grid is known statically for every process. Each process has access
+to its position within the grid via the `replica_id` and `partition_id` ops.
 
 Within the grid, the programs can all be the same (in the "Single Program,
 Multiple Data" style), can all be different (in the "Multiple Program, Multiple
-Data" style) or something in between. Each program has access to its position
-within the grid via the `replica_id` and `partition_id` ops.
+Data" style) or something in between.
 
 Within the grid, the processes are mostly independent from each other - they
 have separate operation statuses, separate input/intermediate/output values and
@@ -173,7 +175,7 @@ Given that execution of most of the ops is only using values from the same
 process, it is usually unambiguous to refer to these values by their names.
 However, when describing semantics of collective ops, that is insufficient, and
 we use the notation `name@process_id` to refer to the value `name` within a
-particular process. (From what perspective, unqualified `name` can be viewed as
+particular process. (From that perspective, unqualified `name` can be viewed as
 a shorthand for `name@(replica_id(), partition_id())`).
 
 The execution order across processes is implementation-defined, except for the
@@ -187,11 +189,10 @@ the processes in the StableHLO grid into **StableHLO process groups** and
 execute a joint computation within each process group, independently from other
 process groups.
 
-For all processes within each process group, collective ops introduce a
-synchronization barrier, i.e. the execution of a collective op in all these
-processes doesn't start until the execution of all these processes reaches
-the op. Further formalization, e.g. elaborating on what it means for execution
-to reach an op and what happens to a process group if it doesn't happen, is TBD.
+Within each process group, collective ops may introduce a synchronization
+barrier. Further formalization, e.g. elaborating on when exactly this
+synchronization happens, how exactly the processes arrive at this barrier,
+and what happens if they don't, is TBD.
 
 If the process group involves cross-partition communication, i.e. there are
 processes in the process group whose partition ids are different, then execution


### PR DESCRIPTION
I think that recent PRs with specs for collective ops (e.g. #503) would benefit from a more formal definition of parallel execution semantics of StableHLO programs.

That will provide additional clarity which is needed at the moment (see discussions in the PRs) and reduce the duplication between the specs of individual collective ops.

The description of execution semantics isn't yet as formal as I'd like, but it can already benefit specs for collective ops. I'll leave the rest to follow-up work within #484.