### PR TITLE
Infer bounds for Reduce op

### DIFF
--- a/stablehlo/dialect/Base.cpp
+++ b/stablehlo/dialect/Base.cpp
@@ -34,6 +34,7 @@ Type getExpressedTypeOrSelf(Type type) {
   auto quantType = type.dyn_cast<quant::QuantizedType>();
   return quantType ? quantType.getExpressedType() : type;
 }
+}  // namespace
 
 LogicalResult verifyCompatibleShapeWithBounds(Type type1, Type type2) {
   if (failed(verifyCompatibleShape(type1, type2))) return failure();
@@ -61,7 +62,6 @@ LogicalResult verifyCompatibleShapeWithBounds(Type type1, Type type2) {
   }
   return success();
 }
-}  // namespace
 
 bool isCompatibleForHloTypeInference(Type tp1, Type tp2) {
   // Dynamism: We don't require shapes to be the same, we only require them

--- a/stablehlo/dialect/Base.h
+++ b/stablehlo/dialect/Base.h
@@ -53,6 +53,10 @@ inline static bool isStaticDimSize(int64_t val) {
   return !isDynamicDimSize(val);
 }
 
+//  Verifies that the two types have compatible shape with bounds but allows
+//  different element types.
+LogicalResult verifyCompatibleShapeWithBounds(Type type1, Type type2);
+
 // Returns true if the given types are the same for the purposes of HLO type
 // inference, accounting for special properties of quantization and sparsity.
 bool isCompatibleForHloTypeInference(Type tp1, Type tp2);

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -1258,12 +1258,15 @@ LogicalResult inferReduceOp(
   for (uint64_t inputIdx = 0; inputIdx < inputs.size(); ++inputIdx) {
     TensorType inputType = inputArgTypes[inputIdx];
     Type elementType = inputType.getElementType();
-    if (inputType.hasRank())
-      inferredReturnShapes.emplace_back(
-          newDimensions, elementType,
-          boundsToEncoding(firstRankedInput.getEncoding(), newBounds));
-    else
+    if (inputType.hasRank()) {
+      Attribute encoding;
+      if (!newBounds.empty()) {
+        encoding = boundsToEncoding(firstRankedInput.getEncoding(), newBounds);
+      }
+      inferredReturnShapes.emplace_back(newDimensions, elementType, encoding);
+    } else {
       inferredReturnShapes.emplace_back(elementType);
+    }
   }
 
   return success();

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -1259,7 +1259,9 @@ LogicalResult inferReduceOp(
     TensorType inputType = inputArgTypes[inputIdx];
     Type elementType = inputType.getElementType();
     if (inputType.hasRank())
-      inferredReturnShapes.emplace_back(newDimensions, elementType);
+      inferredReturnShapes.emplace_back(
+          newDimensions, elementType,
+          boundsToEncoding(firstRankedInput.getEncoding(), newBounds));
     else
       inferredReturnShapes.emplace_back(elementType);
   }


### PR DESCRIPTION
Extended reduce op shape function to also propagate bounds for dimensions that are not reduced.

Also, moved verifyCompatibleShapeWithBounds to public in Base.h

cc @zhouxin913  for review