### PR TITLE
Fix verifier check disallowing dynamic shapes in reduce and related ops

### DIFF
--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -482,8 +482,9 @@ LogicalResult verifyReducerShape(
          outputShapeIdx < static_cast<int64_t>(allowedDimensions.size()) &&
          argShapeIdx < static_cast<int64_t>(argShape.size());
          outputShapeIdx++)
-      if (allowedDimensions[outputShapeIdx] == argShape[argShapeIdx] ||
-          argShape[argShapeIdx] == ShapedType::kDynamic)
+      if (allowedDimensions[outputShapeIdx] == ShapedType::kDynamic ||
+          argShape[argShapeIdx] == ShapedType::kDynamic ||
+          allowedDimensions[outputShapeIdx] == argShape[argShapeIdx])
         argShapeIdx++;
 
     if (argShapeIdx != static_cast<int64_t>(argShape.size()))

--- a/stablehlo/tests/verify_reduce.mlir
+++ b/stablehlo/tests/verify_reduce.mlir
@@ -381,6 +381,23 @@ func.func @verify_reducer_function(%arg0: tensor<8x5xf32>, %arg1 : tensor<4xf32>
 
 // -----
 
+// Verifies that dynamic input type is allowed with reducer function with static shapes.
+func.func @verify_dynamic_operand(%arg0: tensor<8x?xf32>, %arg1 : tensor<4xf32>)
+    -> (tensor<?xf32>) {
+
+  %0 = "stablehlo.reduce"(%arg0, %arg1) ({
+
+  ^bb0(%arg2: tensor<4xf32>, %arg3: tensor<4xf32> ):
+    %1 = "stablehlo.add"(%arg2, %arg3) : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
+    "stablehlo.return"(%1) : (tensor<4xf32>) -> ()
+
+  }) {dimensions = dense<[0]> : tensor<1xi64>} : (tensor<8x?xf32>, tensor<4xf32>) -> tensor<?xf32>
+
+  func.return %0: tensor<?xf32>
+}
+
+// -----
+
 func.func @reduce_verify_rettype(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xi32>,
     %arg2: tensor<f32>, %arg3: tensor<i32>) -> (tensor<?xf32>) {
 


### PR DESCRIPTION
In the verification of the reducer function, while verifying that the block argument shape is a sub-sequence of the computed output shape, it doesn't consider dynamic shapes.

The original intention here might have been to check that `allowedDimensions[argShapeIdx]` was dynamic and not `argShape[argShapeIdx]`. Keeping the original check for now but I wonder if the op should simply disallow dynamic block arguments. Those are not going to be refined based on the input shapes. If so, such a check could be added later on.