### PR TITLE
Add interpreter for DotGeneralOp

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2396,7 +2396,7 @@ planning to address this in
     rhs_contracting_dimensions = [1]
   >,
   precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-} : (tensor<2x2x2xi32>, tensor<2x2x2xi32>) -> tensor<2x2x2xi32>
+} : (tensor<2x2x2xi64>, tensor<2x2x2xi64>) -> tensor<2x2x2xi64>
 // %result: [
 //           [[1, 2],
 //            [3, 4]],

--- a/docs/status.md
+++ b/docs/status.md
@@ -77,7 +77,7 @@ one of the following tracking labels.
 | custom_call              | yes           | yes          | infeasible     | yes             | yes         |
 | divide                   | yes           | yes          | yes            | yes             | yes         |
 | dot                      | no            | revisit      | infeasible     | yes             | revisit     |
-| dot_general              | yes           | revisit      | infeasible     | no              | no          |
+| dot_general              | yes           | revisit      | infeasible     | no              | yes         |
 | dynamic_broadcast_in_dim | no            | revisit      | infeasible     | no              | no          |
 | dynamic_conv             | no            | revisit      | no             | no              | no          |
 | dynamic_gather           | no            | revisit      | revisit        | no              | no          |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2220,8 +2220,10 @@ def StableHLO_DotGeneralOp: StableHLO_ShapedInterfaceOp<"dot_general", [Pure]> {
     Example:
     ```mlir
     %result = stablehlo.dot_general %lhs, %rhs,
-      batching_dims = [0] x [0], contracting_dims = [2] x [1], precision = [DEFAULT, DEFAULT]
-      : (tensor<2x2x2xi32>, tensor<2x2x2xi32>) -> tensor<2x2x2xi32>
+      batching_dims = [0] x [0],
+      contracting_dims = [2] x [1],
+      precision = [DEFAULT, DEFAULT]
+      : (tensor<2x2x2xi64>, tensor<2x2x2xi64>) -> tensor<2x2x2xi64>
     ```
   }];
   let arguments = (ins

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2225,10 +2225,10 @@ def StableHLO_DotGeneralOp: StableHLO_ShapedInterfaceOp<"dot_general", [Pure]> {
     ```
   }];
   let arguments = (ins
-    HLO_Tensor:$lhs,
-    HLO_Tensor:$rhs,
-    StableHLO_DotDimensionNumbers:$dot_dimension_numbers,
-    StableHLO_PrecisionConfigAttr:$precision_config
+    HLO_Tensor:$lhs /*dot_general_i1*/,
+    HLO_Tensor:$rhs /*dot_general_i2*/,
+    StableHLO_DotDimensionNumbers:$dot_dimension_numbers /*dot_general_i3, dot_general_i4, dot_general_i5, dot_general_i6*/,
+    StableHLO_PrecisionConfigAttr:$precision_config /*dot_general_i7*/
   );
 
   let results = (outs HLO_Tensor);

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -1882,16 +1882,16 @@ LogicalResult inferDotGeneralOp(
     ArrayRef<int64_t> rhsContractingDimensions,
     std::optional<ArrayAttr> precisionConfig,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
-  // dot_general_c12
+  // dot_general_c11
   if (failed(verifyPrecisionConfig(location, precisionConfig)))
     return failure();
 
-  // dot_general_c2
+  // dot_general_c1
   if (lhsBatchingDimensions.size() != rhsBatchingDimensions.size())
     return emitOptionalError(location,
                              "lhs and rhs should have the same "
                              "number of batching dimensions");
-  // dot_general_c3
+  // dot_general_c2
   if (lhsContractingDimensions.size() != rhsContractingDimensions.size())
     return emitOptionalError(location,
                              "lhs and rhs should have the same "
@@ -1911,14 +1911,14 @@ LogicalResult inferDotGeneralOp(
     }
     return success();
   };
-  // dot_general_c4
+  // dot_general_c3
   if (failed(checkDimsDistinct(lhsBatchingDimensions, lhsContractingDimensions,
                                dimSet, "lhs_batching_dimensions",
                                "lhs_contracting_dimensions")))
     return failure();
 
   dimSet.clear();
-  // dot_general_c5
+  // dot_general_c4
   if (failed(checkDimsDistinct(rhsBatchingDimensions, rhsContractingDimensions,
                                dimSet, "rhs_batching_dimensions",
                                "rhs_contracting_dimensions")))
@@ -1936,8 +1936,8 @@ LogicalResult inferDotGeneralOp(
   };
   auto lhsRankedType = lhsType.dyn_cast<RankedTensorType>();
   auto rhsRankedType = rhsType.dyn_cast<RankedTensorType>();
+  // dot_general_c5
   // dot_general_c6
-  // dot_general_c7
   if (lhsRankedType) {
     if (failed(checkDimsInRange(lhsRankedType.getRank(), lhsBatchingDimensions,
                                 "lhs_batching_dimensions")) ||
@@ -1946,8 +1946,8 @@ LogicalResult inferDotGeneralOp(
                                 "lhs_contracting_dimensions")))
       return failure();
   }
+  // dot_general_c7
   // dot_general_c8
-  // dot_general_c9
   if (rhsRankedType) {
     if (failed(checkDimsInRange(rhsRankedType.getRank(), rhsBatchingDimensions,
                                 "rhs_batching_dimensions")) ||
@@ -1963,7 +1963,7 @@ LogicalResult inferDotGeneralOp(
 
     for (auto [lhs, rhs] :
          llvm::zip(lhsBatchingDimensions, rhsBatchingDimensions)) {
-      // dot_general_c10
+      // dot_general_c9
       if (!verifyCompatibleDims(lhsShape[lhs], rhsShape[rhs]))
         return emitOptionalError(location,
                                  "batching dimension sizes must "
@@ -1972,7 +1972,7 @@ LogicalResult inferDotGeneralOp(
 
     for (auto [lhs, rhs] :
          llvm::zip(lhsContractingDimensions, rhsContractingDimensions)) {
-      // dot_general_c11
+      // dot_general_c10
       if (!verifyCompatibleDims(lhsShape[lhs], rhsShape[rhs]))
         return emitOptionalError(location,
                                  "contracting dimension sizes must "
@@ -1999,7 +1999,7 @@ LogicalResult inferDotGeneralOp(
     if (!llvm::is_contained(rhsBatchingDimensions, i) &&
         !llvm::is_contained(rhsContractingDimensions, i))
       dimensions.push_back(rhsShape[i]);
-  // dot_general_c13
+  // dot_general_c12
   inferredReturnShapes.emplace_back(dimensions);
   return success();
 }

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -1882,13 +1882,16 @@ LogicalResult inferDotGeneralOp(
     ArrayRef<int64_t> rhsContractingDimensions,
     std::optional<ArrayAttr> precisionConfig,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
+  // dot_general_c12
   if (failed(verifyPrecisionConfig(location, precisionConfig)))
     return failure();
 
+  // dot_general_c2
   if (lhsBatchingDimensions.size() != rhsBatchingDimensions.size())
     return emitOptionalError(location,
                              "lhs and rhs should have the same "
                              "number of batching dimensions");
+  // dot_general_c3
   if (lhsContractingDimensions.size() != rhsContractingDimensions.size())
     return emitOptionalError(location,
                              "lhs and rhs should have the same "
@@ -1908,14 +1911,14 @@ LogicalResult inferDotGeneralOp(
     }
     return success();
   };
-
+  // dot_general_c4
   if (failed(checkDimsDistinct(lhsBatchingDimensions, lhsContractingDimensions,
                                dimSet, "lhs_batching_dimensions",
                                "lhs_contracting_dimensions")))
     return failure();
 
   dimSet.clear();
-
+  // dot_general_c5
   if (failed(checkDimsDistinct(rhsBatchingDimensions, rhsContractingDimensions,
                                dimSet, "rhs_batching_dimensions",
                                "rhs_contracting_dimensions")))
@@ -1933,7 +1936,8 @@ LogicalResult inferDotGeneralOp(
   };
   auto lhsRankedType = lhsType.dyn_cast<RankedTensorType>();
   auto rhsRankedType = rhsType.dyn_cast<RankedTensorType>();
-
+  // dot_general_c6
+  // dot_general_c7
   if (lhsRankedType) {
     if (failed(checkDimsInRange(lhsRankedType.getRank(), lhsBatchingDimensions,
                                 "lhs_batching_dimensions")) ||
@@ -1942,6 +1946,8 @@ LogicalResult inferDotGeneralOp(
                                 "lhs_contracting_dimensions")))
       return failure();
   }
+  // dot_general_c8
+  // dot_general_c9
   if (rhsRankedType) {
     if (failed(checkDimsInRange(rhsRankedType.getRank(), rhsBatchingDimensions,
                                 "rhs_batching_dimensions")) ||
@@ -1957,6 +1963,7 @@ LogicalResult inferDotGeneralOp(
 
     for (auto [lhs, rhs] :
          llvm::zip(lhsBatchingDimensions, rhsBatchingDimensions)) {
+      // dot_general_c10
       if (!verifyCompatibleDims(lhsShape[lhs], rhsShape[rhs]))
         return emitOptionalError(location,
                                  "batching dimension sizes must "
@@ -1965,6 +1972,7 @@ LogicalResult inferDotGeneralOp(
 
     for (auto [lhs, rhs] :
          llvm::zip(lhsContractingDimensions, rhsContractingDimensions)) {
+      // dot_general_c11
       if (!verifyCompatibleDims(lhsShape[lhs], rhsShape[rhs]))
         return emitOptionalError(location,
                                  "contracting dimension sizes must "
@@ -1991,7 +1999,7 @@ LogicalResult inferDotGeneralOp(
     if (!llvm::is_contained(rhsBatchingDimensions, i) &&
         !llvm::is_contained(rhsContractingDimensions, i))
       dimensions.push_back(rhsShape[i]);
-
+  // dot_general_c13
   inferredReturnShapes.emplace_back(dimensions);
   return success();
 }

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -1891,6 +1891,7 @@ LogicalResult inferDotGeneralOp(
     return emitOptionalError(location,
                              "lhs and rhs should have the same "
                              "number of batching dimensions");
+
   // dot_general_c2
   if (lhsContractingDimensions.size() != rhsContractingDimensions.size())
     return emitOptionalError(location,
@@ -1911,6 +1912,7 @@ LogicalResult inferDotGeneralOp(
     }
     return success();
   };
+
   // dot_general_c3
   if (failed(checkDimsDistinct(lhsBatchingDimensions, lhsContractingDimensions,
                                dimSet, "lhs_batching_dimensions",
@@ -1934,11 +1936,11 @@ LogicalResult inferDotGeneralOp(
                                " is out of range: ", "[0, ", rank, ")");
     return success();
   };
+
   auto lhsRankedType = lhsType.dyn_cast<RankedTensorType>();
-  auto rhsRankedType = rhsType.dyn_cast<RankedTensorType>();
-  // dot_general_c5
-  // dot_general_c6
   if (lhsRankedType) {
+    // dot_general_c5
+    // dot_general_c6
     if (failed(checkDimsInRange(lhsRankedType.getRank(), lhsBatchingDimensions,
                                 "lhs_batching_dimensions")) ||
         failed(checkDimsInRange(lhsRankedType.getRank(),
@@ -1946,9 +1948,11 @@ LogicalResult inferDotGeneralOp(
                                 "lhs_contracting_dimensions")))
       return failure();
   }
-  // dot_general_c7
-  // dot_general_c8
+
+  auto rhsRankedType = rhsType.dyn_cast<RankedTensorType>();
   if (rhsRankedType) {
+    // dot_general_c7
+    // dot_general_c8
     if (failed(checkDimsInRange(rhsRankedType.getRank(), rhsBatchingDimensions,
                                 "rhs_batching_dimensions")) ||
         failed(checkDimsInRange(rhsRankedType.getRank(),
@@ -1999,6 +2003,7 @@ LogicalResult inferDotGeneralOp(
     if (!llvm::is_contained(rhsBatchingDimensions, i) &&
         !llvm::is_contained(rhsContractingDimensions, i))
       dimensions.push_back(rhsShape[i]);
+
   // dot_general_c12
   inferredReturnShapes.emplace_back(dimensions);
   return success();

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -53,6 +53,12 @@ Tensor evalConvertOp(const Tensor &operand, ShapedType resultType);
 Tensor evalCosineOp(const Tensor &operand, ShapedType resultType);
 Tensor evalDivideOp(const Tensor &lhs, const Tensor &rhs,
                     ShapedType resultType);
+Tensor evalDotGeneralOp(const Tensor &lhs, const Tensor &rhs,
+                        const Axes &lhsBatchingDimensions,
+                        const Axes &rhsBatchingDimensions,
+                        const Axes &lhsContractingDimensions,
+                        const Axes &rhsContractingDimensions,
+                        ShapedType resultType);
 Tensor evalDynamicSliceOp(const Tensor &operand, ArrayRef<Tensor> startIndices,
                           const Sizes &sliceSizes, ShapedType resultType);
 Tensor evalDynamicUpdateSliceOp(const Tensor &operand, const Tensor &update,

--- a/stablehlo/testdata/dot_general_batch_dimensions_lhs_float32_4_4_3_3_4__rhs_float32_4_4_3_4_2__dimensionnumbers____4____3______0_1_2___0_1_2.mlir
+++ b/stablehlo/testdata/dot_general_batch_dimensions_lhs_float32_4_4_3_3_4__rhs_float32_4_4_3_4_2__dimensionnumbers____4____3______0_1_2___0_1_2.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_batch_dimensions_lhs_float32_8_4_3_3_4__rhs_float32_4_8_3_4_2__dimensionnumbers____4_3___3_2_____0_1___1_0.mlir
+++ b/stablehlo/testdata/dot_general_batch_dimensions_lhs_float32_8_4_3_3_4__rhs_float32_4_8_3_4_2__dimensionnumbers____4_3___3_2_____0_1___1_0.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_1_3_4__rhs_bfloat16_1_4_3__dimensionnumbers____2_1___1-3488071595538934629.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_1_3_4__rhs_bfloat16_1_4_3__dimensionnumbers____2_1___1-3488071595538934629.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_1_3_4__rhs_bfloat16_1_4_3__dimensionnumbers____2_1___1-3776297041219061363.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_1_3_4__rhs_bfloat16_1_4_3__dimensionnumbers____2_1___1-3776297041219061363.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_1_3_4__rhs_bfloat16_1_4_3__dimensionnumbers____2_1___14414396846507850540.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_1_3_4__rhs_bfloat16_1_4_3__dimensionnumbers____2_1___14414396846507850540.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_1_3_4__rhs_bfloat16_1_4_3__dimensionnumbers____2_1___1_2_____0____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_1_3_4__rhs_bfloat16_1_4_3__dimensionnumbers____2_1___1_2_____0____0.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_3_4__rhs_bfloat16_4_2__dimensionnumbers____1____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_3_4__rhs_bfloat16_4_2__dimensionnumbers____1____0.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_3_4__rhs_bfloat16_4_2__dimensionnumbers____1____0_____-1754126126588226380.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_3_4__rhs_bfloat16_4_2__dimensionnumbers____1____0_____-1754126126588226380.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_3_4__rhs_bfloat16_4_2__dimensionnumbers____1____0_____-2296794117335230406.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_3_4__rhs_bfloat16_4_2__dimensionnumbers____1____0_____-2296794117335230406.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_3_4__rhs_bfloat16_4_2__dimensionnumbers____1____0_____-7202245725599589690.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_3_4__rhs_bfloat16_4_2__dimensionnumbers____1____0_____-7202245725599589690.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_7_3_4__rhs_bfloat16_7_4__dimensionnumbers____2____1___-1057231342150989035.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_7_3_4__rhs_bfloat16_7_4__dimensionnumbers____2____1___-1057231342150989035.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_7_3_4__rhs_bfloat16_7_4__dimensionnumbers____2____1___-3405297742316790041.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_7_3_4__rhs_bfloat16_7_4__dimensionnumbers____2____1___-3405297742316790041.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_7_3_4__rhs_bfloat16_7_4__dimensionnumbers____2____1___7892347291040569893.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_7_3_4__rhs_bfloat16_7_4__dimensionnumbers____2____1___7892347291040569893.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_7_3_4__rhs_bfloat16_7_4__dimensionnumbers____2____1______0____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_7_3_4__rhs_bfloat16_7_4__dimensionnumbers____2____1______0____0.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_1_3_4__rhs_bool_1_4_3__dimensionnumbers____2_1___1_2_____0-3484588224050375727.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_1_3_4__rhs_bool_1_4_3__dimensionnumbers____2_1___1_2_____0-3484588224050375727.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_1_3_4__rhs_bool_1_4_3__dimensionnumbers____2_1___1_2_____0-4108919279260287054.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_1_3_4__rhs_bool_1_4_3__dimensionnumbers____2_1___1_2_____0-4108919279260287054.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_1_3_4__rhs_bool_1_4_3__dimensionnumbers____2_1___1_2_____0-4878328097352283363.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_1_3_4__rhs_bool_1_4_3__dimensionnumbers____2_1___1_2_____0-4878328097352283363.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_1_3_4__rhs_bool_1_4_3__dimensionnumbers____2_1___1_2_____0____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_1_3_4__rhs_bool_1_4_3__dimensionnumbers____2_1___1_2_____0____0.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_3_4__rhs_bool_4_2__dimensionnumbers____1____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_3_4__rhs_bool_4_2__dimensionnumbers____1____0.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_3_4__rhs_bool_4_2__dimensionnumbers____1____0_____________-8168146190025525366.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_3_4__rhs_bool_4_2__dimensionnumbers____1____0_____________-8168146190025525366.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_3_4__rhs_bool_4_2__dimensionnumbers____1____0_____________-8768711742441429271.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_3_4__rhs_bool_4_2__dimensionnumbers____1____0_____________-8768711742441429271.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_3_4__rhs_bool_4_2__dimensionnumbers____1____0_____________3842350780159274364.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_3_4__rhs_bool_4_2__dimensionnumbers____1____0_____________3842350780159274364.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_7_3_4__rhs_bool_7_4__dimensionnumbers____2____1______0____-2740531727885652483.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_7_3_4__rhs_bool_7_4__dimensionnumbers____2____1______0____-2740531727885652483.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_7_3_4__rhs_bool_7_4__dimensionnumbers____2____1______0____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_7_3_4__rhs_bool_7_4__dimensionnumbers____2____1______0____0.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_7_3_4__rhs_bool_7_4__dimensionnumbers____2____1______0____2897938142369644973.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_7_3_4__rhs_bool_7_4__dimensionnumbers____2____1______0____2897938142369644973.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_7_3_4__rhs_bool_7_4__dimensionnumbers____2____1______0____7336872569949371587.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_7_3_4__rhs_bool_7_4__dimensionnumbers____2____1______0____7336872569949371587.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_1_3_4__rhs_complex64_1_4_3__dimensionnumbers____2_1__-735411287416952288.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_1_3_4__rhs_complex64_1_4_3__dimensionnumbers____2_1__-735411287416952288.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_1_3_4__rhs_complex64_1_4_3__dimensionnumbers____2_1__-784191692831253394.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_1_3_4__rhs_complex64_1_4_3__dimensionnumbers____2_1__-784191692831253394.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_1_3_4__rhs_complex64_1_4_3__dimensionnumbers____2_1__-8165666907376519597.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_1_3_4__rhs_complex64_1_4_3__dimensionnumbers____2_1__-8165666907376519597.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_1_3_4__rhs_complex64_1_4_3__dimensionnumbers____2_1___1_2_____0____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_1_3_4__rhs_complex64_1_4_3__dimensionnumbers____2_1___1_2_____0____0.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_3_4__rhs_complex64_4_2__dimensionnumbers____1____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_3_4__rhs_complex64_4_2__dimensionnumbers____1____0.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_3_4__rhs_complex64_4_2__dimensionnumbers____1____0___-2036095829843401162.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_3_4__rhs_complex64_4_2__dimensionnumbers____1____0___-2036095829843401162.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_3_4__rhs_complex64_4_2__dimensionnumbers____1____0___3282598972180177227.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_3_4__rhs_complex64_4_2__dimensionnumbers____1____0___3282598972180177227.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_3_4__rhs_complex64_4_2__dimensionnumbers____1____0___6322139621408956459.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_3_4__rhs_complex64_4_2__dimensionnumbers____1____0___6322139621408956459.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_7_3_4__rhs_complex64_7_4__dimensionnumbers____2____1_-3568690752099311792.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_7_3_4__rhs_complex64_7_4__dimensionnumbers____2____1_-3568690752099311792.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_7_3_4__rhs_complex64_7_4__dimensionnumbers____2____1_6996122032990541190.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_7_3_4__rhs_complex64_7_4__dimensionnumbers____2____1_6996122032990541190.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_7_3_4__rhs_complex64_7_4__dimensionnumbers____2____1_7256596681599443155.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_7_3_4__rhs_complex64_7_4__dimensionnumbers____2____1_7256596681599443155.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_7_3_4__rhs_complex64_7_4__dimensionnumbers____2____1______0____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_7_3_4__rhs_complex64_7_4__dimensionnumbers____2____1______0____0.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_1_3_4__rhs_float32_1_4_3__dimensionnumbers____2_1___1_2-3746161505671304111.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_1_3_4__rhs_float32_1_4_3__dimensionnumbers____2_1___1_2-3746161505671304111.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_1_3_4__rhs_float32_1_4_3__dimensionnumbers____2_1___1_2-601699960869302464.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_1_3_4__rhs_float32_1_4_3__dimensionnumbers____2_1___1_2-601699960869302464.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_1_3_4__rhs_float32_1_4_3__dimensionnumbers____2_1___1_26892231390636518787.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_1_3_4__rhs_float32_1_4_3__dimensionnumbers____2_1___1_26892231390636518787.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_1_3_4__rhs_float32_1_4_3__dimensionnumbers____2_1___1_2_____0____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_1_3_4__rhs_float32_1_4_3__dimensionnumbers____2_1___1_2_____0____0.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_3_4__rhs_float32_4_2__dimensionnumbers____1____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_3_4__rhs_float32_4_2__dimensionnumbers____1____0.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_3_4__rhs_float32_4_2__dimensionnumbers____1____0_______2515748806464509716.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_3_4__rhs_float32_4_2__dimensionnumbers____1____0_______2515748806464509716.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_3_4__rhs_float32_4_2__dimensionnumbers____1____0_______3286318053268167699.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_3_4__rhs_float32_4_2__dimensionnumbers____1____0_______3286318053268167699.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_3_4__rhs_float32_4_2__dimensionnumbers____1____0_______3732210740950592224.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_3_4__rhs_float32_4_2__dimensionnumbers____1____0_______3732210740950592224.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_7_3_4__rhs_float32_7_4__dimensionnumbers____2____1_____-3197832446988830601.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_7_3_4__rhs_float32_7_4__dimensionnumbers____2____1_____-3197832446988830601.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_7_3_4__rhs_float32_7_4__dimensionnumbers____2____1_____3738222238009994556.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_7_3_4__rhs_float32_7_4__dimensionnumbers____2____1_____3738222238009994556.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_7_3_4__rhs_float32_7_4__dimensionnumbers____2____1_____3780030947611086597.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_7_3_4__rhs_float32_7_4__dimensionnumbers____2____1_____3780030947611086597.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_7_3_4__rhs_float32_7_4__dimensionnumbers____2____1______0____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_7_3_4__rhs_float32_7_4__dimensionnumbers____2____1______0____0.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_1_3_4__rhs_int16_1_4_3__dimensionnumbers____2_1___1_2____-4742864369009872129.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_1_3_4__rhs_int16_1_4_3__dimensionnumbers____2_1___1_2____-4742864369009872129.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_1_3_4__rhs_int16_1_4_3__dimensionnumbers____2_1___1_2____-7158034838136709443.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_1_3_4__rhs_int16_1_4_3__dimensionnumbers____2_1___1_2____-7158034838136709443.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_1_3_4__rhs_int16_1_4_3__dimensionnumbers____2_1___1_2____1922628071420239357.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_1_3_4__rhs_int16_1_4_3__dimensionnumbers____2_1___1_2____1922628071420239357.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_1_3_4__rhs_int16_1_4_3__dimensionnumbers____2_1___1_2_____0____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_1_3_4__rhs_int16_1_4_3__dimensionnumbers____2_1___1_2_____0____0.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_3_4__rhs_int16_4_2__dimensionnumbers____1____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_3_4__rhs_int16_4_2__dimensionnumbers____1____0.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_3_4__rhs_int16_4_2__dimensionnumbers____1____0___________-2271803244152339341.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_3_4__rhs_int16_4_2__dimensionnumbers____1____0___________-2271803244152339341.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_3_4__rhs_int16_4_2__dimensionnumbers____1____0___________2101610351464245948.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_3_4__rhs_int16_4_2__dimensionnumbers____1____0___________2101610351464245948.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_3_4__rhs_int16_4_2__dimensionnumbers____1____0___________7896444752678988294.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_3_4__rhs_int16_4_2__dimensionnumbers____1____0___________7896444752678988294.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_7_3_4__rhs_int16_7_4__dimensionnumbers____2____1______0__-8124740806626215928.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_7_3_4__rhs_int16_7_4__dimensionnumbers____2____1______0__-8124740806626215928.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_7_3_4__rhs_int16_7_4__dimensionnumbers____2____1______0__289753334994817081.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_7_3_4__rhs_int16_7_4__dimensionnumbers____2____1______0__289753334994817081.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_7_3_4__rhs_int16_7_4__dimensionnumbers____2____1______0__3337013416783310431.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_7_3_4__rhs_int16_7_4__dimensionnumbers____2____1______0__3337013416783310431.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_7_3_4__rhs_int16_7_4__dimensionnumbers____2____1______0____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_7_3_4__rhs_int16_7_4__dimensionnumbers____2____1______0____0.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_1_3_4__rhs_int32_1_4_3__dimensionnumbers____2_1___1_2____-231006999036771167.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_1_3_4__rhs_int32_1_4_3__dimensionnumbers____2_1___1_2____-231006999036771167.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_1_3_4__rhs_int32_1_4_3__dimensionnumbers____2_1___1_2____-7694624932495008475.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_1_3_4__rhs_int32_1_4_3__dimensionnumbers____2_1___1_2____-7694624932495008475.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_1_3_4__rhs_int32_1_4_3__dimensionnumbers____2_1___1_2____7986672474430827476.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_1_3_4__rhs_int32_1_4_3__dimensionnumbers____2_1___1_2____7986672474430827476.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_1_3_4__rhs_int32_1_4_3__dimensionnumbers____2_1___1_2_____0____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_1_3_4__rhs_int32_1_4_3__dimensionnumbers____2_1___1_2_____0____0.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_3_4__rhs_int32_4_2__dimensionnumbers____1____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_3_4__rhs_int32_4_2__dimensionnumbers____1____0.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_3_4__rhs_int32_4_2__dimensionnumbers____1____0___________-3174156855870199286.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_3_4__rhs_int32_4_2__dimensionnumbers____1____0___________-3174156855870199286.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_3_4__rhs_int32_4_2__dimensionnumbers____1____0___________-5353411001541942402.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_3_4__rhs_int32_4_2__dimensionnumbers____1____0___________-5353411001541942402.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_3_4__rhs_int32_4_2__dimensionnumbers____1____0___________1165017806469887730.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_3_4__rhs_int32_4_2__dimensionnumbers____1____0___________1165017806469887730.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_7_3_4__rhs_int32_7_4__dimensionnumbers____2____1______0__-9076583839040242713.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_7_3_4__rhs_int32_7_4__dimensionnumbers____2____1______0__-9076583839040242713.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_7_3_4__rhs_int32_7_4__dimensionnumbers____2____1______0__4165376091224852052.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_7_3_4__rhs_int32_7_4__dimensionnumbers____2____1______0__4165376091224852052.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_7_3_4__rhs_int32_7_4__dimensionnumbers____2____1______0__7424163616416445021.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_7_3_4__rhs_int32_7_4__dimensionnumbers____2____1______0__7424163616416445021.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_7_3_4__rhs_int32_7_4__dimensionnumbers____2____1______0____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_7_3_4__rhs_int32_7_4__dimensionnumbers____2____1______0____0.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_1_3_4__rhs_int8_1_4_3__dimensionnumbers____2_1___1_2_____0-3853546448610067655.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_1_3_4__rhs_int8_1_4_3__dimensionnumbers____2_1___1_2_____0-3853546448610067655.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_1_3_4__rhs_int8_1_4_3__dimensionnumbers____2_1___1_2_____0-4928777745320269696.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_1_3_4__rhs_int8_1_4_3__dimensionnumbers____2_1___1_2_____0-4928777745320269696.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_1_3_4__rhs_int8_1_4_3__dimensionnumbers____2_1___1_2_____0-8601469441317250057.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_1_3_4__rhs_int8_1_4_3__dimensionnumbers____2_1___1_2_____0-8601469441317250057.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_1_3_4__rhs_int8_1_4_3__dimensionnumbers____2_1___1_2_____0____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_1_3_4__rhs_int8_1_4_3__dimensionnumbers____2_1___1_2_____0____0.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_3_4__rhs_int8_4_2__dimensionnumbers____1____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_3_4__rhs_int8_4_2__dimensionnumbers____1____0.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_3_4__rhs_int8_4_2__dimensionnumbers____1____0_____________-2611634671922146939.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_3_4__rhs_int8_4_2__dimensionnumbers____1____0_____________-2611634671922146939.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_3_4__rhs_int8_4_2__dimensionnumbers____1____0_____________3394615931814532441.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_3_4__rhs_int8_4_2__dimensionnumbers____1____0_____________3394615931814532441.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_3_4__rhs_int8_4_2__dimensionnumbers____1____0_____________5154403401871514821.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_3_4__rhs_int8_4_2__dimensionnumbers____1____0_____________5154403401871514821.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_7_3_4__rhs_int8_7_4__dimensionnumbers____2____1______0____-6266355234981290645.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_7_3_4__rhs_int8_7_4__dimensionnumbers____2____1______0____-6266355234981290645.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_7_3_4__rhs_int8_7_4__dimensionnumbers____2____1______0____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_7_3_4__rhs_int8_7_4__dimensionnumbers____2____1______0____0.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_7_3_4__rhs_int8_7_4__dimensionnumbers____2____1______0____263428595008059154.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_7_3_4__rhs_int8_7_4__dimensionnumbers____2____1______0____263428595008059154.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_7_3_4__rhs_int8_7_4__dimensionnumbers____2____1______0____4702378364613486236.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_7_3_4__rhs_int8_7_4__dimensionnumbers____2____1______0____4702378364613486236.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_1_3_4__rhs_uint16_1_4_3__dimensionnumbers____2_1___1_2__-146653715732496678.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_1_3_4__rhs_uint16_1_4_3__dimensionnumbers____2_1___1_2__-146653715732496678.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_1_3_4__rhs_uint16_1_4_3__dimensionnumbers____2_1___1_2__-2338360034038796500.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_1_3_4__rhs_uint16_1_4_3__dimensionnumbers____2_1___1_2__-2338360034038796500.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_1_3_4__rhs_uint16_1_4_3__dimensionnumbers____2_1___1_2__7305651858029495209.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_1_3_4__rhs_uint16_1_4_3__dimensionnumbers____2_1___1_2__7305651858029495209.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_1_3_4__rhs_uint16_1_4_3__dimensionnumbers____2_1___1_2_____0____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_1_3_4__rhs_uint16_1_4_3__dimensionnumbers____2_1___1_2_____0____0.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_3_4__rhs_uint16_4_2__dimensionnumbers____1____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_3_4__rhs_uint16_4_2__dimensionnumbers____1____0.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_3_4__rhs_uint16_4_2__dimensionnumbers____1____0_________-1866955430630412412.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_3_4__rhs_uint16_4_2__dimensionnumbers____1____0_________-1866955430630412412.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_3_4__rhs_uint16_4_2__dimensionnumbers____1____0_________-387512258616889308.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_3_4__rhs_uint16_4_2__dimensionnumbers____1____0_________-387512258616889308.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_3_4__rhs_uint16_4_2__dimensionnumbers____1____0_________-5278629355353596549.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_3_4__rhs_uint16_4_2__dimensionnumbers____1____0_________-5278629355353596549.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_7_3_4__rhs_uint16_7_4__dimensionnumbers____2____1______0-1122680703579366098.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_7_3_4__rhs_uint16_7_4__dimensionnumbers____2____1______0-1122680703579366098.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_7_3_4__rhs_uint16_7_4__dimensionnumbers____2____1______0-2540294669593821117.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_7_3_4__rhs_uint16_7_4__dimensionnumbers____2____1______0-2540294669593821117.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_7_3_4__rhs_uint16_7_4__dimensionnumbers____2____1______02143288615622397436.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_7_3_4__rhs_uint16_7_4__dimensionnumbers____2____1______02143288615622397436.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_7_3_4__rhs_uint16_7_4__dimensionnumbers____2____1______0____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_7_3_4__rhs_uint16_7_4__dimensionnumbers____2____1______0____0.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_1_3_4__rhs_uint32_1_4_3__dimensionnumbers____2_1___1_2__-3828685614544935607.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_1_3_4__rhs_uint32_1_4_3__dimensionnumbers____2_1___1_2__-3828685614544935607.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_1_3_4__rhs_uint32_1_4_3__dimensionnumbers____2_1___1_2__1983506021040082421.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_1_3_4__rhs_uint32_1_4_3__dimensionnumbers____2_1___1_2__1983506021040082421.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_1_3_4__rhs_uint32_1_4_3__dimensionnumbers____2_1___1_2__4074853676794110911.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_1_3_4__rhs_uint32_1_4_3__dimensionnumbers____2_1___1_2__4074853676794110911.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_1_3_4__rhs_uint32_1_4_3__dimensionnumbers____2_1___1_2_____0____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_1_3_4__rhs_uint32_1_4_3__dimensionnumbers____2_1___1_2_____0____0.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_3_4__rhs_uint32_4_2__dimensionnumbers____1____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_3_4__rhs_uint32_4_2__dimensionnumbers____1____0.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_3_4__rhs_uint32_4_2__dimensionnumbers____1____0_________-7142718517056468988.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_3_4__rhs_uint32_4_2__dimensionnumbers____1____0_________-7142718517056468988.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_3_4__rhs_uint32_4_2__dimensionnumbers____1____0_________3265766190081922835.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_3_4__rhs_uint32_4_2__dimensionnumbers____1____0_________3265766190081922835.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_3_4__rhs_uint32_4_2__dimensionnumbers____1____0_________4943295620416399626.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_3_4__rhs_uint32_4_2__dimensionnumbers____1____0_________4943295620416399626.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_7_3_4__rhs_uint32_7_4__dimensionnumbers____2____1______0-2439260603686590970.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_7_3_4__rhs_uint32_7_4__dimensionnumbers____2____1______0-2439260603686590970.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_7_3_4__rhs_uint32_7_4__dimensionnumbers____2____1______0-3523542059064547826.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_7_3_4__rhs_uint32_7_4__dimensionnumbers____2____1______0-3523542059064547826.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_7_3_4__rhs_uint32_7_4__dimensionnumbers____2____1______02825204705189971310.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_7_3_4__rhs_uint32_7_4__dimensionnumbers____2____1______02825204705189971310.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_7_3_4__rhs_uint32_7_4__dimensionnumbers____2____1______0____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_7_3_4__rhs_uint32_7_4__dimensionnumbers____2____1______0____0.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_1_3_4__rhs_uint8_1_4_3__dimensionnumbers____2_1___1_2____-3976120861674915517.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_1_3_4__rhs_uint8_1_4_3__dimensionnumbers____2_1___1_2____-3976120861674915517.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_1_3_4__rhs_uint8_1_4_3__dimensionnumbers____2_1___1_2____469616114700916203.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_1_3_4__rhs_uint8_1_4_3__dimensionnumbers____2_1___1_2____469616114700916203.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_1_3_4__rhs_uint8_1_4_3__dimensionnumbers____2_1___1_2____6468279395723435326.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_1_3_4__rhs_uint8_1_4_3__dimensionnumbers____2_1___1_2____6468279395723435326.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_1_3_4__rhs_uint8_1_4_3__dimensionnumbers____2_1___1_2_____0____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_1_3_4__rhs_uint8_1_4_3__dimensionnumbers____2_1___1_2_____0____0.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_3_4__rhs_uint8_4_2__dimensionnumbers____1____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_3_4__rhs_uint8_4_2__dimensionnumbers____1____0.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_3_4__rhs_uint8_4_2__dimensionnumbers____1____0___________-1252152727279771837.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_3_4__rhs_uint8_4_2__dimensionnumbers____1____0___________-1252152727279771837.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_3_4__rhs_uint8_4_2__dimensionnumbers____1____0___________-2234047840108169469.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_3_4__rhs_uint8_4_2__dimensionnumbers____1____0___________-2234047840108169469.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_3_4__rhs_uint8_4_2__dimensionnumbers____1____0___________-4506489744827934724.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_3_4__rhs_uint8_4_2__dimensionnumbers____1____0___________-4506489744827934724.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_7_3_4__rhs_uint8_7_4__dimensionnumbers____2____1______0__-2500540846752821341.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_7_3_4__rhs_uint8_7_4__dimensionnumbers____2____1______0__-2500540846752821341.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_7_3_4__rhs_uint8_7_4__dimensionnumbers____2____1______0__2563221986579472778.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_7_3_4__rhs_uint8_7_4__dimensionnumbers____2____1______0__2563221986579472778.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_7_3_4__rhs_uint8_7_4__dimensionnumbers____2____1______0__2721838283221210166.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_7_3_4__rhs_uint8_7_4__dimensionnumbers____2____1______0__2721838283221210166.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_7_3_4__rhs_uint8_7_4__dimensionnumbers____2____1______0____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_7_3_4__rhs_uint8_7_4__dimensionnumbers____2____1______0____0.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_preferred_lhs_complex64_3__rhs_complex64_3_6__dimensionnumbers____0____0_____________preferred_complex128.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_complex64_3__rhs_complex64_3_6__dimensionnumbers____0____0_____________preferred_complex128.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_preferred_lhs_complex64_3__rhs_complex64_3__dimensionnumbers____0____0_____________preferred_complex128.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_complex64_3__rhs_complex64_3__dimensionnumbers____0____0_____________preferred_complex128.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_preferred_lhs_complex64_4_3__rhs_complex64_3_6__dimensionnumbers____1____0_____________preferred_complex128.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_complex64_4_3__rhs_complex64_3_6__dimensionnumbers____1____0_____________preferred_complex128.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_preferred_lhs_complex64_4_3__rhs_complex64_3__dimensionnumbers____1____0_____________preferred_complex128.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_complex64_4_3__rhs_complex64_3__dimensionnumbers____1____0_____________preferred_complex128.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_preferred_lhs_float16_3__rhs_float16_3_6__dimensionnumbers____0____0_____________preferred_float32.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_float16_3__rhs_float16_3_6__dimensionnumbers____0____0_____________preferred_float32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_preferred_lhs_float16_3__rhs_float16_3_6__dimensionnumbers____0____0_____________preferred_float64.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_float16_3__rhs_float16_3_6__dimensionnumbers____0____0_____________preferred_float64.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_preferred_lhs_float16_3__rhs_float16_3__dimensionnumbers____0____0_____________preferred_float32.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_float16_3__rhs_float16_3__dimensionnumbers____0____0_____________preferred_float32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_preferred_lhs_float16_3__rhs_float16_3__dimensionnumbers____0____0_____________preferred_float64.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_float16_3__rhs_float16_3__dimensionnumbers____0____0_____________preferred_float64.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_preferred_lhs_float16_4_3__rhs_float16_3_6__dimensionnumbers____1____0_____________preferred_float32.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_float16_4_3__rhs_float16_3_6__dimensionnumbers____1____0_____________preferred_float32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_preferred_lhs_float16_4_3__rhs_float16_3_6__dimensionnumbers____1____0_____________preferred_float64.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_float16_4_3__rhs_float16_3_6__dimensionnumbers____1____0_____________preferred_float64.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_preferred_lhs_float16_4_3__rhs_float16_3__dimensionnumbers____1____0_____________preferred_float32.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_float16_4_3__rhs_float16_3__dimensionnumbers____1____0_____________preferred_float32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_preferred_lhs_float16_4_3__rhs_float16_3__dimensionnumbers____1____0_____________preferred_float64.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_float16_4_3__rhs_float16_3__dimensionnumbers____1____0_____________preferred_float64.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_preferred_lhs_float32_3__rhs_float32_3_6__dimensionnumbers____0____0_____________preferred_float32.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_float32_3__rhs_float32_3_6__dimensionnumbers____0____0_____________preferred_float32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_preferred_lhs_float32_3__rhs_float32_3_6__dimensionnumbers____0____0_____________preferred_float64.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_float32_3__rhs_float32_3_6__dimensionnumbers____0____0_____________preferred_float64.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_preferred_lhs_float32_3__rhs_float32_3__dimensionnumbers____0____0_____________preferred_float32.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_float32_3__rhs_float32_3__dimensionnumbers____0____0_____________preferred_float32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_preferred_lhs_float32_3__rhs_float32_3__dimensionnumbers____0____0_____________preferred_float64.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_float32_3__rhs_float32_3__dimensionnumbers____0____0_____________preferred_float64.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_preferred_lhs_float32_4_3__rhs_float32_3_6__dimensionnumbers____1____0_____________preferred_float32.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_float32_4_3__rhs_float32_3_6__dimensionnumbers____1____0_____________preferred_float32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_preferred_lhs_float32_4_3__rhs_float32_3_6__dimensionnumbers____1____0_____________preferred_float64.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_float32_4_3__rhs_float32_3_6__dimensionnumbers____1____0_____________preferred_float64.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_preferred_lhs_float32_4_3__rhs_float32_3__dimensionnumbers____1____0_____________preferred_float32.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_float32_4_3__rhs_float32_3__dimensionnumbers____1____0_____________preferred_float32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_preferred_lhs_float32_4_3__rhs_float32_3__dimensionnumbers____1____0_____________preferred_float64.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_float32_4_3__rhs_float32_3__dimensionnumbers____1____0_____________preferred_float64.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_preferred_lhs_int32_3__rhs_int32_3_6__dimensionnumbers____0____0_____________preferred_int32.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_int32_3__rhs_int32_3_6__dimensionnumbers____0____0_____________preferred_int32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_preferred_lhs_int32_3__rhs_int32_3_6__dimensionnumbers____0____0_____________preferred_int64.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_int32_3__rhs_int32_3_6__dimensionnumbers____0____0_____________preferred_int64.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_preferred_lhs_int32_3__rhs_int32_3__dimensionnumbers____0____0_____________preferred_int32.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_int32_3__rhs_int32_3__dimensionnumbers____0____0_____________preferred_int32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_preferred_lhs_int32_3__rhs_int32_3__dimensionnumbers____0____0_____________preferred_int64.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_int32_3__rhs_int32_3__dimensionnumbers____0____0_____________preferred_int64.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_preferred_lhs_int32_4_3__rhs_int32_3_6__dimensionnumbers____1____0_____________preferred_int32.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_int32_4_3__rhs_int32_3_6__dimensionnumbers____1____0_____________preferred_int32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_preferred_lhs_int32_4_3__rhs_int32_3_6__dimensionnumbers____1____0_____________preferred_int64.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_int32_4_3__rhs_int32_3_6__dimensionnumbers____1____0_____________preferred_int64.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_preferred_lhs_int32_4_3__rhs_int32_3__dimensionnumbers____1____0_____________preferred_int32.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_int32_4_3__rhs_int32_3__dimensionnumbers____1____0_____________preferred_int32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_preferred_lhs_int32_4_3__rhs_int32_3__dimensionnumbers____1____0_____________preferred_int64.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_int32_4_3__rhs_int32_3__dimensionnumbers____1____0_____________preferred_int64.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_squeeze_lhs_float32_4_4__rhs_float32_4__dimensionnumbers____1____0.mlir
+++ b/stablehlo/testdata/dot_general_squeeze_lhs_float32_4_4__rhs_float32_4__dimensionnumbers____1____0.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_squeeze_lhs_float32_4__rhs_float32_4_4__dimensionnumbers____0____0.mlir
+++ b/stablehlo/testdata/dot_general_squeeze_lhs_float32_4__rhs_float32_4_4__dimensionnumbers____0____0.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/dot_general_squeeze_lhs_float32_4__rhs_float32_4__dimensionnumbers____0____0.mlir
+++ b/stablehlo/testdata/dot_general_squeeze_lhs_float32_4__rhs_float32_4__dimensionnumbers____0____0.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -1508,9 +1508,9 @@ func.func @real_dynamic_slice(%arg0: tensor<?xf32>, %arg1: tensor<1xindex>, %arg
 
 // -----
 
-// CHECK-LABEL: func @dot_general
+// CHECK-LABEL: func @dot_general_c12
 // CHECK-SAME: (%[[ARG0:.*]]: tensor<?x?x?xf32>, %[[ARG1:.*]]: tensor<?x?x?xf32>
-func.func @dot_general(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<3xindex> {
+func.func @dot_general_c12(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<3xindex> {
   // CHECK: %[[C0:.*]] = arith.constant 0 : index
   // CHECK: %[[C2:.*]] = arith.constant 2 : index
   // CHECK: %[[DIM:.*]] = tensor.dim %[[ARG0]], %[[C0]] : tensor<?x?x?xf32>
@@ -1528,21 +1528,6 @@ func.func @dot_general(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> te
   } : (tensor<?x?x?xf32>, tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
   %1 = "hlo_test_infer.reify_return_type_shapes"(%result): (tensor<?x?x?xf32>) -> tensor<3xindex>
   func.return %1: tensor<3xindex>
-}
-
-// -----
-
-func.func @dot_general_c13(%arg0: tensor<2x3x4xf32>, %arg1: tensor<2x3x5xf32>) -> tensor<2x4x6xf32> {
-  // expected-error@+1 {{inferred shape '[2, 4, 5]' is incompatible with return type of operation 'tensor<2x4x6xf32>'}}
-  %0 = "stablehlo.dot_general"(%arg0, %arg1) {
-    dot_dimension_numbers = #stablehlo.dot<
-      lhs_batching_dimensions = [0],
-      rhs_batching_dimensions = [0],
-      lhs_contracting_dimensions = [1],
-      rhs_contracting_dimensions = [1]
-    >
-  } : (tensor<2x3x4xf32>, tensor<2x3x5xf32>) -> tensor<2x4x6xf32>
-  func.return %0 : tensor<2x4x6xf32>
 }
 
 // -----

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -1532,6 +1532,21 @@ func.func @dot_general(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> te
 
 // -----
 
+func.func @dot_general_c13(%arg0: tensor<2x3x4xf32>, %arg1: tensor<2x3x5xf32>) -> tensor<2x4x6xf32> {
+  // expected-error@+1 {{inferred shape '[2, 4, 5]' is incompatible with return type of operation 'tensor<2x4x6xf32>'}}
+  %0 = "stablehlo.dot_general"(%arg0, %arg1) {
+    dot_dimension_numbers = #stablehlo.dot<
+      lhs_batching_dimensions = [0],
+      rhs_batching_dimensions = [0],
+      lhs_contracting_dimensions = [1],
+      rhs_contracting_dimensions = [1]
+    >
+  } : (tensor<2x3x4xf32>, tensor<2x3x5xf32>) -> tensor<2x4x6xf32>
+  func.return %0 : tensor<2x4x6xf32>
+}
+
+// -----
+
 // CHECK-LABEL: func @dynamic_pad
 // CHECK-SAME: (%[[ARG0:.*]]: tensor<?xf32>, %[[ARG1:.*]]: tensor<f32>, %[[ARG2:.*]]: tensor<1xindex>, %[[ARG3:.*]]: tensor<1xindex>, %[[ARG4:.*]]: tensor<1xindex>
 func.func @dynamic_pad(%arg0: tensor<?xf32>, %arg1: tensor<f32>, %arg2: tensor<1xindex>, %arg3: tensor<1xindex>, %arg4: tensor<1xindex>) -> tensor<1xindex> {

--- a/stablehlo/tests/interpret_dot_general.mlir
+++ b/stablehlo/tests/interpret_dot_general.mlir
@@ -1,0 +1,103 @@
+// RUN: stablehlo-translate --interpret -split-input-file %s
+
+func.func @dot_general_op_test_si64() {
+  %lhs = stablehlo.constant dense<[[[1, 2], [3, 4]],
+                                   [[5, 6], [7, 8]]]> : tensor<2x2x2xi64>
+  %rhs = stablehlo.constant dense<[[[1, 0], [0, 1]],
+                                   [[1, 0], [0, 1]]]> : tensor<2x2x2xi64>
+  %result = "stablehlo.dot_general"(%lhs, %rhs) {
+    dot_dimension_numbers = #stablehlo.dot<
+      lhs_batching_dimensions = [0],
+      rhs_batching_dimensions = [0],
+      lhs_contracting_dimensions = [2],
+      rhs_contracting_dimensions = [1]
+    >,
+    precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+  } : (tensor<2x2x2xi64>, tensor<2x2x2xi64>) -> tensor<2x2x2xi64>
+  check.expect_eq_const %result, dense<[[[1, 2], [3, 4]],
+                                        [[5, 6], [7, 8]]]> : tensor<2x2x2xi64>
+  func.return
+}
+
+// -----
+
+func.func @dot_general_op_test_ui64() {
+  %lhs = stablehlo.constant dense<[[[1, 2], [3, 4]],
+                                   [[5, 6], [7, 8]]]> : tensor<2x2x2xui64>
+  %rhs = stablehlo.constant dense<[[[1, 0], [0, 1]],
+                                   [[1, 0], [0, 1]]]> : tensor<2x2x2xui64>
+  %result = "stablehlo.dot_general"(%lhs, %rhs) {
+    dot_dimension_numbers = #stablehlo.dot<
+      lhs_batching_dimensions = [0, 2],
+      rhs_batching_dimensions = [2, 1],
+      lhs_contracting_dimensions = [1],
+      rhs_contracting_dimensions = [0]
+    >,
+    precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+  } : (tensor<2x2x2xui64>, tensor<2x2x2xui64>) -> tensor<2x2xui64>
+  check.expect_eq_const %result, dense<[[4, 0],
+                                        [0, 14]]> : tensor<2x2xui64>
+  func.return
+}
+
+// -----
+
+func.func @dot_general_op_test_i1() {
+  %lhs = stablehlo.constant dense<[[[true, true], [true, true]],
+                                   [[false, false], [false, false]]]> : tensor<2x2x2xi1>
+  %rhs = stablehlo.constant dense<[[[true, false], [false, true]],
+                                   [[true, false], [false, true]]]> : tensor<2x2x2xi1>
+  %result = "stablehlo.dot_general"(%lhs, %rhs) {
+    dot_dimension_numbers = #stablehlo.dot<
+      lhs_batching_dimensions = [0],
+      rhs_batching_dimensions = [0],
+      lhs_contracting_dimensions = [2],
+      rhs_contracting_dimensions = [1]
+    >,
+    precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+  } : (tensor<2x2x2xi1>, tensor<2x2x2xi1>) -> tensor<2x2x2xi1>
+  check.expect_eq_const %result, dense<[[[true, true], [true, true]],
+                                        [[false, false], [false, false]]]> : tensor<2x2x2xi1>
+  func.return
+}
+
+// -----
+
+func.func @dot_general_op_test_f64() {
+  %lhs = stablehlo.constant dense<[[[1.0, 2.0], [3.0, 4.0]],
+                                   [[5.0, 6.0], [7.0, 8.0]]]> : tensor<2x2x2xf64>
+  %rhs = stablehlo.constant dense<[[[1.0, 0.0], [0.0, 1.0]],
+                                   [[1.0, 0.0], [0.0, 1.0]]]> : tensor<2x2x2xf64>
+  %result = "stablehlo.dot_general"(%lhs, %rhs) {
+    dot_dimension_numbers = #stablehlo.dot<
+      lhs_batching_dimensions = [0],
+      rhs_batching_dimensions = [0],
+      lhs_contracting_dimensions = [2],
+      rhs_contracting_dimensions = [1]
+    >,
+    precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+  } : (tensor<2x2x2xf64>, tensor<2x2x2xf64>) -> tensor<2x2x2xf64>
+  check.expect_eq_const %result, dense<[[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]]> : tensor<2x2x2xf64>
+  func.return
+}
+
+// -----
+
+func.func @dot_general_op_test_c128() {
+  %lhs = stablehlo.constant dense<[[[(1.0, 0.0), (2.0, 0.0)], [(3.0, 0.0), (4.0, 0.0)]],
+                                   [[(5.0, 0.0), (6.0, 0.0)], [(7.0, 0.0), (8.0, 0.0)]]]> : tensor<2x2x2xcomplex<f64>>
+  %rhs = stablehlo.constant dense<[[[(1.0, 0.0), (0.0, 0.0)], [(0.0, 0.0), (1.0, 0.0)]],
+                                   [[(1.0, 0.0), (0.0, 0.0)], [(0.0, 0.0), (1.0, 0.0)]]]> : tensor<2x2x2xcomplex<f64>>
+  %result = "stablehlo.dot_general"(%lhs, %rhs) {
+    dot_dimension_numbers = #stablehlo.dot<
+      lhs_batching_dimensions = [0],
+      rhs_batching_dimensions = [0],
+      lhs_contracting_dimensions = [2],
+      rhs_contracting_dimensions = [1]
+    >,
+    precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+  } : (tensor<2x2x2xcomplex<f64>>, tensor<2x2x2xcomplex<f64>>) -> tensor<2x2x2xcomplex<f64>>
+  check.expect_eq_const %result, dense<[[[(1.0, 0.0), (2.0, 0.0)], [(3.0, 0.0), (4.0, 0.0)]],
+                                        [[(5.0, 0.0), (6.0, 0.0)], [(7.0, 0.0), (8.0, 0.0)]]]> : tensor<2x2x2xcomplex<f64>>
+  func.return
+}

--- a/stablehlo/tests/interpret_dot_general.mlir
+++ b/stablehlo/tests/interpret_dot_general.mlir
@@ -5,15 +5,11 @@ func.func @dot_general_op_test_si64() {
                                    [[5, 6], [7, 8]]]> : tensor<2x2x2xi64>
   %rhs = stablehlo.constant dense<[[[1, 0], [0, 1]],
                                    [[1, 0], [0, 1]]]> : tensor<2x2x2xi64>
-  %result = "stablehlo.dot_general"(%lhs, %rhs) {
-    dot_dimension_numbers = #stablehlo.dot<
-      lhs_batching_dimensions = [0],
-      rhs_batching_dimensions = [0],
-      lhs_contracting_dimensions = [2],
-      rhs_contracting_dimensions = [1]
-    >,
-    precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-  } : (tensor<2x2x2xi64>, tensor<2x2x2xi64>) -> tensor<2x2x2xi64>
+  %result = stablehlo.dot_general %lhs, %rhs,
+    batching_dims = [0] x [0],
+    contracting_dims = [2] x [1],
+    precision = [DEFAULT, DEFAULT]
+    : (tensor<2x2x2xi64>, tensor<2x2x2xi64>) -> tensor<2x2x2xi64>
   check.expect_eq_const %result, dense<[[[1, 2], [3, 4]],
                                         [[5, 6], [7, 8]]]> : tensor<2x2x2xi64>
   func.return
@@ -21,83 +17,17 @@ func.func @dot_general_op_test_si64() {
 
 // -----
 
-func.func @dot_general_op_test_ui64() {
-  %lhs = stablehlo.constant dense<[[[1, 2], [3, 4]],
-                                   [[5, 6], [7, 8]]]> : tensor<2x2x2xui64>
-  %rhs = stablehlo.constant dense<[[[1, 0], [0, 1]],
-                                   [[1, 0], [0, 1]]]> : tensor<2x2x2xui64>
-  %result = "stablehlo.dot_general"(%lhs, %rhs) {
-    dot_dimension_numbers = #stablehlo.dot<
-      lhs_batching_dimensions = [0, 2],
-      rhs_batching_dimensions = [2, 1],
-      lhs_contracting_dimensions = [1],
-      rhs_contracting_dimensions = [0]
-    >,
-    precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-  } : (tensor<2x2x2xui64>, tensor<2x2x2xui64>) -> tensor<2x2xui64>
-  check.expect_eq_const %result, dense<[[4, 0],
-                                        [0, 14]]> : tensor<2x2xui64>
-  func.return
-}
-
-// -----
-
-func.func @dot_general_op_test_i1() {
-  %lhs = stablehlo.constant dense<[[[true, true], [true, true]],
-                                   [[false, false], [false, false]]]> : tensor<2x2x2xi1>
-  %rhs = stablehlo.constant dense<[[[true, false], [false, true]],
-                                   [[true, false], [false, true]]]> : tensor<2x2x2xi1>
-  %result = "stablehlo.dot_general"(%lhs, %rhs) {
-    dot_dimension_numbers = #stablehlo.dot<
-      lhs_batching_dimensions = [0],
-      rhs_batching_dimensions = [0],
-      lhs_contracting_dimensions = [2],
-      rhs_contracting_dimensions = [1]
-    >,
-    precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-  } : (tensor<2x2x2xi1>, tensor<2x2x2xi1>) -> tensor<2x2x2xi1>
-  check.expect_eq_const %result, dense<[[[true, true], [true, true]],
-                                        [[false, false], [false, false]]]> : tensor<2x2x2xi1>
-  func.return
-}
-
-// -----
-
-func.func @dot_general_op_test_f64() {
-  %lhs = stablehlo.constant dense<[[[1.0, 2.0], [3.0, 4.0]],
-                                   [[5.0, 6.0], [7.0, 8.0]]]> : tensor<2x2x2xf64>
-  %rhs = stablehlo.constant dense<[[[1.0, 0.0], [0.0, 1.0]],
-                                   [[1.0, 0.0], [0.0, 1.0]]]> : tensor<2x2x2xf64>
-  %result = "stablehlo.dot_general"(%lhs, %rhs) {
-    dot_dimension_numbers = #stablehlo.dot<
-      lhs_batching_dimensions = [0],
-      rhs_batching_dimensions = [0],
-      lhs_contracting_dimensions = [2],
-      rhs_contracting_dimensions = [1]
-    >,
-    precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-  } : (tensor<2x2x2xf64>, tensor<2x2x2xf64>) -> tensor<2x2x2xf64>
-  check.expect_eq_const %result, dense<[[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]]> : tensor<2x2x2xf64>
-  func.return
-}
-
-// -----
-
-func.func @dot_general_op_test_c128() {
-  %lhs = stablehlo.constant dense<[[[(1.0, 0.0), (2.0, 0.0)], [(3.0, 0.0), (4.0, 0.0)]],
-                                   [[(5.0, 0.0), (6.0, 0.0)], [(7.0, 0.0), (8.0, 0.0)]]]> : tensor<2x2x2xcomplex<f64>>
-  %rhs = stablehlo.constant dense<[[[(1.0, 0.0), (0.0, 0.0)], [(0.0, 0.0), (1.0, 0.0)]],
-                                   [[(1.0, 0.0), (0.0, 0.0)], [(0.0, 0.0), (1.0, 0.0)]]]> : tensor<2x2x2xcomplex<f64>>
-  %result = "stablehlo.dot_general"(%lhs, %rhs) {
-    dot_dimension_numbers = #stablehlo.dot<
-      lhs_batching_dimensions = [0],
-      rhs_batching_dimensions = [0],
-      lhs_contracting_dimensions = [2],
-      rhs_contracting_dimensions = [1]
-    >,
-    precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-  } : (tensor<2x2x2xcomplex<f64>>, tensor<2x2x2xcomplex<f64>>) -> tensor<2x2x2xcomplex<f64>>
-  check.expect_eq_const %result, dense<[[[(1.0, 0.0), (2.0, 0.0)], [(3.0, 0.0), (4.0, 0.0)]],
-                                        [[(5.0, 0.0), (6.0, 0.0)], [(7.0, 0.0), (8.0, 0.0)]]]> : tensor<2x2x2xcomplex<f64>>
+func.func @dot_general_op_test_empty_dims() {
+  %lhs = stablehlo.constant dense<[[1, 2], [3, 4]]> : tensor<2x2xi64>
+  %rhs = stablehlo.constant dense<[[1, 0], [0, 1]]> : tensor<2x2xi64>
+  %result = stablehlo.dot_general %lhs, %rhs,
+    batching_dims = [] x [],
+    contracting_dims = [] x [],
+    precision = [DEFAULT, DEFAULT]
+    : (tensor<2x2xi64>, tensor<2x2xi64>) -> tensor<2x2x2x2xi64>
+  check.expect_eq_const %result, dense<[[[[1, 0], [0, 1]],
+                                         [[2, 0], [0, 2]]],
+                                        [[[3, 0], [0, 3]],
+                                         [[4, 0], [0, 4]]]]> : tensor<2x2x2x2xi64>
   func.return
 }

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -2991,21 +2991,6 @@ func.func @dot_general_c1(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) ->
 
 // -----
 
-func.func @dot_general_c1(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) -> tensor<*xf32>{
-  // expected-error @+1 {{lhs and rhs should have the same number of batching dimensions}}
-  %0 = "stablehlo.dot_general"(%arg0, %arg1) {
-    dot_dimension_numbers = #stablehlo.dot<
-      lhs_batching_dimensions = [0],
-      rhs_batching_dimensions = [],
-      lhs_contracting_dimensions = [1],
-      rhs_contracting_dimensions = [1]
-    >
-  } : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
-  func.return %0 : tensor<*xf32>
-}
-
-// -----
-
 func.func @dot_general_c2(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32>{
   // expected-error @+1 {{lhs and rhs should have the same number of contracting dimensions}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
@@ -3021,21 +3006,6 @@ func.func @dot_general_c2(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) ->
 
 // -----
 
-func.func @dot_general_c2(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) -> tensor<*xf32> {
-  // expected-error @+1 {{lhs and rhs should have the same number of contracting dimensions}}
-  %0 = "stablehlo.dot_general"(%arg0, %arg1) {
-    dot_dimension_numbers = #stablehlo.dot<
-      lhs_batching_dimensions = [0],
-      rhs_batching_dimensions = [0],
-      lhs_contracting_dimensions = [],
-      rhs_contracting_dimensions = [1]
-    >
-  } : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
-  func.return %0 : tensor<*xf32>
-}
-
-// -----
-
 func.func @dot_general_c3(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
   // expected-error @+1 {{has duplicated dimension from lhs_batching_dimensions and lhs_contracting_dimensions: 0}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
@@ -3047,21 +3017,6 @@ func.func @dot_general_c3(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) ->
     >
   } : (tensor<?x?x?xf32>, tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
   func.return %0 : tensor<?x?x?xf32>
-}
-
-// -----
-
-func.func @dot_general_c3(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) -> tensor<*xf32> {
-  // expected-error @+1 {{has duplicated dimension from lhs_batching_dimensions and lhs_contracting_dimensions: 0}}
-  %0 = "stablehlo.dot_general"(%arg0, %arg1) {
-    dot_dimension_numbers = #stablehlo.dot<
-      lhs_batching_dimensions = [0, 0],
-      rhs_batching_dimensions = [0, 0],
-      lhs_contracting_dimensions = [1],
-      rhs_contracting_dimensions = [1]
-    >
-  } : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
-  func.return %0 : tensor<*xf32>
 }
 
 // -----
@@ -3081,21 +3036,6 @@ func.func @dot_general_c3(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) ->
 
 // -----
 
-func.func @dot_general_c3(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) -> tensor<*xf32> {
-  // expected-error @+1 {{has duplicated dimension from lhs_batching_dimensions and lhs_contracting_dimensions: 1}}
-  %0 = "stablehlo.dot_general"(%arg0, %arg1) {
-    dot_dimension_numbers = #stablehlo.dot<
-      lhs_batching_dimensions = [0],
-      rhs_batching_dimensions = [0],
-      lhs_contracting_dimensions = [1, 1],
-      rhs_contracting_dimensions = [1, 1]
-    >
-  } : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
-  func.return %0 : tensor<*xf32>
-}
-
-// -----
-
 func.func @dot_general_c3(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
   // expected-error @+1 {{has duplicated dimension from lhs_batching_dimensions and lhs_contracting_dimensions: 0}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
@@ -3107,21 +3047,6 @@ func.func @dot_general_c3(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) ->
     >
   } : (tensor<?x?x?xf32>, tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
   func.return %0 : tensor<?x?x?xf32>
-}
-
-// -----
-
-func.func @dot_general_c3(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) -> tensor<*xf32> {
-  // expected-error @+1 {{has duplicated dimension from lhs_batching_dimensions and lhs_contracting_dimensions: 0}}
-  %0 = "stablehlo.dot_general"(%arg0, %arg1) {
-    dot_dimension_numbers = #stablehlo.dot<
-      lhs_batching_dimensions = [0],
-      rhs_batching_dimensions = [0],
-      lhs_contracting_dimensions = [0],
-      rhs_contracting_dimensions = [1]
-    >
-  } : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
-  func.return %0 : tensor<*xf32>
 }
 
 // -----
@@ -3137,21 +3062,6 @@ func.func @dot_general_c4(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) ->
     >
   } : (tensor<?x?x?xf32>, tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
   func.return %0 : tensor<?x?x?xf32>
-}
-
-// -----
-
-func.func @dot_general_c4(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) -> tensor<*xf32>{
-  // expected-error @+1 {{has duplicated dimension from rhs_batching_dimensions and rhs_contracting_dimensions: 0}}
-  %0 = "stablehlo.dot_general"(%arg0, %arg1) {
-    dot_dimension_numbers = #stablehlo.dot<
-      lhs_batching_dimensions = [0],
-      rhs_batching_dimensions = [0],
-      lhs_contracting_dimensions = [1],
-      rhs_contracting_dimensions = [0]
-    >
-  } : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
-  func.return %0 : tensor<*xf32>
 }
 
 // -----

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -2976,7 +2976,7 @@ func.func @dot_general(%arg0: tensor<?x?x?xf32>, %arg1: tensor<*xf32>) -> tensor
 
 // -----
 
-func.func @dot_general_c2(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
+func.func @dot_general_c1(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
   // expected-error @+1 {{lhs and rhs should have the same number of batching dimensions}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
@@ -2991,7 +2991,7 @@ func.func @dot_general_c2(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) ->
 
 // -----
 
-func.func @dot_general_c2(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) -> tensor<*xf32>{
+func.func @dot_general_c1(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) -> tensor<*xf32>{
   // expected-error @+1 {{lhs and rhs should have the same number of batching dimensions}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
@@ -3006,13 +3006,43 @@ func.func @dot_general_c2(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) -> tensor<
 
 // -----
 
-func.func @dot_general_c3(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32>{
+func.func @dot_general_c2(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32>{
   // expected-error @+1 {{lhs and rhs should have the same number of contracting dimensions}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
       lhs_batching_dimensions = [0],
       rhs_batching_dimensions = [0],
       lhs_contracting_dimensions = [],
+      rhs_contracting_dimensions = [1]
+    >
+  } : (tensor<?x?x?xf32>, tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
+  func.return %0 : tensor<?x?x?xf32>
+}
+
+// -----
+
+func.func @dot_general_c2(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) -> tensor<*xf32> {
+  // expected-error @+1 {{lhs and rhs should have the same number of contracting dimensions}}
+  %0 = "stablehlo.dot_general"(%arg0, %arg1) {
+    dot_dimension_numbers = #stablehlo.dot<
+      lhs_batching_dimensions = [0],
+      rhs_batching_dimensions = [0],
+      lhs_contracting_dimensions = [],
+      rhs_contracting_dimensions = [1]
+    >
+  } : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
+  func.return %0 : tensor<*xf32>
+}
+
+// -----
+
+func.func @dot_general_c3(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
+  // expected-error @+1 {{has duplicated dimension from lhs_batching_dimensions and lhs_contracting_dimensions: 0}}
+  %0 = "stablehlo.dot_general"(%arg0, %arg1) {
+    dot_dimension_numbers = #stablehlo.dot<
+      lhs_batching_dimensions = [0, 0],
+      rhs_batching_dimensions = [0, 0],
+      lhs_contracting_dimensions = [1],
       rhs_contracting_dimensions = [1]
     >
   } : (tensor<?x?x?xf32>, tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
@@ -3022,36 +3052,6 @@ func.func @dot_general_c3(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) ->
 // -----
 
 func.func @dot_general_c3(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) -> tensor<*xf32> {
-  // expected-error @+1 {{lhs and rhs should have the same number of contracting dimensions}}
-  %0 = "stablehlo.dot_general"(%arg0, %arg1) {
-    dot_dimension_numbers = #stablehlo.dot<
-      lhs_batching_dimensions = [0],
-      rhs_batching_dimensions = [0],
-      lhs_contracting_dimensions = [],
-      rhs_contracting_dimensions = [1]
-    >
-  } : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
-  func.return %0 : tensor<*xf32>
-}
-
-// -----
-
-func.func @dot_general_c4(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
-  // expected-error @+1 {{has duplicated dimension from lhs_batching_dimensions and lhs_contracting_dimensions: 0}}
-  %0 = "stablehlo.dot_general"(%arg0, %arg1) {
-    dot_dimension_numbers = #stablehlo.dot<
-      lhs_batching_dimensions = [0, 0],
-      rhs_batching_dimensions = [0, 0],
-      lhs_contracting_dimensions = [1],
-      rhs_contracting_dimensions = [1]
-    >
-  } : (tensor<?x?x?xf32>, tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
-  func.return %0 : tensor<?x?x?xf32>
-}
-
-// -----
-
-func.func @dot_general_c4(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) -> tensor<*xf32> {
   // expected-error @+1 {{has duplicated dimension from lhs_batching_dimensions and lhs_contracting_dimensions: 0}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
@@ -3066,7 +3066,7 @@ func.func @dot_general_c4(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) -> tensor<
 
 // -----
 
-func.func @dot_general_c4(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
+func.func @dot_general_c3(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
   // expected-error @+1 {{has duplicated dimension from lhs_batching_dimensions and lhs_contracting_dimensions: 1}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
@@ -3081,7 +3081,7 @@ func.func @dot_general_c4(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) ->
 
 // -----
 
-func.func @dot_general_c4(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) -> tensor<*xf32> {
+func.func @dot_general_c3(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) -> tensor<*xf32> {
   // expected-error @+1 {{has duplicated dimension from lhs_batching_dimensions and lhs_contracting_dimensions: 1}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
@@ -3096,7 +3096,7 @@ func.func @dot_general_c4(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) -> tensor<
 
 // -----
 
-func.func @dot_general_c4(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
+func.func @dot_general_c3(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
   // expected-error @+1 {{has duplicated dimension from lhs_batching_dimensions and lhs_contracting_dimensions: 0}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
@@ -3111,7 +3111,7 @@ func.func @dot_general_c4(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) ->
 
 // -----
 
-func.func @dot_general_c4(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) -> tensor<*xf32> {
+func.func @dot_general_c3(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) -> tensor<*xf32> {
   // expected-error @+1 {{has duplicated dimension from lhs_batching_dimensions and lhs_contracting_dimensions: 0}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
@@ -3119,6 +3119,36 @@ func.func @dot_general_c4(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) -> tensor<
       rhs_batching_dimensions = [0],
       lhs_contracting_dimensions = [0],
       rhs_contracting_dimensions = [1]
+    >
+  } : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
+  func.return %0 : tensor<*xf32>
+}
+
+// -----
+
+func.func @dot_general_c4(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
+  // expected-error @+1 {{has duplicated dimension from rhs_batching_dimensions and rhs_contracting_dimensions: 0}}
+  %0 = "stablehlo.dot_general"(%arg0, %arg1) {
+    dot_dimension_numbers = #stablehlo.dot<
+      lhs_batching_dimensions = [0],
+      rhs_batching_dimensions = [0],
+      lhs_contracting_dimensions = [1],
+      rhs_contracting_dimensions = [0]
+    >
+  } : (tensor<?x?x?xf32>, tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
+  func.return %0 : tensor<?x?x?xf32>
+}
+
+// -----
+
+func.func @dot_general_c4(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) -> tensor<*xf32>{
+  // expected-error @+1 {{has duplicated dimension from rhs_batching_dimensions and rhs_contracting_dimensions: 0}}
+  %0 = "stablehlo.dot_general"(%arg0, %arg1) {
+    dot_dimension_numbers = #stablehlo.dot<
+      lhs_batching_dimensions = [0],
+      rhs_batching_dimensions = [0],
+      lhs_contracting_dimensions = [1],
+      rhs_contracting_dimensions = [0]
     >
   } : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
   func.return %0 : tensor<*xf32>
@@ -3127,36 +3157,6 @@ func.func @dot_general_c4(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) -> tensor<
 // -----
 
 func.func @dot_general_c5(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
-  // expected-error @+1 {{has duplicated dimension from rhs_batching_dimensions and rhs_contracting_dimensions: 0}}
-  %0 = "stablehlo.dot_general"(%arg0, %arg1) {
-    dot_dimension_numbers = #stablehlo.dot<
-      lhs_batching_dimensions = [0],
-      rhs_batching_dimensions = [0],
-      lhs_contracting_dimensions = [1],
-      rhs_contracting_dimensions = [0]
-    >
-  } : (tensor<?x?x?xf32>, tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
-  func.return %0 : tensor<?x?x?xf32>
-}
-
-// -----
-
-func.func @dot_general_c5(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) -> tensor<*xf32>{
-  // expected-error @+1 {{has duplicated dimension from rhs_batching_dimensions and rhs_contracting_dimensions: 0}}
-  %0 = "stablehlo.dot_general"(%arg0, %arg1) {
-    dot_dimension_numbers = #stablehlo.dot<
-      lhs_batching_dimensions = [0],
-      rhs_batching_dimensions = [0],
-      lhs_contracting_dimensions = [1],
-      rhs_contracting_dimensions = [0]
-    >
-  } : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
-  func.return %0 : tensor<*xf32>
-}
-
-// -----
-
-func.func @dot_general_c6(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
   // expected-error @+1 {{lhs_batching_dimensions value: -1 is out of range: [0, 3)}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
@@ -3171,7 +3171,7 @@ func.func @dot_general_c6(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) ->
 
 // -----
 
-func.func @dot_general_c6(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
+func.func @dot_general_c5(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
   // expected-error @+1 {{lhs_batching_dimensions value: 3 is out of range: [0, 3)}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
@@ -3186,7 +3186,7 @@ func.func @dot_general_c6(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) ->
 
 // -----
 
-func.func @dot_general_c7(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
+func.func @dot_general_c6(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
   // expected-error @+1 {{lhs_contracting_dimensions value: -1 is out of range: [0, 3)}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
@@ -3201,7 +3201,7 @@ func.func @dot_general_c7(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) ->
 
 // -----
 
-func.func @dot_general_c7(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
+func.func @dot_general_c6(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
   // expected-error @+1 {{lhs_contracting_dimensions value: 3 is out of range: [0, 3)}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
@@ -3216,7 +3216,7 @@ func.func @dot_general_c7(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) ->
 
 // -----
 
-func.func @dot_general_c8(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
+func.func @dot_general_c7(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
   // expected-error @+1 {{rhs_batching_dimensions value: -1 is out of range: [0, 3)}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
@@ -3231,7 +3231,7 @@ func.func @dot_general_c8(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) ->
 
 // -----
 
-func.func @dot_general_c8(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
+func.func @dot_general_c7(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
   // expected-error @+1 {{rhs_batching_dimensions value: 3 is out of range: [0, 3)}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
@@ -3246,7 +3246,7 @@ func.func @dot_general_c8(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) ->
 
 // -----
 
-func.func @dot_general_c9(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
+func.func @dot_general_c8(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
   // expected-error @+1 {{rhs_contracting_dimensions value: -1 is out of range: [0, 3)}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
@@ -3261,7 +3261,7 @@ func.func @dot_general_c9(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) ->
 
 // -----
 
-func.func @dot_general_c9(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
+func.func @dot_general_c8(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
   // expected-error @+1 {{rhs_contracting_dimensions value: 3 is out of range: [0, 3)}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
@@ -3276,7 +3276,7 @@ func.func @dot_general_c9(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) ->
 
 // -----
 
-func.func @dot_general_c10(%arg0: tensor<2x?x?xf32>, %arg1: tensor<3x?x?xf32>) -> tensor<?x?x?xf32> {
+func.func @dot_general_c9(%arg0: tensor<2x?x?xf32>, %arg1: tensor<3x?x?xf32>) -> tensor<?x?x?xf32> {
   // expected-error @+1 {{batching dimension sizes must match for lhs/rhs}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
@@ -3291,7 +3291,7 @@ func.func @dot_general_c10(%arg0: tensor<2x?x?xf32>, %arg1: tensor<3x?x?xf32>) -
 
 // -----
 
-func.func @dot_general_c11(%arg0: tensor<?x2x?xf32>, %arg1: tensor<?x3x?xf32>) -> tensor<?x?x?xf32> {
+func.func @dot_general_c10(%arg0: tensor<?x2x?xf32>, %arg1: tensor<?x3x?xf32>) -> tensor<?x?x?xf32> {
   // expected-error @+1 {{contracting dimension sizes must match for lhs/rhs}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
@@ -3306,7 +3306,7 @@ func.func @dot_general_c11(%arg0: tensor<?x2x?xf32>, %arg1: tensor<?x3x?xf32>) -
 
 // -----
 
-func.func @dot_general_c12(%arg0: tensor<2x3x4xf32>, %arg1: tensor<2x3x5xf32>) -> tensor<2x4x5xf32> {
+func.func @dot_general_c11(%arg0: tensor<2x3x4xf32>, %arg1: tensor<2x3x5xf32>) -> tensor<2x4x5xf32> {
   // expected-error@+1 {{expects precision config to be empty or have <= 2 elements}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -3010,36 +3010,6 @@ func.func @dot_general_c3(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) ->
   // expected-error @+1 {{has duplicated dimension from lhs_batching_dimensions and lhs_contracting_dimensions: 0}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
-      lhs_batching_dimensions = [0, 0],
-      rhs_batching_dimensions = [0, 0],
-      lhs_contracting_dimensions = [1],
-      rhs_contracting_dimensions = [1]
-    >
-  } : (tensor<?x?x?xf32>, tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
-  func.return %0 : tensor<?x?x?xf32>
-}
-
-// -----
-
-func.func @dot_general_c3(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
-  // expected-error @+1 {{has duplicated dimension from lhs_batching_dimensions and lhs_contracting_dimensions: 1}}
-  %0 = "stablehlo.dot_general"(%arg0, %arg1) {
-    dot_dimension_numbers = #stablehlo.dot<
-      lhs_batching_dimensions = [0],
-      rhs_batching_dimensions = [0],
-      lhs_contracting_dimensions = [1, 1],
-      rhs_contracting_dimensions = [1, 1]
-    >
-  } : (tensor<?x?x?xf32>, tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
-  func.return %0 : tensor<?x?x?xf32>
-}
-
-// -----
-
-func.func @dot_general_c3(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
-  // expected-error @+1 {{has duplicated dimension from lhs_batching_dimensions and lhs_contracting_dimensions: 0}}
-  %0 = "stablehlo.dot_general"(%arg0, %arg1) {
-    dot_dimension_numbers = #stablehlo.dot<
       lhs_batching_dimensions = [0],
       rhs_batching_dimensions = [0],
       lhs_contracting_dimensions = [0],

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -2916,7 +2916,8 @@ func.func @dot_general(%arg0: tensor<2x3x4xf32>, %arg1: tensor<2x3x5xf32>) -> te
 
 // -----
 
-func.func @dot_general(%arg0: tensor<1x?x1x?xf32>, %arg1: tensor<?x1x?x1x?xf32>) {
+// CHECK-LABEL: func @dot_general
+func.func @dot_general(%arg0: tensor<1x?x1x?xf32>, %arg1: tensor<?x1x?x1x?xf32>) -> tensor<?x?x?xf32> {
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
       lhs_batching_dimensions = [0, 1],
@@ -2925,12 +2926,13 @@ func.func @dot_general(%arg0: tensor<1x?x1x?xf32>, %arg1: tensor<?x1x?x1x?xf32>)
       rhs_contracting_dimensions = [2, 3]
     >
   } : (tensor<1x?x1x?xf32>, tensor<?x1x?x1x?xf32>) -> tensor<?x?x?xf32>
-  func.return
+  func.return %0 : tensor<?x?x?xf32>
 }
 
 // -----
 
-func.func @dot_general(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) {
+// CHECK-LABEL: func @dot_general
+func.func @dot_general(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) -> tensor<*xf32> {
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
       lhs_batching_dimensions = [0],
@@ -2939,12 +2941,13 @@ func.func @dot_general(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) {
       rhs_contracting_dimensions = [1]
     >
   } : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
-  func.return
+  func.return %0 : tensor<*xf32>
 }
 
 // -----
 
-func.func @dot_general(%arg0: tensor<?x?x?xf32>, %arg1: tensor<*xf32>) {
+// CHECK-LABEL: func @dot_general
+func.func @dot_general(%arg0: tensor<?x?x?xf32>, %arg1: tensor<*xf32>) -> tensor<?x?x?xf32> {
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
       lhs_batching_dimensions = [0],
@@ -2953,13 +2956,13 @@ func.func @dot_general(%arg0: tensor<?x?x?xf32>, %arg1: tensor<*xf32>) {
       rhs_contracting_dimensions = [1]
     >
   } : (tensor<?x?x?xf32>, tensor<*xf32>) -> tensor<?x?x?xf32>
-  func.return
+  func.return %0 : tensor<?x?x?xf32>
 }
-
 
 // -----
 
-func.func @dot_general(%arg0: tensor<?x?x?xf32>, %arg1: tensor<*xf32>) {
+// CHECK-LABEL: func @dot_general
+func.func @dot_general(%arg0: tensor<?x?x?xf32>, %arg1: tensor<*xf32>) -> tensor<?x?x?xf32> {
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
       lhs_batching_dimensions = [0],
@@ -2968,12 +2971,12 @@ func.func @dot_general(%arg0: tensor<?x?x?xf32>, %arg1: tensor<*xf32>) {
       rhs_contracting_dimensions = [1]
     >
   } : (tensor<?x?x?xf32>, tensor<*xf32>) -> tensor<?x?x?xf32>
-  func.return
+  func.return %0 : tensor<?x?x?xf32>
 }
 
 // -----
 
-func.func @dot_general(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) {
+func.func @dot_general_c2(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
   // expected-error @+1 {{lhs and rhs should have the same number of batching dimensions}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
@@ -2983,12 +2986,12 @@ func.func @dot_general(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) {
       rhs_contracting_dimensions = [1]
     >
   } : (tensor<?x?x?xf32>, tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
-  func.return
+  func.return %0 : tensor<?x?x?xf32>
 }
 
 // -----
 
-func.func @dot_general(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) {
+func.func @dot_general_c2(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) -> tensor<*xf32>{
   // expected-error @+1 {{lhs and rhs should have the same number of batching dimensions}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
@@ -2998,12 +3001,12 @@ func.func @dot_general(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) {
       rhs_contracting_dimensions = [1]
     >
   } : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
-  func.return
+  func.return %0 : tensor<*xf32>
 }
 
 // -----
 
-func.func @dot_general(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) {
+func.func @dot_general_c3(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32>{
   // expected-error @+1 {{lhs and rhs should have the same number of contracting dimensions}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
@@ -3013,12 +3016,12 @@ func.func @dot_general(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) {
       rhs_contracting_dimensions = [1]
     >
   } : (tensor<?x?x?xf32>, tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
-  func.return
+  func.return %0 : tensor<?x?x?xf32>
 }
 
 // -----
 
-func.func @dot_general(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) {
+func.func @dot_general_c3(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) -> tensor<*xf32> {
   // expected-error @+1 {{lhs and rhs should have the same number of contracting dimensions}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
@@ -3028,12 +3031,12 @@ func.func @dot_general(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) {
       rhs_contracting_dimensions = [1]
     >
   } : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
-  func.return
+  func.return %0 : tensor<*xf32>
 }
 
 // -----
 
-func.func @dot_general(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) {
+func.func @dot_general_c4(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
   // expected-error @+1 {{has duplicated dimension from lhs_batching_dimensions and lhs_contracting_dimensions: 0}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
@@ -3043,12 +3046,12 @@ func.func @dot_general(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) {
       rhs_contracting_dimensions = [1]
     >
   } : (tensor<?x?x?xf32>, tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
-  func.return
+  func.return %0 : tensor<?x?x?xf32>
 }
 
 // -----
 
-func.func @dot_general(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) {
+func.func @dot_general_c4(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) -> tensor<*xf32> {
   // expected-error @+1 {{has duplicated dimension from lhs_batching_dimensions and lhs_contracting_dimensions: 0}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
@@ -3058,12 +3061,12 @@ func.func @dot_general(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) {
       rhs_contracting_dimensions = [1]
     >
   } : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
-  func.return
+  func.return %0 : tensor<*xf32>
 }
 
 // -----
 
-func.func @dot_general(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) {
+func.func @dot_general_c4(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
   // expected-error @+1 {{has duplicated dimension from lhs_batching_dimensions and lhs_contracting_dimensions: 1}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
@@ -3073,12 +3076,12 @@ func.func @dot_general(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) {
       rhs_contracting_dimensions = [1, 1]
     >
   } : (tensor<?x?x?xf32>, tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
-  func.return
+  func.return %0 : tensor<?x?x?xf32>
 }
 
 // -----
 
-func.func @dot_general(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) {
+func.func @dot_general_c4(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) -> tensor<*xf32> {
   // expected-error @+1 {{has duplicated dimension from lhs_batching_dimensions and lhs_contracting_dimensions: 1}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
@@ -3088,12 +3091,12 @@ func.func @dot_general(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) {
       rhs_contracting_dimensions = [1, 1]
     >
   } : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
-  func.return
+  func.return %0 : tensor<*xf32>
 }
 
 // -----
 
-func.func @dot_general(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) {
+func.func @dot_general_c4(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
   // expected-error @+1 {{has duplicated dimension from lhs_batching_dimensions and lhs_contracting_dimensions: 0}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
@@ -3103,12 +3106,12 @@ func.func @dot_general(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) {
       rhs_contracting_dimensions = [1]
     >
   } : (tensor<?x?x?xf32>, tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
-  func.return
+  func.return %0 : tensor<?x?x?xf32>
 }
 
 // -----
 
-func.func @dot_general(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) {
+func.func @dot_general_c4(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) -> tensor<*xf32> {
   // expected-error @+1 {{has duplicated dimension from lhs_batching_dimensions and lhs_contracting_dimensions: 0}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
@@ -3118,12 +3121,12 @@ func.func @dot_general(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) {
       rhs_contracting_dimensions = [1]
     >
   } : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
-  func.return
+  func.return %0 : tensor<*xf32>
 }
 
 // -----
 
-func.func @dot_general(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) {
+func.func @dot_general_c5(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
   // expected-error @+1 {{has duplicated dimension from rhs_batching_dimensions and rhs_contracting_dimensions: 0}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
@@ -3133,12 +3136,12 @@ func.func @dot_general(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) {
       rhs_contracting_dimensions = [0]
     >
   } : (tensor<?x?x?xf32>, tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
-  func.return
+  func.return %0 : tensor<?x?x?xf32>
 }
 
 // -----
 
-func.func @dot_general(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) {
+func.func @dot_general_c5(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) -> tensor<*xf32>{
   // expected-error @+1 {{has duplicated dimension from rhs_batching_dimensions and rhs_contracting_dimensions: 0}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
@@ -3148,12 +3151,12 @@ func.func @dot_general(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) {
       rhs_contracting_dimensions = [0]
     >
   } : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
-  func.return
+  func.return %0 : tensor<*xf32>
 }
 
 // -----
 
-func.func @dot_general(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) {
+func.func @dot_general_c6(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
   // expected-error @+1 {{lhs_batching_dimensions value: -1 is out of range: [0, 3)}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
@@ -3163,12 +3166,12 @@ func.func @dot_general(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) {
       rhs_contracting_dimensions = [1]
     >
   } : (tensor<?x?x?xf32>, tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
-  func.return
+  func.return %0 : tensor<?x?x?xf32>
 }
 
 // -----
 
-func.func @dot_general(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) {
+func.func @dot_general_c6(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
   // expected-error @+1 {{lhs_batching_dimensions value: 3 is out of range: [0, 3)}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
@@ -3178,42 +3181,12 @@ func.func @dot_general(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) {
       rhs_contracting_dimensions = [1]
     >
   } : (tensor<?x?x?xf32>, tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
-  func.return
+  func.return %0 : tensor<?x?x?xf32>
 }
 
 // -----
 
-func.func @dot_general(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) {
-  // expected-error @+1 {{rhs_batching_dimensions value: -1 is out of range: [0, 3)}}
-  %0 = "stablehlo.dot_general"(%arg0, %arg1) {
-    dot_dimension_numbers = #stablehlo.dot<
-      lhs_batching_dimensions = [0],
-      rhs_batching_dimensions = [-1],
-      lhs_contracting_dimensions = [1],
-      rhs_contracting_dimensions = [1]
-    >
-  } : (tensor<?x?x?xf32>, tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
-  func.return
-}
-
-// -----
-
-func.func @dot_general(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) {
-  // expected-error @+1 {{rhs_batching_dimensions value: 3 is out of range: [0, 3)}}
-  %0 = "stablehlo.dot_general"(%arg0, %arg1) {
-    dot_dimension_numbers = #stablehlo.dot<
-      lhs_batching_dimensions = [0],
-      rhs_batching_dimensions = [3],
-      lhs_contracting_dimensions = [1],
-      rhs_contracting_dimensions = [1]
-    >
-  } : (tensor<?x?x?xf32>, tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
-  func.return
-}
-
-// -----
-
-func.func @dot_general(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) {
+func.func @dot_general_c7(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
   // expected-error @+1 {{lhs_contracting_dimensions value: -1 is out of range: [0, 3)}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
@@ -3223,12 +3196,12 @@ func.func @dot_general(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) {
       rhs_contracting_dimensions = [1]
     >
   } : (tensor<?x?x?xf32>, tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
-  func.return
+  func.return %0 : tensor<?x?x?xf32>
 }
 
 // -----
 
-func.func @dot_general(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) {
+func.func @dot_general_c7(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
   // expected-error @+1 {{lhs_contracting_dimensions value: 3 is out of range: [0, 3)}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
@@ -3238,12 +3211,42 @@ func.func @dot_general(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) {
       rhs_contracting_dimensions = [1]
     >
   } : (tensor<?x?x?xf32>, tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
-  func.return
+  func.return %0 : tensor<?x?x?xf32>
 }
 
 // -----
 
-func.func @dot_general(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) {
+func.func @dot_general_c8(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
+  // expected-error @+1 {{rhs_batching_dimensions value: -1 is out of range: [0, 3)}}
+  %0 = "stablehlo.dot_general"(%arg0, %arg1) {
+    dot_dimension_numbers = #stablehlo.dot<
+      lhs_batching_dimensions = [0],
+      rhs_batching_dimensions = [-1],
+      lhs_contracting_dimensions = [1],
+      rhs_contracting_dimensions = [1]
+    >
+  } : (tensor<?x?x?xf32>, tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
+  func.return %0 : tensor<?x?x?xf32>
+}
+
+// -----
+
+func.func @dot_general_c8(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
+  // expected-error @+1 {{rhs_batching_dimensions value: 3 is out of range: [0, 3)}}
+  %0 = "stablehlo.dot_general"(%arg0, %arg1) {
+    dot_dimension_numbers = #stablehlo.dot<
+      lhs_batching_dimensions = [0],
+      rhs_batching_dimensions = [3],
+      lhs_contracting_dimensions = [1],
+      rhs_contracting_dimensions = [1]
+    >
+  } : (tensor<?x?x?xf32>, tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
+  func.return %0 : tensor<?x?x?xf32>
+}
+
+// -----
+
+func.func @dot_general_c9(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
   // expected-error @+1 {{rhs_contracting_dimensions value: -1 is out of range: [0, 3)}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
@@ -3253,12 +3256,12 @@ func.func @dot_general(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) {
       rhs_contracting_dimensions = [-1]
     >
   } : (tensor<?x?x?xf32>, tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
-  func.return
+  func.return %0 : tensor<?x?x?xf32>
 }
 
 // -----
 
-func.func @dot_general(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) {
+func.func @dot_general_c9(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
   // expected-error @+1 {{rhs_contracting_dimensions value: 3 is out of range: [0, 3)}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
@@ -3268,12 +3271,12 @@ func.func @dot_general(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) {
       rhs_contracting_dimensions = [3]
     >
   } : (tensor<?x?x?xf32>, tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
-  func.return
+  func.return %0 : tensor<?x?x?xf32>
 }
 
 // -----
 
-func.func @dot_general(%arg0: tensor<2x?x?xf32>, %arg1: tensor<3x?x?xf32>) {
+func.func @dot_general_c10(%arg0: tensor<2x?x?xf32>, %arg1: tensor<3x?x?xf32>) -> tensor<?x?x?xf32> {
   // expected-error @+1 {{batching dimension sizes must match for lhs/rhs}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
@@ -3283,12 +3286,12 @@ func.func @dot_general(%arg0: tensor<2x?x?xf32>, %arg1: tensor<3x?x?xf32>) {
       rhs_contracting_dimensions = [1]
     >
   } : (tensor<2x?x?xf32>, tensor<3x?x?xf32>) -> tensor<?x?x?xf32>
-  func.return
+  func.return %0 : tensor<?x?x?xf32>
 }
 
 // -----
 
-func.func @dot_general(%arg0: tensor<?x2x?xf32>, %arg1: tensor<?x3x?xf32>) {
+func.func @dot_general_c11(%arg0: tensor<?x2x?xf32>, %arg1: tensor<?x3x?xf32>) -> tensor<?x?x?xf32> {
   // expected-error @+1 {{contracting dimension sizes must match for lhs/rhs}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
@@ -3298,43 +3301,12 @@ func.func @dot_general(%arg0: tensor<?x2x?xf32>, %arg1: tensor<?x3x?xf32>) {
       rhs_contracting_dimensions = [1]
     >
   } : (tensor<?x2x?xf32>, tensor<?x3x?xf32>) -> tensor<?x?x?xf32>
-  func.return
+  func.return %0 : tensor<?x?x?xf32>
 }
 
 // -----
 
-// CHECK-LABEL: func @dot_general
-func.func @dot_general(%arg0: tensor<2x3x4xf32>, %arg1: tensor<2x3x5xf32>) -> tensor<2x4x6xf32> {
-  // expected-error@+1 {{inferred shape '[2, 4, 5]' is incompatible with return type of operation 'tensor<2x4x6xf32>'}}
-  %0 = "stablehlo.dot_general"(%arg0, %arg1) {
-    dot_dimension_numbers = #stablehlo.dot<
-      lhs_batching_dimensions = [0],
-      rhs_batching_dimensions = [0],
-      lhs_contracting_dimensions = [1],
-      rhs_contracting_dimensions = [1]
-    >
-  } : (tensor<2x3x4xf32>, tensor<2x3x5xf32>) -> tensor<2x4x6xf32>
-  func.return %0 : tensor<2x4x6xf32>
-}
-
-// -----
-
-func.func @dot_general_one_element_precision_config(%arg0: tensor<2x3x4xf32>, %arg1: tensor<2x3x5xf32>) -> tensor<2x4x5xf32> {
-  %0 = "stablehlo.dot_general"(%arg0, %arg1) {
-    dot_dimension_numbers = #stablehlo.dot<
-      lhs_batching_dimensions = [0],
-      rhs_batching_dimensions = [0],
-      lhs_contracting_dimensions = [1],
-      rhs_contracting_dimensions = [1]
-    >,
-    precision_config = [#stablehlo<precision DEFAULT>]
-  } : (tensor<2x3x4xf32>, tensor<2x3x5xf32>) -> tensor<2x4x5xf32>
-  func.return %0 : tensor<2x4x5xf32>
-}
-
-// -----
-
-func.func @dot_general_three_element_precision_config(%arg0: tensor<2x3x4xf32>, %arg1: tensor<2x3x5xf32>) -> tensor<2x4x5xf32> {
+func.func @dot_general_c12(%arg0: tensor<2x3x4xf32>, %arg1: tensor<2x3x5xf32>) -> tensor<2x4x5xf32> {
   // expected-error@+1 {{expects precision config to be empty or have <= 2 elements}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
@@ -3344,6 +3316,22 @@ func.func @dot_general_three_element_precision_config(%arg0: tensor<2x3x4xf32>, 
       rhs_contracting_dimensions = [1]
     >,
     precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+  } : (tensor<2x3x4xf32>, tensor<2x3x5xf32>) -> tensor<2x4x5xf32>
+  func.return %0 : tensor<2x4x5xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func @dot_general_one_element_precision_config
+func.func @dot_general_one_element_precision_config(%arg0: tensor<2x3x4xf32>, %arg1: tensor<2x3x5xf32>) -> tensor<2x4x5xf32> {
+  %0 = "stablehlo.dot_general"(%arg0, %arg1) {
+    dot_dimension_numbers = #stablehlo.dot<
+      lhs_batching_dimensions = [0],
+      rhs_batching_dimensions = [0],
+      lhs_contracting_dimensions = [1],
+      rhs_contracting_dimensions = [1]
+    >,
+    precision_config = [#stablehlo<precision DEFAULT>]
   } : (tensor<2x3x4xf32>, tensor<2x3x5xf32>) -> tensor<2x4x5xf32>
   func.return %0 : tensor<2x4x5xf32>
 }


### PR DESCRIPTION
We have the following non-quantization-related constraints (excluding C13, C15-C20) in the spec:

```
(I1) lhs tensor.
(I2) rhs tensor.
(I3) lhs_batching_dimensions 1-dimensional tensor constant of type `si64`.
(I4) rhs_batching_dimensions 1-dimensional tensor constant of type `si64`.
(I5) lhs_contracting_dimensions 1-dimensional tensor constant of type `si64`.
(I6) rhs_contracting_dimensions 1-dimensional tensor constant of type `si64`.
(I7) precision_config variadic number of enum of `DEFAULT`, `HIGH`, and `HIGHEST`.
(C1) size(`lhs_batching_dimensions`) = size(`rhs_batching_dimensions`).
(C2) size(`lhs_contracting_dimensions`) =
size(`rhs_contracting_dimensions`).
(C3) `lhs_batching_dimensions` and `lhs_contracting_dimensions` combined are
unique.
(C4) `rhs_batching_dimensions` and `rhs_contracting_dimensions` combined are
unique.
(C5) 0 <= `lhs_batching_dimensions[i]` < rank(`lhs`) for all `i`
in [0, size(`lhs_batching_dimensions`)).
(C6) 0 <= `lhs_contracting_dimensions[i]` < rank(`lhs`) for all `i`
in [0, size(`lhs_contracting_dimensions`)).
(C7) 0 <= `rhs_batching_dimensions[i]` < rank(`rhs`) for all `i`
in [0, size(`rhs_batching_dimensions`)).
(C8) 0 <= `rhs_contracting_dimensions[i]` < rank(`rhs`) for all `i`
in [0, size(`rhs_contracting_dimensions`)).
(C9) dim(`lhs`, `lhs_batching_dimensions[i]`) =
dim(`rhs`, `rhs_batching_dimensions[i]`) for all `i` in [0,
size(`lhs_batching_dimensions`)).
(C10) dim(`lhs`, `lhs_contracting_dimensions[i]`) =
dim(`rhs`, `rhs_contracting_dimensions[i]`) for all `i` in [0,
size(`lhs_contracting_dimensions`)).
(C11) size(`precision_config`) = 2.
(C12) shape(`result`) = dim(`lhs`, `lhs_batching_dimensions`) +
dim(`lhs`, `lhs_result_dimensions`) + dim(`rhs`, `rhs_result_dimensions`).
(C14) element_type(`lhs`) = element_type(`rhs`).
```

These constraints will be comprehensively covered by the following tests:

```
I1: a) lhs is not a tensor. (Covered by ODS).
I2: a) rhs is not a tensor. (Covered by ODS).
I3: a) lhs_batching_dimensions is not a 1-dimensional tensor. (Covered by ODS).
    b) element_type(lhs_batching_dimesnions) != `si64`. (Covered by ODS).
