### PR TITLE
Implement type inference for ReturnOp

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -124,7 +124,7 @@ one of the following tracking labels.
 | remainder                | yes           | yes          | yes            | yes             | no          |
 | replica_id               | yes           | yes          | yes            | yes             | no          |
 | reshape                  | yes           | yes          | infeasible     | yes             | yes         |
-| return                   | no            | revisit      | no             | yes             | no          |
+| return                   | no            | revisit      | yes            | yes             | no          |
 | reverse                  | yes           | revisit      | yes            | yes             | no          |
 | rng                      | yes           | yes          | yes            | yes             | no          |
 | rng_bit_generator        | yes           | revisit      | infeasible     | yes             | no          |

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -3325,12 +3325,23 @@ LogicalResult ReduceOp::reifyReturnTypeShapes(
 // OptimizationBarrierOp
 //===----------------------------------------------------------------------===//
 LogicalResult OptimizationBarrierOp::inferReturnTypes(
-    MLIRContext*, Optional<Location>, ValueRange operands,
+    MLIRContext*, Optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, RegionRange,
     SmallVectorImpl<Type>& inferredReturnTypes) {
   OptimizationBarrierOp::Adaptor adaptor(operands, attributes);
-  return hlo::inferOptimizationBarrierOp(adaptor.getOperand(),
+  return hlo::inferOptimizationBarrierOp(location, adaptor.getOperand(),
                                          inferredReturnTypes);
+}
+
+//===----------------------------------------------------------------------===//
+// OptimizationBarrierOp
+//===----------------------------------------------------------------------===//
+LogicalResult ReturnOp::inferReturnTypes(
+    MLIRContext*, Optional<Location> location, ValueRange operands,
+    DictionaryAttr attributes, RegionRange,
+    SmallVectorImpl<Type>& inferredReturnTypes) {
+  ReturnOp::Adaptor adaptor(operands, attributes);
+  return hlo::inferReturnOp(location, inferredReturnTypes);
 }
 
 //===----------------------------------------------------------------------===//

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -3334,7 +3334,7 @@ LogicalResult OptimizationBarrierOp::inferReturnTypes(
 }
 
 //===----------------------------------------------------------------------===//
-// OptimizationBarrierOp
+// ReturnOp
 //===----------------------------------------------------------------------===//
 LogicalResult ReturnOp::inferReturnTypes(
     MLIRContext*, Optional<Location> location, ValueRange operands,

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2773,7 +2773,9 @@ def StableHLO_ReduceWindowOp: StableHLO_Op<"reduce_window", [
   }];
 }
 
-def StableHLO_ReturnOp : StableHLO_Op<"return", [Pure, Terminator]> {
+def StableHLO_ReturnOp : StableHLO_Op<"return",
+      [Pure, Terminator,
+      DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
   let summary = [{
     The `hlo.return` operation terminates a region and returns values.
 

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -981,7 +981,8 @@ LogicalResult inferPadOp(Optional<Location> location, Value operand,
 }
 
 LogicalResult inferOptimizationBarrierOp(
-    ValueRange operand, SmallVectorImpl<Type>& inferredReturnTypes) {
+    Optional<Location> location, ValueRange operand,
+    SmallVectorImpl<Type>& inferredReturnTypes) {
   for (auto inputArgType : operand.getTypes()) {
     inferredReturnTypes.emplace_back(inputArgType);
   }
@@ -1171,6 +1172,11 @@ LogicalResult inferReduceWindowOp(
           initValueTypes[i].getElementType());
   }
 
+  return success();
+}
+
+LogicalResult inferReturnOp(Optional<Location> location,
+                            SmallVectorImpl<Type>& inferredReturnTypes) {
   return success();
 }
 

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -148,7 +148,8 @@ LogicalResult inferPadOp(Optional<Location> location, Value operand,
                          SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferOptimizationBarrierOp(
-    ValueRange operand, SmallVectorImpl<Type>& inferredReturnTypes);
+    Optional<Location> location, ValueRange operand,
+    SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferReduceOp(
     Optional<Location> location, ValueRange inputs, ValueRange initValues,
@@ -163,6 +164,9 @@ LogicalResult inferReduceWindowOp(
     Optional<DenseIntElementsAttr> windowDilations,
     Optional<DenseIntElementsAttr> padding, Region& body,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
+
+LogicalResult inferReturnOp(Optional<Location> location,
+                            SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferSelectOp(
     Optional<Location> location, Value pred, Value onTrue, Value onFalse,


### PR DESCRIPTION
Cannot write a FileCheck-based test because ReturnOp doesn't have result values.