### PR TITLE
Fix typos in AllGatherOp's status

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -45,7 +45,7 @@ one of the following tracking labels.
 | abs                      | yes           | yes          | yes            | yes             | no          |
 | add                      | yes           | yes          | yes            | yes             | yes         |
 | after_all                | yes           | yes          | no             | yes             | no          |
-| all_gather               | yes           | resivit      | revisit        | no              | no          |
+| all_gather               | yes           | revisit      | no             | no              | no          |
 | all_reduce               | yes           | revisit      | yes            | no              | no          |
 | all_to_all               | yes           | revisit      | yes            | no              | no          |
 | and                      | yes           | yes          | yes            | yes             | yes         |


### PR DESCRIPTION
Type Inference is set to "no", because "revisit" implies that there is an implementation that needs to be revisited.