### PR TITLE
More MD syntax fixes, mostly line length

### DIFF
--- a/build_tools/README.md
+++ b/build_tools/README.md
@@ -3,30 +3,38 @@
 To build the code in this repository, you need a clone of the LLVM/MLIR
 git repository:
 
-`$ git clone https://github.com/llvm/llvm-project.git`
+```bash
+git clone https://github.com/llvm/llvm-project.git
+````
 
 You need to make sure you have the right commit checked out in
 the LLVM repository (you need to do this every time you pull from this repo):
 
-`$ (cd llvm-project && git fetch && git checkout $(cat ../build_tools/llvm_version.txt))`
+```bash
+(cd llvm-project && git fetch && git checkout $(cat ../build_tools/llvm_version.txt))
+```
 
 We provide a script to configure and build LLVM/MLIR:
 
-`$ build_tools/build_mlir.sh ${PWD}/llvm-project/ ${PWD}/llvm-build`
+```bash
+build_tools/build_mlir.sh ${PWD}/llvm-project/ ${PWD}/llvm-build
+````
 
 Again this is something to do every time you pull from this repository and the
 LLVM revision changes.
 
 Finally you can build and test this repository:
 
-```
-$ mkdir build && cd build
-$ cmake .. -GNinja \
-   -DLLVM_ENABLE_LLD=ON \
-   -DCMAKE_BUILD_TYPE=Release \
-   -DLLVM_ENABLE_ASSERTIONS=On \
-   -DMLIR_DIR=${PWD}/../llvm-build/lib/cmake/mlir
-$ ninja check-stablehlo
+```bash
+mkdir build && cd build
+
+cmake .. -GNinja \
+  -DLLVM_ENABLE_LLD=ON \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DLLVM_ENABLE_ASSERTIONS=On \
+  -DMLIR_DIR=${PWD}/../llvm-build/lib/cmake/mlir
+
+ninja check-stablehlo
 ```
 
 ## Python API
@@ -35,24 +43,28 @@ Note that the python package produced by this procedure includes the `mlir`
 package and is not suitable for deployment as-is (but it can be included into
 a larger aggregate).
 
-```
-$ mkdir build && cd build
-$ cmake -GNinja -B. ${PWD}/../llvm-project/llvm \
-   -DCMAKE_BUILD_TYPE=Release \
-   -DLLVM_ENABLE_PROJECTS=mlir \
-   -DLLVM_EXTERNAL_PROJECTS=stablehlo \
-   -DLLVM_EXTERNAL_STABLEHLO_SOURCE_DIR=${PWD}/.. \
-   -DLLVM_TARGETS_TO_BUILD=host \
-   -DPython3_EXECUTABLE=$(which python3) \
-   -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
-   -DSTABLEHLO_ENABLE_BINDINGS_PYTHON=ON
-$ ninja check-stablehlo-python
+```bash
+mkdir build && cd build
+
+cmake -GNinja -B. ${PWD}/../llvm-project/llvm \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DLLVM_ENABLE_PROJECTS=mlir \
+  -DLLVM_EXTERNAL_PROJECTS=stablehlo \
+  -DLLVM_EXTERNAL_STABLEHLO_SOURCE_DIR=${PWD}/.. \
+  -DLLVM_TARGETS_TO_BUILD=host \
+  -DPython3_EXECUTABLE=$(which python3) \
+  -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
+  -DSTABLEHLO_ENABLE_BINDINGS_PYTHON=ON
+
+ninja check-stablehlo-python
 ```
 
 Here's how you can use the Python bindings:
 
