### PR TITLE
Add type inference for OutfeedOp

### DIFF
--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -3051,7 +3051,7 @@ operation.
 
 ### Semantics
 
-Writes `inputs` to the outfeed and produces `result`.
+Writes `inputs` to the outfeed and produces a `result` token.
 
 Semantics of `outfeed_config` is implementation-defined.
 

--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -3426,16 +3426,16 @@ More formally, `results[:][result_index] = reduce(windows, init_values, axes(inp
 
 ### Inputs
 
-| Name                | Type                                                           | Constraints                                    |
-|---------------------|----------------------------------------------------------------|------------------------------------------------|
+| Name                | Type                                                           | Constraints                                     |
+|---------------------|----------------------------------------------------------------|-------------------------------------------------|
 | `inputs`            | variadic number of tensors of any supported type               | (C1-C4), (C6), (C8), (C10), (C12), (C13), (C15) |
-| `init_values`       | variadic number of 0-dimensional tensors of any supported type | (C1), (C13), (C16)                             |
-| `window_dimensions` | 1-dimensional tensor constant of type `si64`                   | (C4), (C5), (C15)                              |
-| `window_strides`    | 1-dimensional tensor constant of type `si64`                   | (C6), (C7), (C15)                              |
-| `base_dilations`    | 1-dimensional tensor constant of type `si64`                   | (C8), (C9), (C15)                              |
-| `window_dilations`  | 1-dimensional tensor constant of type `si64`                   | (C10), (C11), (C15)                            |
-| `padding`           | 2-dimensional tensor constant of type `si64`                   | (C12), (C15)                                   |
-| `body`              | `function`                                                     | (C13)                                          |
+| `init_values`       | variadic number of 0-dimensional tensors of any supported type | (C1), (C13), (C16)                              |
+| `window_dimensions` | 1-dimensional tensor constant of type `si64`                   | (C4), (C5), (C15)                               |
+| `window_strides`    | 1-dimensional tensor constant of type `si64`                   | (C6), (C7), (C15)                               |
+| `base_dilations`    | 1-dimensional tensor constant of type `si64`                   | (C8), (C9), (C15)                               |
+| `window_dilations`  | 1-dimensional tensor constant of type `si64`                   | (C10), (C11), (C15)                             |
+| `padding`           | 2-dimensional tensor constant of type `si64`                   | (C12), (C15)                                    |
+| `body`              | `function`                                                     | (C13)                                           |
 
 ### Outputs
 
@@ -4067,7 +4067,7 @@ where `pred_val = rank(pred) == 0 ? pred : pred[i0, ..., iR-1]`.
 
 ### Semantics
 
-Sends `inputs` to a channel `channel_id`.
+Sends `inputs` to a channel `channel_id` and produces a `result` token.
 
 The operation takes a token and produces a token to reify its side effects
 as a value that other operations can take a data dependency on.

--- a/docs/status.md
+++ b/docs/status.md
@@ -110,7 +110,7 @@ one of the following tracking labels.
 | not                      | yes           | yes          | yes            | yes             | yes         |
 | optimization_barrier     | yes           | yes          | yes            | yes             | no          |
 | or                       | yes           | yes          | yes            | yes             | yes         |
-| outfeed                  | yes           | yes          | no             | no              | no          |
+| outfeed                  | yes           | yes          | yes            | no              | no          |
 | pad                      | yes           | yes          | yes            | yes             | no          |
 | popcnt                   | yes           | yes          | yes            | yes             | no          |
 | power                    | yes           | revisit      | yes            | yes             | no          |

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -339,7 +339,6 @@ LogicalResult AfterAllOp::inferReturnTypes(
     MLIRContext* context, Optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<Type>& inferredReturnTypes) {
-  AfterAllOp::Adaptor adaptor(operands, attributes, regions);
   return hlo::inferAfterAllOp(context, location, inferredReturnTypes);
 }
 
@@ -457,7 +456,6 @@ LogicalResult CreateTokenOp::inferReturnTypes(
     MLIRContext* context, Optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<Type>& inferredReturnTypes) {
-  CreateTokenOp::Adaptor adaptor(operands, attributes, regions);
   return hlo::inferCreateTokenOp(context, location, inferredReturnTypes);
 }
 
@@ -2891,8 +2889,7 @@ LogicalResult OutfeedOp::inferReturnTypes(
     MLIRContext* context, Optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<Type>& inferredReturnTypes) {
-  OutfeedOp::Adaptor adaptor(operands, attributes, regions);
-  return hlo::inferOutfeedOp(location, adaptor.getToken(), inferredReturnTypes);
+  return hlo::inferOutfeedOp(context, location, inferredReturnTypes);
 }
 
 //===----------------------------------------------------------------------===//

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -2892,9 +2892,7 @@ LogicalResult OutfeedOp::inferReturnTypes(
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<Type>& inferredReturnTypes) {
   OutfeedOp::Adaptor adaptor(operands, attributes, regions);
-  return hlo::inferOutfeedOp(location, adaptor.getInputs(), adaptor.getToken(),
-                             adaptor.getOutfeedConfigAttr(),
-                             inferredReturnTypes);
+  return hlo::inferOutfeedOp(location, adaptor.getToken(), inferredReturnTypes);
 }
 
 //===----------------------------------------------------------------------===//

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -2884,6 +2884,20 @@ LogicalResult MapOp::reifyReturnTypeShapes(
 }
 
 //===----------------------------------------------------------------------===//
+// OutfeedOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult OutfeedOp::inferReturnTypes(
+    MLIRContext* context, Optional<Location> location, ValueRange operands,
+    DictionaryAttr attributes, RegionRange regions,
+    SmallVectorImpl<Type>& inferredReturnTypes) {
+  OutfeedOp::Adaptor adaptor(operands, attributes, regions);
+  return hlo::inferOutfeedOp(location, adaptor.getInputs(), adaptor.getToken(),
+                             adaptor.getOutfeedConfigAttr(),
+                             inferredReturnTypes);
+}
+
+//===----------------------------------------------------------------------===//
 // Send Op
 //===----------------------------------------------------------------------===//
 

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1003,12 +1003,13 @@ def StableHLO_InfeedOp : StableHLO_Op<"infeed", []> {
 
 // OutfeedOp corresponds to 'OutfeedWithToken' xla client API and not 'Outfeed'.
 // OutfeedWithToken allows ordering of outfeed HLO instructions using tokens.
-def StableHLO_OutfeedOp : StableHLO_Op<"outfeed", []> {
+def StableHLO_OutfeedOp : StableHLO_Op<"outfeed",
+    [DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
 
   let summary = "Outfeed operator";
 
   let description = [{
-    Writes `inputs` to the outfeed and produces `result`.
+    Writes `inputs` to the outfeed and produces a `result` token.
 
     See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlooutfeed

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1036,7 +1036,7 @@ def StableHLO_SendOp : StableHLO_Op<"send",
   let summary = "Send operator";
 
   let description = [{
-    Sends `inputs` to a channel `channel_id`.
+    Sends `inputs` to a channel `channel_id` and produces a `result` token.
 
     See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec_draft.md#stablehlosend

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -1055,6 +1055,13 @@ LogicalResult inferOptimizationBarrierOp(
   return success();
 }
 
+LogicalResult inferOutfeedOp(Optional<Location> location, ValueRange inputs,
+                             Value token, StringAttr outfeed_config,
+                             SmallVectorImpl<Type>& inferredReturnTypes) {
+  inferredReturnTypes.emplace_back(token.getType());
+  return success();
+}
+
 // We intend to verify the following properties
 //  P1. Verify all `inputs` need to have compatible shapes.
 //  P2. Verify that

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -1055,10 +1055,9 @@ LogicalResult inferOptimizationBarrierOp(
   return success();
 }
 
-LogicalResult inferOutfeedOp(Optional<Location> location, ValueRange inputs,
-                             Value token, StringAttr outfeed_config,
+LogicalResult inferOutfeedOp(Optional<Location> location, Value token,
                              SmallVectorImpl<Type>& inferredReturnTypes) {
-  inferredReturnTypes.emplace_back(token.getType());
+  inferredReturnTypes.push_back(token.getType());
   return success();
 }
 

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -1055,9 +1055,9 @@ LogicalResult inferOptimizationBarrierOp(
   return success();
 }
 
-LogicalResult inferOutfeedOp(Optional<Location> location, Value token,
+LogicalResult inferOutfeedOp(MLIRContext* context, Optional<Location> location,
                              SmallVectorImpl<Type>& inferredReturnTypes) {
-  inferredReturnTypes.push_back(token.getType());
+  inferredReturnTypes.push_back(stablehlo::TokenType::get(context));
   return success();
 }
 

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -163,8 +163,7 @@ LogicalResult inferOptimizationBarrierOp(
     Optional<Location> location, ValueRange operand,
     SmallVectorImpl<Type>& inferredReturnTypes);
 
-LogicalResult inferOutfeedOp(Optional<Location> location, ValueRange inputs,
-                             Value token, StringAttr outfeed_config,
+LogicalResult inferOutfeedOp(Optional<Location> location, Value token,
                              SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferReduceOp(

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -163,7 +163,7 @@ LogicalResult inferOptimizationBarrierOp(
     Optional<Location> location, ValueRange operand,
     SmallVectorImpl<Type>& inferredReturnTypes);
 
-LogicalResult inferOutfeedOp(Optional<Location> location, Value token,
+LogicalResult inferOutfeedOp(MLIRContext* context, Optional<Location> location,
                              SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferReduceOp(

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -163,6 +163,10 @@ LogicalResult inferOptimizationBarrierOp(
     Optional<Location> location, ValueRange operand,
     SmallVectorImpl<Type>& inferredReturnTypes);
 
+LogicalResult inferOutfeedOp(Optional<Location> location, ValueRange inputs,
+                             Value token, StringAttr outfeed_config,
+                             SmallVectorImpl<Type>& inferredReturnTypes);
+
 LogicalResult inferReduceOp(
     Optional<Location> location, ValueRange inputs, ValueRange initValues,
     DenseIntElementsAttr dimensions, Region& body,

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -347,6 +347,18 @@ func.func @sort(%input0: tensor<16x16xf32>, %input1: tensor<16x16xi32>) {
 
 // -----
 
+// CHECK-LABEL: func @outfeed
+func.func @outfeed(%arg0: tensor<3x3x3xi32>, %arg1: !stablehlo.token) -> !stablehlo.token {
+  %0 = "stablehlo.outfeed"(%arg0, %arg1) {
+    outfeed_config = ""
+  } : (tensor<3x3x3xi32>, !stablehlo.token) -> !stablehlo.token
+  %1 = "hlo_test_infer.get_return_types"(%0) : (!stablehlo.token) -> !stablehlo.token
+  // CHECK: %1 = "hlo_test_infer.return_types"(%0) {types0 = !stablehlo.token} : (!stablehlo.token) -> !stablehlo.token
+  func.return %1 : !stablehlo.token
+}
+
+// -----
+
 // CHECK-LABEL: func @while
 func.func @while(%arg0: tensor<4xf32>, %arg1: tensor<f32>, %arg2: tensor<f32>, %arg3: tensor<4xf32>, %arg4: tensor<f32>, %arg5: tensor<f32>, %arg6: tensor<f32>, %arg7: tensor<f32>, %arg8: tensor<i32>) -> tensor<index> {
   %cst = arith.constant dense<-1> : tensor<i32>

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -1765,6 +1765,16 @@ func.func @map_mismatch_arguments_and_dimensions(%arg0: tensor<4x5xf32>, %arg1: 
 
 // -----
 
+// CHECK-LABEL: func @outfeed
+func.func @outfeed(%arg0: tensor<3x3x3xi32>, %arg1: !stablehlo.token) -> !stablehlo.token {
+  %0 = "stablehlo.outfeed"(%arg0, %arg1) {
+    outfeed_config = ""
+  } : (tensor<3x3x3xi32>, !stablehlo.token) -> !stablehlo.token
+  func.return %0 : !stablehlo.token
+}
+
+// -----
+
 // CHECK-LABEL: func @real_fp_input
 func.func @real_fp_input(%arg0: tensor<*xf32>) -> tensor<*xf32> {
   %0 = "stablehlo.real"(%arg0) : (tensor<*xf32>) -> tensor<*xf32>


### PR DESCRIPTION
In addition, it updates the semantics of OutfeedOp and SendOp to explicitly mention that the 'result' is a token type.
Also removes adaptors from CreateTokenOp and AfterAllOp that are not used.
closes #699