### PR TITLE
Slight rewording of the BitcastConvertOp spec

### DIFF
--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -614,8 +614,7 @@ Let `E` and `E'` be the `operand` and `result` element type respectively, and
 
 The behavior of `bits` is implementation-defined because the exact
 representation of tensors is implementation-defined, and the exact
-representation of floating-point types is implementation-defined (e.g. IEEE-754
-allows implementations to deviate on endianness).
+representation of element types is implementation-defined as well.
 
 ### Inputs
 


### PR DESCRIPTION
I merged #434 and only then realized that the explanation of why `bits` has implementation-defined behavior could've been updated to reflect the latest conversation on the pull request.

It's not just the floating-point representation is implementation-defined, it's also integer representation and boolean representation.