### PR TITLE
Sever the dependency from TypeInference.h to StablehloOps.h

### DIFF
--- a/stablehlo/dialect/Base.cpp
+++ b/stablehlo/dialect/Base.cpp
@@ -187,8 +187,8 @@ Attribute boundsToEncoding(Attribute prototype, ArrayRef<int64_t> bounds) {
     llvm::report_fatal_error(
         "Expect an prototype attribute to obtain the underlying dialect but "
         "got none");
-  auto dialect = cast<BoundedDialectInterface>(&prototype.getDialect());
-  return dialect->createBoundedAttr(bounds);
+  auto dialect = cast<HloDialectInterface>(&prototype.getDialect());
+  return dialect->createTypeExtensions(bounds);
 }
 
 // Inference rules to concat dimensions with bounds (lhs/rhs are commutative):

--- a/stablehlo/dialect/Base.h
+++ b/stablehlo/dialect/Base.h
@@ -125,11 +125,11 @@ class HloDialectInterface : public DialectInterface::Base<HloDialectInterface> {
  public:
   HloDialectInterface(Dialect *dialect) : Base(dialect) {}
 
-  // Creates a TokenType type, specific this dialect.
+  // Creates a TokenType type, specific to this dialect.
   // See docs for the particular type in the corresponding dialect.
   virtual Type createTokenType() const = 0;
 
-  // Creates a TypeExtensions attribute, specific this dialect.
+  // Creates a TypeExtensions attribute, specific to this dialect.
   // See docs for the particular attribute in the corresponding dialect.
   virtual Attribute createTypeExtensions(ArrayRef<int64_t> bounds) const = 0;
 };

--- a/stablehlo/dialect/Base.h
+++ b/stablehlo/dialect/Base.h
@@ -118,14 +118,20 @@ ArrayRef<int64_t> encodingToBounds(Attribute encoding);
 // the underlying dialect that knows how to create these attributes.
 Attribute boundsToEncoding(Attribute prototype, ArrayRef<int64_t> bounds);
 
