### PR TITLE
Improve type inference for SelectOp

### DIFF
--- a/stablehlo/dialect/Base.cpp
+++ b/stablehlo/dialect/Base.cpp
@@ -295,5 +295,19 @@ LogicalResult inferMostSpecificType(
   return success();
 }
 
+LogicalResult inferMostSpecificTypeComponents(
+    Optional<Location> location, TypeRange inputTypes,
+    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
+  SmallVector<Type> inferredReturnTypes;
+  if (failed(hlo::inferMostSpecificType(location, inputTypes,
+                                        inferredReturnTypes))) {
+    return failure();
+  }
+  for (auto inferredReturnType : inferredReturnTypes) {
+    inferredReturnShapes.emplace_back(inferredReturnType.cast<ShapedType>());
+  }
+  return success();
+}
+
 }  // namespace hlo
 }  // namespace mlir

--- a/stablehlo/dialect/Base.h
+++ b/stablehlo/dialect/Base.h
@@ -77,6 +77,10 @@ LogicalResult inferMostSpecificType(Optional<Location> location,
                                     TypeRange inputTypes,
                                     SmallVectorImpl<Type> &inferredReturnTypes);
 
+LogicalResult inferMostSpecificTypeComponents(
+    Optional<Location> location, TypeRange inputTypes,
+    SmallVectorImpl<ShapedTypeComponents> &inferredReturnShapes);
+
 // Shape derivation function that computes the shape of the result based on an
 // operand. For a 2-dimensional input tensor, this produces IR of the form
 //

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -3388,13 +3388,13 @@ LogicalResult RngOp::reifyReturnTypeShapes(
 // SelectOp
 //===----------------------------------------------------------------------===//
 
-LogicalResult SelectOp::inferReturnTypes(
-    MLIRContext*, Optional<Location> location, ValueRange operands,
+LogicalResult SelectOp::inferReturnTypeComponents(
+    MLIRContext*, Optional<Location> location, ValueShapeRange operands,
     DictionaryAttr attributes, RegionRange,
-    SmallVectorImpl<Type>& inferredReturnTypes) {
+    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   SelectOp::Adaptor op(operands, attributes);
   return hlo::inferSelectOp(location, op.getPred(), op.getOnTrue(),
-                            op.getOnFalse(), inferredReturnTypes);
+                            op.getOnFalse(), inferredReturnShapes);
 }
 
 LogicalResult SelectOp::reifyReturnTypeShapes(

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -3388,15 +3388,13 @@ LogicalResult RngOp::reifyReturnTypeShapes(
 // SelectOp
 //===----------------------------------------------------------------------===//
 
-// Makes it such that a SelectOp that is a non-root operation in a DRR infers
-// the return type based on operand type.
-LogicalResult SelectOp::inferReturnTypeComponents(
-    MLIRContext*, Optional<Location> location, ValueShapeRange operands,
+LogicalResult SelectOp::inferReturnTypes(
+    MLIRContext*, Optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, RegionRange,
-    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
+    SmallVectorImpl<Type>& inferredReturnTypes) {
   SelectOp::Adaptor op(operands, attributes);
   return hlo::inferSelectOp(location, op.getPred(), op.getOnTrue(),
-                            op.getOnFalse(), inferredReturnShapes);
+                            op.getOnFalse(), inferredReturnTypes);
 }
 
 LogicalResult SelectOp::reifyReturnTypeShapes(

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2446,9 +2446,8 @@ def StableHLO_ScatterOp: StableHLO_Op<"scatter", [SameVariadicOperandSize, Recur
   let hasVerifier = 1;
 }
 
-def StableHLO_SelectOp: StableHLO_ShapedInterfaceOp<"select",
-      [Pure, HLO_BroadcastingElementwise,
-      DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
+def StableHLO_SelectOp: StableHLO_Op<"select", [Pure, HLO_BroadcastingElementwise,
+    InferTensorTypeWithReify]> {
   let summary = "Select operator";
   let description = [{
     Produces a `result` tensor where each element is selected from `on_true` or

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2446,8 +2446,9 @@ def StableHLO_ScatterOp: StableHLO_Op<"scatter", [SameVariadicOperandSize, Recur
   let hasVerifier = 1;
 }
 
-def StableHLO_SelectOp: StableHLO_Op<"select", [Pure, HLO_BroadcastingElementwise,
-    InferTensorTypeWithReify]> {
+def StableHLO_SelectOp: StableHLO_ShapedInterfaceOp<"select",
+      [Pure, HLO_BroadcastingElementwise,
+      DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
   let summary = "Select operator";
   let description = [{
     Produces a `result` tensor where each element is selected from `on_true` or

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2469,8 +2469,6 @@ def StableHLO_SelectOp: StableHLO_Op<"select", [Pure, HLO_BroadcastingElementwis
 
   let results = (outs HLO_Tensor:$result);
 
-  let hasVerifier = 1;
-
   let assemblyFormat = [{
     operands attr-dict `:`
       custom<SelectOpType>(type($pred), type($on_true), type($on_false), type($result))

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -1173,7 +1173,7 @@ LogicalResult inferSelectOp(Optional<Location> location, Value pred,
   auto trueType = onTrue.getType().cast<ShapedType>();
   auto falseType = onFalse.getType().cast<ShapedType>();
 
-  // The operands 'on_true' and 'on_false' should have compatible types, i.e.,
+  // The operands `onTrue` and `onFalse` should have compatible types, i.e.,
   //   (a) have the same element type, and
   //   (b) have compatible shapes (i.e. the same shape and/or at least one
   //       dynamic shape)
@@ -1189,8 +1189,8 @@ LogicalResult inferSelectOp(Optional<Location> location, Value pred,
       return emitOptionalError(location,
                                "requires the same shape for all operands");
 
-  // The output shape should be the most general of the operand shapes at each
-  // dimension.
+  // The output shape should be derived from the most specific parts of the
+  // `onTrue` and `onFalse` (see documentation for details).
   return hlo::inferMostSpecificType(location, {trueType, falseType},
                                     inferredReturnTypes);
 }

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -1166,9 +1166,9 @@ LogicalResult inferReduceWindowOp(
   return success();
 }
 
-LogicalResult inferSelectOp(Optional<Location> location, Value pred,
-                            Value onTrue, Value onFalse,
-                            SmallVectorImpl<Type>& inferredReturnTypes) {
+LogicalResult inferSelectOp(
+    Optional<Location> location, Value pred, Value onTrue, Value onFalse,
+    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   auto predType = pred.getType().cast<ShapedType>();
   auto trueType = onTrue.getType().cast<ShapedType>();
   auto falseType = onFalse.getType().cast<ShapedType>();
@@ -1191,8 +1191,9 @@ LogicalResult inferSelectOp(Optional<Location> location, Value pred,
 
   // The output shape should be derived from the most specific parts of the
   // `onTrue` and `onFalse` (see documentation for details).
-  return hlo::inferMostSpecificType(location, {trueType, falseType},
-                                    inferredReturnTypes);
+  SmallVector<Type> inferredReturnTypes;
+  return hlo::inferMostSpecificTypeComponents(location, {trueType, falseType},
+                                              inferredReturnShapes);
 }
 
 // The following properties are already enforced by the ODS:

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -163,9 +163,9 @@ LogicalResult inferReduceWindowOp(
     Optional<DenseIntElementsAttr> padding, Region& body,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
-LogicalResult inferSelectOp(Optional<Location> location, Value pred,
-                            Value onTrue, Value onFalse,
-                            SmallVectorImpl<Type>& inferredReturnTypes);
+LogicalResult inferSelectOp(
+    Optional<Location> location, Value pred, Value onTrue, Value onFalse,
+    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferSliceOp(Optional<Location> location, Value operand,
                            DenseIntElementsAttr startIndices,

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -163,6 +163,10 @@ LogicalResult inferReduceWindowOp(
     Optional<DenseIntElementsAttr> padding, Region& body,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
+LogicalResult inferSelectOp(
+    Optional<Location> location, Value pred, Value onTrue, Value onFalse,
+    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
+
 LogicalResult inferSliceOp(Optional<Location> location, Value operand,
                            DenseIntElementsAttr startIndices,
                            DenseIntElementsAttr limitIndices,

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -163,9 +163,9 @@ LogicalResult inferReduceWindowOp(
     Optional<DenseIntElementsAttr> padding, Region& body,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
-LogicalResult inferSelectOp(
-    Optional<Location> location, Value pred, Value onTrue, Value onFalse,
-    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
+LogicalResult inferSelectOp(Optional<Location> location, Value pred,
+                            Value onTrue, Value onFalse,
+                            SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferSliceOp(Optional<Location> location, Value operand,
                            DenseIntElementsAttr startIndices,

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -19,9 +19,9 @@ func.func @select(%pred : tensor<i1>, %a : tensor<?x2x3xf32>, %b : tensor<1x?x3x
     -> tensor<1x2x3xindex> {
   %0 = "stablehlo.select"(%pred, %a, %b)
       : (tensor<i1>, tensor<?x2x3xf32>, tensor<1x?x3xf32>) -> tensor<*xf32>
-  %1 = "hlo_test_infer.get_return_types"(%0)
+  %1 = "hlo_test_infer.get_return_type_components"(%0)
       : (tensor<*xf32>) -> tensor<1x2x3xindex>
-  // CHECK: %1 = "hlo_test_infer.return_types"(%0) {types0 = tensor<1x2x3xf32>} : (tensor<*xf32>) -> tensor<1x2x3xindex>
+  // CHECK: %1 = "hlo_test_infer.return_type_components"(%0) {dims0 = "[1, 2, 3]", element_type0 = f32} : (tensor<*xf32>) -> tensor<1x2x3xindex>
   func.return %1 : tensor<1x2x3xindex>
 }
 

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -1,20 +1,5 @@
 // RUN: stablehlo-opt --hlo-test-infer --allow-unregistered-dialect --split-input-file --verify-diagnostics %s | FileCheck %s
 
-// CHECK-LABEL: @select
-// CHECK-SAME: (%{{.*}}: tensor<i1>, %[[SHAPED_ARG:.*]]: tensor<2x?xf32>, %{{.*}}: tensor<2x?xf32>
-func.func @select(%pred : tensor<i1>, %a : tensor<2x?xf32>, %b : tensor<2x?xf32>)
-    -> tensor<2xindex> {
-  // CHECK: %[[SHAPE:.*]] = shape.shape_of %[[SHAPED_ARG]] : tensor<2x?xf32> -> tensor<2xindex>
-  // CHECK: return %[[SHAPE]] : tensor<2xindex>
-  %0 = "stablehlo.select"(%pred, %a, %b)
-      : (tensor<i1>, tensor<2x?xf32>, tensor<2x?xf32>) -> tensor<2x?xf32>
-  %1 = "hlo_test_infer.reify_return_type_shapes"(%0)
-      : (tensor<2x?xf32>) -> tensor<2xindex>
-  func.return %1 : tensor<2xindex>
-}
-
-// -----
-
 // CHECK-LABEL: @compare
 // CHECK-SAME: (%[[A:.*]]: tensor<2x?xf32>,
 func.func @compare(%a : tensor<2x?xf32>, %b : tensor<2x?xf32>) -> tensor<2xindex> {
@@ -30,14 +15,14 @@ func.func @compare(%a : tensor<2x?xf32>, %b : tensor<2x?xf32>) -> tensor<2xindex
 // -----
 
 // CHECK-LABEL: @select
-func.func @select(%pred : tensor<i1>, %a : tensor<2x2xf32>, %b : tensor<2x2xf32>)
-    -> tensor<2x2xindex> {
+func.func @select(%pred : tensor<i1>, %a : tensor<?x2x3xf32>, %b : tensor<1x?x3xf32>)
+    -> tensor<1x2x3xindex> {
   %0 = "stablehlo.select"(%pred, %a, %b)
-      : (tensor<i1>, tensor<2x2xf32>, tensor<2x2xf32>) -> tensor<2x2xf32>
+      : (tensor<i1>, tensor<?x2x3xf32>, tensor<1x?x3xf32>) -> tensor<*xf32>
   %1 = "hlo_test_infer.get_return_type_components"(%0)
-      : (tensor<2x2xf32>) -> tensor<2x2xindex>
-// CHECK: %1 = "hlo_test_infer.return_type_components"(%0) {dims0 = "[2, 2]", element_type0 = f32} : (tensor<2x2xf32>) -> tensor<2x2xindex>
-  func.return %1 : tensor<2x2xindex>
+      : (tensor<*xf32>) -> tensor<1x2x3xindex>
+// CHECK: %1 = "hlo_test_infer.return_type_components"(%0) {dims0 = "[1, 2, 3]", element_type0 = f32} : (tensor<*xf32>) -> tensor<1x2x3xindex>
+  func.return %1 : tensor<1x2x3xindex>
 }
 
 // -----

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -19,9 +19,9 @@ func.func @select(%pred : tensor<i1>, %a : tensor<?x2x3xf32>, %b : tensor<1x?x3x
     -> tensor<1x2x3xindex> {
   %0 = "stablehlo.select"(%pred, %a, %b)
       : (tensor<i1>, tensor<?x2x3xf32>, tensor<1x?x3xf32>) -> tensor<*xf32>
-  %1 = "hlo_test_infer.get_return_type_components"(%0)
+  %1 = "hlo_test_infer.get_return_types"(%0)
       : (tensor<*xf32>) -> tensor<1x2x3xindex>
-// CHECK: %1 = "hlo_test_infer.return_type_components"(%0) {dims0 = "[1, 2, 3]", element_type0 = f32} : (tensor<*xf32>) -> tensor<1x2x3xindex>
+  // CHECK: %1 = "hlo_test_infer.return_types"(%0) {types0 = tensor<1x2x3xf32>} : (tensor<*xf32>) -> tensor<1x2x3xindex>
   func.return %1 : tensor<1x2x3xindex>
 }
 


### PR DESCRIPTION
The implementation says "the output shape should be the most general of the operand shapes at each dimensions", but falls a bit short of delivering that. This PR fixes it.

Also merges the verifier into the shape function, to follow the design pattern that we've established for type inference, and switches to `inferMostSpecificType` which is used for the same purpose in several other ops. The latter prompted switching from `inferReturnTypeComponents` to `inferReturnTypes`, because `inferMostSpecificType` is only compatible with the latter.