### PR TITLE
Add spec for InfeedOp and OutfeedOp

### DIFF
--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -379,6 +379,7 @@ syntax.
    * [get_tuple_element](#stablehloget_tuple_element)
    * [if](#stablehloif)
    * [imag](#stablehloimag)
+   * [infeed](#stablehloinfeed)
    * [iota](#stablehloiota)
    * [is_finite](#stablehlois_finite)
    * [log](#stablehlolog)
@@ -392,6 +393,7 @@ syntax.
    * [not](#stablehlonot)
    * [optimization_barrier](#stablehlooptimization_barrier)
    * [or](#stablehloor)
+   * [outfeed](#stablehlooutfeed)
    * [pad](#stablehlopad)
    * [popcnt](#stablehlopopcnt)
    * [power](#stablehlopower)
@@ -2324,6 +2326,48 @@ More formally, for each element `x`: `imag(x) = is_complex(x) ? x.imag : 0.0`.
 
 [Back to Ops](#index-of-ops)
 
+
+## stablehlo.infeed
+
+### Semantics
+
+Reads `results` from the infeed queue of the device. Multiple
+`stablehlo.infeed` operations are allowed in a computation, but there must be a
+total order among them.
+
+The infeed configuration `infeed_config` includes target-dependent metadata
+needed for the backend compiler (e.g., infeed buffer address).
+
+### Inputs
+
+| Name            | Type                                                                                     |
+|-----------------|------------------------------------------------------------------------------------------|
+| `token`         | `token`                                                                                  |
+| `infeed_config` | string                                                                                   |
+| `layout`        | array of array of type `integer` [todo](https://github.com/openxla/stablehlo/issues/629) |
+
+### Outputs
+
+| Name      | Type                                                       |
+|-----------|------------------------------------------------------------|
+| `results` | variadic number of tensors of any supported type or tokens |
+
+### Constraints
+
+  * (C1) size(`results`) $\ge$ 1.
+  * (C2) type(`results`[-1]) $=$ `token`.
+  * (C3) size(`layout`) $=$ size(`results`) - 1.
+  * (C4) size(`layout[i]`) $=$ rank(`results[i]`) for all i $\in$ [0,
+         size(`layout`)).
+
+### Examples
+
+```mlir
+%results:2 = "stablehlo.infeed"(%token) { infeed_config = "", layout = [[2, 0, 1] } : (!stablehlo.token) -> (tensor<3x3x3xi32>, !stablehlo.token)
+```
+
+[Back to Ops](#index-of-ops)
+
 ## stablehlo.iota
 
 ### Semantics
@@ -2891,6 +2935,38 @@ operation.
 // %rhs: [[false, true], [false, true]]
 %result = "stablehlo.or"(%lhs, %rhs) : (tensor<2x2xi1>, tensor<2x2xi1>) -> tensor<2x2xi1>
 // %result: [[false, true], [true, true]]
+```
+
+[Back to Ops](#index-of-ops)
+
+## stablehlo.outfeed
+
+### Semantics
+
+Writes `inputs` to the outfeed queue of the device. The input `token` is used
+for ordering side-effecting operations.
+
+The outfeed configuration `outfeed_config` includes target-dependent metadata
+needed for the backend compiler.
+
+### Inputs
+
+| Name             | Type                                             |
+|------------------|--------------------------------------------------|
+| `inputs`         | variadic number of tensors of any supported type |
+| `token`          | `token`                                          |
+| `outfeed_config` | string                                           |
+
+### Outputs
+
+| Name      | Type    |
+|-----------|---------|
+| `results` | `token` |
+
+### Examples
+
+```mlir
+%results = "stablehlo.outfeed"(%arg0, %arg1) {outfeed_config = ""} : (tensor<3x3x3xi32>, !stablehlo.token) -> !stablehlo.token
 ```
 
 [Back to Ops](#index-of-ops)

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -2331,12 +2331,13 @@ More formally, for each element `x`: `imag(x) = is_complex(x) ? x.imag : 0.0`.
 
 ### Semantics
 
-Reads `results` from the infeed queue of the device. Multiple
-`stablehlo.infeed` operations are allowed in a computation, but there must be a
-total order among them.
+Reads `results` from the infeed queue of the device.
 
-The infeed configuration `infeed_config` includes target-dependent metadata
-needed for the backend compiler (e.g., infeed buffer address).
+Not having a total order among the infeed operations in a program might lead to
+data races or even deadlocks.
+
+The infeed configuration string `infeed_config` includes target-dependent
+metadata.
 
 ### Inputs
 
@@ -2363,7 +2364,7 @@ needed for the backend compiler (e.g., infeed buffer address).
 ### Examples
 
 ```mlir
-%results:2 = "stablehlo.infeed"(%token) { infeed_config = "", layout = [[2, 0, 1] } : (!stablehlo.token) -> (tensor<3x3x3xi32>, !stablehlo.token)
+%results:2 = "stablehlo.infeed"(%token) { infeed_config = "", layout = [[2, 0, 1]] } : (!stablehlo.token) -> (tensor<3x3x3xi32>, !stablehlo.token)
 ```
 
 [Back to Ops](#index-of-ops)
@@ -2943,11 +2944,13 @@ operation.
 
 ### Semantics
 
-Writes `inputs` to the outfeed queue of the device. The input `token` is used
-for ordering side-effecting operations.
+Writes `inputs` to the outfeed queue of the device.
 
-The outfeed configuration `outfeed_config` includes target-dependent metadata
-needed for the backend compiler.
+Not having a total order among the outfeed operations in a program might lead to
+data races or even deadlocks.
+
+The outfeed configuration string  `outfeed_config` includes target-dependent
+metadata.
 
 ### Inputs
 
@@ -2966,7 +2969,7 @@ needed for the backend compiler.
 ### Examples
 
 ```mlir
-%results = "stablehlo.outfeed"(%arg0, %arg1) {outfeed_config = ""} : (tensor<3x3x3xi32>, !stablehlo.token) -> !stablehlo.token
+%results = "stablehlo.outfeed"(%input0, %token) {outfeed_config = ""} : (tensor<3x3x3xi32>, !stablehlo.token) -> !stablehlo.token
 ```
 
 [Back to Ops](#index-of-ops)

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -26,9 +26,6 @@ Following are the supported element types in StableHLO:
     (represents a pair of `f64`). Exact representation of complex types
     (e.g. whether the real part or the imaginary part comes first in memory)
     is implementation-defined.
-  * **String type**  represent a sequence of bytes. Exact representation of
-    string type (e.g. null terminated or not, encoding etc.) is
-    implementation-defined.
 
 **Tensor types** are the cornerstone of the StableHLO type system. They model
 immutable n-dimensional arrays and are referred to in the document as
@@ -97,11 +94,19 @@ the full form: `(I1, ..., IN) -> (O1, ..., OM)`, or 2) the short form:
 `function`, where:
   * `Ii` are types of inputs of the corresponding function.
   * `Oj` are types of outputs of the corresponding function.
-  * Neither input nor output types can be function types themselves.
+  * Input types and output types are one of tensor, token or tuple.
 
 Function types are not first class, i.e. StableHLO doesn't support values of
 function types. Some StableHLO ops can take functions as inputs, but they are
 never produced as outputs.
+
+**String type** represent a sequence of bytes and is referred to in the document
+as `string`. Exact representation of string type (e.g. null terminated or not,
+encoding etc.) is implementation-defined.
+
+Strings types are not first class, i.e. StableHLO doesn't support values of
+string types. Some StableHLO ops can take strings as inputs, but they are never
+produced as outputs.
 
 ## Programs
 
@@ -355,13 +360,13 @@ syntax.
   floating-point constants of `f32` or `f64` types, e.g. `(12.34, 56.78)`,
   where the first constant is the real part, and the second constant is the
   imaginary part.
-  * **String constants** String constants are represented as a sequence of
-  bytes enclosed in double quotation mark symbols, e.g. "foo123?" (in ASCII
-  encoding) or "\18\A3" (in hex encoding).
   * **Tensor constants** use NumPy notation. For example,
   `[[1, 2, 3], [4, 5, 6]]` is a constant of type `tensor<2x3xf32>` with the
   following mapping from indices to elements: `{0, 0} => 1`, `{0, 1} => 2`,
   `{0, 2} => 3`, `{1, 0} => 4`, `{1, 1} => 5`, `{1, 2} => 6`.
+  * **String constants** String constants are represented as a sequence of
+  bytes enclosed in double quotation mark symbols, e.g. "foo123?" (in ASCII
+  encoding) or "\18\A3" (in hex encoding).
 
 ## Index of Ops
    * [abs](#stablehloabs)
@@ -2381,8 +2386,7 @@ as a value that other operations can take a data dependency on.
 
 ```mlir
 %results:2 = "stablehlo.infeed"(%token) {
-  infeed_config = "",
-  layout = [[2, 0, 1]]
+  infeed_config = ""
 } : (!stablehlo.token) -> (tensor<3x3x3xi32>, !stablehlo.token)
 ```
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -96,7 +96,7 @@ one of the following tracking labels.
 | get_tuple_element        | yes           | yes          | yes            | yes             | no          |
 | if                       | yes           | revisit      | yes            | no              | no          |
 | imag                     | yes           | yes          | yes            | yes             | no          |
-| infeed                   | no            | revisit      | no             | no              | no          |
+| infeed                   | yes           | revisit      | infeasible     | no              | no          |
 | iota                     | yes           | yes          | infeasible     | yes             | yes         |
 | is_finite                | yes           | yes          | yes            | yes             | no          |
 | log                      | yes           | yes          | yes            | yes             | no          |
@@ -110,7 +110,7 @@ one of the following tracking labels.
 | not                      | yes           | yes          | yes            | yes             | yes         |
 | optimization_barrier     | yes           | yes          | yes            | yes             | no          |
 | or                       | yes           | yes          | yes            | yes             | yes         |
-| outfeed                  | no            | revisit      | no             | no              | no          |
+| outfeed                  | yes           | yes          | no             | no              | no          |
 | pad                      | yes           | yes          | yes            | yes             | no          |
 | popcnt                   | yes           | yes          | yes            | yes             | no          |
 | power                    | yes           | revisit      | yes            | yes             | no          |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1012,7 +1012,7 @@ def StableHLO_OutfeedOp : StableHLO_Op<"outfeed", []> {
 
     Example:
     ```mlir
-    %results = "stablehlo.outfeed"(%arg0, %arg1) {outfeed_config = ""} : (tensor<3x3x3xi32>, !stablehlo.token) -> !stablehlo.token
+    %results = "stablehlo.outfeed"(%input0, %token) {outfeed_config = ""} : (tensor<3x3x3xi32>, !stablehlo.token) -> !stablehlo.token
     ```
   }];
 

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -978,14 +978,17 @@ def StableHLO_InfeedOp : StableHLO_Op<"infeed", []> {
   let summary = "Infeed operator";
 
   let description = [{
-    Reads `results` from the infeed queue of the device.
+    Reads data from the infeed and produces `results`.
 
     See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehloinfeed
 
     Example:
     ```mlir
-    %results:2 = "stablehlo.infeed"(%token) { infeed_config = "", layout = [[2, 0, 1] } : (!stablehlo.token) -> (tensor<3x3x3xi32>, !stablehlo.token)
+    %results:2 = "stablehlo.infeed"(%token) {
+      infeed_config = "",
+      layout = [[2, 0, 1]]
+    } : (!stablehlo.token) -> (tensor<3x3x3xi32>, !stablehlo.token)
     ```
   }];
 
@@ -1005,14 +1008,16 @@ def StableHLO_OutfeedOp : StableHLO_Op<"outfeed", []> {
   let summary = "Outfeed operator";
 
   let description = [{
-    Writes `inputs` to the outfeed queue of the device.
+    Writes `inputs` to the outfeed and produces `result`.
 
     See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlooutfeed
 
     Example:
     ```mlir
-    %results = "stablehlo.outfeed"(%input0, %token) {outfeed_config = ""} : (tensor<3x3x3xi32>, !stablehlo.token) -> !stablehlo.token
+    %result = "stablehlo.outfeed"(%inputs0, %token) {
+      outfeed_config = ""
+    } : (tensor<3x3x3xi32>, !stablehlo.token) -> !stablehlo.token
     ```
   }];
 

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -978,17 +978,15 @@ def StableHLO_InfeedOp : StableHLO_Op<"infeed", []> {
   let summary = "Infeed operator";
 
   let description = [{
-    Reads a single data item from the implicit Infeed streaming interface of
-    the device, interpreting the data as the given shape, and returns a XlaOp
-    of the data. Multiple Infeed operations are allowed in a computation, but
-    there must be a total order among the Infeed operations.
+    Reads `results` from the infeed queue of the device.
 
-    Attributes:
-      layout:  Array attribute. Each element of the array is a minor_to_major
-               array corresponding to the shape of the data read from the infeed
-               interface.
+    See:
+    https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehloinfeed
 
-    See https://www.tensorflow.org/xla/operation_semantics#infeed.
+    Example:
+    ```mlir
+    %results:2 = "stablehlo.infeed"(%token) { infeed_config = "", layout = [[2, 0, 1] } : (!stablehlo.token) -> (tensor<3x3x3xi32>, !stablehlo.token)
+    ```
   }];
 
   let arguments = (ins
@@ -1007,11 +1005,15 @@ def StableHLO_OutfeedOp : StableHLO_Op<"outfeed", []> {
   let summary = "Outfeed operator";
 
   let description = [{
-    Generates outgoing data transfers for the given data. It takes data and a
-    token type operand and produces a token type value. Tokens are used for
-    ordering side-effecting operations.
+    Writes `inputs` to the outfeed queue of the device.
 
-    See https://www.tensorflow.org/xla/operation_semantics#outfeed.
+    See:
+    https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlooutfeed
+
+    Example:
+    ```mlir
+    %results = "stablehlo.outfeed"(%arg0, %arg1) {outfeed_config = ""} : (tensor<3x3x3xi32>, !stablehlo.token) -> !stablehlo.token
+    ```
   }];
 
   let arguments = (ins

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -986,8 +986,7 @@ def StableHLO_InfeedOp : StableHLO_Op<"infeed", []> {
     Example:
     ```mlir
     %results:2 = "stablehlo.infeed"(%token) {
-      infeed_config = "",
-      layout = [[2, 0, 1]]
+      infeed_config = ""
     } : (!stablehlo.token) -> (tensor<3x3x3xi32>, !stablehlo.token)
     ```
   }];


### PR DESCRIPTION
fixes #525 

verification of infeed op is revisit based on https://github.com/openxla/stablehlo/issues/639

Note that for outfeed op we are using the  output name  as `results` based on the implicit name [introduced by the tablegen file](https://github.com/openxla/stablehlo/blob/dbf9964c6ce980e1976041700807bd94e6adf849/stablehlo/dialect/StablehloOps.td#L1030 ) even though it should be explicitly called out as `result` (singular). This will be addressed in https://github.com/openxla/stablehlo/issues/351#issuecomment-1326914173, item 4.