-// This interface is used for HLO dialects that have accompanying
-// BoundedAttrInterface attributes which can carry bounds for dimension sizes
-// of accompanying shaped types.
-class BoundedDialectInterface
-    : public DialectInterface::Base<BoundedDialectInterface> {
+// This interface is implemented by both StableHLO and MHLO dialects
+// and is used as the foundation for sharing verification, type inference and
+// prettyprinting logic between them.
+class HloDialectInterface : public DialectInterface::Base<HloDialectInterface> {
  public:
-  BoundedDialectInterface(Dialect *dialect) : Base(dialect) {}
-  virtual Attribute createBoundedAttr(ArrayRef<int64_t> bounds) const = 0;
+  HloDialectInterface(Dialect *dialect) : Base(dialect) {}
+
+  // Creates a TokenType type, specific this dialect.
+  // See docs for the particular type in the corresponding dialect.
+  virtual Type createTokenType() const = 0;
+
+  // Creates a TypeExtensions attribute, specific this dialect.
+  // See docs for the particular attribute in the corresponding dialect.
+  virtual Attribute createTypeExtensions(ArrayRef<int64_t> bounds) const = 0;
 };
 
 namespace bytecode {

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -339,7 +339,8 @@ LogicalResult AfterAllOp::inferReturnTypes(
     MLIRContext* context, Optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<Type>& inferredReturnTypes) {
-  return hlo::inferAfterAllOp(context, location, inferredReturnTypes);
+  auto dialect = context->getLoadedDialect<StablehloDialect>();
+  return hlo::inferAfterAllOp(dialect, location, inferredReturnTypes);
 }
 
 //===----------------------------------------------------------------------===//
@@ -456,7 +457,8 @@ LogicalResult CreateTokenOp::inferReturnTypes(
     MLIRContext* context, Optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<Type>& inferredReturnTypes) {
-  return hlo::inferCreateTokenOp(context, location, inferredReturnTypes);
+  auto dialect = context->getLoadedDialect<StablehloDialect>();
+  return hlo::inferCreateTokenOp(dialect, location, inferredReturnTypes);
 }
 
 //===----------------------------------------------------------------------===//
@@ -2889,7 +2891,8 @@ LogicalResult OutfeedOp::inferReturnTypes(
     MLIRContext* context, Optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<Type>& inferredReturnTypes) {
-  return hlo::inferOutfeedOp(context, location, inferredReturnTypes);
+  auto dialect = context->getLoadedDialect<StablehloDialect>();
+  return hlo::inferOutfeedOp(dialect, location, inferredReturnTypes);
 }
 
 //===----------------------------------------------------------------------===//
@@ -4477,7 +4480,7 @@ namespace stablehlo {
 //===----------------------------------------------------------------------===//
 
 namespace {
-struct HLOInlinerInterface : public DialectInlinerInterface {
+struct StablehloDialectInlinerInterface : public DialectInlinerInterface {
   using DialectInlinerInterface::DialectInlinerInterface;
 
   // Allow all call operations to be inlined.
@@ -4499,10 +4502,14 @@ struct HLOInlinerInterface : public DialectInlinerInterface {
   }
 };
 
-struct HLOBoundedDialectInterface : public hlo::BoundedDialectInterface {
-  using BoundedDialectInterface::BoundedDialectInterface;
+struct StablehloHloDialectInterface : public hlo::HloDialectInterface {
+  using HloDialectInterface::HloDialectInterface;
 
-  Attribute createBoundedAttr(ArrayRef<int64_t> bounds) const override {
+  Type createTokenType() const override {
+    return TokenType::get(getDialect()->getContext());
+  }
+
+  Attribute createTypeExtensions(ArrayRef<int64_t> bounds) const override {
     return TypeExtensionsAttr::get(getDialect()->getContext(), bounds);
   }
 };
@@ -4518,8 +4525,8 @@ StablehloDialect::StablehloDialect(MLIRContext* context)
 #define GET_OP_LIST
 #include "stablehlo/dialect/StablehloOps.cpp.inc"
       >();
-  addInterfaces<HLOInlinerInterface>();
-  addInterfaces<HLOBoundedDialectInterface>();
+  addInterfaces<StablehloDialectInlinerInterface>();
+  addInterfaces<StablehloHloDialectInterface>();
   addBytecodeInterface(this);
   addTypes<TokenType>();
   addAttributes<

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -56,7 +56,6 @@ limitations under the License.
 #include "mlir/Support/LogicalResult.h"
 #include "stablehlo/dialect/AssemblyFormat.h"
 #include "stablehlo/dialect/Base.h"
-#include "stablehlo/dialect/StablehloOps.h"
 
 namespace mlir {
 namespace hlo {
@@ -506,9 +505,10 @@ LogicalResult verifyReducerShape(Optional<Location> loc, Block& block,
 // Shape functions for ops.
 //===----------------------------------------------------------------------===//
 
-LogicalResult inferAfterAllOp(MLIRContext* context, Optional<Location> location,
+LogicalResult inferAfterAllOp(Dialect* dialect, Optional<Location> location,
                               SmallVectorImpl<Type>& inferredReturnTypes) {
-  inferredReturnTypes.push_back(stablehlo::TokenType::get(context));
+  auto hloDialect = cast<HloDialectInterface>(dialect);
+  inferredReturnTypes.push_back(hloDialect->createTokenType());
   return success();
 }
 
@@ -692,10 +692,10 @@ LogicalResult inferConcatenateOp(Optional<Location> location, ValueRange inputs,
   return success();
 }
 
-LogicalResult inferCreateTokenOp(MLIRContext* context,
-                                 Optional<Location> location,
+LogicalResult inferCreateTokenOp(Dialect* dialect, Optional<Location> location,
                                  SmallVectorImpl<Type>& inferredReturnTypes) {
-  inferredReturnTypes.push_back(stablehlo::TokenType::get(context));
+  auto hloDialect = cast<HloDialectInterface>(dialect);
+  inferredReturnTypes.push_back(hloDialect->createTokenType());
   return success();
 }
 
@@ -1055,9 +1055,10 @@ LogicalResult inferOptimizationBarrierOp(
   return success();
 }
 
-LogicalResult inferOutfeedOp(MLIRContext* context, Optional<Location> location,
+LogicalResult inferOutfeedOp(Dialect* dialect, Optional<Location> location,
                              SmallVectorImpl<Type>& inferredReturnTypes) {
-  inferredReturnTypes.push_back(stablehlo::TokenType::get(context));
+  auto hloDialect = cast<HloDialectInterface>(dialect);
+  inferredReturnTypes.push_back(hloDialect->createTokenType());
   return success();
 }
 

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -21,9 +21,7 @@ limitations under the License.
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/Location.h"
-#include "mlir/IR/Region.h"
 #include "mlir/IR/Types.h"
-#include "mlir/IR/Value.h"
 #include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Support/LogicalResult.h"
 

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -19,8 +19,11 @@ limitations under the License.
 
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Dialect.h"
 #include "mlir/IR/Location.h"
+#include "mlir/IR/Region.h"
 #include "mlir/IR/Types.h"
+#include "mlir/IR/Value.h"
 #include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Support/LogicalResult.h"
 
@@ -102,7 +105,7 @@ LogicalResult verifyReplicaGroups(Optional<Location> location,
 // These parameters have the same names as in the ODS and come in the same
 // order in which they are declared in the ODS.
 
-LogicalResult inferAfterAllOp(MLIRContext* context, Optional<Location> location,
+LogicalResult inferAfterAllOp(Dialect* dialect, Optional<Location> location,
                               SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferBatchNormGradOp(
@@ -127,8 +130,7 @@ LogicalResult inferConcatenateOp(Optional<Location> location, ValueRange inputs,
                                  int64_t dimension,
                                  SmallVectorImpl<Type>& inferredReturnTypes);
 
-LogicalResult inferCreateTokenOp(MLIRContext* context,
-                                 Optional<Location> location,
+LogicalResult inferCreateTokenOp(Dialect* dialect, Optional<Location> location,
                                  SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferDotGeneralOp(
@@ -163,7 +165,7 @@ LogicalResult inferOptimizationBarrierOp(
     Optional<Location> location, ValueRange operand,
     SmallVectorImpl<Type>& inferredReturnTypes);
 
-LogicalResult inferOutfeedOp(MLIRContext* context, Optional<Location> location,
+LogicalResult inferOutfeedOp(Dialect* dialect, Optional<Location> location,
                              SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferReduceOp(


### PR DESCRIPTION
I missed something important when reviewing #711.

We cannot have a dependency from TypeInference.h to StablehloOps.h. It should be the other way around - both StablehloOps.h and hlo_ops.h depending on TypeInference.h

This PR severs the dependency by introducing an interface that abstracts away creating token types.