-```
-$ ninja StablehloUnifiedPythonModules
-$ export PYTHONPATH=$PWD/tools/stablehlo/python_packages/stablehlo
-$ python -c "import mlir.dialects.chlo; import mlir.dialects.stablehlo"
+```bash
+ninja StablehloUnifiedPythonModules
+
+export PYTHONPATH=$PWD/tools/stablehlo/python_packages/stablehlo
+
+python -c "import mlir.dialects.chlo; import mlir.dialects.stablehlo"
 ```

--- a/docs/bytecode.md
+++ b/docs/bytecode.md
@@ -4,10 +4,11 @@
 
 ### StableHLO Attributes and Types
 
-Documentation on the structure of the encoded attributes and types can be found in the
-following code comments:
+Documentation on the structure of the encoded attributes and types can be found
+in the following code comments:
 
-**Attributes:** See `stablehlo_encoding::AttributeCode` in `StablehloBytecode.cpp`
+**Attributes:** See `stablehlo_encoding::AttributeCode` in
+`StablehloBytecode.cpp`
 [[link](https://github.com/openxla/stablehlo/search?q=filename%3AStablehloBytecode+AttributeCode)]
 
 **Types:**
@@ -16,8 +17,8 @@ See `stablehlo_encoding::TypeCode` in `StablehloBytecode.cpp`
 
 ### CHLO Attributes and Types
 
-Documentation on the structure of the encoded attributes and types can be found in the
-following code comments:
+Documentation on the structure of the encoded attributes and types can be found
+in the following code comments:
 
 **Attributes:** See `chlo_encoding::AttributeCode` in `ChloBytecode.cpp`
 [[link](https://github.com/openxla/stablehlo/search?q=filename%3AChloBytecode+AttributeCode)]
@@ -67,11 +68,11 @@ into the bytecode implementations in the Builtin Dialect.
 **Special Cases:**
 
 - `StableHLO_ConvolutionAttributes`
-  + Despite its name,  is not an attribute and is not encoded.
+  - Despite its name,  is not an attribute and is not encoded.
     Rather, it is a dag which gets expanded into several attributes
     which are all encoded separately.
 - `StableHLO_CustomCallApiVersionAttr`
-  + This enum is defined strictly as an attribute of `I32EnumAttr`
+  - This enum is defined strictly as an attribute of `I32EnumAttr`
     and not an `EnumAttr` of the `StablehloDialect`. This differs from
    `FftType` and other enum attributes. Because of this, it is handled by
     the builtin encoding.
@@ -83,7 +84,7 @@ into the bytecode implementations in the Builtin Dialect.
 Testing that the round-trip of an MLIR file produces the same results is a good
 way to test that the bytecode is implemented properly.
 
-```
+```bash
 stablehlo-opt -emit-bytecode stablehlo/tests/print_stablehlo.mlir | stablehlo-opt
 ```
 
@@ -96,7 +97,7 @@ _Note: Currently all types/attrs are implemented and log only shows
 the dialect name `stablehlo` and the unregistered `stablehlo.frontend_attributes`
 and `stablehlo.sharding` attributes._
 
-```
+```bash
 $ stablehlo-opt -emit-bytecode file.mlir | strings | grep stablehlo
 stablehlo
 stablehlo.frontend_attributes
@@ -105,10 +106,12 @@ stablehlo.sharding
 
 ### Debugging Bytecode with Traces
 
-Each read/write function called during bytecoding is traced, and can be viewed using the flag `-debug-only=stablehlo-bytecode` for StableHLO and `-debug-only=chlo-bytecode` for CHLO.
+Each read/write function called during bytecoding is traced, and can be viewed
+using the flag `-debug-only=stablehlo-bytecode` for StableHLO and
+`-debug-only=chlo-bytecode` for CHLO.
 
-```
-stablehlo-opt -emit-bytecode -debug-only=stablehlo-bytecode ../tmp.mlir
+```bash
+$ stablehlo-opt -emit-bytecode -debug-only=stablehlo-bytecode ../tmp.mlir
 Called: writeType(mlir::Type, mlir::DialectBytecodeWriter &)::(anonymous class)::operator()(auto) const [type:auto = mlir::stablehlo::TokenType]
 Called: writeAttribute(mlir::Attribute, mlir::DialectBytecodeWriter &)::(anonymous class)::operator()(auto) const [attr:auto = mlir::stablehlo::TransposeAttr]
 Called: writeAttribute(mlir::Attribute, mlir::DialectBytecodeWriter &)::(anonymous class)::operator()(auto) const [attr:auto = mlir::stablehlo::RngAlgorithmAttr]
