### PR TITLE
Introduce inferSendOp

### DIFF
--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -2898,10 +2898,10 @@ LogicalResult OutfeedOp::inferReturnTypes(
 //===----------------------------------------------------------------------===//
 
 LogicalResult SendOp::inferReturnTypes(
-    MLIRContext* context, Optional<Location>, ValueRange operands,
+    MLIRContext* context, Optional<Location> location, ValueRange operands,
     DictionaryAttr, RegionRange, SmallVectorImpl<Type>& inferredReturnTypes) {
-  inferredReturnTypes.push_back(operands[operands.size() - 1].getType());
-  return success();
+  auto dialect = context->getLoadedDialect<StablehloDialect>();
+  return hlo::inferSendOp(dialect, location, inferredReturnTypes);
 }
 
 //===----------------------------------------------------------------------===//

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -1348,6 +1348,13 @@ LogicalResult inferSelectAndScatterOp(
   return success();
 }
 
+LogicalResult inferSendOp(Dialect* dialect, Optional<Location> location,
+                          SmallVectorImpl<Type>& inferredReturnTypes) {
+  auto hloDialect = cast<HloDialectInterface>(dialect);
+  inferredReturnTypes.push_back(hloDialect->createTokenType());
+  return success();
+}
+
 // The following properties are already enforced by the ODS:
 //  type(start_indices) == type(limit_indices) == type(strides).
 // Verify the following properties:

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -203,6 +203,9 @@ LogicalResult inferSelectOp(
 LogicalResult inferSelectAndScatterOp(
     Value operand, SmallVectorImpl<Type>& inferredReturnTypes);
 
+LogicalResult inferSendOp(Dialect* dialect, Optional<Location> location,
+                          SmallVectorImpl<Type>& inferredReturnTypes);
+
 LogicalResult inferSliceOp(Optional<Location> location, Value operand,
                            DenseIntElementsAttr startIndices,
                            DenseIntElementsAttr limitIndices,


### PR DESCRIPTION
The implementation is a oneliner, but I think it'll still be good to share it with MHLO for consistency reasons.