### PR TITLE
Fix typo for AllReduceOp columns

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -46,7 +46,7 @@ one of the following tracking labels.
 | add                      | yes           | yes          | yes            | yes             | yes         |
 | after_all                | yes           | yes          | yes            | yes             | no          |
 | all_gather               | yes           | revisit      | no             | no              | no          |
-| all_reduce               | yes           | revisit      | yes            | no              | no          |
+| all_reduce               | yes           | yes          | revisit        | no              | no          |
 | all_to_all               | yes           | revisit      | yes            | no              | no          |
 | and                      | yes           | yes          | yes            | yes             | yes         |
 | atan2                    | yes           | revisit      | yes            | yes             | no          |


### PR DESCRIPTION
According to #510, the type inference column was accidentally set to `yes` instead of the verification column.