### PR TITLE
Minor bookkeeping for recently approved RFCs

### DIFF
--- a/rfcs/20220912-compatibility.md
+++ b/rfcs/20220912-compatibility.md
@@ -1,5 +1,9 @@
 # StableHLO Compatibility RFC v2
 
+Status: Approved
+Initial version: 9/12/2022
+Last updated: 12/13/2022
+
 Based on discussions held over the past two months, and new use cases and feedback left in comments on the first revision of this RFC, we propose the following path forward for compatibility guarantees for StableHLO programs:
 - Proposal 1: Add StableHLO forks of modularity ops, as well as builtin/quant types and attributes. Maintain conversion patterns to their upstream equivalents.
 - Proposal 2: Use _Major.Minor.Patch_ versioning for StableHLO releases.

--- a/rfcs/20220912-compatibility.md
+++ b/rfcs/20220912-compatibility.md
@@ -1,7 +1,7 @@
 # StableHLO Compatibility RFC v2
 
-Status: Approved
-Initial version: 9/12/2022
+Status: Approved<br/>
+Initial version: 9/12/2022<br/>
 Last updated: 12/13/2022
 
 Based on discussions held over the past two months, and new use cases and feedback left in comments on the first revision of this RFC, we propose the following path forward for compatibility guarantees for StableHLO programs:

--- a/rfcs/20221031-fp8.md
+++ b/rfcs/20221031-fp8.md
@@ -1,0 +1,7 @@
+# FP8 in StableHLO
+
+Status: Approved
+Initial version: 10/31/2022
+Last updated: 12/12/2022
+
+See [the OpenXLA RFC](https://github.com/openxla/xla/discussions/22).

--- a/rfcs/20221031-fp8.md
+++ b/rfcs/20221031-fp8.md
@@ -1,7 +1,7 @@
 # FP8 in StableHLO
 
-Status: Approved
-Initial version: 10/31/2022
+Status: Approved<br/>
+Initial version: 10/31/2022<br/>
 Last updated: 12/12/2022
 
 See [the OpenXLA RFC](https://github.com/openxla/xla/discussions/22).


### PR DESCRIPTION
Added "Status", "Initial version", "Last updated" metadata. Also added an FP8 RFC which redirects to the OpenXLA RFC to keep track of it.