### PR TITLE
Add spec for GetDimensionSizeOp

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2833,7 +2833,7 @@ behavior is undefined. More formally, for all `id < jd` from `indices(result)`,
 
 ### Semantics
 
-Returns the size of the given `dimension` of the `operand`.
+Produces the size of the given `dimension` of the `operand`.
 
 ### Inputs
 
@@ -2850,8 +2850,7 @@ Returns the size of the given `dimension` of the `operand`.
 
 ### Constraints
 
-  * (C1) 0 $\le$ `dimension` $\lt$ rank of `operand`. [todo](https://github.com/openxla/stablehlo/issues/790)
-  * (C2) dim(operand, dimension) $\le$ std::numeric_limits<int32_t>::max(). [todo](https://github.com/openxla/stablehlo/issues/790)
+  * (C1) 0 $\le$ `dimension` $\lt$ `rank(operand)`. [todo](https://github.com/openxla/stablehlo/issues/790)
 
 ### Examples
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2837,10 +2837,10 @@ Returns the size of the given `dimension` of the `operand`.
 
 ### Inputs
 
-| Name      | Type                         |
-|-----------|------------------------------|
-| `operand` | tensor of any supported type |
-| `index`   | constant of type `si64`      |
+| Name          | Type                         |
+|---------------|------------------------------|
+| `operand`     | tensor of any supported type |
+| `dimension`   | constant of type `si64`      |
 
 ### Outputs
 
@@ -2852,7 +2852,6 @@ Returns the size of the given `dimension` of the `operand`.
 
   * (C1) 0 $\le$ `dimension` $\lt$ rank of `operand`. [todo](https://github.com/openxla/stablehlo/issues/790)
   * (C2) dim(operand, dimension) $\le$ std::numeric_limits<int32_t>::max(). [todo](https://github.com/openxla/stablehlo/issues/790)
-  * (C3) `result` is of type `tensor<i32>`
 
 ### Examples
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -413,6 +413,7 @@ syntax.
    * [fft](#stablehlofft)
    * [floor](#stablehlofloor)
    * [gather](#stablehlogather)
+   * [get_dimension_size](#stablehloget_dimension_size)
    * [get_tuple_element](#stablehloget_tuple_element)
    * [if](#stablehloif)
    * [imag](#stablehloimag)
@@ -2824,6 +2825,43 @@ behavior is undefined. More formally, for all `id < jd` from `indices(result)`,
 //              [[17, 18], [19, 20]]
 //            ]
 //          ]
+```
+
+[Back to Ops](#index-of-ops)
+
+## stablehlo.get_dimension_size
+
+### Semantics
+
+Returns the size of the given `dimension` of the `operand`.
+
+### Inputs
+
+| Name      | Type                         |
+|-----------|------------------------------|
+| `operand` | tensor of any supported type |
+| `index`   | constant of type `si64`      |
+
+### Outputs
+
+| Name     | Type                                |
+|----------|-------------------------------------|
+| `result` | 0-dimensional tensor of type `si32` |
+
+### Constraints
+
+  * (C1) 0 $\le$ `dimension` $\lt$ rank of `operand`. [todo](https://github.com/openxla/stablehlo/issues/790)
+  * (C2) dim(operand, dimension) $\le$ std::numeric_limits<int32_t>::max(). [todo](https://github.com/openxla/stablehlo/issues/790)
+  * (C3) `result` is of type `tensor<i32>`
+
+### Examples
+
+```mlir
+// %operand: [[1, 2, 3], [4, 5, 6]]
+%result = "stablehlo.get_dimension_size"(%operand) {
+  dimension = 1 : i64
+} : (tensor<2x3xf32>) -> tensor<i32>
+// %result: 3
 ```
 
 [Back to Ops](#index-of-ops)

--- a/docs/status.md
+++ b/docs/status.md
@@ -92,7 +92,7 @@ one of the following tracking labels.
 | fft                      | yes           | revisit      | yes            | yes             | no          |
 | floor                    | yes           | yes          | yes            | yes             | yes         |
 | gather                   | yes           | yes          | yes            | no              | no          |
-| get_dimension_size       | no            | yes\*        | yes\*          | yes             | no          |
+| get_dimension_size       | yes           | revisit      | yes            | yes             | no          |
 | get_tuple_element        | yes           | yes          | yes            | yes             | no          |
 | if                       | yes           | revisit      | yes            | no              | no          |
 | imag                     | yes           | yes          | yes            | yes             | no          |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2368,15 +2368,15 @@ def StableHLO_GetDimensionSizeOp: StableHLO_Op<"get_dimension_size", [Pure,
     DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
   let summary = "GetDimensionSize operator";
   let description = [{
-    Returns the size of the given dimension of the operand.
+    Returns the size of the given `dimension` of the `operand`.
 
     See
-    https://www.tensorflow.org/xla/operation_semantics#getdimensionsize.
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloget_dimension_size
 
     Example:
 
     ```mlir
-    %0 = stablehlo.get_dimension_size %arg0, dim = 1 : (tensor<4x2xf32>) -> tensor<i32>
+    %result = stablehlo.get_dimension_size %operand, dim = 1 : (tensor<2x3xf32>) -> tensor<i32>
     ```
   }];
   let arguments = (ins

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2368,7 +2368,7 @@ def StableHLO_GetDimensionSizeOp: StableHLO_Op<"get_dimension_size", [Pure,
     DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
   let summary = "GetDimensionSize operator";
   let description = [{
-    Returns the size of the given `dimension` of the `operand`.
+    Produces the size of the given `dimension` of the `operand`.
 
     See
     https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloget_dimension_size


### PR DESCRIPTION
Verification is missing two constraints. Filed https://github.com/openxla/stablehlo/issues/790 for that.

RFC discussing this op: https://github.com/openxla/stablehlo/pull/194