### PR TITLE
Temporarily allow empty `replica_group` for MHLO parity

### DIFF
--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -263,6 +263,7 @@ LogicalResult verifyReduceScatter(Operation* op, TypeRange operandTypes,
 LogicalResult ReduceScatterOp::verify() {
   if (failed(hlo::verifyReplicaGroups(getLoc(), getReplicaGroups(),
                                       /*allGroupsMustHaveSameSize=*/true,
+                                      getUseGlobalDeviceIds(),
                                       /*expectedGroupSize=*/llvm::None)))
     return failure();
   auto operandType = getOperand().getType().cast<TensorType>();
@@ -1932,6 +1933,7 @@ LogicalResult AllToAllOp::inferReturnTypeComponents(
 
   if (failed(hlo::verifyReplicaGroups(location, adaptor.getReplicaGroups(),
                                       /*allGroupsMustHaveSameSize=*/true,
+                                      /*useGlobalDeviceIds=*/false,
                                       splitCount)))
     return failure();
 
@@ -1989,6 +1991,7 @@ LogicalResult AllToAllOp::inferReturnTypeComponents(
 LogicalResult AllGatherOp::verify() {
   if (failed(hlo::verifyReplicaGroups(getLoc(), getReplicaGroups(),
                                       /*allGroupsMustHaveSameSize=*/true,
+                                      getUseGlobalDeviceIds(),
                                       /*expectedGroupSize=*/llvm::None)))
     return failure();
 
@@ -2046,6 +2049,7 @@ LogicalResult AllGatherOp::verify() {
 LogicalResult AllReduceOp::verify() {
   if (failed(hlo::verifyReplicaGroups(getLoc(), getReplicaGroups(),
                                       /*allGroupsMustHaveSameSize=*/false,
+                                      getUseGlobalDeviceIds(),
                                       /*expectedGroupSize=*/llvm::None)))
     return failure();
 

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -326,6 +326,7 @@ unsigned potentiallyComplexBitwidth(Type type) {
 LogicalResult verifyReplicaGroups(Optional<Location> location,
                                   DenseIntElementsAttr replicaGroups,
                                   bool allGroupsMustHaveSameSize,
+                                  bool useGlobalDeviceIds,
                                   Optional<size_t> expectedGroupSize) {
   auto replicaGroupType = replicaGroups.getType().cast<RankedTensorType>();
 
@@ -334,8 +335,11 @@ LogicalResult verifyReplicaGroups(Optional<Location> location,
                              "replica groups should be a rank 2 tensor");
 
   // Revisit the following check in light of #498.
-  if (replicaGroupType.getShape()[0] * replicaGroupType.getShape()[1] == 0) {
-    return emitOptionalError(location, "replica groups cannot be empty");
+  if (useGlobalDeviceIds &&
+      (replicaGroupType.getShape()[0] * replicaGroupType.getShape()[1] == 0)) {
+    return emitOptionalError(location,
+                             "if `use_global_device_ids` is set, the replica "
+                             "groups cannot be empty");
   }
 
   auto replicaIds = replicaGroups.getValues<int64_t>();

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -94,6 +94,7 @@ LogicalResult verifyReducerShape(Optional<Location> loc, Block& block,
 LogicalResult verifyReplicaGroups(Optional<Location> location,
                                   DenseIntElementsAttr replicaGroups,
                                   bool allGroupsMustHaveSameSize,
+                                  bool useGlobalDeviceIds,
                                   Optional<size_t> expectedGroupSize);
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
[Here](https://github.com/openxla/stablehlo/issues/498#issuecomment-1331396793) we decided on StableHLO to dis-allowing empty `replica_groups` but that needs some extra work to achieve that. 

If we want to share [verifyReplicaGroups](https://github.com/openxla/stablehlo/blob/59b68c586ea1381a7cb53e1217904f31755bb390/stablehlo/dialect/TypeInference.cpp#L326) logic with MHLO, we cannot just prevent empty `replica_groups` as there exists MHLO based tests [allowing](https://github.com/tensorflow/tensorflow/blob/1c83485345d1d7ff3e9c3afcce55d303e793e216/tensorflow/compiler/xla/mlir_hlo/mhlo/IR/hlo_ops_common.h#L67) that. 

The current  PR will temporarily preserve the same behavior of MHLO to allow code sharing till #498 is fixed.  Note the verification for all the collective ops are already marked as `revisit`. 
