### PR TITLE
Fix typo in the spec of AllReduceOp

### DIFF
--- a/docs/spec_draft.md
+++ b/docs/spec_draft.md
@@ -713,7 +713,7 @@ Afterwards, within each `process_group`:
          from `indices(replica_groups)`.
   * (C4) If `use_global_device_ids = true`, then `channel_id > 0`. [todo](https://github.com/openxla/stablehlo/issues/654)
   * (C5) `computation` has type `(tensor<E>, tensor<E>) -> (tensor<E>)` where
-         `E = element_type(`operand`).
+         `E = element_type(operand)`.
   * (C6) type(`result`) $=$ type(`operand`).
 
 ### Examples


### PR DESCRIPTION
I noticed that something breaks markdown highlighting, and it was this typo.