### PR TITLE
Move 26 verifiers shape functions to shared target

### DIFF
--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -1718,20 +1718,7 @@ LogicalResult GetTupleElementOp::verify() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult TupleOp::verify() {
-  auto opType = getType().dyn_cast<TupleType>();
-  if (!opType) return emitOpError("tuple op with non-tuple result");
-  if (getNumOperands() != opType.size())
-    return emitOpError(
-        "number of operands to tuple expected to match number of types in "
-        "resultant tuple type");
-  for (const auto& it :
-       llvm::enumerate(llvm::zip_first(getOperandTypes(), opType.getTypes()))) {
-    if (std::get<0>(it.value()) != std::get<1>(it.value()))
-      return emitOpError("has return type mismatch at ")
-             << it.index() << "th value (" << std::get<0>(it.value())
-             << " != " << std::get<1>(it.value()) << ")";
-  }
-  return success();
+  return hlo::verifyTupleOp(getLoc(), getOperandTypes(), getType());
 }
 
 //===----------------------------------------------------------------------===//

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -2008,8 +2008,10 @@ LogicalResult ClampOp::reifyReturnTypeShapes(
 
 LogicalResult ComplexOp::inferReturnTypes(
     MLIRContext*, Optional<Location> location, ValueRange operands,
-    DictionaryAttr, RegionRange, SmallVectorImpl<Type>& inferredReturnTypes) {
-  return hlo::inferComplexOp(location, operands[0], inferredReturnTypes);
+    DictionaryAttr attributes, RegionRange regions,
+    SmallVectorImpl<Type>& inferredReturnTypes) {
+  ComplexOp::Adaptor adaptor(operands, attributes, regions);
+  return hlo::inferComplexOp(location, adaptor.getLhs(), inferredReturnTypes);
 }
 
 //===----------------------------------------------------------------------===//
@@ -2030,9 +2032,11 @@ LogicalResult ImagOp::inferReturnTypes(
 
 LogicalResult IsFiniteOp::inferReturnTypes(
     MLIRContext* ctx, Optional<Location> location, ValueRange operands,
-    DictionaryAttr, RegionRange, SmallVectorImpl<Type>& inferredReturnTypes) {
-  return hlo::inferFiniteOp(ctx, location, operands.front(),
-                            inferredReturnTypes);
+    DictionaryAttr attributes, RegionRange regions,
+    SmallVectorImpl<Type>& inferredReturnTypes) {
+  IsFiniteOp::Adaptor adaptor(operands, attributes, regions);
+  return hlo::inferIsFiniteOp(ctx, location, adaptor.getX(),
+                              inferredReturnTypes);
 }
 
 //===----------------------------------------------------------------------===//
@@ -2041,8 +2045,10 @@ LogicalResult IsFiniteOp::inferReturnTypes(
 
 LogicalResult RealOp::inferReturnTypes(
     MLIRContext*, Optional<Location> location, ValueRange operands,
-    DictionaryAttr, RegionRange, SmallVectorImpl<Type>& inferredReturnTypes) {
-  return hlo::inferRealOp(location, operands[0], inferredReturnTypes);
+    DictionaryAttr attributes, RegionRange regions,
+    SmallVectorImpl<Type>& inferredReturnTypes) {
+  RealOp::Adaptor adaptor(operands, attributes, regions);
+  return hlo::inferRealOp(location, adaptor.getOperand(), inferredReturnTypes);
 }
 
 //===----------------------------------------------------------------------===//

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -2143,14 +2143,9 @@ LogicalResult DynamicSliceOp::inferReturnTypeComponents(
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   DynamicSliceOp::Adaptor adaptor(operands, attributes, regions);
-  Value operand = adaptor.getOperand();
-  auto operandType = operand.getType().dyn_cast<RankedTensorType>();
-  if (!operandType) return failure();
-
-  auto sliceSizes = adaptor.getSliceSizes();
-  Type elementTy = operandType.getElementType();
-  inferredReturnShapes.emplace_back(sliceSizes.getValues<int64_t>(), elementTy);
-  return success();
+  return hlo::inferDynamicSliceOp(location, adaptor.getOperand(),
+                                  adaptor.getSliceSizes(),
+                                  inferredReturnShapes);
 }
 
 //===----------------------------------------------------------------------===//

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -1709,20 +1709,8 @@ void ConvertOp::build(OpBuilder& builder, OperationState& result, Value operand,
 //===----------------------------------------------------------------------===//
 
 LogicalResult GetTupleElementOp::verify() {
-  auto indexVal = getIndex();
-  auto operandType = getOperand().getType().cast<TupleType>();
-  if (indexVal >= operandType.size()) {
-    return emitOpError(
-        llvm::formatv("index {0} is out of bounds of operand with size {1}",
-                      indexVal, operandType.size()));
-  }
-
-  auto expectedType = operandType.getType(indexVal);
-  if (getType() != expectedType) {
-    return emitOpError(llvm::formatv("has return type {0}, but expected {1}",
-                                     getType(), expectedType));
-  }
-  return success();
+  return hlo::verifyGetTupleElementOp(getLoc(), getOperand(), getIndex(),
+                                      getType());
 }
 
 //===----------------------------------------------------------------------===//

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -2007,13 +2007,9 @@ LogicalResult ClampOp::reifyReturnTypeShapes(
 //===----------------------------------------------------------------------===//
 
 LogicalResult ComplexOp::inferReturnTypes(
-    MLIRContext*, Optional<Location>, ValueRange operands, DictionaryAttr,
-    RegionRange, SmallVectorImpl<Type>& inferredReturnTypes) {
-  TensorType operandType = operands[0].getType().cast<TensorType>();
-  ComplexType elementTy = ComplexType::get(operandType.getElementType());
-  inferredReturnTypes.push_back(
-      hlo::getSameShapeTensorType(operandType, elementTy));
-  return success();
+    MLIRContext*, Optional<Location> location, ValueRange operands,
+    DictionaryAttr, RegionRange, SmallVectorImpl<Type>& inferredReturnTypes) {
+  return hlo::inferComplexOp(location, operands[0], inferredReturnTypes);
 }
 
 //===----------------------------------------------------------------------===//

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -211,14 +211,9 @@ void CollectivePermuteOp::build(OpBuilder& odsBuilder, OperationState& odsState,
 //===----------------------------------------------------------------------===//
 
 LogicalResult ReduceScatterOp::verify() {
-  return hlo::verifyReduceScatterOp(getLoc(), getOperand(),
-                                    getScatterDimension(), getReplicaGroups(),
-<<<<<<< HEAD
-                                    getUseGlobalDeviceIds(),
-                                    getComputation(), getType());
-=======
-                                    getComputation(), getResult());
->>>>>>> 8892b74 (Address 3nd round comments)
+  return hlo::verifyReduceScatterOp(
+      getLoc(), getOperand(), getScatterDimension(), getReplicaGroups(),
+      getUseGlobalDeviceIds(), getComputation(), getResult());
 }
 
 //===----------------------------------------------------------------------===//
@@ -1786,28 +1781,8 @@ LogicalResult AllGatherOp::verify() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult AllReduceOp::verify() {
-<<<<<<< HEAD
-  if (failed(hlo::verifyReplicaGroups(getLoc(), getReplicaGroups(),
-                                      /*allGroupsMustHaveSameSize=*/false,
-                                      getUseGlobalDeviceIds(),
-                                      /*expectedGroupSize=*/std::nullopt)))
-    return failure();
-
-  auto operandType = getOperand().getType().cast<TensorType>();
-  bool operandTypeRanked = operandType.isa<RankedTensorType>();
-  Block& block = getComputation().front();
-  if (failed(hlo::verifyReducerShape(
-          this->getLoc(), block, {operandType},
-          {RankedTensorType::get({}, operandType.getElementType())},
-          /*numInputs=*/1, /*allowedDimensions=*/{},
-          /*allInputsUnranked=*/!operandTypeRanked)))
-    return failure();
-
-  return success();
-=======
   return hlo::verifyAllReduceOp(getLoc(), getOperand(), getReplicaGroups(),
-                                getComputation());
->>>>>>> 3bc4b6a (Move verifyAllReduceOp)
+                                getUseGlobalDeviceIds(), getComputation());
 }
 
 //===----------------------------------------------------------------------===//

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -1986,14 +1986,12 @@ LogicalResult ClampOp::verify() {
 }
 
 LogicalResult ClampOp::inferReturnTypeComponents(
-    MLIRContext*, Optional<Location> /*location*/, ValueShapeRange operands,
+    MLIRContext*, Optional<Location> location, ValueShapeRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   ClampOp::Adaptor adaptor(operands, attributes, regions);
-  RankedTensorType operandType =
-      adaptor.getOperand().getType().cast<RankedTensorType>();
-  inferredReturnShapes.emplace_back(operandType.cast<ShapedType>());
-  return success();
+  return hlo::inferClampOp(location, adaptor.getOperand(),
+                           inferredReturnShapes);
 }
 
 LogicalResult ClampOp::reifyReturnTypeShapes(

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -1891,9 +1891,8 @@ LogicalResult BitcastConvertOp::reifyReturnTypeShapes(
                                      &reifiedReturnShapes);
 }
 
-
 LogicalResult BitcastConvertOp::verify() {
-   return hlo::verifyBitcastConvertOp(getLoc(), getOperand(), getResult());
+  return hlo::verifyBitcastConvertOp(getLoc(), getOperand(), getResult());
 }
 
 //===----------------------------------------------------------------------===//
@@ -1910,22 +1909,9 @@ LogicalResult BroadcastOp::inferReturnTypeComponents(
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   BroadcastOp::Adaptor adaptor(operands, attributes, regions);
-  Value operand = adaptor.getOperand();
-  auto operandType = operand.getType().dyn_cast<RankedTensorType>();
-  if (!operandType) return failure();
-
-  Type elementTy = operandType.getElementType();
-  auto dimensionAttr = adaptor.getBroadcastSizes();
-  for (int64_t size : dimensionAttr.getValues<int64_t>()) {
-    if (size < 0)
-      return emitOptionalError(location,
-                               "Broadcast with negative dimension size ", size);
-  }
-  SmallVector<int64_t> shapeValues(dimensionAttr.getValues<int64_t>());
-  llvm::append_range(shapeValues, operandType.getShape());
-
-  inferredReturnShapes.emplace_back(shapeValues, elementTy);
-  return success();
+  return hlo::inferBroadcastOp(location, adaptor.getOperand(),
+                               adaptor.getBroadcastSizes(),
+                               inferredReturnShapes);
 }
 
 LogicalResult BroadcastOp::reifyReturnTypeShapes(

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -1730,62 +1730,10 @@ LogicalResult AllToAllOp::inferReturnTypeComponents(
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   AllToAllOp::Adaptor adaptor(operands, attributes, regions);
-
-  int64_t splitCount = adaptor.getSplitCount();
-  if (splitCount <= 0)
-    return emitOptionalError(location, "AllToAll split_count must be > 0");
-
-  if (failed(hlo::verifyReplicaGroups(location, adaptor.getReplicaGroups(),
-                                      /*allGroupsMustHaveSameSize=*/true,
-                                      /*useGlobalDeviceIds=*/false,
-                                      splitCount)))
-    return failure();
-
-  int64_t splitDimension = static_cast<int64_t>(adaptor.getSplitDimension());
-  if (splitDimension < 0)
-    return emitOptionalError(location,
-                             "AllToAll split_dimension cannot be negative");
-
-  int64_t concatDimension = static_cast<int64_t>(adaptor.getConcatDimension());
-  if (concatDimension < 0)
-    return emitOptionalError(location,
-                             "AllToAll concat_dimension cannot be negative");
-
-  Type operandType = adaptor.getOperand().getType();
-  RankedTensorType operandRankedType = operandType.dyn_cast<RankedTensorType>();
-  if (!operandRankedType) {
-    inferredReturnShapes.emplace_back(
-        operandType.cast<TensorType>().getElementType());
-    return success();
-  }
-
-  int64_t inputRank = operandRankedType.getRank();
-  if (splitDimension >= inputRank) {
-    return emitOptionalError(location, "AllToAll split_dimension ",
-                             splitDimension,
-                             " is out-of-bounds for input rank ", inputRank);
-  }
-  if (concatDimension >= inputRank) {
-    return emitOptionalError(location, "AllToAll concat_dimension ",
-                             concatDimension,
-                             " is out-of-bounds for input rank ", inputRank);
-  }
-
-  // If operand is ranked, size of split dimension should be a multiple of split
-  // count.
-  auto splitDimSize = operandRankedType.getDimSize(splitDimension);
-  if (splitDimSize % splitCount != 0) {
-    return emitOptionalError(
-        location, "split dimension has size ", splitDimSize,
-        ", expected to be a multiple of split_count ", splitCount);
-  }
-  SmallVector<int64_t> resultShape(operandRankedType.getShape().begin(),
-                                   operandRankedType.getShape().end());
-  resultShape[splitDimension] /= splitCount;
-  resultShape[concatDimension] *= splitCount;
-  inferredReturnShapes.emplace_back(resultShape,
-                                    operandRankedType.getElementType());
-  return success();
+  return hlo::inferAllToAllOp(
+      location, adaptor.getOperand(), adaptor.getSplitDimension(),
+      adaptor.getConcatDimension(), adaptor.getSplitCount(),
+      adaptor.getReplicaGroups(), inferredReturnShapes);
 }
 
 //===----------------------------------------------------------------------===//

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -563,41 +563,12 @@ void CustomCallOp::getEffects(
 // CholeskyOp
 //===----------------------------------------------------------------------===//
 
-// The following properties are already enforced by the ODS:
-//   P0. a.element_type is floating or complex
-// We intend to verify the following properties
-//   P1. The 'a' argument to Cholesky must have rank >= 2, got shape %s
-//   P2. The two minor dimensions of 'a' must have equal size, got %s.
 LogicalResult CholeskyOp::inferReturnTypeComponents(
     MLIRContext*, Optional<Location> location, ValueShapeRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   CholeskyOp::Adaptor adaptor(operands, attributes, regions);
-  Type aType = adaptor.getA().getType();
-  RankedTensorType aRankedType = aType.dyn_cast<RankedTensorType>();
-  if (!aRankedType) {
-    inferredReturnShapes.emplace_back(
-        aType.cast<TensorType>().getElementType());
-    return success();
-  }
-
-  ArrayRef<int64_t> aShape = aRankedType.getShape();
-  if (aShape.size() < 2) {
-    return emitOptionalError(
-        location, "argument 'a' must have rank >= 2, got shape ", aShape, ".");
-  }
-
-  int64_t lastDim = aShape[aShape.size() - 1];
-  int64_t penultimateDim = aShape[aShape.size() - 2];
-  if (!hlo::isDynamicDimSize(lastDim) &&
-      !hlo::isDynamicDimSize(penultimateDim) && lastDim != penultimateDim) {
-    return emitOptionalError(
-        location, "minor dimensions of 'a' must have equal size, got shape ",
-        aShape, ".");
-  }
-  inferredReturnShapes.emplace_back(aRankedType.getShape(),
-                                    aRankedType.getElementType());
-  return success();
+  return hlo::inferCholeskyOp(location, adaptor.getA(), inferredReturnShapes);
 }
 
 //===----------------------------------------------------------------------===//

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -1273,16 +1273,7 @@ LogicalResult GetDimensionSizeOp::inferReturnTypes(
 //===----------------------------------------------------------------------===//
 
 LogicalResult IotaOp::verify() {
-  auto shape = getType().cast<ShapedType>();
-  if (!shape.hasRank()) return success();
-
-  if (shape.getRank() == 0) return emitOpError() << "does not support scalars.";
-
-  auto iotaDimension = static_cast<int64_t>(this->getIotaDimension());
-  if (iotaDimension >= shape.getRank() || iotaDimension < 0)
-    return emitOpError()
-           << "iota dimension cannot go beyond the output rank or be negative.";
-  return success();
+  return hlo::verifyIotaOp(getLoc(), getIotaDimension(), getType());
 }
 
 //===----------------------------------------------------------------------===//

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -2040,11 +2040,9 @@ LogicalResult IsFiniteOp::inferReturnTypes(
 //===----------------------------------------------------------------------===//
 
 LogicalResult RealOp::inferReturnTypes(
-    MLIRContext*, Optional<Location>, ValueRange operands, DictionaryAttr,
-    RegionRange, SmallVectorImpl<Type>& inferredReturnTypes) {
-  inferredReturnTypes.push_back(
-      hlo::createRealType(operands[0].getType().cast<TensorType>()));
-  return success();
+    MLIRContext*, Optional<Location> location, ValueRange operands,
+    DictionaryAttr, RegionRange, SmallVectorImpl<Type>& inferredReturnTypes) {
+  return hlo::inferRealOp(location, operands[0], inferredReturnTypes);
 }
 
 //===----------------------------------------------------------------------===//

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -1705,14 +1705,6 @@ void ConvertOp::build(OpBuilder& builder, OperationState& result, Value operand,
 }
 
 //===----------------------------------------------------------------------===//
-// TupleOp
-//===----------------------------------------------------------------------===//
-
-LogicalResult TupleOp::verify() {
-  return hlo::verifyTupleOp(getLoc(), getOperandTypes(), getType());
-}
-
-//===----------------------------------------------------------------------===//
 // AllToAllOp
 //===----------------------------------------------------------------------===//
 
@@ -3285,11 +3277,10 @@ LogicalResult GetTupleElementOp::inferReturnTypes(
 //===----------------------------------------------------------------------===//
 
 LogicalResult TupleOp::inferReturnTypes(
-    MLIRContext* context, Optional<Location>, ValueRange operands,
-    DictionaryAttr attributes, RegionRange,
-    SmallVectorImpl<Type>& inferredReturnTypes) {
-  inferredReturnTypes.push_back(TupleType::get(context, TypeRange(operands)));
-  return success();
+    MLIRContext* context, Optional<Location> location, ValueRange operands,
+    DictionaryAttr, RegionRange, SmallVectorImpl<Type>& inferredReturnTypes) {
+  return hlo::inferTupleOp(context, location, TypeRange(operands),
+                           inferredReturnTypes);
 }
 
 //===----------------------------------------------------------------------===//

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -1982,32 +1982,7 @@ LogicalResult DynamicBroadcastInDimOp::reifyReturnTypeShapes(
 //===----------------------------------------------------------------------===//
 
 LogicalResult ClampOp::verify() {
-  auto operandType = getOperand().getType().cast<RankedTensorType>();
-  auto operandShape = operandType.getShape();
-  auto minType = getMin().getType().cast<RankedTensorType>();
-
-  auto minShape = minType.getShape();
-  if (failed(verifyCompatibleShape(minType, operandType)) &&
-      minType.getRank() != 0) {
-    return emitOpError(llvm::formatv(
-        "min shape [{0}] is not scalar and is not compatible to operand shape "
-        "[{1}]",
-        llvm::make_range(minShape.begin(), minShape.end()),
-        llvm::make_range(operandShape.begin(), operandShape.end())));
-  }
-
-  auto maxType = getMax().getType().cast<RankedTensorType>();
-  auto maxShape = maxType.getShape();
-  if (failed(verifyCompatibleShape(maxType, operandType)) &&
-      maxType.getRank() != 0) {
-    return emitOpError(llvm::formatv(
-        "max shape [{0}] is not scalar and is not compatible to operand shape "
-        "[{1}]",
-        llvm::make_range(maxShape.begin(), maxShape.end()),
-        llvm::make_range(operandShape.begin(), operandShape.end())));
-  }
-
-  return success();
+  return hlo::verifyClampOp(getLoc(), getMin(), getOperand(), getMax());
 }
 
 LogicalResult ClampOp::inferReturnTypeComponents(

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -1799,6 +1799,7 @@ LogicalResult AllGatherOp::verify() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult AllReduceOp::verify() {
+<<<<<<< HEAD
   if (failed(hlo::verifyReplicaGroups(getLoc(), getReplicaGroups(),
                                       /*allGroupsMustHaveSameSize=*/false,
                                       getUseGlobalDeviceIds(),
@@ -1816,6 +1817,10 @@ LogicalResult AllReduceOp::verify() {
     return failure();
 
   return success();
+=======
+  return hlo::verifyAllReduceOp(getLoc(), getOperand(), getReplicaGroups(),
+                                getComputation());
+>>>>>>> 3bc4b6a (Move verifyAllReduceOp)
 }
 
 //===----------------------------------------------------------------------===//

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -2117,15 +2117,7 @@ LogicalResult ConcatenateOp::reifyReturnTypeShapes(
 //===----------------------------------------------------------------------===//
 
 LogicalResult DynamicReshapeOp::verify() {
-  auto resultType = getResult().getType().dyn_cast<RankedTensorType>();
-  auto outputShapeType =
-      getOutputShape().getType().dyn_cast<RankedTensorType>();
-  if (resultType && outputShapeType && outputShapeType.hasStaticShape() &&
-      outputShapeType.getDimSize(0) != resultType.getRank()) {
-    return emitError() << "output should have a rank equal to the number of "
-                          "elements in output_shape";
-  }
-  return success();
+  return hlo::verifyDynamicReshapeOp(getLoc(), getOutputShape(),  getResult());
 }
 
 LogicalResult DynamicReshapeOp::reifyReturnTypeShapes(

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -1902,15 +1902,7 @@ LogicalResult BitcastConvertOp::verify() {
 
 // TODO(b/129012527) These should be expressed as type constraints.
 LogicalResult BroadcastOp::verify() {
-  auto sizes = getBroadcastSizes();
-  auto sizesType = sizes.getType();
-  auto sizesRank = sizesType.getRank();
-  if (sizesRank != 1) {
-    return emitOpError(llvm::formatv(
-        "broadcast_sizes has rank {0} instead of rank 1", sizesRank));
-  }
-
-  return success();
+  return hlo::verifyBroadcastOp(getLoc(), getBroadcastSizes());
 }
 
 LogicalResult BroadcastOp::inferReturnTypeComponents(

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -213,8 +213,12 @@ void CollectivePermuteOp::build(OpBuilder& odsBuilder, OperationState& odsState,
 LogicalResult ReduceScatterOp::verify() {
   return hlo::verifyReduceScatterOp(getLoc(), getOperand(),
                                     getScatterDimension(), getReplicaGroups(),
+<<<<<<< HEAD
                                     getUseGlobalDeviceIds(),
                                     getComputation(), getType());
+=======
+                                    getComputation(), getResult());
+>>>>>>> 8892b74 (Address 3nd round comments)
 }
 
 //===----------------------------------------------------------------------===//
@@ -1273,7 +1277,7 @@ LogicalResult GetDimensionSizeOp::inferReturnTypes(
 //===----------------------------------------------------------------------===//
 
 LogicalResult IotaOp::verify() {
-  return hlo::verifyIotaOp(getLoc(), getIotaDimension(), getType());
+  return hlo::verifyIotaOp(getLoc(), getIotaDimension(), getResult());
 }
 
 //===----------------------------------------------------------------------===//
@@ -3278,8 +3282,10 @@ LogicalResult GetTupleElementOp::inferReturnTypes(
 
 LogicalResult TupleOp::inferReturnTypes(
     MLIRContext* context, Optional<Location> location, ValueRange operands,
-    DictionaryAttr, RegionRange, SmallVectorImpl<Type>& inferredReturnTypes) {
-  return hlo::inferTupleOp(context, location, TypeRange(operands),
+    DictionaryAttr attributes, RegionRange regions,
+    SmallVectorImpl<Type>& inferredReturnTypes) {
+  TupleOp::Adaptor adaptor(operands, attributes, regions);
+  return hlo::inferTupleOp(context, location, adaptor.getVal(),
                            inferredReturnTypes);
 }
 

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -2029,13 +2029,10 @@ LogicalResult ImagOp::inferReturnTypes(
 //===----------------------------------------------------------------------===//
 
 LogicalResult IsFiniteOp::inferReturnTypes(
-    MLIRContext* ctx, Optional<Location>, ValueRange operands, DictionaryAttr,
-    RegionRange, SmallVectorImpl<Type>& inferredReturnTypes) {
-  auto argTy = operands.front().getType().cast<TensorType>();
-  Builder b(ctx);
-  inferredReturnTypes.push_back(
-      hlo::getSameShapeTensorType(argTy, b.getI1Type()));
-  return success();
+    MLIRContext* ctx, Optional<Location> location, ValueRange operands,
+    DictionaryAttr, RegionRange, SmallVectorImpl<Type>& inferredReturnTypes) {
+  return hlo::inferFiniteOp(ctx, location, operands.front(),
+                            inferredReturnTypes);
 }
 
 //===----------------------------------------------------------------------===//

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -1316,25 +1316,11 @@ LogicalResult DynamicUpdateSliceOp::inferReturnTypeComponents(
 //===----------------------------------------------------------------------===//
 
 LogicalResult AbsOp::inferReturnTypes(
-    MLIRContext*, Optional<Location>, ValueRange operands, DictionaryAttr,
-    RegionRange, SmallVectorImpl<Type>& inferredReturnTypes) {
-  auto operandTy = (*operands.begin()).getType().cast<ShapedType>();
-  Type elementTy = operandTy.getElementType();
-  if (auto complexTy = elementTy.dyn_cast<ComplexType>()) {
-    elementTy = complexTy.getElementType();
-  }
-
-  Type resultTy;
-  if (auto rankedOperandTy = operandTy.dyn_cast<RankedTensorType>()) {
-    resultTy = RankedTensorType::get(operandTy.getShape(), elementTy,
-                                     rankedOperandTy.getEncoding());
-  } else if (operandTy.hasRank()) {
-    resultTy = RankedTensorType::get(operandTy.getShape(), elementTy);
-  } else {
-    resultTy = UnrankedTensorType::get(elementTy);
-  }
-  inferredReturnTypes.push_back(resultTy);
-  return success();
+    MLIRContext*, Optional<Location> location, ValueRange operands,
+    DictionaryAttr attributes, RegionRange regions,
+    SmallVectorImpl<Type>& inferredReturnTypes) {
+  AbsOp::Adaptor adaptor(operands, attributes, regions);
+  return hlo::inferAbsOp(location, adaptor.getOperand(), inferredReturnTypes);
 }
 
 //===----------------------------------------------------------------------===//

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -1899,11 +1899,6 @@ LogicalResult BitcastConvertOp::verify() {
 // BroadcastOp
 //===----------------------------------------------------------------------===//
 
-// TODO(b/129012527) These should be expressed as type constraints.
-LogicalResult BroadcastOp::verify() {
-  return hlo::verifyBroadcastOp(getLoc(), getBroadcastSizes());
-}
-
 LogicalResult BroadcastOp::inferReturnTypeComponents(
     MLIRContext*, Optional<Location> location, ValueShapeRange operands,
     DictionaryAttr attributes, RegionRange regions,
@@ -1981,17 +1976,13 @@ LogicalResult DynamicBroadcastInDimOp::reifyReturnTypeShapes(
 // ClampOp
 //===----------------------------------------------------------------------===//
 
-LogicalResult ClampOp::verify() {
-  return hlo::verifyClampOp(getLoc(), getMin(), getOperand(), getMax());
-}
-
 LogicalResult ClampOp::inferReturnTypeComponents(
     MLIRContext*, Optional<Location> location, ValueShapeRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   ClampOp::Adaptor adaptor(operands, attributes, regions);
-  return hlo::inferClampOp(location, adaptor.getOperand(),
-                           inferredReturnShapes);
+  return hlo::inferClampOp(location, adaptor.getMin(), adaptor.getOperand(),
+                           adaptor.getMax(), inferredReturnShapes);
 }
 
 LogicalResult ClampOp::reifyReturnTypeShapes(

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -2151,36 +2151,10 @@ LogicalResult DynamicSliceOp::inferReturnTypeComponents(
 //===----------------------------------------------------------------------===//
 // RealDynamicSliceOp
 //===----------------------------------------------------------------------===//
-// Verifies that operand rank matches start_indices/limit_indices/strides size
 LogicalResult RealDynamicSliceOp::verify() {
-  auto inputType = getOperand().getType().dyn_cast<RankedTensorType>();
-  // If operand is unranked, there is very little to verify statically.
-  if (!inputType) return success();
-  int inputRank = inputType.getRank();
-
-  auto startType = getStartIndices().getType().cast<RankedTensorType>();
-  auto limitType = getLimitIndices().getType().cast<RankedTensorType>();
-  auto stridesType = getStrides().getType().cast<RankedTensorType>();
-
-  if (inputRank != startType.getNumElements()) {
-    return emitOpError() << "has mismatched number of operand rank ("
-                         << inputRank << ") and start_indices size ("
-                         << startType.getNumElements() << ")";
-  }
-
-  if (inputRank != limitType.getNumElements()) {
-    return emitOpError() << "has mismatched number of operand rank ("
-                         << inputRank << ") and limit_indices size ("
-                         << limitType.getNumElements() << ")";
-  }
-
-  if (inputRank != stridesType.getNumElements()) {
-    return emitOpError() << "has mismatched number of operand rank ("
-                         << inputRank << ") and strides size ("
-                         << stridesType.getNumElements() << ")";
-  }
-
-  return success();
+  return hlo::verifyRealDynamicSliceOp(getLoc(), getOperand(),
+                                       getStartIndices(), getLimitIndices(),
+                                       getStrides());
 }
 
 LogicalResult RealDynamicSliceOp::reifyReturnTypeShapes(

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -2130,19 +2130,14 @@ LogicalResult DynamicReshapeOp::reifyReturnTypeShapes(
 // DynamicSliceOp
 //===----------------------------------------------------------------------===//
 
-LogicalResult DynamicSliceOp::verify() {
-  return hlo::verifyDynamicSliceOp(getLoc(), getOperand(), getStartIndices(),
-                                   getSliceSizes());
-}
-
 LogicalResult DynamicSliceOp::inferReturnTypeComponents(
     MLIRContext*, Optional<Location> location, ValueShapeRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   DynamicSliceOp::Adaptor adaptor(operands, attributes, regions);
-  return hlo::inferDynamicSliceOp(location, adaptor.getOperand(),
-                                  adaptor.getSliceSizes(),
-                                  inferredReturnShapes);
+  return hlo::inferDynamicSliceOp(
+      location, adaptor.getOperand(), adaptor.getStartIndices(),
+      adaptor.getSliceSizes(), inferredReturnShapes);
 }
 
 //===----------------------------------------------------------------------===//

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -325,13 +325,12 @@ void ConstantOp::build(OpBuilder& /*builder*/, OperationState& result,
 }
 
 LogicalResult ConstantOp::inferReturnTypes(
-    MLIRContext*, Optional<Location>, ValueRange operands,
+    MLIRContext*, Optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, RegionRange,
     SmallVectorImpl<Type>& inferredReturnTypes) {
   ConstantOpAdaptor adaptor(operands, attributes);
-  Type type = adaptor.getValue().getType();
-  inferredReturnTypes.push_back(type);
-  return success();
+  return hlo::inferConstantOp(location, adaptor.getValue(),
+                              inferredReturnTypes);
 }
 
 bool ConstantOp::isCompatibleReturnTypes(TypeRange l, TypeRange r) {

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -2117,7 +2117,7 @@ LogicalResult ConcatenateOp::reifyReturnTypeShapes(
 //===----------------------------------------------------------------------===//
 
 LogicalResult DynamicReshapeOp::verify() {
-  return hlo::verifyDynamicReshapeOp(getLoc(), getOutputShape(),  getResult());
+  return hlo::verifyDynamicReshapeOp(getLoc(), getOutputShape(), getResult());
 }
 
 LogicalResult DynamicReshapeOp::reifyReturnTypeShapes(
@@ -2133,40 +2133,9 @@ LogicalResult DynamicReshapeOp::reifyReturnTypeShapes(
 // DynamicSliceOp
 //===----------------------------------------------------------------------===//
 
-// Verifies that the number of slice sizes and the number of start indices match
 LogicalResult DynamicSliceOp::verify() {
-  int numSliceSizes = getSliceSizes().getNumElements();
-  int numStartIndices = getStartIndices().size();
-  if (numStartIndices != numSliceSizes) {
-    return emitOpError() << "has mismatched number of slice sizes ("
-                         << numSliceSizes << ") and number of start indices ("
-                         << numStartIndices << ")";
-  }
-  auto operandType = getOperand().getType().dyn_cast<RankedTensorType>();
-  if (!operandType) return failure();
-
-  if (operandType.getRank() != numStartIndices) {
-    return emitOpError() << "has mismatched number of start indices ("
-                         << numStartIndices << ") and the rank of operand ("
-                         << operandType.getRank() << ")";
-  }
-
-  for (int i = 0; i < numSliceSizes; ++i) {
-    int64_t sliceSize = getSliceSizes().getValues<int64_t>()[i];
-    if (sliceSize < 0) {
-      return emitOpError() << "has negative size index to dynamic slice: "
-                           << sliceSize;
-    }
-    if (!operandType.isDynamicDim(i)) {
-      int64_t dimSize = operandType.getDimSize(i);
-      if (sliceSize > dimSize) {
-        return emitOpError() << "has slice size " << sliceSize
-                             << " greater than dimension size " << dimSize
-                             << " in dimension " << i << " of operand";
-      }
-    }
-  }
-  return success();
+  return hlo::verifyDynamicSliceOp(getLoc(), getOperand(), getStartIndices(),
+                                   getSliceSizes());
 }
 
 LogicalResult DynamicSliceOp::inferReturnTypeComponents(

--- a/stablehlo/dialect/StablehloOps.h
+++ b/stablehlo/dialect/StablehloOps.h
@@ -90,10 +90,6 @@ class TokenType : public Type::TypeBase<TokenType, Type, TypeStorage> {
 LogicalResult verifyCollectivePermuteSourceTargetPairs(
     Operation *op, DenseIntElementsAttr attr);
 
-LogicalResult verifyReduceScatter(Operation *op, TypeRange operandTypes,
-                                  TypeRange resultTypes,
-                                  uint64_t scatterDimension);
-
 void printConvolutionDimensions(AsmPrinter &p, ConvDimensionNumbersAttr dnums);
 void printConvolutionDimensions(AsmPrinter &p, Operation *,
                                 ConvDimensionNumbersAttr dnums);

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1510,8 +1510,6 @@ def StableHLO_GetTupleElementOp: StableHLO_Op<"get_tuple_element", [Pure,
 
   let results = (outs HLO_TensorOrTokenOrTuple);
 
-  let hasVerifier = 1;
-
   let assemblyFormat = [{
     $operand `[` $index `]` attr-dict `:` functional-type(operands, results)
   }];

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1639,7 +1639,6 @@ def StableHLO_DynamicSliceOp: StableHLO_Op<"dynamic_slice",
   );
 
   let results = (outs HLO_Tensor:$result);
-  let hasVerifier = 1;
 
   let assemblyFormat = [{
     $operand `,` custom<VariadicOperandWithAttribute>($start_indices)

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1533,8 +1533,6 @@ def StableHLO_TupleOp : StableHLO_Op<"tuple", [Pure,
   let arguments = (ins Variadic<HLO_TensorOrTokenOrTuple>:$val);
   let results = (outs HLO_Tuple:$result);
 
-  let hasVerifier = 1;
-
   let assemblyFormat = [{
     $val attr-dict `:` custom<TupleOpType>(type($val), type($result))
   }];

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1846,8 +1846,6 @@ def StableHLO_BroadcastOp : StableHLO_ShapedInterfaceOp<"broadcast",
 
   let results = (outs HLO_Tensor);
 
-  let hasVerifier = 1;
-
   let assemblyFormat = [{
     $operand `,` `sizes` `=` custom<DenseI64Array>($broadcast_sizes)
       attr-dict `:` functional-type(operands, results)
@@ -1981,8 +1979,6 @@ def StableHLO_ClampOp : StableHLO_ShapedInterfaceOp<"clamp", [Pure,
     HLO_Tensor:$max
   );
   let results = (outs HLO_Tensor:$result);
-
-  let hasVerifier = 1;
 
   let assemblyFormat = [{
     $min `,` $operand `,` $max attr-dict

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -1969,6 +1969,36 @@ LogicalResult verifyBroadcastInDimOp(Optional<Location> location, Value operand,
   return success();
 }
 
+LogicalResult verifyClampOp(Optional<Location> location, Value min,
+                            Value operand, Value max) {
+  auto operandType = operand.getType().cast<RankedTensorType>();
+  auto operandShape = operandType.getShape();
+  auto minType = min.getType().cast<RankedTensorType>();
+
+  auto minShape = minType.getShape();
+  if (failed(verifyCompatibleShape(minType, operandType)) &&
+      minType.getRank() != 0) {
+    return emitOptionalError(
+        location, "min shape [",
+        llvm::make_range(minShape.begin(), minShape.end()),
+        "] is not scalar and is not compatible to operand shape [",
+        llvm::make_range(operandShape.begin(), operandShape.end()), "]");
+  }
+
+  auto maxType = max.getType().cast<RankedTensorType>();
+  auto maxShape = maxType.getShape();
+  if (failed(verifyCompatibleShape(maxType, operandType)) &&
+      maxType.getRank() != 0) {
+    return emitOptionalError(
+        location, "max shape [",
+        llvm::make_range(maxShape.begin(), maxShape.end()),
+        "] is not scalar and is not compatible to operand shape [",
+        llvm::make_range(operandShape.begin(), operandShape.end()), "]");
+  }
+
+  return success();
+}
+
 LogicalResult verifyCollectivePermuteOp(
     Optional<Location> location, DenseIntElementsAttr sourceTargetPairs) {
   // Verifies the source target pairs attached to collective permute.

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -1787,6 +1787,94 @@ LogicalResult verifyAllReduceOp(Optional<Location> location, Value operand,
   return success();
 }
 
+/*
+ * We intend to verify the following properties
+ * P1. We cannot convert between complex and real types (cf xla)
+ * P3. The dimensions of the operand and the target
+ * shape must match, except that the shape with the smaller element bitwidth has
+ * an appropriately-sized additional innermost dimension, e.g.
+ * ... x f32 => [bitcast_convert] => ... x 4 x i8
+ * ... x 4 x i8 => [bitcast_convert] => ... x f32
+ */
+LogicalResult verifyBitcastConvertOp(Optional<Location> location, Value operand,
+                                     Value result) {
+  auto operandTensorType = operand.getType().cast<TensorType>();
+  auto targetTensorType = result.getType().cast<TensorType>();
+
+  // P1.
+  auto targetElt = targetTensorType.getElementType();
+  auto operandElt = operandTensorType.getElementType();
+  if (targetElt.isa<ComplexType>() != operandElt.isa<ComplexType>()) {
+    return emitOptionalError(
+        location, "cannot convert between real and complex types, but got: ",
+        operandTensorType, " and ", targetTensorType);
+  }
+
+  auto targetEltBitwidth = hlo::potentiallyComplexBitwidth(targetElt);
+  auto operandEltBitwidth = hlo::potentiallyComplexBitwidth(operandElt);
+
+  // P2.
+  auto operandType = operandTensorType.dyn_cast<RankedTensorType>();
+  auto targetType = targetTensorType.dyn_cast<RankedTensorType>();
+  if (!operandType || !targetType) return success();
+
+  auto targetShape = targetType.getShape();
+  auto operandShape = operandType.getShape();
+  ArrayRef<int64_t> smallerEltShape, biggerEltShape;
+  Type smallerElt, biggerElt;
+  if (operandEltBitwidth < targetEltBitwidth) {
+    smallerEltShape = operandShape;
+    smallerElt = operandElt;
+    biggerEltShape = targetShape;
+    biggerElt = targetElt;
+  } else {
+    smallerEltShape = targetShape;
+    smallerElt = targetElt;
+    biggerEltShape = operandShape;
+    biggerElt = operandElt;
+  }
+
+  ArrayRef<int64_t> smallerEltPrefix;
+  auto smallerEltBitwidth = std::min(targetEltBitwidth, operandEltBitwidth);
+  auto biggerEltBitwidth = std::max(targetEltBitwidth, operandEltBitwidth);
+  if (operandEltBitwidth != targetEltBitwidth) {
+    if (smallerEltShape.empty()) {
+      return emitOptionalError(location,
+                               "does not allow the smaller element type to be "
+                               "part of a 0d tensor, but got: ",
+                               operandType, " and ", targetType, ".");
+    }
+    smallerEltPrefix = smallerEltShape.drop_back();
+    if (!hlo::isDynamicDimSize(smallerEltShape.back()) &&
+        smallerEltShape.back() * smallerEltBitwidth != biggerEltBitwidth) {
+      return emitOptionalError(
+          location, "requires compatible bitwidths. ", "Got: ", operandType,
+          " and ", targetType, ", but ", smallerEltBitwidth, " * ",
+          smallerEltShape.back(), " != ", biggerEltBitwidth, ".");
+    }
+  } else {
+    smallerEltPrefix = smallerEltShape;
+  }
+
+  for (auto it : llvm::zip(smallerEltPrefix, biggerEltShape)) {
+    auto targetDim = std::get<0>(it);
+    auto operandDim = std::get<1>(it);
+    if (!hlo::isDynamicDimSize(targetDim) &&
+        !hlo::isDynamicDimSize(operandDim)) {
+      if (targetDim != operandDim) {
+        return emitOptionalError(
+            location,
+            "operand and result shapes must match except "
+            "for the innermost dimension of the shape with "
+            "the smaller element type. Got: ",
+            operandType, " and ", targetType, ".");
+      }
+    }
+  }
+
+  return success();
+}
+
 LogicalResult verifyCollectivePermuteOp(
     Optional<Location> location, DenseIntElementsAttr sourceTargetPairs) {
   // Verifies the source target pairs attached to collective permute.

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -1215,6 +1215,17 @@ LogicalResult inferDotGeneralOp(
   return success();
 }
 
+LogicalResult inferDynamicSliceOp(
+    Optional<Location> location, Value operand, DenseIntElementsAttr sliceSizes,
+    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
+  auto operandType = operand.getType().dyn_cast<RankedTensorType>();
+  if (!operandType) return failure();
+
+  Type elementTy = operandType.getElementType();
+  inferredReturnShapes.emplace_back(sliceSizes.getValues<int64_t>(), elementTy);
+  return success();
+}
+
 LogicalResult inferDynamicUpdateSliceOp(
     Optional<Location> location, Value operand, Value update,
     ValueRange startIndices,

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -1875,6 +1875,16 @@ LogicalResult verifyBitcastConvertOp(Optional<Location> location, Value operand,
   return success();
 }
 
+LogicalResult verifyBroadcastOp(Optional<Location> location,
+                                DenseIntElementsAttr sizes) {
+  auto sizesType = sizes.getType();
+  auto sizesRank = sizesType.getRank();
+  if (sizesRank != 1)
+    return emitOptionalError(location, "broadcast_sizes has rank ", sizesRank,
+                             " instead of rank 1");
+  return success();
+}
+
 LogicalResult verifyCollectivePermuteOp(
     Optional<Location> location, DenseIntElementsAttr sourceTargetPairs) {
   // Verifies the source target pairs attached to collective permute.

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -1486,6 +1486,13 @@ LogicalResult inferOutfeedOp(Dialect* dialect, Optional<Location> location,
   return success();
 }
 
+LogicalResult inferRealOp(Optional<Location>, Value operand,
+                          SmallVectorImpl<Type>& inferredReturnTypes) {
+  inferredReturnTypes.push_back(
+      createRealType(operand.getType().cast<TensorType>()));
+  return success();
+}
+
 LogicalResult inferReduceOp(
     Optional<Location> location, ValueRange inputs, ValueRange initValues,
     DenseIntElementsAttr dimensions,

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -1709,6 +1709,43 @@ LogicalResult inferWhileOp(Optional<Location>, ValueRange operand,
 // Verifiers for ops.
 //===----------------------------------------------------------------------===//
 
+LogicalResult verifyCollectivePermuteOp(
+    Optional<Location> location, DenseIntElementsAttr sourceTargetPairs) {
+  // Verifies the source target pairs attached to collective permute.
+  auto type = sourceTargetPairs.getType().dyn_cast<RankedTensorType>();
+  if (type.getRank() != 2)
+    return emitOptionalError(location,
+                             "expect source_target_pairs attribute to be of "
+                             "rank 2, but got rank ",
+                             type.getRank());
+  if (type.getShape()[1] != 2)
+    return emitOptionalError(
+        location,
+        "expect source_target_pairs attribute of shape (N, 2), but got (",
+        type.getShape(), ")");
+  // Check source target pairs for duplicate sources or targets.
+  llvm::DenseSet<int64_t> sources;
+  llvm::DenseSet<int64_t> targets;
+  for (auto i = sourceTargetPairs.begin(), e = sourceTargetPairs.end(); i != e;
+       ++i) {
+    auto val = (*i).getSExtValue();
+    if (val < 0)
+      return emitOptionalError(
+          location, "replica ids in source_target_pairs must be >= 0.");
+
+    if (i.getIndex() % 2 == 0) {
+      bool isUnique = sources.insert(val).second;
+      if (!isUnique)
+        return emitOptionalError(location, "duplicate sources not allowed.");
+    } else {
+      bool isUnique = targets.insert(val).second;
+      if (!isUnique)
+        return emitOptionalError(location, "duplicate targets not allowed.");
+    }
+  }
+  return success();
+}
+
 LogicalResult verifyIotaOp(Optional<Location> location, uint64_t iotaDimension,
                            Type resultType) {
   auto shape = resultType.cast<ShapedType>();

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2158,6 +2158,19 @@ LogicalResult verifyDynamicBroadcastInDimOp(
   return success();
 }
 
+LogicalResult verifyDynamicReshapeOp(Optional<Location> location,
+                                     Value outputShape, Value result) {
+  auto resultType = result.getType().dyn_cast<RankedTensorType>();
+  auto outputShapeType = outputShape.getType().dyn_cast<RankedTensorType>();
+  if (resultType && outputShapeType && outputShapeType.hasStaticShape() &&
+      outputShapeType.getDimSize(0) != resultType.getRank()) {
+    return emitOptionalError(location,
+                             "output should have a rank equal to the number of "
+                             "elements in output_shape");
+  }
+  return success();
+}
+
 LogicalResult verifyGetTupleElementOp(Optional<Location> location,
                                       Value operand, uint32_t indexVal,
                                       Type resultType) {

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -587,6 +587,60 @@ LogicalResult verifyReducerShape(Optional<Location> loc, Block& block,
   return success();
 }
 
+LogicalResult verifyReduceScatter(Optional<Location> location,
+                                  TypeRange operandTypes, TypeRange resultTypes,
+                                  uint64_t scatterDimension) {
+  // If operand and result are both ranked, then the size of the scatter
+  // dimension in the operand should be a multiple of the size of the scatter
+  // dimension in the result.
+
+  // TODO(zhouxin) Change the ODS definition to return int64_t.
+  if (static_cast<int64_t>(scatterDimension) < 0) {
+    return emitOptionalError(location, "expects scatter_dimension >= 0");
+  }
+
+  for (auto it : llvm::zip(operandTypes, resultTypes)) {
+    auto operandType = std::get<0>(it).cast<ShapedType>();
+    auto resultType = std::get<1>(it).cast<ShapedType>();
+    if (!operandType.hasRank() || !resultType.hasRank()) continue;
+    if (operandType.getRank() != resultType.getRank())
+      return emitOptionalError(location,
+                               "operand and result should have same rank");
+    if (static_cast<int64_t>(scatterDimension) >= operandType.getRank())
+      return emitOptionalError(
+          location, "scatter dim should be less than operand/result rank");
+    if (operandType.isDynamicDim(scatterDimension) ||
+        resultType.isDynamicDim(scatterDimension))
+      continue;
+    if (operandType.getDimSize(scatterDimension) == 0)
+      return emitOptionalError(location,
+                               "operand scatter dimension cannot be zero");
+    if (resultType.getDimSize(scatterDimension) == 0)
+      return emitOptionalError(location,
+                               "result scatter dimension cannot be zero");
+    if ((operandType.getDimSize(scatterDimension) %
+         resultType.getDimSize(scatterDimension)) != 0)
+      return emitOptionalError(
+          location, "operand scatter dimension has size ",
+          operandType.getDimSize(scatterDimension),
+          ", expected to be a multiple of result scatter dimension size ",
+          resultType.getDimSize(scatterDimension));
+
+    // Non scatter dimensions should be equal.
+    for (uint64_t index : llvm::seq<uint64_t>(0, operandType.getRank())) {
+      if (index == scatterDimension || operandType.isDynamicDim(index) ||
+          resultType.isDynamicDim(index))
+        continue;
+      if (operandType.getDimSize(index) != resultType.getDimSize(index))
+        return emitOptionalError(
+            location, "non scatter dimensions should be same for operand (",
+            operandType.getDimSize(index), ") and result (",
+            resultType.getDimSize(index), ")");
+    }
+  }
+  return success();
+}
+
 LogicalResult verifyReduceWindowOpInputsAndInferWindow(
     Optional<Location> location, SmallVector<TensorType> inputArgTypes,
     SmallVector<TensorType> initValueTypes,
@@ -1629,6 +1683,31 @@ LogicalResult verifyReduceOp(Optional<Location> location, ValueRange inputs,
                                 numInputs, newDimensions, allInputsUnranked)))
     return failure();
   return success();
+}
+
+LogicalResult verifyReduceScatterOp(Optional<Location> location, Value operand,
+                                    uint64_t scatterDimension,
+                                    DenseIntElementsAttr replicaGroups,
+                                    bool useGlobalDeviceIds,
+                                    Region& computation,
+                                    TypeRange resultTypes) {
+  if (failed(hlo::verifyReplicaGroups(location, replicaGroups,
+                                      /*allGroupsMustHaveSameSize=*/true,
+                                      useGlobalDeviceIds,
+                                      /*expectedGroupSize=*/std::nullopt)))
+    return failure();
+  auto operandType = operand.getType().cast<TensorType>();
+  bool operandTypeRanked = operandType.isa<RankedTensorType>();
+  Block& block = computation.front();
+  if (failed(hlo::verifyReducerShape(
+          location, block, {operandType},
+          {RankedTensorType::get({}, operandType.getElementType())},
+          /*numInputs=*/1, /*allowedDimensions=*/{},
+          /*allInputsUnranked=*/!operandTypeRanked)))
+    return failure();
+
+  return verifyReduceScatter(location, operand.getType(), resultTypes,
+                             scatterDimension);
 }
 
 // We intend to verify the following properties

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -1688,6 +1688,21 @@ LogicalResult inferWhileOp(Optional<Location>, ValueRange operand,
 // Verifiers for ops.
 //===----------------------------------------------------------------------===//
 
+LogicalResult verifyIotaOp(Optional<Location> location, uint64_t iotaDimension,
+                           Type resultType) {
+  auto shape = resultType.cast<ShapedType>();
+  if (!shape.hasRank()) return success();
+  if (shape.getRank() == 0)
+    return emitOptionalError(location, "does not support scalars.");
+
+  if (static_cast<int64_t>(iotaDimension) >= shape.getRank() ||
+      static_cast<int64_t>(iotaDimension) < 0)
+    return emitOptionalError(
+        location,
+        "iota dimension cannot go beyond the output rank or be negative.");
+  return success();
+}
+
 // We intend to verify the following properties
 //  P1. Verify all `inputs` need to have compatible shapes.
 //  P2. Verify that

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -1944,6 +1944,26 @@ LogicalResult verifySortOp(Optional<Location> location, ValueRange inputs,
   return success();
 }
 
+LogicalResult verifyTupleOp(Optional<Location> location, TypeRange operandTypes,
+                            Type resultType) {
+  auto opType = resultType.dyn_cast<TupleType>();
+  if (!opType)
+    return emitOptionalError(location, "tuple op with non-tuple result");
+  if (operandTypes.size() != opType.size())
+    return emitOptionalError(
+        location,
+        "number of operands to tuple expected to match number of types in "
+        "resultant tuple type");
+  for (const auto& it :
+       llvm::enumerate(llvm::zip_first(operandTypes, opType.getTypes()))) {
+    if (std::get<0>(it.value()) != std::get<1>(it.value()))
+      return emitOptionalError(
+          location, "has return type mismatch at ", it.index(), "th value (",
+          std::get<0>(it.value()), " != ", std::get<1>(it.value()), ")");
+  }
+  return success();
+}
+
 LogicalResult verifyWhileOp(Optional<Location> location, ValueRange operand,
                             Region& cond, Region& body) {
   auto operandTypes = operand.getTypes();

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -921,6 +921,12 @@ LogicalResult inferConcatenateOp(Optional<Location> location, ValueRange inputs,
   return success();
 }
 
+LogicalResult inferConstantOp(Optional<Location>, ElementsAttr value,
+                              SmallVectorImpl<Type>& inferredReturnTypes) {
+  inferredReturnTypes.push_back(value.getType());
+  return success();
+}
+
 LogicalResult inferCreateTokenOp(Dialect* dialect, Optional<Location> location,
                                  SmallVectorImpl<Type>& inferredReturnTypes) {
   auto hloDialect = cast<HloDialectInterface>(dialect);
@@ -1642,6 +1648,10 @@ LogicalResult inferWhileOp(Optional<Location>, ValueRange operand,
     inferredReturnTypes.push_back(resultType);
   return success();
 }
+
+//===----------------------------------------------------------------------===//
+// Verifiers for ops.
+//===----------------------------------------------------------------------===//
 
 // We intend to verify the following properties
 //  P1. Verify all `inputs` need to have compatible shapes.

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -955,6 +955,15 @@ LogicalResult inferCholeskyOp(
   return success();
 }
 
+LogicalResult inferClampOp(
+    Optional<Location> location, Value operand,
+    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
+  RankedTensorType operandType =
+      operand.getType().cast<RankedTensorType>();
+  inferredReturnShapes.emplace_back(operandType.cast<ShapedType>());
+  return success();
+}
+
 LogicalResult inferConcatenateOp(Optional<Location> location, ValueRange inputs,
                                  int64_t dimension,
                                  SmallVectorImpl<Type>& inferredReturnTypes) {

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -963,9 +963,8 @@ LogicalResult inferClampOp(
   return success();
 }
 
-LogicalResult inferComplexOp(
-    Optional<Location> location, Value operand,
-    SmallVectorImpl<Type>& inferredReturnTypes) {
+LogicalResult inferComplexOp(Optional<Location> location, Value operand,
+                             SmallVectorImpl<Type>& inferredReturnTypes) {
   TensorType operandType = operand.getType().cast<TensorType>();
   ComplexType elementTy = ComplexType::get(operandType.getElementType());
   inferredReturnTypes.push_back(
@@ -1279,6 +1278,16 @@ LogicalResult inferDynamicUpdateSliceOp(
   } else {
     inferredReturnShapes.emplace_back(operandType.getElementType());
   }
+  return success();
+}
+
+LogicalResult inferFiniteOp(MLIRContext* context, Optional<Location>,
+                            Value operand,
+                            SmallVectorImpl<Type>& inferredReturnTypes) {
+  auto argTy = operand.getType().cast<TensorType>();
+  Builder b(context);
+  inferredReturnTypes.push_back(
+      hlo::getSameShapeTensorType(argTy, b.getI1Type()));
   return success();
 }
 

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -1746,6 +1746,22 @@ LogicalResult verifyCollectivePermuteOp(
   return success();
 }
 
+LogicalResult verifyGetTupleElementOp(Optional<Location> location,
+                                      Value operand, uint32_t indexVal,
+                                      Type resultType) {
+  auto operandType = operand.getType().cast<TupleType>();
+  if (indexVal >= operandType.size())
+    return emitOptionalError(location, "index ", indexVal,
+                             " is out of bounds of operand with size ",
+                             operandType.size());
+
+  auto expectedType = operandType.getType(indexVal);
+  if (resultType != expectedType)
+    return emitOptionalError(location, "has return type ", resultType,
+                             ", but expected ", expectedType);
+  return success();
+}
+
 LogicalResult verifyIotaOp(Optional<Location> location, uint64_t iotaDimension,
                            Type resultType) {
   auto shape = resultType.cast<ShapedType>();

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -1352,13 +1352,10 @@ LogicalResult inferGetTupleElementOp(
     SmallVectorImpl<Type>& inferredReturnTypes) {
   auto operandType = operand.getType().dyn_cast<TupleType>();
   if (!operandType) return failure();
-  if (index >= static_cast<int64_t>(operandType.size()))
+  if (index < 0 || index >= static_cast<int64_t>(operandType.size()))
     return emitOptionalError(location, "index ", index,
                              " is out of bounds of operand with size ",
                              operandType.size());
-
-  if (index < 0 || index >= static_cast<int64_t>(operandType.size()))
-    return failure();
 
   inferredReturnTypes.push_back(operandType.getType(index));
   return success();

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -958,9 +958,18 @@ LogicalResult inferCholeskyOp(
 LogicalResult inferClampOp(
     Optional<Location> location, Value operand,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
-  RankedTensorType operandType =
-      operand.getType().cast<RankedTensorType>();
+  RankedTensorType operandType = operand.getType().cast<RankedTensorType>();
   inferredReturnShapes.emplace_back(operandType.cast<ShapedType>());
+  return success();
+}
+
+LogicalResult inferComplexOp(
+    Optional<Location> location, Value operand,
+    SmallVectorImpl<Type>& inferredReturnTypes) {
+  TensorType operandType = operand.getType().cast<TensorType>();
+  ComplexType elementTy = ComplexType::get(operandType.getElementType());
+  inferredReturnTypes.push_back(
+      hlo::getSameShapeTensorType(operandType, elementTy));
   return success();
 }
 

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -1895,6 +1895,13 @@ LogicalResult inferTriangularSolveOp(
   return success();
 }
 
+LogicalResult inferTupleOp(MLIRContext* context, Optional<Location>,
+                           TypeRange operandTypes,
+                           SmallVectorImpl<Type>& inferredReturnTypes) {
+  inferredReturnTypes.push_back(TupleType::get(context, operandTypes));
+  return success();
+}
+
 LogicalResult inferWhileOp(Optional<Location>, ValueRange operand,
                            SmallVectorImpl<Type>& inferredReturnTypes) {
   for (const auto& resultType : operand.getType())
@@ -2422,26 +2429,6 @@ LogicalResult verifySortOp(Optional<Location> location, ValueRange inputs,
     return emitOptionalError(location,
                              "comparator must return tensor<i1> but got ",
                              comparatorResult[0].getType());
-  return success();
-}
-
-LogicalResult verifyTupleOp(Optional<Location> location, TypeRange operandTypes,
-                            Type resultType) {
-  auto opType = resultType.dyn_cast<TupleType>();
-  if (!opType)
-    return emitOptionalError(location, "tuple op with non-tuple result");
-  if (operandTypes.size() != opType.size())
-    return emitOptionalError(
-        location,
-        "number of operands to tuple expected to match number of types in "
-        "resultant tuple type");
-  for (const auto& it :
-       llvm::enumerate(llvm::zip_first(operandTypes, opType.getTypes()))) {
-    if (std::get<0>(it.value()) != std::get<1>(it.value()))
-      return emitOptionalError(
-          location, "has return type mismatch at ", it.index(), "th value (",
-          std::get<0>(it.value()), " != ", std::get<1>(it.value()), ")");
-  }
   return success();
 }
 

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -134,6 +134,10 @@ LogicalResult inferBatchNormTrainingOp(
 LogicalResult inferCaseOp(Optional<Location> location, RegionRange branches,
                           SmallVectorImpl<Type>& inferredReturnTypes);
 
+LogicalResult inferCholeskyOp(
+    Optional<Location> location, Value a,
+    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
+
 LogicalResult inferConcatenateOp(Optional<Location> location, ValueRange inputs,
                                  int64_t dimension,
                                  SmallVectorImpl<Type>& inferredReturnTypes);
@@ -237,7 +241,7 @@ LogicalResult inferWhileOp(Optional<Location> location, ValueRange operand,
 
 //===----------------------------------------------------------------------===//
 // Verifiers for ops.
-//===----------------------------------------------------------------------===//                    
+//===----------------------------------------------------------------------===//
 
 LogicalResult verifyReduceOp(Optional<Location> location, ValueRange inputs,
                              ValueRange initValues,

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -178,7 +178,8 @@ LogicalResult inferDotGeneralOp(
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferDynamicSliceOp(
-    Optional<Location> location, Value operand, DenseIntElementsAttr sliceSizes,
+    Optional<Location> location, Value operand, ValueRange startIndices,
+    DenseIntElementsAttr sliceSizes,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferDynamicUpdateSliceOp(
@@ -299,10 +300,6 @@ LogicalResult verifyDynamicBroadcastInDimOp(
 
 LogicalResult verifyDynamicReshapeOp(Optional<Location> location,
                                      Value outputShape, Value result);
-
-LogicalResult verifyDynamicSliceOp(Optional<Location> location, Value operand,
-                                   ValueRange startIndices,
-                                   DenseIntElementsAttr sliceSizes);
 
 LogicalResult verifyGetTupleElementOp(Optional<Location> location,
                                       Value operand, uint32_t indexVal,

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -276,6 +276,9 @@ LogicalResult verifyReduceWindowOp(
 LogicalResult verifySortOp(Optional<Location> location, ValueRange inputs,
                            uint64_t dimension, Region& comparator);
 
+LogicalResult verifyTupleOp(Optional<Location> location, TypeRange operandTypes,
+                            Type resultType);
+
 LogicalResult verifyWhileOp(Optional<Location> location, ValueRange operand,
                             Region& cond, Region& body);
 }  // end namespace hlo

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -138,6 +138,9 @@ LogicalResult inferConcatenateOp(Optional<Location> location, ValueRange inputs,
                                  int64_t dimension,
                                  SmallVectorImpl<Type>& inferredReturnTypes);
 
+LogicalResult inferConstantOp(Optional<Location>, ElementsAttr value,
+                              SmallVectorImpl<Type>& inferredReturnTypes);
+
 LogicalResult inferCreateTokenOp(Dialect* dialect, Optional<Location> location,
                                  SmallVectorImpl<Type>& inferredReturnTypes);
 
@@ -231,6 +234,10 @@ LogicalResult inferTriangularSolveOp(
 
 LogicalResult inferWhileOp(Optional<Location> location, ValueRange operand,
                            SmallVectorImpl<Type>& inferredReturnTypes);
+
+//===----------------------------------------------------------------------===//
+// Verifiers for ops.
+//===----------------------------------------------------------------------===//                    
 
 LogicalResult verifyReduceOp(Optional<Location> location, ValueRange inputs,
                              ValueRange initValues,

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -315,6 +315,10 @@ LogicalResult verifyGetTupleElementOp(Optional<Location> location,
 LogicalResult verifyIotaOp(Optional<Location> location, uint64_t iotaDimension,
                            Type resultType);
 
+LogicalResult verifyRealDynamicSliceOp(Optional<Location> location,
+                                       Value operand, Value startIndices,
+                                       Value limitIndices, Value strides);
+
 LogicalResult verifyReduceOp(Optional<Location> location, ValueRange inputs,
                              ValueRange initValues,
                              DenseIntElementsAttr dimensions, Region& body);

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -290,9 +290,6 @@ LogicalResult verifyAllReduceOp(Optional<Location> location, Value operand,
 LogicalResult verifyBitcastConvertOp(Optional<Location> location, Value operand,
                                      Value result);
 
-LogicalResult verifyBroadcastOp(Optional<Location> location,
-                                DenseIntElementsAttr sizes);
-
 LogicalResult verifyBroadcastInDimOp(Optional<Location> location, Value operand,
                                      DenseIntElementsAttr broadcastDimensions,
                                      Value result);

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -83,10 +83,6 @@ LogicalResult verifyReducerShape(Optional<Location> loc, Block& block,
                                  ArrayRef<int64_t> allowedDimensions,
                                  bool allInputsUnranked);
 
-LogicalResult verifyReduceScatter(Operation* op, TypeRange operandTypes,
-                                  TypeRange resultTypes,
-                                  int64_t scatterDimension);
-
 // Verifies replica groups attached to collective communication operations.
 // P1. 'replicaGroups' must be a 2-D tensor.
 // P2. replicaGroups' cannot be empty.
@@ -273,7 +269,7 @@ LogicalResult inferTriangularSolveOp(
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferTupleOp(MLIRContext* context, Optional<Location> location,
-                           TypeRange operandTypes,
+                           ValueRange val,
                            SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferWhileOp(Optional<Location> location, ValueRange operand,
@@ -307,7 +303,7 @@ LogicalResult verifyDynamicReshapeOp(Optional<Location> location,
                                      Value outputShape, Value result);
 
 LogicalResult verifyIotaOp(Optional<Location> location, int64_t iotaDimension,
-                           Type resultType);
+                           Value result);
 
 LogicalResult verifyRealDynamicSliceOp(Optional<Location> location,
                                        Value operand, Value startIndices,
@@ -321,7 +317,7 @@ LogicalResult verifyReduceScatterOp(Optional<Location> location, Value operand,
                                     int64_t scatterDimension,
                                     DenseIntElementsAttr replicaGroups,
                                     bool useGlobalDeviceIds,
-                                    Region& computation, TypeRange resultTypes);
+                                    Region& computation, Value result);
 
 LogicalResult verifyReduceWindowOp(
     Optional<Location> location, ValueRange inputs, ValueRange initValues,

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -259,6 +259,9 @@ LogicalResult verifyAllReduceOp(Optional<Location> location, Value operand,
 LogicalResult verifyBitcastConvertOp(Optional<Location> location, Value operand,
                                      Value result);
 
+LogicalResult verifyBroadcastOp(Optional<Location> location,
+                                DenseIntElementsAttr sizes);
+
 LogicalResult verifyCollectivePermuteOp(Optional<Location> location,
                                         DenseIntElementsAttr sourceTargetPairs);
 

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -274,6 +274,12 @@ LogicalResult verifyBroadcastInDimOp(Optional<Location> location, Value operand,
 LogicalResult verifyCollectivePermuteOp(Optional<Location> location,
                                         DenseIntElementsAttr sourceTargetPairs);
 
+LogicalResult verifyDynamicBroadcastInDimOp(
+    Optional<Location> location, Value operand, Value outputDimensions,
+    DenseIntElementsAttr broadcastDimensions,
+    Optional<DenseIntElementsAttr> knownExpandingDimensions,
+    Optional<DenseIntElementsAttr> knownNonexpandingDimensions, Value result) ;
+
 LogicalResult verifyGetTupleElementOp(Optional<Location> location,
                                       Value operand, uint32_t indexVal,
                                       Type resultType);

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -272,6 +272,10 @@ LogicalResult inferTriangularSolveOp(
     bool isTransposeAInvalid,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
+LogicalResult inferTupleOp(MLIRContext* context, Optional<Location> location,
+                           TypeRange operandTypes,
+                           SmallVectorImpl<Type>& inferredReturnTypes);
+
 LogicalResult inferWhileOp(Optional<Location> location, ValueRange operand,
                            SmallVectorImpl<Type>& inferredReturnTypes);
 
@@ -332,9 +336,6 @@ LogicalResult verifyReduceWindowOp(
 
 LogicalResult verifySortOp(Optional<Location> location, ValueRange inputs,
                            uint64_t dimension, Region& comparator);
-
-LogicalResult verifyTupleOp(Optional<Location> location, TypeRange operandTypes,
-                            Type resultType);
 
 LogicalResult verifyWhileOp(Optional<Location> location, ValueRange operand,
                             Region& cond, Region& body);

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -187,6 +187,10 @@ LogicalResult inferDynamicUpdateSliceOp(
     ValueRange startIndices,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
+LogicalResult inferGetTupleElementOp(
+    Optional<Location> location, Value operand, int32_t index,
+    SmallVectorImpl<Type>& inferredReturnTypes);
+
 LogicalResult inferIsFiniteOp(MLIRContext* context, Optional<Location>, Value x,
                               SmallVectorImpl<Type>& inferredReturnTypes);
 
@@ -300,10 +304,6 @@ LogicalResult verifyDynamicBroadcastInDimOp(
 
 LogicalResult verifyDynamicReshapeOp(Optional<Location> location,
                                      Value outputShape, Value result);
-
-LogicalResult verifyGetTupleElementOp(Optional<Location> location,
-                                      Value operand, uint32_t indexVal,
-                                      Type resultType);
 
 LogicalResult verifyIotaOp(Optional<Location> location, uint64_t iotaDimension,
                            Type resultType);

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -298,7 +298,11 @@ LogicalResult verifyDynamicBroadcastInDimOp(
     Optional<DenseIntElementsAttr> knownNonexpandingDimensions, Value result);
 
 LogicalResult verifyDynamicReshapeOp(Optional<Location> location,
-                                     Value outputShape, Value result); 
+                                     Value outputShape, Value result);
+
+LogicalResult verifyDynamicSliceOp(Optional<Location> location, Value operand,
+                                   ValueRange startIndices,
+                                   DenseIntElementsAttr sliceSizes);
 
 LogicalResult verifyGetTupleElementOp(Optional<Location> location,
                                       Value operand, uint32_t indexVal,

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -177,6 +177,10 @@ LogicalResult inferDotGeneralOp(
     ArrayRef<int64_t> rhsContractingDimensions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
+LogicalResult inferDynamicSliceOp(
+    Optional<Location> location, Value operand, DenseIntElementsAttr sliceSizes,
+    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
+
 LogicalResult inferDynamicUpdateSliceOp(
     Optional<Location> location, Value operand, Value update,
     ValueRange startIndices,

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -85,7 +85,7 @@ LogicalResult verifyReducerShape(Optional<Location> loc, Block& block,
 
 LogicalResult verifyReduceScatter(Operation* op, TypeRange operandTypes,
                                   TypeRange resultTypes,
-                                  uint64_t scatterDimension);
+                                  int64_t scatterDimension);
 
 // Verifies replica groups attached to collective communication operations.
 // P1. 'replicaGroups' must be a 2-D tensor.
@@ -127,17 +127,17 @@ LogicalResult inferAllToAllOp(
 
 LogicalResult inferBatchNormGradOp(
     Optional<Location> location, Value operand, Value scale,
-    uint64_t featureIndex,
+    int64_t featureIndex,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferBatchNormInferenceOp(
     Optional<Location> location, Value operand, Value scale,
-    uint64_t featureIndex,
+    int64_t featureIndex,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferBatchNormTrainingOp(
     Optional<Location> location, Value operand, Value scale,
-    uint64_t featureIndex,
+    int64_t featureIndex,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferBroadcastOp(
@@ -309,7 +309,7 @@ LogicalResult verifyDynamicBroadcastInDimOp(
 LogicalResult verifyDynamicReshapeOp(Optional<Location> location,
                                      Value outputShape, Value result);
 
-LogicalResult verifyIotaOp(Optional<Location> location, uint64_t iotaDimension,
+LogicalResult verifyIotaOp(Optional<Location> location, int64_t iotaDimension,
                            Type resultType);
 
 LogicalResult verifyRealDynamicSliceOp(Optional<Location> location,
@@ -321,7 +321,7 @@ LogicalResult verifyReduceOp(Optional<Location> location, ValueRange inputs,
                              DenseIntElementsAttr dimensions, Region& body);
 
 LogicalResult verifyReduceScatterOp(Optional<Location> location, Value operand,
-                                    uint64_t scatterDimension,
+                                    int64_t scatterDimension,
                                     DenseIntElementsAttr replicaGroups,
                                     bool useGlobalDeviceIds,
                                     Region& computation, TypeRange resultTypes);
@@ -335,7 +335,7 @@ LogicalResult verifyReduceWindowOp(
     Optional<DenseIntElementsAttr> padding, Region& body);
 
 LogicalResult verifySortOp(Optional<Location> location, ValueRange inputs,
-                           uint64_t dimension, Region& comparator);
+                           int64_t dimension, Region& comparator);
 
 LogicalResult verifyWhileOp(Optional<Location> location, ValueRange operand,
                             Region& cond, Region& body);

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -297,6 +297,9 @@ LogicalResult verifyDynamicBroadcastInDimOp(
     Optional<DenseIntElementsAttr> knownExpandingDimensions,
     Optional<DenseIntElementsAttr> knownNonexpandingDimensions, Value result);
 
+LogicalResult verifyDynamicReshapeOp(Optional<Location> location,
+                                     Value outputShape, Value result); 
+
 LogicalResult verifyGetTupleElementOp(Optional<Location> location,
                                       Value operand, uint32_t indexVal,
                                       Type resultType);

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -140,6 +140,11 @@ LogicalResult inferBatchNormTrainingOp(
     uint64_t featureIndex,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
+LogicalResult inferBroadcastOp(
+    Optional<Location> location, Value operand,
+    DenseIntElementsAttr dimensionAttr,
+    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
+
 LogicalResult inferCaseOp(Optional<Location> location, RegionRange branches,
                           SmallVectorImpl<Type>& inferredReturnTypes);
 

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -252,6 +252,10 @@ LogicalResult inferWhileOp(Optional<Location> location, ValueRange operand,
 // Verifiers for ops.
 //===----------------------------------------------------------------------===//
 
+LogicalResult verifyAllReduceOp(Optional<Location> location, Value operand,
+                                DenseIntElementsAttr replicaGroups,
+                                bool useGlobalDeviceIds, Region& computation);
+
 LogicalResult verifyCollectivePermuteOp(Optional<Location> location,
                                         DenseIntElementsAttr sourceTargetPairs);
 
@@ -269,6 +273,7 @@ LogicalResult verifyReduceOp(Optional<Location> location, ValueRange inputs,
 LogicalResult verifyReduceScatterOp(Optional<Location> location, Value operand,
                                     uint64_t scatterDimension,
                                     DenseIntElementsAttr replicaGroups,
+                                    bool useGlobalDeviceIds,
                                     Region& computation, TypeRange resultTypes);
 
 LogicalResult verifyReduceWindowOp(

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -271,6 +271,9 @@ LogicalResult verifyBroadcastInDimOp(Optional<Location> location, Value operand,
                                      DenseIntElementsAttr broadcastDimensions,
                                      Value result);
 
+LogicalResult verifyClampOp(Optional<Location> location, Value min,
+                            Value operand, Value max);
+
 LogicalResult verifyCollectivePermuteOp(Optional<Location> location,
                                         DenseIntElementsAttr sourceTargetPairs);
 

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -156,6 +156,10 @@ LogicalResult inferClampOp(
     Optional<Location> location, Value operand,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
+LogicalResult inferComplexOp(
+    Optional<Location> location, Value operand,
+    SmallVectorImpl<Type>& inferredReturnTypes);
+
 LogicalResult inferConcatenateOp(Optional<Location> location, ValueRange inputs,
                                  int64_t dimension,
                                  SmallVectorImpl<Type>& inferredReturnTypes);

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -113,6 +113,9 @@ LogicalResult verifyReplicaGroups(Optional<Location> location,
 // These parameters have the same names as in the ODS and come in the same
 // order in which they are declared in the ODS.
 
+LogicalResult inferAbsOp(Optional<Location>, Value operand,
+                         SmallVectorImpl<Type>& inferredReturnTypes); 
+
 LogicalResult inferAfterAllOp(Dialect* dialect, Optional<Location> location,
                               SmallVectorImpl<Type>& inferredReturnTypes);
 
@@ -244,7 +247,7 @@ LogicalResult inferWhileOp(Optional<Location> location, ValueRange operand,
 //===----------------------------------------------------------------------===//
 
 LogicalResult verifyIotaOp(Optional<Location> location, uint64_t iotaDimension,
-                           Type resultType); 
+                           Type resultType);
 
 LogicalResult verifyReduceOp(Optional<Location> location, ValueRange inputs,
                              ValueRange initValues,

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -114,7 +114,7 @@ LogicalResult verifyReplicaGroups(Optional<Location> location,
 // order in which they are declared in the ODS.
 
 LogicalResult inferAbsOp(Optional<Location>, Value operand,
-                         SmallVectorImpl<Type>& inferredReturnTypes); 
+                         SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferAfterAllOp(Dialect* dialect, Optional<Location> location,
                               SmallVectorImpl<Type>& inferredReturnTypes);
@@ -245,6 +245,9 @@ LogicalResult inferWhileOp(Optional<Location> location, ValueRange operand,
 //===----------------------------------------------------------------------===//
 // Verifiers for ops.
 //===----------------------------------------------------------------------===//
+
+LogicalResult verifyCollectivePermuteOp(Optional<Location> location,
+                                        DenseIntElementsAttr sourceTargetPairs);
 
 LogicalResult verifyIotaOp(Optional<Location> location, uint64_t iotaDimension,
                            Type resultType);

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -267,6 +267,10 @@ LogicalResult verifyBitcastConvertOp(Optional<Location> location, Value operand,
 LogicalResult verifyBroadcastOp(Optional<Location> location,
                                 DenseIntElementsAttr sizes);
 
+LogicalResult verifyBroadcastInDimOp(Optional<Location> location, Value operand,
+                                     DenseIntElementsAttr broadcastDimensions,
+                                     Value result);
+
 LogicalResult verifyCollectivePermuteOp(Optional<Location> location,
                                         DenseIntElementsAttr sourceTargetPairs);
 

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -152,6 +152,10 @@ LogicalResult inferCholeskyOp(
     Optional<Location> location, Value a,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
+LogicalResult inferClampOp(
+    Optional<Location> location, Value operand,
+    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
+
 LogicalResult inferConcatenateOp(Optional<Location> location, ValueRange inputs,
                                  int64_t dimension,
                                  SmallVectorImpl<Type>& inferredReturnTypes);

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -156,9 +156,8 @@ LogicalResult inferClampOp(
     Optional<Location> location, Value operand,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
-LogicalResult inferComplexOp(
-    Optional<Location> location, Value operand,
-    SmallVectorImpl<Type>& inferredReturnTypes);
+LogicalResult inferComplexOp(Optional<Location> location, Value operand,
+                             SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferConcatenateOp(Optional<Location> location, ValueRange inputs,
                                  int64_t dimension,
@@ -182,6 +181,10 @@ LogicalResult inferDynamicUpdateSliceOp(
     Optional<Location> location, Value operand, Value update,
     ValueRange startIndices,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
+
+LogicalResult inferFiniteOp(MLIRContext* context, Optional<Location>,
+                            Value operand,
+                            SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferGetDimensionSizeOp(
     MLIRContext* context, Optional<Location> location,
@@ -289,7 +292,7 @@ LogicalResult verifyDynamicBroadcastInDimOp(
     Optional<Location> location, Value operand, Value outputDimensions,
     DenseIntElementsAttr broadcastDimensions,
     Optional<DenseIntElementsAttr> knownExpandingDimensions,
-    Optional<DenseIntElementsAttr> knownNonexpandingDimensions, Value result) ;
+    Optional<DenseIntElementsAttr> knownNonexpandingDimensions, Value result);
 
 LogicalResult verifyGetTupleElementOp(Optional<Location> location,
                                       Value operand, uint32_t indexVal,

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -153,7 +153,7 @@ LogicalResult inferCholeskyOp(
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferClampOp(
-    Optional<Location> location, Value operand,
+    Optional<Location> location, Value min, Value operand, Value max,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferComplexOp(Optional<Location> location, Value lhs,
@@ -287,9 +287,6 @@ LogicalResult verifyBroadcastOp(Optional<Location> location,
 LogicalResult verifyBroadcastInDimOp(Optional<Location> location, Value operand,
                                      DenseIntElementsAttr broadcastDimensions,
                                      Value result);
-
-LogicalResult verifyClampOp(Optional<Location> location, Value min,
-                            Value operand, Value max);
 
 LogicalResult verifyCollectivePermuteOp(Optional<Location> location,
                                         DenseIntElementsAttr sourceTargetPairs);

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -142,7 +142,7 @@ LogicalResult inferBatchNormTrainingOp(
 
 LogicalResult inferBroadcastOp(
     Optional<Location> location, Value operand,
-    DenseIntElementsAttr dimensionAttr,
+    DenseIntElementsAttr broadcastSizes,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferCaseOp(Optional<Location> location, RegionRange branches,
@@ -156,7 +156,7 @@ LogicalResult inferClampOp(
     Optional<Location> location, Value operand,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
-LogicalResult inferComplexOp(Optional<Location> location, Value operand,
+LogicalResult inferComplexOp(Optional<Location> location, Value lhs,
                              SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferConcatenateOp(Optional<Location> location, ValueRange inputs,
@@ -186,9 +186,8 @@ LogicalResult inferDynamicUpdateSliceOp(
     ValueRange startIndices,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
-LogicalResult inferFiniteOp(MLIRContext* context, Optional<Location>,
-                            Value operand,
-                            SmallVectorImpl<Type>& inferredReturnTypes);
+LogicalResult inferIsFiniteOp(MLIRContext* context, Optional<Location>, Value x,
+                              SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferGetDimensionSizeOp(
     MLIRContext* context, Optional<Location> location,

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -119,6 +119,12 @@ LogicalResult inferAbsOp(Optional<Location>, Value operand,
 LogicalResult inferAfterAllOp(Dialect* dialect, Optional<Location> location,
                               SmallVectorImpl<Type>& inferredReturnTypes);
 
+LogicalResult inferAllToAllOp(
+    Optional<Location> location, Value operand, int64_t splitDimension,
+    int64_t concatDimension, int64_t splitCount,
+    DenseIntElementsAttr replicaGroups,
+    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
+
 LogicalResult inferBatchNormGradOp(
     Optional<Location> location, Value operand, Value scale,
     uint64_t featureIndex,

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -83,6 +83,10 @@ LogicalResult verifyReducerShape(Optional<Location> loc, Block& block,
                                  ArrayRef<int64_t> allowedDimensions,
                                  bool allInputsUnranked);
 
+LogicalResult verifyReduceScatter(Operation* op, TypeRange operandTypes,
+                                  TypeRange resultTypes,
+                                  uint64_t scatterDimension);
+
 // Verifies replica groups attached to collective communication operations.
 // P1. 'replicaGroups' must be a 2-D tensor.
 // P2. replicaGroups' cannot be empty.
@@ -231,6 +235,11 @@ LogicalResult inferWhileOp(Optional<Location> location, ValueRange operand,
 LogicalResult verifyReduceOp(Optional<Location> location, ValueRange inputs,
                              ValueRange initValues,
                              DenseIntElementsAttr dimensions, Region& body);
+
+LogicalResult verifyReduceScatterOp(Optional<Location> location, Value operand,
+                                    uint64_t scatterDimension,
+                                    DenseIntElementsAttr replicaGroups,
+                                    Region& computation, TypeRange resultTypes);
 
 LogicalResult verifyReduceWindowOp(
     Optional<Location> location, ValueRange inputs, ValueRange initValues,

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -256,6 +256,9 @@ LogicalResult verifyAllReduceOp(Optional<Location> location, Value operand,
                                 DenseIntElementsAttr replicaGroups,
                                 bool useGlobalDeviceIds, Region& computation);
 
+LogicalResult verifyBitcastConvertOp(Optional<Location> location, Value operand,
+                                     Value result);
+
 LogicalResult verifyCollectivePermuteOp(Optional<Location> location,
                                         DenseIntElementsAttr sourceTargetPairs);
 

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -243,6 +243,9 @@ LogicalResult inferWhileOp(Optional<Location> location, ValueRange operand,
 // Verifiers for ops.
 //===----------------------------------------------------------------------===//
 
+LogicalResult verifyIotaOp(Optional<Location> location, uint64_t iotaDimension,
+                           Type resultType); 
+
 LogicalResult verifyReduceOp(Optional<Location> location, ValueRange inputs,
                              ValueRange initValues,
                              DenseIntElementsAttr dimensions, Region& body);

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -212,6 +212,9 @@ LogicalResult inferOptimizationBarrierOp(
 LogicalResult inferOutfeedOp(Dialect* dialect, Optional<Location> location,
                              SmallVectorImpl<Type>& inferredReturnTypes);
 
+LogicalResult inferRealOp(Optional<Location> location, Value operand,
+                          SmallVectorImpl<Type>& inferredReturnTypes);
+
 LogicalResult inferReduceOp(
     Optional<Location> location, ValueRange inputs, ValueRange initValues,
     DenseIntElementsAttr dimensions,

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -249,6 +249,10 @@ LogicalResult inferWhileOp(Optional<Location> location, ValueRange operand,
 LogicalResult verifyCollectivePermuteOp(Optional<Location> location,
                                         DenseIntElementsAttr sourceTargetPairs);
 
+LogicalResult verifyGetTupleElementOp(Optional<Location> location,
+                                      Value operand, uint32_t indexVal,
+                                      Type resultType);
+
 LogicalResult verifyIotaOp(Optional<Location> location, uint64_t iotaDimension,
                            Type resultType);
 

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -2590,7 +2590,7 @@ func.func @tuple_token(%arg0: tensor<f32>, %arg1: !stablehlo.token) -> tuple<ten
 // -----
 
 func.func @tuple_arg_size_mismatch(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tuple<tensor<f32>, tensor<f32>, tensor<f32>> {
-  // expected-error@+1 {{number of operands to tuple expected to match number of types}}
+  // expected-error@+1 {{'tuple<tensor<f32>, tensor<f32>>' are incompatible with return type(s) of operation 'tuple<tensor<f32>, tensor<f32>, tensor<f32>>'}}
   %0 = "stablehlo.tuple"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tuple<tensor<f32>, tensor<f32>, tensor<f32>>
   func.return %0 : tuple<tensor<f32>, tensor<f32>, tensor<f32>>
 }
@@ -2598,7 +2598,7 @@ func.func @tuple_arg_size_mismatch(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tu
 // -----
 
 func.func @tuple_type_mismatch(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tuple<tensor<f32>, tensor<i32>> {
-  // expected-error@+1 {{has return type mismatch at 1th value}}
+  // expected-error@+1 {{inferred type(s) 'tuple<tensor<f32>, tensor<f32>>' are incompatible with return type(s) of operation 'tuple<tensor<f32>, tensor<i32>>'}}
   %0 = "stablehlo.tuple"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tuple<tensor<f32>, tensor<i32>>
   func.return %0 : tuple<tensor<f32>, tensor<i32>>
 }

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -2598,7 +2598,7 @@ func.func @tuple_arg_size_mismatch(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tu
 // -----
 
 func.func @tuple_type_mismatch(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tuple<tensor<f32>, tensor<i32>> {
-  // expected-error@+1 {{op has return type mismatch at 1th value}}
+  // expected-error@+1 {{has return type mismatch at 1th value}}
   %0 = "stablehlo.tuple"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tuple<tensor<f32>, tensor<i32>>
   func.return %0 : tuple<tensor<f32>, tensor<i32>>
 }

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -2620,7 +2620,7 @@ func.func @get_tuple_element_token(%arg0: tuple<tensor<f32>, !stablehlo.token>) 
 // -----
 
 func.func @get_tuple_element_bad_type(%arg0: tuple<tensor<f32>, tensor<i32>>) -> tensor<i32> {
-  // expected-error@+1 {{has return type tensor<i32>, but expected tensor<f32>}}
+  // expected-error@+1 {{has return type 'tensor<i32>', but expected 'tensor<f32>'}}
   %0 = "stablehlo.get_tuple_element"(%arg0) {index = 0 : i32} : (tuple<tensor<f32>, tensor<i32>>) -> tensor<i32>
   func.return %0 : tensor<i32>
 }

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -2620,7 +2620,7 @@ func.func @get_tuple_element_token(%arg0: tuple<tensor<f32>, !stablehlo.token>) 
 // -----
 
 func.func @get_tuple_element_bad_type(%arg0: tuple<tensor<f32>, tensor<i32>>) -> tensor<i32> {
-  // expected-error@+1 {{has return type 'tensor<i32>', but expected 'tensor<f32>'}}
+  // expected-error@+1 {{inferred type(s) 'tensor<f32>' are incompatible with return type(s) of operation 'tensor<i32>'}}
   %0 = "stablehlo.get_tuple_element"(%arg0) {index = 0 : i32} : (tuple<tensor<f32>, tensor<i32>>) -> tensor<i32>
   func.return %0 : tensor<i32>
 }

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -3415,7 +3415,7 @@ func.func @bitcast_convert_width_mismatch(%arg: tensor<f32>) -> tensor<f64> {
 // -----
 
 func.func @bitcast_convert_empty_target(%arg: tensor<1xf64>) -> tensor<f32> {
-  // expected-error@+1 {{op does not allow the smaller element type to be part of a 0d tensor, but got: 'tensor<1xf64>' and 'tensor<f32>'.}}
+  // expected-error@+1 {{does not allow the smaller element type to be part of a 0d tensor, but got: 'tensor<1xf64>' and 'tensor<f32>'.}}
   %0 = "stablehlo.bitcast_convert"(%arg) : (tensor<1xf64>) -> tensor<f32>
   return %0 : tensor<f32>
 }
@@ -3423,7 +3423,7 @@ func.func @bitcast_convert_empty_target(%arg: tensor<1xf64>) -> tensor<f32> {
 // -----
 
 func.func @bitcast_convert_empty_operand(%arg: tensor<f32>) -> tensor<1xf64> {
-  // expected-error@+1 {{op does not allow the smaller element type to be part of a 0d tensor, but got: 'tensor<f32>' and 'tensor<1xf64>'.}}
+  // expected-error@+1 {{does not allow the smaller element type to be part of a 0d tensor, but got: 'tensor<f32>' and 'tensor<1xf64>'.}}
   %0 = "stablehlo.bitcast_convert"(%arg) : (tensor<f32>) -> tensor<1xf64>
   return %0 : tensor<1xf64>
 }


### PR DESCRIPTION
To continue deduplicate the verifiers and shape functions among StableHLO and MHLO, this PR, following https://github.com/openxla/stablehlo/pull/26, continue move 24 verifiers & shape functions from `StablehloOps.cc` to `TypeInference.h/cpp` with change to static methods and organize with alphabetical order.

This PR also includes:
1. Unify emit error methods with static `emitOptionalError()`
2. Similar to the discussion of https://github.com/openxla/stablehlo/issues/481, in the signuature of the new `inferAllToAllOp()`, I use `int64_t` instead of `uint64_t` to pass all the parameters to avoid verbose "static_cast to int" for each of attr in the method body. 
5. **Few or trivial tests changes**: No semantic changes or optimization.

Includes moves for (they are select in the first half of code for `StablehloOps.cc`) : strikethrough means the verifiers are merged into corresponding shape functions.
1. inferAbsOp
1. inferAllToAllOp
1. inferBroadcastOp
1. inferCholeskyOp
1. inferClampOp
1. inferComplexOp
1. inferConstant
1. inferDynamicSliceOp
1. inferIsFiniteOp
1. inferRealOp
1. inferGetTupleElementOp
1. inferTupleOp
1. verifyAllReduceOp
1. verifyBitcastConvertOp
1. ~~verifyBroadcastOp~~
1. verifyBroadcastInDimOp
1. ~~verifyClampOp~~
1. verifyCollectivePermuteOp
1. verifyDynamicBroadcastInDimOp
1. verifyDynamicReshapeOp
1. ~~verifyDynamicSliceOp~~
1. ~~verifyGetTupleElementOp~~
1. verifyIotaOp
1. verifyRealDynamicSliceOp
1. verifyReduceScatter
1. ~~verifyTupleOp~~

Expect there are ~30 methods remaining to be moved. Why not include them all before send this PR out? That will need more time and it's better to send PRs early and frequently to avoid code conflict burden.