I4: a) rhs_batching_dimensions is not a 1-dimensional tensor. (Covered by ODS).
    b) element_type(rhs_batching_dimesnions) != `si64`. (Covered by ODS).
I5: a) lhs_contracting_dimensions is not a 1-dimensional tensor. (Covered by ODS).
    b) element_type(lhs_contracting_dimensions) != `si64`. (Covered by ODS).
I6: a) rhs_contracting_dimensions is not a 1-dimensional tensor. (Covered by ODS).
    b) element_type(rhs_contracting_dimensions) != `si64`. (Covered by ODS).
I7: a) precision_config does not have variadic number of enum of `DEFAULT`, `HIGH`, and `HIGHEST`. (Covered by ODS).
C1: a) size(lhs_batching_dimensions) != size(rhs_batching_dimensions).
C2: a) size(lhs_contracting_dimensions) != size(rhs_contracting_dimensions).
C3: a) lhs_batching_dimensions and lhs_contracting_dimensions combined are not unique.
C4: a) rhs_batching_dimensions and rhs_contracting_dimensions combined are not unique.
C5: a) lhs_batching_dimensions[i] < 0 for any i.
    b) lhs_batching_dimensions[i] >= rank(lhs) for any i.
C6: a) lhs_contracting_dimensions[i] < 0 for any i.
    b) lhs_contracting_dimensions[i] >= rank(lhs) for any i.
