### PR TITLE
Separate VhloTypes into separate tablegen file

### DIFF
--- a/stablehlo/dialect/VhloAttrs.td
+++ b/stablehlo/dialect/VhloAttrs.td
@@ -18,13 +18,24 @@ limitations under the License.
 #define STABLEHLO_DIALECT_VHLO_ATTRS
 
 include "stablehlo/dialect/VhloBase.td"
-include "stablehlo/dialect/VhloEnums.td"
 
 include "mlir/IR/AttrTypeBase.td"
 
 //===----------------------------------------------------------------------===//
 // Attribute Versioning
 //===----------------------------------------------------------------------===//
+
+def VHLO_VersionedAttrInterface : AttrInterface<"VersionedAttrInterface"> {
+  let cppNamespace = "::mlir::vhlo";
+  let methods = [
+    InterfaceMethod<
+      "Returns the minimum version of the VHLO dialect an attribute is supported in.",
+      "mlir::vhlo::Version", "getMinVersion">,
+    InterfaceMethod<
+      "Returns the maximum version (inclusive) of the VHLO dialect an attribute is supported in.",
+      "mlir::vhlo::Version", "getMaxVersion">,
+  ];
+}
 
 class VHLO_AttrDef<string name,
                    string minVersion = "0.3.0",

--- a/stablehlo/dialect/VhloBase.td
+++ b/stablehlo/dialect/VhloBase.td
@@ -17,70 +17,7 @@ limitations under the License.
 #ifndef STABLEHLO_DIALECT_VHLO_BASE
 #define STABLEHLO_DIALECT_VHLO_BASE
 
-include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/OpBase.td"
-
-//===----------------------------------------------------------------------===//
-// VHLO Versioning Interfaces
-//===----------------------------------------------------------------------===//
-
-def VersionedOpInterface : OpInterface<"VersionedOpInterface"> {
-  let methods = [
-    InterfaceMethod<
-      "Returns the minimum version of the VHLO dialect an op is supported in.",
-      "mlir::vhlo::Version", "getMinVersion">,
-    InterfaceMethod<
-      "Returns the maximum version (inclusive) of the VHLO dialect an op is supported in.",
-      "mlir::vhlo::Version", "getMaxVersion">,
-  ];
-}
-
-def VHLO_VersionedAttrInterface : AttrInterface<"VersionedAttrInterface"> {
-  let cppNamespace = "::mlir::vhlo";
-  let methods = [
-    InterfaceMethod<
-      "Returns the minimum version of the VHLO dialect an attribute is supported in.",
-      "mlir::vhlo::Version", "getMinVersion">,
-    InterfaceMethod<
-      "Returns the maximum version (inclusive) of the VHLO dialect an attribute is supported in.",
-      "mlir::vhlo::Version", "getMaxVersion">,
-  ];
-}
-
-def VHLO_VersionedTypeInterface : TypeInterface<"VersionedTypeInterface"> {
-  let cppNamespace = "::mlir::vhlo";
-  let methods = [
-    InterfaceMethod<
-      "Returns the minimum version of the VHLO dialect an attribute is supported in.",
-      "mlir::vhlo::Version", "getMinVersion">,
-    InterfaceMethod<
-      "Returns the maximum version (inclusive) of the VHLO dialect an attribute is supported in.",
-      "mlir::vhlo::Version", "getMaxVersion">,
-  ];
-}
-
-//===----------------------------------------------------------------------===//
-// VHLO Type Versioning
-//===----------------------------------------------------------------------===//
-
-class VHLO_TypeDef<string name,
-                   string minVersion = "0.3.0",
-                   string maxVersion = "current">
-  : TypeDef<VHLO_Dialect, name, [VHLO_VersionedTypeInterface]> {
-  let extraClassDeclaration = [{
-    mlir::vhlo::Version getMinVersion() {
-      auto version = mlir::vhlo::Version::fromString("}] #  minVersion # [{");
-      if (failed(version)) llvm_unreachable("invalid version }] # minVersion # [{ in }] # name # [{");
-      return *version;
-    }
-    mlir::vhlo::Version getMaxVersion() {
-      if (!strcmp("}] # maxVersion # [{", "current")) return VhloDialect::getCurrentVersion();
-      auto version = mlir::vhlo::Version::fromString("}] #  maxVersion # [{");
-      if (failed(version)) llvm_unreachable("invalid version }] # maxVersion # [{ in }] # name # [{");
-      return *version;
-    }
-  }];
-}
 
 //===----------------------------------------------------------------------===//
 // VHLO Type Definitions.
@@ -90,11 +27,6 @@ class VHLO_TypeDef<string name,
 def VHLO_AnyType : AnyTypeOf<[AnyType]>;
 def VHLO_AnyAttr : AnyAttrOf<[AnyAttr]>;
 def VHLO_AnyRegion : Region<CPred<"true">, "any region">;
