### PR TITLE
Verify bounds of ranked tensors

### DIFF
--- a/stablehlo/dialect/Base.cpp
+++ b/stablehlo/dialect/Base.cpp
@@ -164,9 +164,9 @@ LogicalResult verifyBounds(ArrayRef<int64_t> bounds, RankedTensorType type,
     int64_t bound = bounds[dim];
     int64_t dimSize = type.getDimSize(dim);
     if (bound != ShapedType::kDynamic && dimSize != ShapedType::kDynamic) {
-      return emitError() << "Bound is " << bound << " for dimension " << dim
-                         << " with size " << dimSize
-                         << ", expected bound to be dynamic(?)";
+      return emitError() << "Static dimension " << dim
+                         << " cannot have a bound, use ShapedType::kDynamic to "
+                            "indicate a missing bound";
     }
   }
 

--- a/stablehlo/dialect/Base.h
+++ b/stablehlo/dialect/Base.h
@@ -100,9 +100,10 @@ TensorType getSameShapeTensorType(TensorType tensorType, Type elementType);
 //   Ex: tensor<4xcomplex<f32>>  -->  tensor<4xf32>
 Type createRealType(TensorType type);
 
-// Verify bounds expressed by HLO_BoundedInterface against the provided type.
-// See documentation for HLO_BoundedInterface for the list of checks.
-LogicalResult verifyBounds(ArrayRef<int64_t> bounds, ShapedType type,
+// Verify bounds expressed by HLOBoundedDialectInterface against the provided
+// type. See documentation for HLOBoundedDialectInterface for the list of
+// checks.
+LogicalResult verifyBounds(ArrayRef<int64_t> bounds, RankedTensorType type,
                            function_ref<InFlightDiagnostic()> emitError);
 
 // If an encoding attribute conforms to HLO_BoundedAttrInterface, return the

--- a/stablehlo/dialect/Base.h
+++ b/stablehlo/dialect/Base.h
@@ -100,9 +100,8 @@ TensorType getSameShapeTensorType(TensorType tensorType, Type elementType);
 //   Ex: tensor<4xcomplex<f32>>  -->  tensor<4xf32>
 Type createRealType(TensorType type);
 
-// Verify bounds expressed by HLOBoundedDialectInterface against the provided
-// type. See documentation for HLOBoundedDialectInterface for the list of
-// checks.
+// Verify bounds expressed by HLO_BoundedAttrInterface against the provided
+// type. See documentation for HLO_BoundedAttrInterface for the list of checks.
 LogicalResult verifyBounds(ArrayRef<int64_t> bounds, RankedTensorType type,
                            function_ref<InFlightDiagnostic()> emitError);
 

--- a/stablehlo/dialect/StablehloAttrs.td
+++ b/stablehlo/dialect/StablehloAttrs.td
@@ -152,8 +152,6 @@ def StableHLO_ChannelHandle : AttrDef<StableHLO_Dialect, "ChannelHandle"> {
   let assemblyFormat = "`<` struct(params) `>`";
 }
 
-// Note: This is an experimental attribute and shouldn't be relied upon for
-// production.
 def StableHLO_TypeExtensions : AttrDef<StableHLO_Dialect, "TypeExtensions", [
     DeclareAttrInterfaceMethods<VerifiableTensorEncoding>,
     DeclareAttrInterfaceMethods<HLO_BoundedAttrInterface>]> {

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -180,10 +180,10 @@ Value maybeCastTo(OpBuilder& b, Location loc, Value value, Type type) {
 //===----------------------------------------------------------------------===//
 
 LogicalResult TypeExtensionsAttr::verifyEncoding(
-    llvm::ArrayRef<int64_t> bounds, mlir::Type elementType,
+    llvm::ArrayRef<int64_t> shape, mlir::Type elementType,
     llvm::function_ref<mlir::InFlightDiagnostic()> emitError) const {
   return hlo::verifyBounds(
-      getBounds(), RankedTensorType::get(bounds, elementType), emitError);
+      getBounds(), RankedTensorType::get(shape, elementType), emitError);
 }
 
 //===----------------------------------------------------------------------===//

--- a/stablehlo/tests/verify_bounds.mlir
+++ b/stablehlo/tests/verify_bounds.mlir
@@ -1,0 +1,13 @@
+// RUN: stablehlo-opt %s -verify-diagnostics -split-input-file
+
+// expected-error@+1 {{Bounds length is 1, expected to be equal to rank(2) of the tensor}}
+func.func @incorrect_bounds_length(%arg0: tensor<?x?xf32, #stablehlo.type_extensions<bounds = [3]>>) -> tensor<?x?xf32, #stablehlo.type_extensions<bounds = [3]>> {
+  func.return %arg0 : tensor<?x?xf32, #stablehlo.type_extensions<bounds = [3]>>
+}
+
+// -----
+
+// expected-error@+1 {{Bound is 3 for dimension 0 with size 3, expected bound to be dynamic(?)}}
+func.func @static_dim_with_bound(%arg0: tensor<3xf32, #stablehlo.type_extensions<bounds = [3]>>) -> tensor<?xf32, #stablehlo.type_extensions<bounds = [3]>> {
+  func.return %arg0 : tensor<?xf32, #stablehlo.type_extensions<bounds = [3]>>
+}

--- a/stablehlo/tests/verify_bounds.mlir
+++ b/stablehlo/tests/verify_bounds.mlir
@@ -7,7 +7,7 @@ func.func @incorrect_bounds_length(%arg0: tensor<?x?xf32, #stablehlo.type_extens
 
 // -----
 
-// expected-error@+1 {{Bound is 3 for dimension 0 with size 3, expected bound to be dynamic(?)}}
+// expected-error@+1 {{Static dimension 0 cannot have a bound, use ShapedType::kDynamic to indicate a missing bound}}
 func.func @static_dim_with_bound(%arg0: tensor<3xf32, #stablehlo.type_extensions<bounds = [3]>>) -> tensor<?xf32, #stablehlo.type_extensions<bounds = [3]>> {
   func.return %arg0 : tensor<?xf32, #stablehlo.type_extensions<bounds = [3]>>
 }


### PR DESCRIPTION
Implements TODO to add verification for bounds.

This is in preparation for moving bounds out of experimental as part of https://github.com/openxla/stablehlo/pull/194

I considered doing this in the RFC itself but better to do the code change separately and immediately given that these invariants are already assumed during type inference.