### PR TITLE
Update type inference status for CrossReplicaSumOp

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -72,7 +72,7 @@ one of the following tracking labels.
 | cosine                   | yes           | yes          | yes            | yes             | yes         |
 | count_leading_zeros      | yes           | yes          | yes            | yes             | no          |
 | create_token             | no            | yes*         | yes*           | yes             | no          |
-| cross-replica-sum        | no            | revisit      | revisit        | no              | no          |
+| cross-replica-sum        | no            | revisit      | yes*           | no              | no          |
 | cstr_reshapable          | no            | revisit      | no             | yes             | no          |
 | custom_call              | no            | revisit      | infeasible     | yes             | no          |
 | divide                   | yes           | yes          | yes            | yes             | no          |


### PR DESCRIPTION
The type inference already exists under [StablehloOps.cpp](https://github.com/openxla/stablehlo/blob/main/stablehlo/dialect/StablehloOps.cpp#L302), so this PR only updates the status.md to reflect that, marking it as `yes*` since we do not have a spec for it yet.
closes #701