-
-// Token type.
-def VHLO_Token : VHLO_TypeDef<"Token"> {
-  let mnemonic = "token";
-}
 
 //===----------------------------------------------------------------------===//
 // VHLO traits

--- a/stablehlo/dialect/VhloEnums.td
+++ b/stablehlo/dialect/VhloEnums.td
@@ -18,10 +18,10 @@ limitations under the License.
 #define STABLEHLO_DIALECT_VHLO_ENUMS
 
 include "stablehlo/dialect/VhloBase.td"
+include "stablehlo/dialect/VhloAttrs.td"
 
 include "mlir/IR/EnumAttr.td"
 include "mlir/IR/PatternBase.td"
-
 
 //===----------------------------------------------------------------------===//
 // Enum Versioning

--- a/stablehlo/dialect/VhloOps.td
+++ b/stablehlo/dialect/VhloOps.td
@@ -43,8 +43,20 @@ def VHLO_Dialect : Dialect {
   let useDefaultTypePrinterParser = 0;
 }
 
+include "stablehlo/dialect/VhloTypes.td"
 include "stablehlo/dialect/VhloEnums.td"
 include "stablehlo/dialect/VhloAttrs.td"
+
+def VersionedOpInterface : OpInterface<"VersionedOpInterface"> {
+  let methods = [
+    InterfaceMethod<
+      "Returns the minimum version of the VHLO dialect an op is supported in.",
+      "mlir::vhlo::Version", "getMinVersion">,
+    InterfaceMethod<
+      "Returns the maximum version (inclusive) of the VHLO dialect an op is supported in.",
+      "mlir::vhlo::Version", "getMaxVersion">,
+  ];
+}
 
 // Most ops should not use traits. Exceptions are:
 // - ReturnOp needs a trait for Terminator.

--- a/stablehlo/dialect/VhloTypes.td
+++ b/stablehlo/dialect/VhloTypes.td
@@ -1,0 +1,68 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+   Copyright 2022 The StableHLO Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef STABLEHLO_DIALECT_VHLO_TYPES
+#define STABLEHLO_DIALECT_VHLO_TYPES
+
+include "stablehlo/dialect/VhloBase.td"
+
+include "mlir/IR/AttrTypeBase.td"
+
+//===----------------------------------------------------------------------===//
+// VHLO Type Versioning
+//===----------------------------------------------------------------------===//
+
+def VHLO_VersionedTypeInterface : TypeInterface<"VersionedTypeInterface"> {
+  let cppNamespace = "::mlir::vhlo";
+  let methods = [
+    InterfaceMethod<
+      "Returns the minimum version of the VHLO dialect an attribute is supported in.",
+      "mlir::vhlo::Version", "getMinVersion">,
+    InterfaceMethod<
+      "Returns the maximum version (inclusive) of the VHLO dialect an attribute is supported in.",
+      "mlir::vhlo::Version", "getMaxVersion">,
+  ];
+}
+
+class VHLO_TypeDef<string name,
+                   string minVersion = "0.3.0",
+                   string maxVersion = "current">
+  : TypeDef<VHLO_Dialect, name, [VHLO_VersionedTypeInterface]> {
+  let extraClassDeclaration = [{
+    mlir::vhlo::Version getMinVersion() {
+      auto version = mlir::vhlo::Version::fromString("}] #  minVersion # [{");
+      if (failed(version)) llvm_unreachable("invalid version }] # minVersion # [{ in }] # name # [{");
+      return *version;
+    }
+    mlir::vhlo::Version getMaxVersion() {
+      if (!strcmp("}] # maxVersion # [{", "current")) return VhloDialect::getCurrentVersion();
+      auto version = mlir::vhlo::Version::fromString("}] #  maxVersion # [{");
+      if (failed(version)) llvm_unreachable("invalid version }] # maxVersion # [{ in }] # name # [{");
+      return *version;
+    }
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// VHLO Type Definitions.
+//===----------------------------------------------------------------------===//
+
+// Token type.
+def VHLO_Token : VHLO_TypeDef<"Token"> {
+  let mnemonic = "token";
+}
+
+#endif // STABLEHLO_DIALECT_VHLO_TYPES


### PR DESCRIPTION
This is similar to how MHLO manages their custom types in [hlo_ops_typedefs.td](https://github.com/tensorflow/mlir-hlo/blob/master/mhlo/IR/hlo_ops_typedefs.td). 

These typedefs will also grow in upcoming submissions as other types are forked.

This allows us to use `VhloBase.td` as a tablegen target in a bazel build since it does not have complicated dependencies (adding typedefs makes a new dependency to VHLO_Dialect from VhloOps.td).