C7: a) rhs_batching_dimensions[i] < 0 for any i.
    b) rhs_batching_dimensions[i] >= rank(rhs) for any i.
C8: a) rhs_contracting_dimensions[i] < 0 for any i.
    b) rhs_contracting_dimensions[i] >= rank(rhs) for any i.
C9: a) dim(lhs, lhs_batching_dimensions[i]) != dim(rhs, rhs_batching_dimensions[i]) for any i.
C10: a) dim(lhs, lhs_contracting_dimensions[i]) != dim(rhs, rhs_contracting_dimensions[i]) for any i.
C11: a) size(precision_config) != 2.
C12: no negative test needed since it's just inferring the shape.
C14: a) element_type(lhs) != element_type(rhs).
```

If we drop the "Covered by ODS" pieces, this will leave us with the following test cases:

```
C1a: size(lhs_batching_dimensions) != size(rhs_batching_dimensions).
C2a: size(lhs_contracting_dimensions) != size(rhs_contracting_dimensions).
C3a: lhs_batching_dimensions and lhs_contracting_dimensions combined are not unique.
C4a: rhs_batching_dimensions and rhs_contracting_dimensions combined are not unique.
C5a: lhs_batching_dimensions[i] < 0 for any i.
C5b: lhs_batching_dimensions[i] >= rank(lhs) for any i.
C6a: lhs_contracting_dimensions[i] < 0 for any i.
C6b: lhs_contracting_dimensions[i] >= rank(lhs) for any i.
C7a: rhs_batching_dimensions[i] < 0 for any i.
C7b: rhs_batching_dimensions[i] >= rank(rhs) for any i.
C8a: rhs_contracting_dimensions[i] < 0 for any i.
C8b: rhs_contracting_dimensions[i] >= rank(rhs) for any i.
C9a: dim(lhs, lhs_batching_dimensions[i]) != dim(rhs, rhs_batching_dimensions[i]) for any i.
C10a: dim(lhs, lhs_contracting_dimensions[i]) != dim(rhs, rhs_contracting_dimensions[i]) for any i.
C11a: size(precision_config) != 2.
C14a: element_type(lhs) != element_type(rhs).
```

Notes:
* (C14) currently does not have a test and consider removing it #755
* (C11) currently does not have a test due to #755 and #879.

closes #336