@@ -117,7 +120,7 @@ Called: writeAttribute(mlir::Attribute, mlir::DialectBytecodeWriter &)::(anonymo
 Called: writeAttribute(mlir::Attribute, mlir::DialectBytecodeWriter &)::(anonymous class)::operator()(auto) const [attr:auto = mlir::stablehlo::TypeExtensionsAttr]
 ...
 
-stablehlo-opt -emit-bytecode -debug-only=stablehlo-bytecode bytecoded_file.mlir
+$ stablehlo-opt -emit-bytecode -debug-only=stablehlo-bytecode bytecoded_file.mlir
 Called: readComparisonDirectionAttr(mlir::DialectBytecodeReader &) const
 Called: readTypeExtensionsAttr(mlir::DialectBytecodeReader &) const
 Called: readChannelHandleAttr(mlir::DialectBytecodeReader &) const
@@ -128,11 +131,14 @@ Called: readRngAlgorithmAttr(mlir::DialectBytecodeReader &) const
 ### Adding Bytecode for a New Type / Attribute
 
 Adding bytecode for a new type or attribute is simple. In the file
-`StablehloBytecode.cpp` or `ChloBytecode.cpp` search for the term `TO ADD ATTRIBUTE` or `TO ADD TYPE`
-depending on the change. Ensure that each location tagged with `TO ADD`
-instructions is addressed. If so, bytecode for the attr/type should be generated
-on next call to `stablehlo-opt -emit-bytecode`. This can be verified using the proper bytecode trace.
+`StablehloBytecode.cpp` or `ChloBytecode.cpp` search for the term `TO ADD
+ATTRIBUTE` or `TO ADD TYPE` depending on the change. Ensure that each location
+tagged with `TO ADD` instructions is addressed. If so, bytecode for the
+attr/type should be generated on next call to `stablehlo-opt -emit-bytecode`.
+This can be verified using the proper bytecode trace.
 
 ### Encoding `enum class` values
 
-Enum class values can be encoded as their underlying numeric types using `varint`. Currently all enums in StableHLO use `uint32_t` as the underlying value.
+Enum class values can be encoded as their underlying numeric types using
+`varint`. Currently all enums in StableHLO use `uint32_t` as the underlying
+value.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -37,9 +37,9 @@ which does the following:
 1. Tracks the SSA arguments of `func` and their associated runtime `Tensor`
    values, provided in `args`, using a symbol table map, M.
 2. Foreach op within `func` in their SSACFG order:
-   * Invokes `eval` on op. For each SSA operand of the op, extract its
-  runtime value from M to be provided as argument to the `eval` invocation.
-   * Tracks the SSA result(s) of the op and the evaluated value in M.
+   - Invokes `eval` on op. For each SSA operand of the op, extract its
+     runtime value from M to be provided as argument to the `eval` invocation.
+   - Tracks the SSA result(s) of the op and the evaluated value in M.
 
 The op-level `eval` as mentioned in (2) is responsible for implementing the
 execution semantics of the op. Following is an example for `stablehlo::AddOp`.

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,4 +1,4 @@
-# StableHLO progress
+# StableHLO status
 
 When bootstrapping StableHLO from MHLO, we have inherited MHLO's implementation
 of many things, including prettyprinting, verification and shape inference.

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,4 +1,4 @@
-## About
+# StableHLO progress
 
 When bootstrapping StableHLO from MHLO, we have inherited MHLO's implementation
 of many things, including prettyprinting, verification and shape inference.
@@ -10,7 +10,7 @@ This live document is for the developers and the users to track the progress on
 various aspects of the opset - specification, verification, type inference,
 pretty printing, interpreter, etc.
 
-### How to use it
+## How to use it
 
 The progress of a StableHLO op, as mentioned in the corresponding row, on a
 particular aspect, as mentioned in the corresponding column, is tracked using

--- a/docs/type_inference.md
+++ b/docs/type_inference.md
@@ -1,68 +1,127 @@
 # Type Inference
 
-StableHLO has been originally bootstrapped from [the MHLO dialect](https://github.com/tensorflow/mlir-hlo#meta-hlo-dialect-mhlo), including inheriting the implementation of type inference. The implementation progress is tracked in [status.md](https://github.com/openxla/stablehlo/blob/main/docs/status.md).
+StableHLO has been originally bootstrapped from
+[the MHLO dialect](https://github.com/tensorflow/mlir-hlo#meta-hlo-dialect-mhlo),
+including inheriting the implementation of type inference. The implementation
+progress is tracked in
+[status.md](https://github.com/openxla/stablehlo/blob/main/docs/status.md).
 
-To implement high-quality verifiers and shape functions for StableHLO ops, these guidelines are proposed below to follow:
+To implement high-quality verifiers and shape functions for StableHLO ops, these
+guidelines are proposed below to follow:
 
-# Proposal
+## Proposal
 
-These proposals apply to both revisiting existing implementations, and achieving new ops until a comprehensive coverage.
+These proposals apply to both revisiting existing implementations, and achieving
+new ops until a comprehensive coverage.
 
-## (P1) Use the StableHLO spec as the source of truth
+### (P1) Use the StableHLO spec as the source of truth
 
-The [spec](https://github.com/openxla/stablehlo/blob/main/docs/spec.md) is the source of truth for all verifiers and shape functions of the StableHLO ops. The existing verifiers and shape functions of every op need revisited to be fully aligned with the specification. Note that the specification document keeps evolving, in cases that the spec for an op is not available, the XLA implementation should be used as the source of truth instead: including [xla/service/shape\_inference.cc](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/xla/service/shape_inference.cc) and [xla/service/hlo\_verifier.cc](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/xla/service/hlo_verifier.cc). XLA implementation doesn't cover unbounded dynamism, so for unbounded dynamism we'll apply common sense until the dynamism RFC is available.
+The [spec](https://github.com/openxla/stablehlo/blob/main/docs/spec.md) is the
+source of truth for all verifiers and shape functions of the StableHLO ops. The
+existing verifiers and shape functions of every op need revisited to be fully
+aligned with the specification. Note that the specification document keeps
+evolving, in cases that the spec for an op is not available, the XLA
+implementation should be used as the source of truth instead: including
+[xla/service/shape\_inference.cc](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/xla/service/shape_inference.cc)
+and [xla/service/hlo\_verifier.cc](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/xla/service/hlo_verifier.cc).
+XLA implementation doesn't cover unbounded dynamism, so for unbounded dynamism
+we'll apply common sense until the dynamism RFC is available.
 
+### (P2) Make the most of ODS
 
-## (P2) Make the most of ODS
+ODS files (like
+[StablehloOps.td](https://github.com/openxla/stablehlo/blob/main/stablehlo/dialect/StablehloOps.td))
+define ops with traits and types for each operands/attributes/results and will
+do the verifications. Thus NO verification code needed in the verifiers or
+shape functions for the properties which are already guaranteed by the ODS.
+Remove the verification code if duplicated with ODS, as they will never be
+triggered.
 
-ODS files (like [StablehloOps.td](https://github.com/openxla/stablehlo/blob/main/stablehlo/dialect/StablehloOps.td)) define ops with traits and types for each operands/attributes/results and will do the verifications. Thus NO verification code needed in the verifiers or shape functions for the properties which are already guaranteed by the ODS.  Remove the verification code if duplicated with ODS, as they will never be triggered.
+Do we need adding tests for the constraints from the ODS? Please see “Establish
+testing guidelines” below.
 
-Do we need adding tests for the constraints from the ODS? Please see “Establish testing guidelines” below.
-
-
-## (P3) Maintain verification code in verifiers and shape functions
+### (P3) Maintain verification code in verifiers and shape functions
 
 Both:
 
 - **verifiers**: implemented by `Op::verify()`, and
-- **shape functions**: implemented by `InferTypeOpInterface` like `Op::inferReturnTypes()` or `Op::inferReturnTypeComponents`
+- **shape functions**: implemented by `InferTypeOpInterface` like
+    `Op::inferReturnTypes()` or `Op::inferReturnTypeComponents`
 
-may have verification code to check operands/attributes/results. An initial split would be that: let the verifiers check the operands/attributes, then let shape functions only calculate inferred result types and check the compatibility against the real result types. However, in reality this split has a few problems:
+may have verification code to check operands/attributes/results. An initial
+split would be that: let the verifiers check the operands/attributes, then let
+shape functions only calculate inferred result types and check the
+compatibility against the real result types. However, in reality this split has
+a few problems:
 
-- The shape function can be called by the autogenerated `build()` functions, without calling the verifier first. So the related inputs must be verified in shape function as well.
-- Duplicated code: for example in verifiers we do some processing on the operands then verify some intermediate results, then in shape functions these intermediate results are useful to infer the final results. These intermediate results have to be calculated twice.
-- Maintenance burden: as verifications of an op are contained in two different methods.
+- The shape function can be called by the autogenerated `build()` functions,
+  without calling the verifier first. So the related inputs must be verified in
+  shape function as well.
+- Duplicated code: for example in verifiers we do some processing on the
+  operands then verify some intermediate results, then in shape functions these
+  intermediate results are useful to infer the final results. These
+  intermediate results have to be calculated twice.
+- Maintenance burden: as verifications of an op are contained in two different
+  methods.
 
 The solution is as follows:
 
-1. **For most ops without regions** (like `PadOp`):
-Put all the verification code into the shape functions, and discard verifiers totally.
+1. **For most ops without regions** (like `PadOp`): Put all the verification
+code into the shape functions, and discard verifiers totally.
 
-2. **For ops with regions** (like `ReduceOp/IfOp`, a full list is [here](https://github.com/openxla/stablehlo/pull/401)): the autogenerated builders don't take regions as parameters, so if these builders involve type inference, then the shape function will be called with empty regions, for [example](https://github.com/tensorflow/mlir-hlo/blob/129ae36971a9e3e110d8b91b91a150942d13ff81/mhlo/transforms/mhlo_canonicalize_reduction/mhlo_canonicalize_reduction.cc#L221).
-    1. If the regions are not needed for type inference (like `ReduceOp`), put the region related verification logic in verifiers instead of the shape functions. Duplicate some code if it is inevitable.
-    2. If the regions are needed for type inference (`IfOp/CaseOp/MapOp`), then additionally the shape function must verify the regions are not empty explicitly, even though the ODS may already guarantee its existence in the Op definition.
+2. **For ops with regions** (like `ReduceOp/IfOp`, a full list is
+[here](https://github.com/openxla/stablehlo/pull/401)): the autogenerated
+builders don't take regions as parameters, so if these builders involve type
+inference, then the shape function will be called with empty regions, for
+[example](https://github.com/tensorflow/mlir-hlo/blob/129ae36971a9e3e110d8b91b91a150942d13ff81/mhlo/transforms/mhlo_canonicalize_reduction/mhlo_canonicalize_reduction.cc#L221).
 
+    1. If the regions are not needed for type inference (like `ReduceOp`), put
+    the region related verification logic in verifiers instead of the shape
+    functions. Duplicate some code if it is inevitable.
 
-## (P4) Establish testing guidelines
+    2. If the regions are needed for type inference (`IfOp/CaseOp/MapOp`), then
+    additionally the shape function must verify the regions are not empty
+    explicitly, even though the ODS may already guarantee its existence in the
+    Op definition.
+
+### (P4) Establish testing guidelines
 
 **Do we need to add/maintain tests for verifications that are covered by ODS?**
 
-We do not. The tests should focus on the verifiers and shape functions, while changes to ODS need a revisit of this op.
+We do not. The tests should focus on the verifiers and shape functions, while
+changes to ODS need a revisit of this op.
 
-But stay careful about the missing pieces: for example, if the op contains the trait `SameOperandsAndResultShape` which checks only shapes but not element type, then the verification for element types of operands/results still need tests.
+But stay careful about the missing pieces: for example, if the op contains the
+trait `SameOperandsAndResultShape` which checks only shapes but not element
+type, then the verification for element types of operands/results still need
+tests.
 
 **Where do we put tests for verifiers and type inference?**
 
-[ops\_stablehlo.mlir](https://github.com/openxla/stablehlo/blob/main/stablehlo/tests/ops_stablehlo.mlir) contains the positive cases of ops, and (at least) 1 negative test for every verification error. It is also able to check the inferred return type is **compatible** (not the same!) as the real result type.
+[ops\_stablehlo.mlir](https://github.com/openxla/stablehlo/blob/main/stablehlo/tests/ops_stablehlo.mlir)
+contains the positive cases of ops, and (at least) 1 negative test for every
+verification error. It is also able to check the inferred return type
+is **compatible** (not the same!) as the real result type.
 
-[infer\_stablehlo.mlir](https://github.com/openxla/stablehlo/blob/main/stablehlo/tests/infer_stablehlo.mlir) verifies the existence of the shape function of an op by line with `hlo_test_infer.get_return_type_components"(%x):...` and the inferred type matches exactly as expected. One positive test per op in general.
+[infer\_stablehlo.mlir](https://github.com/openxla/stablehlo/blob/main/stablehlo/tests/infer_stablehlo.mlir)
+verifies the existence of the shape function of an op by line with
+`hlo_test_infer.get_return_type_components"(%x):...` and the inferred type
+matches exactly as expected. One positive test per op in general.
 
-### What to do
+#### What to do
 
 When implementing or revisiting the verifier and/or shape function of an op:
 
-1. Put all positive cases and negative cases in [ops\_stablehlo.mlir](https://github.com/openxla/stablehlo/blob/main/stablehlo/tests/ops_stablehlo.mlir).
-2. Add a single positive test in [infer\_stablehlo.mlir](https://github.com/openxla/stablehlo/blob/main/stablehlo/tests/infer_stablehlo.mlir) to test the interface.
-3. (Optional) If an op is complicated and could contain a lot of tests, consider adding a separate test file named `verify_<op_name>.mlir` or `verify_<your_topic>.mlir` within the same folder.
+1. Put all positive cases and negative cases in
+[ops\_stablehlo.mlir](https://github.com/openxla/stablehlo/blob/main/stablehlo/tests/ops_stablehlo.mlir).
 
-Note: For now, the tests for new **bounded dynamism / sparsity** are also put in [infer\_stablehlo.mlir](https://github.com/openxla/stablehlo/blob/main/stablehlo/tests/infer_stablehlo.mlir).
+2. Add a single positive test in
+[infer\_stablehlo.mlir](https://github.com/openxla/stablehlo/blob/main/stablehlo/tests/infer_stablehlo.mlir)
+to test the interface.
+
+3. (Optional) If an op is complicated and could contain a lot of tests, consider
+adding a separate test file named `verify_<op_name>.mlir` or
+`verify_<your_topic>.mlir` within the same folder.
+
+Note: For now, the tests for new **bounded dynamism / sparsity** are also put in
+[infer\_stablehlo.mlir](https://github.com/openxla/stablehlo/blob/main/stablehlo/tests/infer_stablehlo.mlir).

--- a/rfcs/20220912-compatibility.md
+++ b/rfcs/20220912-compatibility.md
@@ -4,72 +4,176 @@ Status: Approved<br/>
 Initial version: 9/12/2022<br/>
 Last updated: 12/13/2022
 
-Based on discussions held over the past two months, and new use cases and feedback left in comments on the first revision of this RFC, we propose the following path forward for compatibility guarantees for StableHLO programs:
-- Proposal 1: Add StableHLO forks of modularity ops, as well as builtin/quant types and attributes. Maintain conversion patterns to their upstream equivalents.
+Based on discussions held over the past two months, and new use cases and
+feedback left in comments on the first revision of this RFC, we propose the
+following path forward for compatibility guarantees for StableHLO programs:
+
+- Proposal 1: Add StableHLO forks of modularity ops, as well as builtin/quant
+  types and attributes. Maintain conversion patterns to their upstream
+  equivalents.
 - Proposal 2: Use _Major.Minor.Patch_ versioning for StableHLO releases.
-- Proposal 3: Provide forward / backward compatibility within a major release, with major releases spaced at least 5 years apart. Additionally provide backward compatibility for serialized artifacts across 1 major release.
-- Proposal 4: Maintain a shallow versioned copy of StableHLO (VHLO) which is used for serialization/deserialization, and upgrade/downgrades. Keep the StableHLO opset at the latest version of VHLO.
+- Proposal 3: Provide forward / backward compatibility within a major release,
+  with major releases spaced at least 5 years apart. Additionally provide
+  backward compatibility for serialized artifacts across 1 major release.
+- Proposal 4: Maintain a shallow versioned copy of StableHLO (VHLO) which is
+  used for serialization/deserialization, and upgrade/downgrades. Keep the
+  StableHLO opset at the latest version of VHLO.
 
 ## StableHLO Programs
 
-For the purposes of compatibility guarantees, we define StableHLO programs as programs that only include ops, attributes, and types from the StableHLO opset. There will be several additions to the StableHLO opset to accomplish this goal of providing a self-contained opset that satisfies current use cases.
+For the purposes of compatibility guarantees, we define StableHLO programs as
+programs that only include ops, attributes, and types from the StableHLO opset.
+There will be several additions to the StableHLO opset to accomplish this goal
+of providing a self-contained opset that satisfies current use cases.
 
 These include:
+
 - Modularity ops: `ModuleOp`, `FuncOp`, `CallOp`.
 - Forks of types / attributes from Builtin and Quant dialect.
-- Additional new ops, attributes and types may be proposed and added by the Dynamism RFC, Sparsity RFC or other RFCs in the future.
+- Additional new ops, attributes and types may be proposed and added by the
+  Dynamism RFC, Sparsity RFC or other RFCs in the future.
 
-For all ops, attributes and types that are introduced in StableHLO but are not present in MHLO, a legalization to/from upstream dialects will be maintained. If incompatible changes are made upstream, legalization may fail, and the mismatch will need to be handled separately by the user (i.e. the producer will want to find a way to represent the upstream op in a different way using existing StableHLO ops, and the consumer will want to handle the StableHLO op directly).
+For all ops, attributes and types that are introduced in StableHLO but are not
+present in MHLO, a legalization to/from upstream dialects will be maintained.
+If incompatible changes are made upstream, legalization may fail, and the
+mismatch will need to be handled separately by the user (i.e. the producer will
+want to find a way to represent the upstream op in a different way using
+existing StableHLO ops, and the consumer will want to handle the StableHLO op
+directly).
 
-**Proposal 1:** Add StableHLO forks of modularity ops, as well as builtin/quant types and attributes. Maintain conversion patterns to their upstream equivalents.
+**Proposal 1:** Add StableHLO forks of modularity ops, as well as builtin/quant
+  types and attributes. Maintain conversion patterns to their upstream
+  equivalents.
 
 ## StableHLO Versioning
-StableHLO (opset, libStablehlo and serialization format) will version in compliance with [semver](https://semver.org/) (Semantic Versioning 2.0.0), with additions and modifications described in this section. Serialization format will be described in a future Serialization RFC in Q4 2022.
 
-**Major Version Bumps:** Backward incompatible changes will cause the major version to be bumped. This includes removing ops, and other semantic changes that prevent IR upgrades.
+StableHLO (opset, libStablehlo and serialization format) will version in
+compliance with [semver](https://semver.org/) (Semantic Versioning 2.0.0), with
+additions and modifications described in this section. Serialization format
+will be described in a future Serialization RFC in Q4 2022.
 
-**Minor Version Bumps:** Backward compatible changes will bump the minor version number. These changes may be forward compatible, depending on whether new semantics are introduced. This includes feature additions and feature renaming.
+**Major Version Bumps:** Backward incompatible changes will cause the major
+  version to be bumped. This includes removing ops, and other semantic changes
+  that prevent IR upgrades.
 
-**Patch Version Bumps:** All other changes will bump the patch version. This includes error message improvements, changing crashes into an error, doc improvements that occur between releases, prettyprint enhancements, and feature additions not related to the StableHLO opset such as new legalization passes or tooling improvements.
+**Minor Version Bumps:** Backward compatible changes will bump the minor version
+  number. These changes may be forward compatible, depending on whether new
+  semantics are introduced. This includes feature additions and feature
+  renaming.
 
-**StableHLO Releases:** Commits will be tagged with a release number at least once a week, and only after tests which verify compatibility have passed. Users are only guaranteed compatibility if using a tagged commit. If a commit is found to be broken, it will be flagged as invalid, and a patch release will be tagged as soon as possible.
+**Patch Version Bumps:** All other changes will bump the patch version. This
+  includes error message improvements, changing crashes into an error, doc
+  improvements that occur between releases, prettyprint enhancements, and
+  feature additions not related to the StableHLO opset such as new legalization
+  passes or tooling improvements.
 
-**Forward compatibility** will be provided at the serialization layer by allowing clients to target previous releases when a program only uses features compatible with a previous release. For example, if a program uses features (ops, attributes and/or types) compatible with `v0.9.0+`, `v1.1.0+` and `v1.2.0+`, then `v1.2.0` is the minimal version that the program is compatible with.
+**StableHLO Releases:** Commits will be tagged with a release number at least
+  once a week, and only after tests which verify compatibility have passed.
+  Users are only guaranteed compatibility if using a tagged commit. If a commit
+  is found to be broken, it will be flagged as invalid, and a patch release
+  will be tagged as soon as possible.
+
+**Forward compatibility** will be provided at the serialization layer by
+  allowing clients to target previous releases when a program only uses
+  features compatible with a previous release. For example, if a program uses
+  features (ops, attributes and/or types) compatible with `v0.9.0+`, `v1.1.0+`
+  and `v1.2.0+`, then `v1.2.0` is the minimal version that the program is
+  compatible with.
 
 **Proposal 2:** Use _Major.Minor.Patch_ versioning for StableHLO releases.
 
 ## Compatibility Guarantees
-**(G1) Backward compatibility:** StableHLO provides backward compatibility within major releases, i.e. StableHLO programs serialized by an old version of libStablehlo have the same semantics* when deserialized by new versions of libStablehlo within a major release. Additionally, any program serialized in major version `N` can be deserialized in major version `N+1`. The same is not true of serialization, as deprecated features in version `N+1` may prevent the serialization of a program.
 
-**(G2) Forward compatibility:** StableHLO provides forward compatibility within major releases when possible, and an additional 1 month between major releases, i.e. StableHLO programs serialized by a new version of libStablehlo have the same semantics when deserialized by old versions of libStablehlo within a major release, unless they are using new features introduced since the old version.
+**(G1) Backward compatibility:** StableHLO provides backward compatibility
+  within major releases, i.e. StableHLO programs serialized by an old version
+  of libStablehlo have the same semantics* when deserialized by new versions of
+  libStablehlo within a major release. Additionally, any program serialized in
+  major version `N` can be deserialized in major version `N+1`. The same is not
+  true of serialization, as deprecated features in version `N+1` may prevent
+  the serialization of a program.
 
-**(G3) Source compatibility** for C, C++ and Python APIs within libStablehlo is an aspirational goal. At the moment, we don't offer source compatibility guarantees, but please let us know if this is an important use case for you, and we can have a discussion about supporting it.
+**(G2) Forward compatibility:** StableHLO provides forward compatibility within
+  major releases when possible, and an additional 1 month between major
+  releases, i.e. StableHLO programs serialized by a new version of libStablehlo
+  have the same semantics when deserialized by old versions of libStablehlo
+  within a major release, unless they are using new features introduced since
+  the old version.
 
-**(G4) Version 0.x.x:** There will be some stability guarantees while in major version 0. There is not stability guaranteed within the major version, but we will provide 1 month of forward and backward compatibility between minor versions. This approach is chosen to allow dialect evolution and cleanup in the early days, as well as refine compatibility procedures while meeting the requirements of early adopters. Stability within major version will begin with version `1.x.x` and will happen in 2023.
+**(G3) Source compatibility** for C, C++ and Python APIs within libStablehlo is
+  an aspirational goal. At the moment, we don't offer source compatibility
+  guarantees, but please let us know if this is an important use case for you,
+  and we can have a discussion about supporting it.
 
-_*StableHLO semantics is defined by the StableHLO specification and can be tested using the StableHLO interpreter. Refer to the [StableHLO Specification](https://github.com/openxla/stablehlo/blob/main/docs/spec.md) for reference semantics._
+**(G4) Version 0.x.x:** There will be some stability guarantees while in major
+  version 0. There is not stability guaranteed within the major version, but we
+  will provide 1 month of forward and backward compatibility between minor
+  versions. This approach is chosen to allow dialect evolution and cleanup in
+  the early days, as well as refine compatibility procedures while meeting the
+  requirements of early adopters. Stability within major version will begin
+  with version `1.x.x` and will happen in 2023.
 
-**Proposal 3:** Provide forward / backward compatibility within a major release, with major releases happening at least 5 years apart. Additionally provide backward compatibility for serialized artifacts across 1 major release.
+_\*StableHLO semantics is defined by the StableHLO specification and can be
+   tested using the StableHLO interpreter. Refer to the
+   [StableHLO Specification](https://github.com/openxla/stablehlo/blob/main/docs/spec.md)
+   for reference semantics._
+
+**Proposal 3:** Provide forward / backward compatibility within a major release,
+  with major releases happening at least 5 years apart. Additionally provide
+  backward compatibility for serialized artifacts across 1 major release.
 
 ## What's not covered?
-**Bugs:** We may make backward incompatible changes if the current implementation is clearly broken, that is, if it contradicts the Operation's spec.
 
-**Unspecced features:** We may make backward incompatible changes to features which haven't been specced (see [StableHLO Specification](https://github.com/openxla/stablehlo/blob/main/docs/spec.md)).
+**Bugs:** We may make backward incompatible changes if the current
+  implementation is clearly broken, that is, if it contradicts the Operation's
+  spec.
 
-**Numerical accuracy:** StableHLO has multiple ops that have implementation-defined accuracy across consumers and even within the same consumer across versions. As a result, StableHLO doesn't aim to make any guarantees about numerical accuracy, although this may change in a future RFC.
+**Unspecced features:** We may make backward incompatible changes to features
+  which haven't been specced (see
+  [StableHLO Specification](https://github.com/openxla/stablehlo/blob/main/docs/spec.md)).
+
+**Numerical accuracy:** StableHLO has multiple ops that have
+  implementation-defined accuracy across consumers and even within the same
+  consumer across versions. As a result, StableHLO doesn't aim to make any
+  guarantees about numerical accuracy, although this may change in a future
+  RFC.
 
 ## Compatibility Implementation
 
 ### Upgrades and Downgrades
-To improve the experience of producers and consumers, we will keep the StableHLO dialect at the latest version of the opset, so that the dialect doesn't get polluted with compatibility constructs, e.g. `FooV2Op` ops. Backward and forward compatibility guarantees will be maintained via upgrade and downgrade hooks correspondingly, which will be run during serialization and deserialization as described below. Use cases requiring sending artifacts will be able specify a target version for serialization, so that artifacts can be shared and used on various versions of libStablehlo.
+
+To improve the experience of producers and consumers, we will keep the StableHLO
+dialect at the latest version of the opset, so that the dialect doesn't get
+polluted with compatibility constructs, e.g. `FooV2Op` ops. Backward and
+forward compatibility guarantees will be maintained via upgrade and downgrade
+hooks correspondingly, which will be run during serialization and
+deserialization as described below. Use cases requiring sending artifacts will
+be able specify a target version for serialization, so that artifacts can be
+shared and used on various versions of libStablehlo.
 
 ### The Versioned Dialect
-The versioned dialect is a shallow versioned copy of the StableHLO dialect which is used for upgrades, downgrades, and serialization/deserialization. Operations in this dialect use versioned attributes and types, equivalent to the op they are forked from, but do not have traits, custom verifiers, or prettyprinters, and they are unchanged after addition to the dialect. Upgrades and downgrades will be defined as conversion patterns on the versioned dialect. Serialization and deserialization of StableHLO dialect will involve legalization to and from the versioned dialect. Only the most recent version of an op is able to be legalized to the StableHLO dialect.
 
-The following demonstrates serialization on a `v0.5.0` producer that targets the `v0.3.0` opset, and is deserialized on a `v0.4.0` consumer:
+The versioned dialect is a shallow versioned copy of the StableHLO dialect which
+is used for upgrades, downgrades, and serialization/deserialization. Operations
+in this dialect use versioned attributes and types, equivalent to the op they
+are forked from, but do not have traits, custom verifiers, or prettyprinters,
+and they are unchanged after addition to the dialect. Upgrades and downgrades
+will be defined as conversion patterns on the versioned dialect. Serialization
+and deserialization of StableHLO dialect will involve legalization to and from
+the versioned dialect. Only the most recent version of an op is able to be
+legalized to the StableHLO dialect.
+
+The following demonstrates serialization on a `v0.5.0` producer that targets the
+`v0.3.0` opset, and is deserialized on a `v0.4.0` consumer:
 
 ![Version Dialect Roundtrip. Use 'View File' feature to load image properly.](images/20220912-compatibility/version_dialect.png)
 
-A new op is added to the versioned dialect at every bump in minor version number to reflect the backward compatible change made. Additionally, if an attribute or type used by an op is changed and requires a version bump, the op using it will also require a new version. The process of upgrading/downgrading versioned IR and legalizing to/from StableHLO must always succeed if compatibility guarantees are applicable.
+A new op is added to the versioned dialect at every bump in minor version number
+to reflect the backward compatible change made. Additionally, if an attribute
+or type used by an op is changed and requires a version bump, the op using it
+will also require a new version. The process of upgrading/downgrading versioned
+IR and legalizing to/from StableHLO must always succeed if compatibility
+guarantees are applicable.
 
-**Proposal 4:** Maintain a shallow versioned copy of StableHLO (VHLO) which is used for serialization/deserialization, and upgrade/downgrades. Keep the StableHLO opset at the latest version of VHLO.
+**Proposal 4:** Maintain a shallow versioned copy of StableHLO (VHLO) which is
+  used for serialization/deserialization, and upgrade/downgrades. Keep the
+  StableHLO opset at the latest version of VHLO.


### PR DESCRIPTION
More fixes for #792 with expanded scope to MD files not under /docs. (Still not touching the spec yet.)

This includes markdownlint fixes that could not be fixed by `markdownlint-cli`, such as line length (80 char), consistent list item indications, proper heading levels, removal of bash "$" character when not necessary ([rationale](https://cirosantilli.com/markdown-style-guide/#dollar-signs-in-shell-code); if the snippet includes multiple commands, then add a line break).
