### PR TITLE
fix clang-tidy suggestions

### DIFF
--- a/stablehlo/dialect/VhloOps.cpp
+++ b/stablehlo/dialect/VhloOps.cpp
@@ -31,9 +31,6 @@ limitations under the License.
 namespace mlir {
 namespace vhlo {
 
-using mlir::hlo::parseDimSizes;
-using mlir::hlo::printDimSizes;
-
 //===----------------------------------------------------------------------===//
 // StableHLO Dialect Constructor
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
The fixes are suggested by internal presubmits.