### PR TITLE
Support dynamic shapes in DynamicUpdateSliceOp's type inference

### DIFF
--- a/stablehlo/dialect/Base.h
+++ b/stablehlo/dialect/Base.h
@@ -50,6 +50,10 @@ inline static bool isDynamicDimSize(int64_t val) {
   return ShapedType::isDynamic(val);
 }
 
+inline static bool isStaticDimSize(int64_t val) {
+  return !isDynamicDimSize(val);
+}
+
 // Returns true if the given types are the same for the purposes of HLO type
 // inference, accounting for special properties of quantization and sparsity.
 bool isCompatibleForHloTypeInference(Type tp1, Type tp2);

--- a/stablehlo/dialect/Base.h
+++ b/stablehlo/dialect/Base.h
@@ -45,7 +45,6 @@ namespace hlo {
 
 // TODO(zhouxin) change to a better name as it's used by both of size and bound
 // Check if the dimension size is dynamic.
-// TODO(zhouxin) add isStaticDimSize() as well.
 inline static bool isDynamicDimSize(int64_t val) {
   return ShapedType::isDynamic(val);
 }

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -960,18 +960,19 @@ LogicalResult inferDynamicUpdateSliceOp(
   auto updateType = update.getType().cast<ShapedType>();
 
   // (C3)
-  int64_t operandRank = operandType.getRank();
-  int64_t updateRank = updateType.getRank();
-  if (updateRank != operandRank)
+  if (updateType.hasRank() && operandType.hasRank() &&
+      updateType.getRank() != operandType.getRank())
     return emitOptionalError(
-        location, "update rank does not match operand rank: ", updateRank,
-        " vs ", operandRank, ".");
+        location,
+        "update rank does not match operand rank: ", updateType.getRank(),
+        " vs ", operandType.getRank(), ".");
 
   // (C4)
-  if ((int64_t)startIndices.size() != operandRank)
+  if (operandType.hasRank() &&
+      (int64_t)startIndices.size() != operandType.getRank())
     return emitOptionalError(
         location, "expects number of start_indices to match operand rank: ",
-        startIndices.size(), " vs ", operandRank, ".");
+        startIndices.size(), " vs ", operandType.getRank(), ".");
 
   // (C5)
   if (!startIndices.empty()) {
@@ -989,17 +990,31 @@ LogicalResult inferDynamicUpdateSliceOp(
   }
 
   // (C6)
-  for (auto [index, dims] : llvm::enumerate(
-           llvm::zip(operandType.getShape(), updateType.getShape()))) {
-    auto [operandDim, updateDim] = dims;
-    if (updateDim < 0 || updateDim > operandDim)
-      return emitOptionalError(location, "expects size at dimension ", index,
-                               " of update to be in range [0, ", operandDim,
-                               "]. Got: ", updateDim, ".");
-  }
+  if (operandType.hasRank() && updateType.hasRank())
+    for (auto [index, dims] : llvm::enumerate(
+             llvm::zip(operandType.getShape(), updateType.getShape()))) {
+      auto [operandDim, updateDim] = dims;
+      if (hlo::isDynamicDimSize(updateDim)) continue;
+      if (hlo::isStaticDimSize(operandDim)) {
+        if (updateDim < 0 || updateDim > operandDim)
+          return emitOptionalError(location, "expects size at dimension ",
+                                   index, " of update to be in range [0, ",
+                                   operandDim, "]. Got: ", updateDim, ".");
+      } else {
+        if (updateDim < 0)
+          return emitOptionalError(
+              location, "expects size at dimension ", index,
+              " of update to be non-negative. Got: ", updateDim, ".");
+      }
+    }
 
-  inferredReturnShapes.emplace_back(operandType.getShape(),
-                                    operandType.getElementType());
+  // (C1)
+  if (operandType.hasRank()) {
+    inferredReturnShapes.emplace_back(operandType.getShape(),
+                                      operandType.getElementType());
+  } else {
+    inferredReturnShapes.emplace_back(operandType.getElementType());
+  }
   return success();
 }
 

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -2393,6 +2393,30 @@ func.func @dynamic_update_slice_invalid_update_size(%input: tensor<3x4xi64>, %up
 
 // -----
 
+// CHECK-LABEL: func @dynamic_update_slice_dynamic_rank_input
+func.func @dynamic_update_slice_dynamic_rank_input(%input: tensor<*xi64>, %update: tensor<1x4xi64>, %start1: tensor<i64>, %start2: tensor<i64>) -> tensor<*xi64> {
+  %0 = "stablehlo.dynamic_update_slice"(%input, %update, %start1, %start2) : (tensor<*xi64>, tensor<1x4xi64>, tensor<i64>, tensor<i64>) -> tensor<*xi64>
+  func.return %0 : tensor<*xi64>
+}
+
+// -----
+
+// CHECK-LABEL: func @dynamic_update_slice_dynamic_rank_update
+func.func @dynamic_update_slice_dynamic_rank_update(%input: tensor<3x4xi64>, %update: tensor<*xi64>, %start1: tensor<i64>, %start2: tensor<i64>) -> tensor<3x4xi64> {
+  %0 = "stablehlo.dynamic_update_slice"(%input, %update, %start1, %start2) : (tensor<3x4xi64>, tensor<*xi64>, tensor<i64>, tensor<i64>) -> tensor<3x4xi64>
+  func.return %0 : tensor<3x4xi64>
+}
+
+// -----
+
+// CHECK-LABEL: func @dynamic_update_slice_dynamic_sizes
+func.func @dynamic_update_slice_dynamic_sizes(%input: tensor<?x4xi64>, %update: tensor<1x?xi64>, %start1: tensor<i64>, %start2: tensor<i64>) -> tensor<?x4xi64> {
+  %0 = "stablehlo.dynamic_update_slice"(%input, %update, %start1, %start2) : (tensor<?x4xi64>, tensor<1x?xi64>, tensor<i64>, tensor<i64>) -> tensor<?x4xi64>
+  func.return %0 : tensor<?x4xi64>
+}
+
+// -----
+
 // CHECK-LABEL: func @transpose
 func.func @transpose(%arg0: tensor<1x2x3x4xi32>) -> tensor<2x1x4x3xi32> {
   %0 = "stablehlo.transpose"(%arg0) {permutation = dense<[1, 0, 3, 2]> : tensor<4xi64>} : (tensor<1x2x3x4xi32>) -> tensor<2x1x4x3xi32>


### PR DESCRIPTION
https://github.com/openxla/stablehlo/pull/686 implemented type inference for DynamicUpdateSliceOp using the currently statically-shaped spec. To support the previous dynamically-shaped uses of DynamicUpdateSliceOp, this PR adds support for dynamic shapes as well.