### PR TITLE
Disable shape functions for ConvolutionOp, DotOp and DotGeneralOp

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -68,7 +68,7 @@ one of the following tracking labels.
 | concatenate              | yes           | yes          | yes            | yes             | no          |
 | constant                 | yes           | yes          | yes            | yes             | yes         |
 | convert                  | yes           | yes          | infeasible     | yes             | no          |
-| convolution              | revisit       | yes          | revisit        | revisit         | no          |
+| convolution              | revisit       | yes          | infeasible     | revisit         | no          |
 | cosine                   | yes           | yes          | yes            | yes             | yes         |
 | count_leading_zeros      | yes           | yes          | yes            | yes             | no          |
 | create_token             | no            | yes\*        | yes\*          | yes             | no          |
@@ -76,8 +76,8 @@ one of the following tracking labels.
 | cstr_reshapable          | no            | revisit      | no             | yes             | no          |
 | custom_call              | yes           | yes          | infeasible     | yes             | no          |
 | divide                   | yes           | yes          | yes            | yes             | no          |
-| dot                      | no            | revisit      | revisit        | yes             | no          |
-| dot_general              | yes           | revisit      | revisit        | no              | no          |
+| dot                      | no            | revisit      | infeasible     | yes             | no          |
+| dot_general              | yes           | revisit      | infeasible     | no              | no          |
 | dynamic_broadcast_in_dim | no            | revisit      | infeasible     | no              | no          |
 | dynamic_conv             | no            | revisit      | no             | no              | no          |
 | dynamic_gather           | no            | revisit      | revisit        | no              | no          |

--- a/stablehlo/dialect/AssemblyFormat.cpp
+++ b/stablehlo/dialect/AssemblyFormat.cpp
@@ -312,11 +312,24 @@ std::string dimSizeToString(int64_t dimSize) {
   return std::to_string(dimSize);
 }
 
-void printDimSizes(AsmPrinter& p, llvm::ArrayRef<int64_t> dimSizes) {
-  p << '[';
-  llvm::interleaveComma(
-      dimSizes, p, [&p](int64_t dimSize) { p << dimSizeToString(dimSize); });
-  p << ']';
+template <typename Stream>
+void printDimSizes(Stream& stream, ArrayRef<int64_t> dimSizes) {
+  stream << '[';
+  llvm::interleaveComma(dimSizes, stream, [&](int64_t dimSize) {
+    stream << dimSizeToString(dimSize);
+  });
+  stream << ']';
+}
+
+std::string dimSizesToString(ArrayRef<int64_t> dimSizes) {
+  std::string buffer;
+  llvm::raw_string_ostream os(buffer);
+  printDimSizes(os, dimSizes);
+  return buffer;
+}
+
+void printDimSizes(AsmPrinter& p, ArrayRef<int64_t> dimSizes) {
+  printDimSizes<AsmPrinter>(p, dimSizes);
 }
 
 FailureOr<SmallVector<int64_t>> parseDimSizes(AsmParser& parser) {

--- a/stablehlo/dialect/AssemblyFormat.h
+++ b/stablehlo/dialect/AssemblyFormat.h
@@ -180,6 +180,7 @@ ParseResult parseDenseI64Array(OpAsmParser& parser, DenseIntElementsAttr& attr);
 //   Custom:
 //     [1, ?]
 std::string dimSizeToString(int64_t dimSize);
+std::string dimSizesToString(llvm::ArrayRef<int64_t> dimSize);
 
 void printDimSizes(AsmPrinter& p, llvm::ArrayRef<int64_t> dimSizes);
 

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2059,7 +2059,7 @@ def StableHLO_CollectivePermuteOp: StableHLO_Op<"collective_permute",
       "::mlir::DenseIntElementsAttr":$source_target_pairs)>];
 }
 
-def StableHLO_ConvolutionOp : StableHLO_Op<"convolution", [Pure, InferTensorType]> {
+def StableHLO_ConvolutionOp : StableHLO_Op<"convolution", [Pure]> {
   let summary = "Convolution operator";
   let description = [{
     Computes dot products between windows of `lhs` and slices of `rhs` and
@@ -2090,15 +2090,13 @@ def StableHLO_ConvolutionOp : StableHLO_Op<"convolution", [Pure, InferTensorType
     StableHLO_ConvolutionAttributes.attributes);
 
   let results = (outs HLO_Tensor);
+  let hasVerifier = 1;
 
   let extraClassDeclaration = [{
     bool hasWindowReversal() {
       auto reversal = getWindowReversalAttr();
       return reversal && llvm::any_of(reversal.getValues<bool>(),
                                       [](bool v) { return v; });
-    }
-    static bool isCompatibleReturnTypes(TypeRange l, TypeRange r) {
-      return succeeded(mlir::verifyCompatibleShapes(l, r));
     }
   }];
 
@@ -2186,8 +2184,7 @@ def StableHLO_CustomCallOp: StableHLO_Op<"custom_call",
   }];
 }
 
-def StableHLO_DotOp: StableHLO_Op<"dot",
-    [Pure, DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
+def StableHLO_DotOp: StableHLO_Op<"dot", [Pure]> {
   let summary = "Dot operator";
   let description = [{
     Performs dot products between vectors, vector/matrix and matrix/matrix
@@ -2208,12 +2205,7 @@ def StableHLO_DotOp: StableHLO_Op<"dot",
     StableHLO_PrecisionConfigAttr:$precision_config
   );
   let results = (outs HLO_Tensor);
-
-  let extraClassDeclaration = [{
-    static bool isCompatibleReturnTypes(TypeRange l, TypeRange r) {
-      return succeeded(mlir::verifyCompatibleShapes(l, r));
-    }
-  }];
+  let hasVerifier = 1;
 
   // Use empty `` to prevent extra whitespace before precision config.
   let assemblyFormat = [{
@@ -2222,8 +2214,7 @@ def StableHLO_DotOp: StableHLO_Op<"dot",
   }];
 }
 
-def StableHLO_DotGeneralOp: StableHLO_ShapedInterfaceOp<"dot_general",
-    [Pure, InferTensorTypeWithReify]> {
+def StableHLO_DotGeneralOp: StableHLO_ShapedInterfaceOp<"dot_general", [Pure]> {
   let summary = "General Dot operator";
   let description = [{
     Computes dot products between slices of `lhs` and slices of `rhs` and
@@ -2253,12 +2244,7 @@ def StableHLO_DotGeneralOp: StableHLO_ShapedInterfaceOp<"dot_general",
   );
 
   let results = (outs HLO_Tensor);
-
-  let extraClassDeclaration = [{
-    static bool isCompatibleReturnTypes(TypeRange l, TypeRange r) {
-      return succeeded(mlir::verifyCompatibleShapes(l, r));
-    }
-  }];
+  let hasVerifier = 1;
 }
 
 // Define Base Einsum op within the HLO dialect as these are client ops and

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2300,13 +2300,15 @@ LogicalResult verifyDotOp(Optional<Location> location, Value lhs, Value rhs,
   auto lhsType = lhs.getType().dyn_cast<RankedTensorType>();
   auto rhsType = rhs.getType().dyn_cast<RankedTensorType>();
   auto resultType = result.getType().dyn_cast<RankedTensorType>();
-  if (!lhsType || !rhsType || !resultType) return success();
+  if (!lhsType || !rhsType) return success();
 
   SmallVector<int64_t> inferredShape;
   if (failed(inferDotShape(lhsType, rhsType, inferredShape)))
-    return emitOptionalError(location, "failed to infer shape");
+    return emitOptionalError(location, "failed to infer shape for lhs ",
+                             lhsType, " and rhs ", rhsType);
 
-  if (failed(verifyCompatibleShape(inferredShape, resultType.getShape())))
+  if (resultType &&
+      failed(verifyCompatibleShape(inferredShape, resultType.getShape())))
     return emitOptionalError(
         location, "inferred shape '", dimSizesToString(inferredShape), "' ",
         "is incompatible with return type of operation ", resultType, "");

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -96,6 +96,11 @@ bool compatibleShapeAndElementType(Type type1, Type type2,
                                type2.cast<ShapedType>(), ignoreFpPrecision);
 }
 
+bool verifyCompatibleDims(int64_t dimSize1, int64_t dimSize2) {
+  return hlo::isDynamicDimSize(dimSize1) || hlo::isDynamicDimSize(dimSize2) ||
+         dimSize1 == dimSize2;
+}
+
 // Convert a 1D dense int64 attribute to a list of values.
 FailureOr<SmallVector<int64_t>> convert1DAttribute(
     Optional<DenseIntElementsAttr> optionalAttr, Optional<Location> loc,
@@ -680,6 +685,231 @@ LogicalResult verifyRegionNotEmpty(Optional<Location> location,
   return success();
 }
 
+// Checks:
+//  P1. Same sizes for input, kernel and output spatialDims.
+//  P2. Spatial and non-spatial dimentions (for input,kernel, &output) should
+//      be unique and in range [0, num_dims), where num_dims = rank of input
+//      (lhs/rhs) tensors.
+//
+//  Note that the spatial + non-spatial dimensions may not cover all the
+//  dimensions in the range [0,num) because of the presence of 'unknown'
+//  dimensions (ref. `printConvolutionDimensions()`)
+LogicalResult isSpatialDimensionsValid(
+    Value lhs, int64_t inputBatchDimension, int64_t inputFeatureDimension,
+    ArrayRef<int64_t> inputSpatialDimensions,
+    int64_t kernelInputFeatureDimension, int64_t kernelOutputFeatureDimension,
+    ArrayRef<int64_t> kernelSpatialDimensions, int64_t outputBatchDimension,
+    int64_t outputFeatureDimension, ArrayRef<int64_t> outputSpatialDimensions,
+    Optional<Location> location) {
+  uint64_t spatialDimNum = inputSpatialDimensions.size();
+  // P1.
+  if ((spatialDimNum != kernelSpatialDimensions.size()) ||
+      (spatialDimNum != outputSpatialDimensions.size()))
+    return emitOptionalError(location,
+                             "expects the same size for input, kernel "
+                             "and output spatial-dimensions, but got ",
+                             spatialDimNum, ", ",
+                             kernelSpatialDimensions.size(), ", and ",
+                             outputSpatialDimensions.size(), " resp.");
+
+  // P2.
+  SmallVector<int64_t> inputDimNums(spatialDimNum + 2);
+  inputDimNums[0] = inputBatchDimension;
+  inputDimNums[1] = inputFeatureDimension;
+  std::copy(inputSpatialDimensions.begin(), inputSpatialDimensions.end(),
+            inputDimNums.begin() + 2);
+
+  SmallVector<int64_t> windowDimNums(spatialDimNum + 2);
+  windowDimNums[0] = kernelInputFeatureDimension;
+  windowDimNums[1] = kernelOutputFeatureDimension;
+  std::copy(kernelSpatialDimensions.begin(), kernelSpatialDimensions.end(),
+            windowDimNums.begin() + 2);
+
+  SmallVector<int64_t> OutputDimNums(spatialDimNum + 2);
+  OutputDimNums[0] = outputBatchDimension;
+  OutputDimNums[1] = outputFeatureDimension;
+  std::copy(outputSpatialDimensions.begin(), outputSpatialDimensions.end(),
+            OutputDimNums.begin() + 2);
+
+  auto numDims = lhs.getType().cast<RankedTensorType>().getRank();
+  const auto inRange = [numDims](int64_t i) { return 0 <= i && i < numDims; };
+
+  if (!llvm::all_of(inputDimNums, inRange) ||
+      !llvm::all_of(windowDimNums, inRange) ||
+      !llvm::all_of(OutputDimNums, inRange))
+    return emitOptionalError(location,
+                             "expects input, kernel, and output "
+                             "dimension-numbers to be in-range [0, ",
+                             numDims, ").");
+
+  if (hasDuplicates(inputDimNums))
+    return emitOptionalError(
+        location, "expects input dimension-numbers to be unique, got {",
+        inputDimNums, "}.");
+
+  if (hasDuplicates(windowDimNums))
+    return emitOptionalError(
+        location, "expects kernel dimension-numbers to be unique, got {",
+        windowDimNums, "}.");
+
+  if (hasDuplicates(OutputDimNums))
+    return emitOptionalError(
+        location, "expects output dimension-numbers to be unique, got {",
+        OutputDimNums, "}.");
+
+  return success();
+}
+
+// Verifies the following properties:
+//  P1. The input, kernel, and output spatial-dimentions are valid.
+//  P2. Given,
+//          input-dimensions: b * input-spatial-dims * f
+//          kernel-dimensions: kernel-spatial-dims * i * o
+//          output-dimensions: b' * out-spatial-dims * f'
+//            where b = input-batch-dim
+//            where f = input-feature-dim
+//            where i = kernel-input-feature-dim
+//            where o = kernel-output-feature-dim
+//            where b' = output-batch-dim
+//            where f' = output-feature-dim
+//      Check the following properties w.r.t feature_group_count (fgc) and
+//      batch_group_count (bgc).
+//        * fgc > 0, bgc > 0 and !(fgc > 1 && bgc > 1)
+//        * dim(lhs, b) % bgc == 0
+//        * dim(lhs, f) % fgc == 0 and
+//          dim(lhs, f) / fgc = dim(rhs, i)
+//        * dim(rhs, o) (or dim(output, f')) % bgc == 0 and
+//          dim(rhs, o) (or dim(output, f')) % fgc == 0
+LogicalResult verifyConvolutionAttributes(
+    Value lhs, Value rhs, int64_t inputBatchDimension,
+    int64_t inputFeatureDimension, ArrayRef<int64_t> inputSpatialDimensions,
+    int64_t kernelInputFeatureDimension, int64_t kernelOutputFeatureDimension,
+    ArrayRef<int64_t> kernelSpatialDimensions, int64_t outputBatchDimension,
+    int64_t outputFeatureDimension, ArrayRef<int64_t> outputSpatialDimensions,
+    int64_t featureGroupCount, int64_t batchGroupCount,
+    Optional<Location> location) {
+  // P1.
+  if (failed(isSpatialDimensionsValid(
+          lhs, inputBatchDimension, inputFeatureDimension,
+          inputSpatialDimensions, kernelInputFeatureDimension,
+          kernelOutputFeatureDimension, kernelSpatialDimensions,
+          outputBatchDimension, outputFeatureDimension, outputSpatialDimensions,
+          location)))
+    return failure();
+
+  // P2.
+  if (featureGroupCount <= 0)
+    return emitOptionalError(
+        location, "expects feature_group_count to be a positive number, got ",
+        featureGroupCount, ".");
+
+  if (batchGroupCount <= 0)
+    return emitOptionalError(
+        location, "expects batch_group_count to be a positive number, got ",
+        batchGroupCount, ".");
+
+  if (batchGroupCount > 1 && featureGroupCount > 1)
+    return emitOptionalError(
+        location,
+        "expects batch_group_count and feature_group_count not to be both "
+        "greater than 1. Got ",
+        batchGroupCount, " and ", featureGroupCount, " resp.");
+
+  auto lhsType = lhs.getType().cast<RankedTensorType>();
+  const int64_t inputFeatures = lhsType.getShape()[inputFeatureDimension];
+  const int64_t inputBatch = lhsType.getShape()[inputBatchDimension];
+
+  auto rhsType = rhs.getType().cast<RankedTensorType>();
+  const int64_t kernelInputFeatures =
+      rhsType.getShape()[kernelInputFeatureDimension];
+  const int64_t kernelOutputFeatures =
+      rhsType.getShape()[kernelOutputFeatureDimension];
+
+  if (!hlo::isDynamicDimSize(kernelOutputFeatures)) {
+    if (kernelOutputFeatures % batchGroupCount != 0)
+      return emitOptionalError(
+          location, "expects output feature dimension size (",
+          kernelOutputFeatures,
+          ") to be a multiple of batch_group_count. Got batch_group_count = ",
+          batchGroupCount, ".");
+
+    if (kernelOutputFeatures % featureGroupCount != 0)
+      return emitOptionalError(location,
+                               "expects kernel output feature dimension (",
+                               kernelOutputFeatures,
+                               ") to be divisible by feature_group_count. For "
+                               "feature_group_count = ",
+                               featureGroupCount, ".");
+  }
+
+  if (!hlo::isDynamicDimSize(inputFeatures)) {
+    if (inputFeatures % featureGroupCount != 0)
+      return emitOptionalError(location, "expects input feature dimension (",
+                               inputFeatures,
+                               ") to be a multiple of feature_group_count. Got "
+                               "feature_group_count = ",
+                               featureGroupCount, ".");
+
+    if (!hlo::isDynamicDimSize(kernelInputFeatures) &&
+        inputFeatures / featureGroupCount != kernelInputFeatures)
+      return emitOptionalError(
+          location, "expects input feature dimension (", inputFeatures,
+          ") / "
+          "feature_group_count = kernel input feature dimension (",
+          kernelInputFeatures,
+          "). Got feature_group_count = ", featureGroupCount, ".");
+  }
+
+  if (!hlo::isDynamicDimSize(inputBatch) && inputBatch % batchGroupCount != 0)
+    return emitOptionalError(location, "expects input batch dimension (",
+                             inputBatch,
+                             ") to be divisible by "
+                             "batch_group_count. Got batch_group_count = ",
+                             batchGroupCount, ".");
+
+  return success();
+}
+
+// Checks if the precision config has a valid size, if provided.
+LogicalResult verifyPrecisionConfig(Optional<Location> loc,
+                                    Optional<ArrayAttr> maybeArrayAttr) {
+  if (!maybeArrayAttr.has_value()) return success();
+  auto arrayAttr = maybeArrayAttr.value();
+  return !arrayAttr || arrayAttr.size() == 2 || arrayAttr.empty()
+             ? success()
+             : emitOptionalError(
+                   loc, "expects precision config to be null or of size 2.");
+}
+
+LogicalResult inferDotShape(RankedTensorType lhs, RankedTensorType rhs,
+                            SmallVector<int64_t>& result) {
+  // vector dot vector
+  if (1 == lhs.getRank() && 1 == rhs.getRank() &&
+      verifyCompatibleDims(lhs.getDimSize(0), rhs.getDimSize(0))) {
+    return success();
+  }
+  // matrix dot vector
+  if (2 == lhs.getRank() && 1 == rhs.getRank() &&
+      verifyCompatibleDims(lhs.getDimSize(1), rhs.getDimSize(0))) {
+    result.push_back(lhs.getDimSize(0));
+    return success();
+  }
+  // vector dot matrix
+  if (1 == lhs.getRank() && 2 == rhs.getRank() &&
+      verifyCompatibleDims(lhs.getDimSize(0), rhs.getDimSize(0))) {
+    result.push_back(rhs.getDimSize(1));
+    return success();
+  }
+  // matrix dot matrix
+  if (2 == lhs.getRank() && 2 == rhs.getRank() &&
+      verifyCompatibleDims(lhs.getDimSize(1), rhs.getDimSize(0))) {
+    result.push_back(lhs.getDimSize(0));
+    result.push_back(rhs.getDimSize(1));
+    return success();
+  }
+  return failure();
+}
+
 //===----------------------------------------------------------------------===//
 // Shape functions for ops.
 //===----------------------------------------------------------------------===//
@@ -1060,133 +1290,6 @@ LogicalResult inferCreateTokenOp(Dialect* dialect, Optional<Location> location,
                                  SmallVectorImpl<Type>& inferredReturnTypes) {
   auto hloDialect = cast<HloDialectInterface>(dialect);
   inferredReturnTypes.push_back(hloDialect->createTokenType());
-  return success();
-}
-
-LogicalResult inferDotGeneralOp(
-    Optional<Location> location, Value lhs, Value rhs,
-    ArrayRef<int64_t> lhsBatchingDimensions,
-    ArrayRef<int64_t> rhsBatchingDimensions,
-    ArrayRef<int64_t> lhsContractingDimensions,
-    ArrayRef<int64_t> rhsContractingDimensions,
-    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
-  if (lhsBatchingDimensions.size() != rhsBatchingDimensions.size())
-    return emitOptionalError(location,
-                             "lhs and rhs should have the same "
-                             "number of batching dimensions");
-  if (lhsContractingDimensions.size() != rhsContractingDimensions.size())
-    return emitOptionalError(location,
-                             "lhs and rhs should have the same "
-                             "number of contracting dimensions");
-
-  llvm::SmallDenseSet<int64_t> dimSet;
-  auto checkDimsDistinct =
-      [&](ArrayRef<int64_t> batchingDims, ArrayRef<int64_t> contractingDims,
-          llvm::SmallDenseSet<int64_t>& dimSet, llvm::StringRef lhs,
-          llvm::StringRef rhs) -> LogicalResult {
-    auto dims = llvm::concat<const int64_t>(batchingDims, contractingDims);
-    for (auto dim : dims) {
-      auto [_, wasInserted] = dimSet.insert(dim);
-      if (!wasInserted)
-        return emitOptionalError(location, "has duplicated dimension from ",
-                                 lhs, " and ", rhs, ": ", dim);
-    }
-    return success();
-  };
-
-  if (failed(checkDimsDistinct(lhsBatchingDimensions, lhsContractingDimensions,
-                               dimSet, "lhs_batching_dimensions",
-                               "lhs_contracting_dimensions")))
-    return failure();
-
-  dimSet.clear();
-
-  if (failed(checkDimsDistinct(rhsBatchingDimensions, rhsContractingDimensions,
-                               dimSet, "rhs_batching_dimensions",
-                               "rhs_contracting_dimensions")))
-    return failure();
-
-  auto checkDimsInRange = [&](int64_t rank, ArrayRef<int64_t> dims,
-                              llvm::StringRef dimName) -> LogicalResult {
-    auto inRange = [&](int64_t i) -> bool { return 0 <= i && i < rank; };
-    const auto* dimsNotInRange =
-        std::find_if_not(dims.begin(), dims.end(), inRange);
-    if (dimsNotInRange != dims.end())
-      return emitOptionalError(location, dimName, " value: ", *dimsNotInRange,
-                               " is out of range: ", "[0, ", rank, ")");
-    return success();
-  };
-  auto lhsRankedType = lhs.getType().dyn_cast<RankedTensorType>();
-  auto rhsRankedType = rhs.getType().dyn_cast<RankedTensorType>();
-
-  if (lhsRankedType) {
-    if (failed(checkDimsInRange(lhsRankedType.getRank(), lhsBatchingDimensions,
-                                "lhs_batching_dimensions")) ||
-        failed(checkDimsInRange(lhsRankedType.getRank(),
-                                lhsContractingDimensions,
-                                "lhs_contracting_dimensions")))
-      return failure();
-  }
-  if (rhsRankedType) {
-    if (failed(checkDimsInRange(rhsRankedType.getRank(), rhsBatchingDimensions,
-                                "rhs_batching_dimensions")) ||
-        failed(checkDimsInRange(rhsRankedType.getRank(),
-                                rhsContractingDimensions,
-                                "rhs_contracting_dimensions")))
-      return failure();
-  }
-  if (lhsRankedType && rhsRankedType) {
-    // Dimension sizes must be compatible for lhs/rhs.
-    auto lhsShape = lhsRankedType.getShape();
-    auto rhsShape = rhsRankedType.getShape();
-
-    for (auto [lhs, rhs] :
-         llvm::zip(lhsBatchingDimensions, rhsBatchingDimensions)) {
-      if (hlo::isDynamicDimSize(lhsShape[lhs])) continue;
-      if (hlo::isDynamicDimSize(rhsShape[rhs])) continue;
-      if (lhsShape[lhs] != rhsShape[rhs])
-        return emitOptionalError(location,
-                                 "batching dimension sizes must "
-                                 "match for lhs/rhs");
-    }
-
-    for (auto [lhs, rhs] :
-         llvm::zip(lhsContractingDimensions, rhsContractingDimensions)) {
-      if (hlo::isDynamicDimSize(lhsShape[lhs])) continue;
-      if (hlo::isDynamicDimSize(rhsShape[rhs])) continue;
-      if (lhsShape[lhs] != rhsShape[rhs])
-        return emitOptionalError(location,
-                                 "contracting dimension sizes must "
-                                 "match for lhs/rhs");
-    }
-  }
-
-  auto lhsType = lhs.getType().cast<ShapedType>();
-  auto rhsType = rhs.getType().cast<ShapedType>();
-  auto elementType = lhsType.getElementType();
-
-  if (!lhsType.hasRank() || !rhsType.hasRank()) {
-    inferredReturnShapes.emplace_back(elementType);
-    return success();
-  }
-
-  auto lhsShape = lhsType.getShape();
-  auto rhsShape = rhsType.getShape();
-
-  // Infer the output dimensions of the operation.
-  SmallVector<int64_t> dimensions;
-  for (const int64_t lhsBatchingDim : lhsBatchingDimensions)
-    dimensions.push_back(lhsShape[lhsBatchingDim]);
-  for (int64_t i = 0; i < lhsType.getRank(); i++)
-    if (!llvm::is_contained(lhsBatchingDimensions, i) &&
-        !llvm::is_contained(lhsContractingDimensions, i))
-      dimensions.push_back(lhsShape[i]);
-  for (int64_t i = 0; i < rhsType.getRank(); i++)
-    if (!llvm::is_contained(rhsBatchingDimensions, i) &&
-        !llvm::is_contained(rhsContractingDimensions, i))
-      dimensions.push_back(rhsShape[i]);
-
-  inferredReturnShapes.emplace_back(dimensions, elementType);
   return success();
 }
 
@@ -2066,6 +2169,280 @@ LogicalResult verifyCollectivePermuteOp(
         return emitOptionalError(location, "duplicate targets not allowed.");
     }
   }
+  return success();
+}
+
+/*
+ * We intend to verify the following properties
+ *  P1. Verify the input, kernel types.
+ *  P2. Verify the convolution atributes.
+ *  P3. Verify and collect the window atributes.
+ *  P4. Verify precision_config attribute.
+ *  P5. Verify the return shape.
+ *      TODO(b/232574102): Verify the element-type of return-value.
+ */
+LogicalResult verifyConvolutionOp(
+    Optional<Location> location, Value lhs, Value rhs,
+    Optional<DenseIntElementsAttr> windowStrides,
+    Optional<DenseIntElementsAttr> padding,
+    Optional<DenseIntElementsAttr> lhsDilation,
+    Optional<DenseIntElementsAttr> rhsDilation,
+    Optional<DenseElementsAttr> windowReversal, int64_t inputBatchDimension,
+    int64_t inputFeatureDimension, ArrayRef<int64_t> inputSpatialDimensions,
+    int64_t kernelInputFeatureDimension, int64_t kernelOutputFeatureDimension,
+    ArrayRef<int64_t> kernelSpatialDimensions, int64_t outputBatchDimension,
+    int64_t outputFeatureDimension, ArrayRef<int64_t> outputSpatialDimensions,
+    int64_t featureGroupCount, int64_t batchGroupCount,
+    Optional<ArrayAttr> precisionConfig, Value result) {
+  auto lhsType = lhs.getType().dyn_cast<RankedTensorType>();
+  auto rhsType = rhs.getType().dyn_cast<RankedTensorType>();
+  if (!lhsType || !rhsType) return success();
+
+  // P1.
+  int numDims = lhsType.getRank();
+  if (numDims != rhsType.getRank())
+    return emitOptionalError(location,
+                             "expects convolution arguments to have same "
+                             "number of dimensions. Got: ",
+                             lhsType, " and ", rhsType, ".");
+
+  if (numDims < 2)
+    return emitOptionalError(
+        location,
+        "expects convolution arguments to have >= 2 dimensions. Got: ", lhsType,
+        " and ", rhsType, ".");
+
+  // P2.
+  if (failed(verifyConvolutionAttributes(
+          lhs, rhs, inputBatchDimension, inputFeatureDimension,
+          inputSpatialDimensions, kernelInputFeatureDimension,
+          kernelOutputFeatureDimension, kernelSpatialDimensions,
+          outputBatchDimension, outputFeatureDimension, outputSpatialDimensions,
+          featureGroupCount, batchGroupCount, location)))
+    return failure();
+
+  if ((size_t)numDims != inputSpatialDimensions.size() + 2)
+    return emitOptionalError(location, "expects convolution arguments to have ",
+                             inputSpatialDimensions.size() + 2,
+                             " dimensions. Got: ", numDims);
+
+  // P3.
+  SmallVector<int64_t> windowDimensions(kernelSpatialDimensions.size());
+  for (size_t i = 0; i < windowDimensions.size(); i++)
+    windowDimensions[i] = rhsType.getShape()[kernelSpatialDimensions[i]];
+
+  auto paddingOrErr = hlo::convertPaddingAttribute(padding, location);
+  if (failed(paddingOrErr)) return failure();
+
+  // TODO: add missing tests for ConvolutionOp.
+  auto windowStridesOrErr =
+      hlo::convert1DAttribute(windowStrides, location, "window_strides");
+  if (failed(windowStridesOrErr)) return failure();
+  auto lhsDilationOrErr =
+      hlo::convert1DAttribute(lhsDilation, location, "lhs_dilation");
+  if (failed(lhsDilationOrErr)) return failure();
+  auto rhsDilationOrErr =
+      hlo::convert1DAttribute(rhsDilation, location, "rhs_dilation");
+  if (failed(rhsDilationOrErr)) return failure();
+  auto windowReversalOrErr = hlo::convertWindowReversalAttribute(
+      windowReversal, location, "window_reversal");
+  if (failed(windowReversalOrErr)) return failure();
+
+  auto windowOrErr = hlo::verifyWindowAttributesAndInferWindowDimensions(
+      windowDimensions, *windowStridesOrErr, *paddingOrErr, *lhsDilationOrErr,
+      *rhsDilationOrErr, *windowReversalOrErr, location);
+  if (failed(windowOrErr)) return failure();
+
+  // P3.
+  if (failed(verifyPrecisionConfig(location, precisionConfig)))
+    return failure();
+
+  // P5.
+  SmallVector<int64_t> outputDimensions(lhsType.getShape().size(),
+                                        ShapedType::kDynamic);
+
+  // Infer the output spatial dimensions.
+  auto numSpatialDims = inputSpatialDimensions.size();
+  SmallVector<int64_t> inputSpatialDimVals(numSpatialDims);
+  for (int64_t i = 0; i < static_cast<int64_t>(numSpatialDims); ++i)
+    inputSpatialDimVals[i] = lhsType.getShape()[inputSpatialDimensions[i]];
+
+  auto windowOutputShape =
+      hlo::inferWindowOutputShape(inputSpatialDimVals, *windowOrErr);
+
+  for (int64_t i = 0; i < static_cast<int64_t>(windowOrErr->size()); ++i)
+    outputDimensions[outputSpatialDimensions[i]] = windowOutputShape[i];
+
+  // Infer the output-batch-dimension and output-feature-dimension.
+  const int64_t inputBatch = lhsType.getShape()[inputBatchDimension];
+  const int64_t kernelOutputFeatures =
+      rhsType.getShape()[kernelOutputFeatureDimension];
+
+  outputDimensions[outputBatchDimension] = hlo::isDynamicDimSize(inputBatch)
+                                               ? ShapedType::kDynamic
+                                               : inputBatch / batchGroupCount;
+  outputDimensions[outputFeatureDimension] = kernelOutputFeatures;
+
+  auto resultType = result.getType().dyn_cast<RankedTensorType>();
+  if (!resultType) return success();
+
+  if (failed(verifyCompatibleShape(outputDimensions, resultType.getShape())))
+    return emitOptionalError(
+        location, "inferred shape '", dimSizesToString(outputDimensions), "' ",
+        "is incompatible with return type of operation ", resultType, "");
+
+  return success();
+}
+
+LogicalResult verifyDotOp(Optional<Location> location, Value lhs, Value rhs,
+                          Optional<ArrayAttr> /*precisionConfig*/,
+                          Value result) {
+  auto lhsType = lhs.getType().dyn_cast<RankedTensorType>();
+  auto rhsType = rhs.getType().dyn_cast<RankedTensorType>();
+  auto resultType = result.getType().dyn_cast<RankedTensorType>();
+  if (!lhsType || !rhsType || !resultType) return success();
+
+  SmallVector<int64_t> inferredShape;
+  if (failed(inferDotShape(lhsType, rhsType, inferredShape)))
+    return emitOptionalError(location, "failed to infer shape");
+
+  if (failed(verifyCompatibleShape(inferredShape, resultType.getShape())))
+    return emitOptionalError(
+        location, "inferred shape '", dimSizesToString(inferredShape), "' ",
+        "is incompatible with return type of operation ", resultType, "");
+
+  return success();
+}
+
+LogicalResult verifyDotGeneralOp(Optional<Location> location, Value lhs,
+                                 Value rhs,
+                                 ArrayRef<int64_t> lhsBatchingDimensions,
+                                 ArrayRef<int64_t> rhsBatchingDimensions,
+                                 ArrayRef<int64_t> lhsContractingDimensions,
+                                 ArrayRef<int64_t> rhsContractingDimensions,
+                                 Optional<ArrayAttr> precisionConfig,
+                                 Value result) {
+  if (failed(verifyPrecisionConfig(location, precisionConfig)))
+    return failure();
+
+  if (lhsBatchingDimensions.size() != rhsBatchingDimensions.size())
+    return emitOptionalError(location,
+                             "lhs and rhs should have the same "
+                             "number of batching dimensions");
+  if (lhsContractingDimensions.size() != rhsContractingDimensions.size())
+    return emitOptionalError(location,
+                             "lhs and rhs should have the same "
+                             "number of contracting dimensions");
+
+  llvm::SmallDenseSet<int64_t> dimSet;
+  auto checkDimsDistinct =
+      [&](ArrayRef<int64_t> batchingDims, ArrayRef<int64_t> contractingDims,
+          llvm::SmallDenseSet<int64_t>& dimSet, llvm::StringRef lhs,
+          llvm::StringRef rhs) -> LogicalResult {
+    auto dims = llvm::concat<const int64_t>(batchingDims, contractingDims);
+    for (auto dim : dims) {
+      auto [_, wasInserted] = dimSet.insert(dim);
+      if (!wasInserted)
+        return emitOptionalError(location, "has duplicated dimension from ",
+                                 lhs, " and ", rhs, ": ", dim);
+    }
+    return success();
+  };
+
+  if (failed(checkDimsDistinct(lhsBatchingDimensions, lhsContractingDimensions,
+                               dimSet, "lhs_batching_dimensions",
+                               "lhs_contracting_dimensions")))
+    return failure();
+
+  dimSet.clear();
+
+  if (failed(checkDimsDistinct(rhsBatchingDimensions, rhsContractingDimensions,
+                               dimSet, "rhs_batching_dimensions",
+                               "rhs_contracting_dimensions")))
+    return failure();
+
+  auto checkDimsInRange = [&](int64_t rank, ArrayRef<int64_t> dims,
+                              llvm::StringRef dimName) -> LogicalResult {
+    auto inRange = [&](int64_t i) -> bool { return 0 <= i && i < rank; };
+    const auto* dimsNotInRange =
+        std::find_if_not(dims.begin(), dims.end(), inRange);
+    if (dimsNotInRange != dims.end())
+      return emitOptionalError(location, dimName, " value: ", *dimsNotInRange,
+                               " is out of range: ", "[0, ", rank, ")");
+    return success();
+  };
+  auto lhsRankedType = lhs.getType().dyn_cast<RankedTensorType>();
+  auto rhsRankedType = rhs.getType().dyn_cast<RankedTensorType>();
+
+  if (lhsRankedType) {
+    if (failed(checkDimsInRange(lhsRankedType.getRank(), lhsBatchingDimensions,
+                                "lhs_batching_dimensions")) ||
+        failed(checkDimsInRange(lhsRankedType.getRank(),
+                                lhsContractingDimensions,
+                                "lhs_contracting_dimensions")))
+      return failure();
+  }
+  if (rhsRankedType) {
+    if (failed(checkDimsInRange(rhsRankedType.getRank(), rhsBatchingDimensions,
+                                "rhs_batching_dimensions")) ||
+        failed(checkDimsInRange(rhsRankedType.getRank(),
+                                rhsContractingDimensions,
+                                "rhs_contracting_dimensions")))
+      return failure();
+  }
+  if (lhsRankedType && rhsRankedType) {
+    // Dimension sizes must be compatible for lhs/rhs.
+    auto lhsShape = lhsRankedType.getShape();
+    auto rhsShape = rhsRankedType.getShape();
+
+    for (auto [lhs, rhs] :
+         llvm::zip(lhsBatchingDimensions, rhsBatchingDimensions)) {
+      if (hlo::isDynamicDimSize(lhsShape[lhs])) continue;
+      if (hlo::isDynamicDimSize(rhsShape[rhs])) continue;
+      if (lhsShape[lhs] != rhsShape[rhs])
+        return emitOptionalError(location,
+                                 "batching dimension sizes must "
+                                 "match for lhs/rhs");
+    }
+
+    for (auto [lhs, rhs] :
+         llvm::zip(lhsContractingDimensions, rhsContractingDimensions)) {
+      if (hlo::isDynamicDimSize(lhsShape[lhs])) continue;
+      if (hlo::isDynamicDimSize(rhsShape[rhs])) continue;
+      if (lhsShape[lhs] != rhsShape[rhs])
+        return emitOptionalError(location,
+                                 "contracting dimension sizes must "
+                                 "match for lhs/rhs");
+    }
+  }
+
+  auto lhsType = lhs.getType().dyn_cast<RankedTensorType>();
+  auto rhsType = rhs.getType().dyn_cast<RankedTensorType>();
+  auto resultType = result.getType().dyn_cast<RankedTensorType>();
+  if (!lhsType || !rhsType || !resultType) return success();
+
+  auto lhsShape = lhsType.getShape();
+  auto rhsShape = rhsType.getShape();
+  auto resultShape = resultType.getShape();
+
+  // Infer the output dimensions of the operation.
+  SmallVector<int64_t> dimensions;
+  for (const int64_t lhsBatchingDim : lhsBatchingDimensions)
+    dimensions.push_back(lhsShape[lhsBatchingDim]);
+  for (int64_t i = 0; i < lhsType.getRank(); i++)
+    if (!llvm::is_contained(lhsBatchingDimensions, i) &&
+        !llvm::is_contained(lhsContractingDimensions, i))
+      dimensions.push_back(lhsShape[i]);
+  for (int64_t i = 0; i < rhsType.getRank(); i++)
+    if (!llvm::is_contained(rhsBatchingDimensions, i) &&
+        !llvm::is_contained(rhsContractingDimensions, i))
+      dimensions.push_back(rhsShape[i]);
+
+  if (failed(verifyCompatibleShape(dimensions, resultShape)))
+    return emitOptionalError(
+        location, "inferred shape '", dimSizesToString(dimensions), "' ",
+        "is incompatible with return type of operation ", resultType, "");
+
   return success();
 }
 

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -165,14 +165,6 @@ LogicalResult inferConstantOp(Optional<Location>, ElementsAttr value,
 LogicalResult inferCreateTokenOp(Dialect* dialect, Optional<Location> location,
                                  SmallVectorImpl<Type>& inferredReturnTypes);
 
-LogicalResult inferDotGeneralOp(
-    Optional<Location> location, Value lhs, Value rhs,
-    ArrayRef<int64_t> lhsBatchingDimensions,
-    ArrayRef<int64_t> rhsBatchingDimensions,
-    ArrayRef<int64_t> lhsContractingDimensions,
-    ArrayRef<int64_t> rhsContractingDimensions,
-    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
-
 LogicalResult inferDynamicSliceOp(
     Optional<Location> location, Value operand, ValueRange startIndices,
     DenseIntElementsAttr sliceSizes,
@@ -296,6 +288,32 @@ LogicalResult verifyBroadcastInDimOp(Optional<Location> location, Value operand,
 
 LogicalResult verifyCollectivePermuteOp(Optional<Location> location,
                                         DenseIntElementsAttr sourceTargetPairs);
+
+LogicalResult verifyConvolutionOp(
+    Optional<Location> location, Value lhs, Value rhs,
+    Optional<DenseIntElementsAttr> windowStrides,
+    Optional<DenseIntElementsAttr> padding,
+    Optional<DenseIntElementsAttr> lhsDilation,
+    Optional<DenseIntElementsAttr> rhsDilation,
+    Optional<DenseElementsAttr> windowReversal, int64_t inputBatchDimension,
+    int64_t inputFeatureDimension, ArrayRef<int64_t> inputSpatialDimensions,
+    int64_t kernelInputFeatureDimension, int64_t kernelOutputFeatureDimension,
+    ArrayRef<int64_t> kernelSpatialDimensions, int64_t outputBatchDimension,
+    int64_t outputFeatureDimension, ArrayRef<int64_t> outputSpatialDimensions,
+    int64_t featureGroupCount, int64_t batchGroupCount,
+    Optional<ArrayAttr> precisionConfig, Value result);
+
+LogicalResult verifyDotOp(Optional<Location> location, Value lhs, Value rhs,
+                          Optional<ArrayAttr> precisionConfig, Value result);
+
+LogicalResult verifyDotGeneralOp(Optional<Location> location, Value lhs,
+                                 Value rhs,
+                                 ArrayRef<int64_t> lhsBatchingDimensions,
+                                 ArrayRef<int64_t> rhsBatchingDimensions,
+                                 ArrayRef<int64_t> lhsContractingDimensions,
+                                 ArrayRef<int64_t> rhsContractingDimensions,
+                                 Optional<ArrayAttr> precisionConfig,
+                                 Value result);
 
 LogicalResult verifyDynamicBroadcastInDimOp(
     Optional<Location> location, Value operand, Value outputDimensions,

--- a/stablehlo/tests/TestUtils.cpp
+++ b/stablehlo/tests/TestUtils.cpp
@@ -42,17 +42,6 @@ namespace hlo {
 
 namespace {
 
-// Convert dynamic dimensions to -1 for infer tests.
-std::string dimSizesToString(ArrayRef<int64_t> dimSizes) {
-  std::string buffer;
-  llvm::raw_string_ostream os(buffer);
-  os << '[';
-  llvm::interleaveComma(
-      dimSizes, os, [&](int64_t dimSize) { os << dimSizeToString(dimSize); });
-  os << ']';
-  return buffer;
-}
-
 struct InferReturnTypesPattern : public RewritePattern {
   explicit InferReturnTypesPattern(MLIRContext *context)
       : RewritePattern("hlo_test_infer.get_return_types", 1, context) {}

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -314,23 +314,6 @@ func.func @case(%index : tensor<i32>, %branch_operand : tensor<2xf32>) {
 
 // -----
 
-// CHECK-LABEL: func @dot_general
-func.func @dot_general(%arg0: tensor<2x3x4xf32>, %arg1: tensor<2x3x5xf32>) -> tensor<2x4x5xindex> {
-  %0 = "stablehlo.dot_general"(%arg0, %arg1) {
-    dot_dimension_numbers = #stablehlo.dot<
-      lhs_batching_dimensions = [0],
-      rhs_batching_dimensions = [0],
-      lhs_contracting_dimensions = [1],
-      rhs_contracting_dimensions = [1]
-    >
-  } : (tensor<2x3x4xf32>, tensor<2x3x5xf32>) -> tensor<2x4x5xf32>
-  %1 = "hlo_test_infer.get_return_type_components"(%0) : (tensor<2x4x5xf32>) -> tensor<2x4x5xindex>
-  // CHECK: %1 = "hlo_test_infer.return_type_components"(%0) {dims0 = "[2, 4, 5]", element_type0 = f32} : (tensor<2x4x5xf32>) -> tensor<2x4x5xindex>
-  func.return %1 : tensor<2x4x5xindex>
-}
-
-// -----
-
 // CHECK-LABEL: func @sort
 func.func @sort(%input0: tensor<16x16xf32>, %input1: tensor<16x16xi32>) {
   %0:2 = "stablehlo.sort"(%input0, %input1) ({
@@ -381,36 +364,6 @@ func.func @while(%arg0: tensor<4xf32>, %arg1: tensor<f32>, %arg2: tensor<f32>, %
   // CHECK: (tensor<i32>) -> tensor<index>
   %6 = "hlo_test_infer.get_return_type_components"(%1#2) : (tensor<i32>) -> tensor<index>
   func.return %4 : tensor<index>
-}
-
-// -----
-
-// CHECK-LABEL: func @convolution
-func.func @convolution(%arg0 : tensor<100x26x26x32xf32>, %arg1 : tensor<3x3x1x32xf32>) ->
-    tensor<100x28x28x1xindex> {
-  %result = "stablehlo.convolution"(%arg0, %arg1) {
-    batch_group_count = 1 : i64,
-    dimension_numbers = #stablehlo.conv<raw
-      input_batch_dimension = 0,
-      input_feature_dimension = 3,
-      input_spatial_dimensions = [1, 2],
-      kernel_input_feature_dimension = 3,
-      kernel_output_feature_dimension = 2,
-      kernel_spatial_dimensions = [0, 1],
-      output_batch_dimension = 0,
-      output_feature_dimension = 3,
-      output_spatial_dimensions = [1, 2]
-    >,
-    feature_group_count = 1 : i64,
-    lhs_dilation = dense<1> : tensor<2xi64>,
-    padding = dense<2> : tensor<2x2xi64>,
-    rhs_dilation = dense<1> : tensor<2xi64>,
-    window_strides = dense<1> : tensor<2xi64>
-  } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>) -> tensor<100x28x28x1xf32>
-
-  // CHECK: (tensor<100x28x28x1xf32>) -> tensor<100x28x28x1xindex>
-  %1 = "hlo_test_infer.get_return_type_components"(%result) : (tensor<100x28x28x1xf32>) -> tensor<100x28x28x1xindex>
-  func.return %1 : tensor<100x28x28x1xindex>
 }
 
 // -----

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -1505,10 +1505,25 @@ func.func @dot_more_dynamic_output_type(%arg0: tensor<3xf32>, %arg1: tensor<?x3x
 
 // -----
 
-func.func @dot_illegal_result_type(%arg0: tensor<?x3xf32>, %arg1: tensor<3xf32>) -> tensor<3x?xf32> {
+func.func @dot_cannot_infer_type(%arg0: tensor<?x?x3xf32>, %arg1: tensor<?x3x?xf32>) -> tensor<*xf32> {
+  // expected-error@+1 {{failed to infer shape for lhs 'tensor<?x?x3xf32>' and rhs 'tensor<?x3x?xf32>'}}
+  %0 = "stablehlo.dot"(%arg0, %arg1) : (tensor<?x?x3xf32>, tensor<?x3x?xf32>) -> tensor<*xf32>
+  func.return %0 : tensor<*xf32>
+}
+
+// -----
+
+func.func @dot_result_type_mismatch_with_inferred_type(%arg0: tensor<?x3xf32>, %arg1: tensor<3xf32>) -> tensor<3x?xf32> {
   // expected-error@+1 {{inferred shape '[?]' is incompatible with return type of operation 'tensor<3x?xf32>'}}
   %0 = "stablehlo.dot"(%arg0, %arg1) : (tensor<?x3xf32>, tensor<3xf32>) -> tensor<3x?xf32>
   func.return %0 : tensor<3x?xf32>
+}
+
+// -----
+
+func.func @dot_result_type_match_with_inferred_type(%arg0: tensor<?x3xf32>, %arg1: tensor<3xf32>) -> tensor<*xf32> {
+  %0 = "stablehlo.dot"(%arg0, %arg1) : (tensor<?x3xf32>, tensor<3xf32>) -> tensor<*xf32>
+  func.return %0 : tensor<*xf32>
 }
 
 // -----

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -1506,7 +1506,7 @@ func.func @dot_more_dynamic_output_type(%arg0: tensor<3xf32>, %arg1: tensor<?x3x
 // -----
 
 func.func @dot_illegal_result_type(%arg0: tensor<?x3xf32>, %arg1: tensor<3xf32>) -> tensor<3x?xf32> {
-// expected-error@+1 {{'stablehlo.dot' op inferred type(s) 'tensor<?xf32>' are incompatible with return type(s) of operation 'tensor<3x?xf32>'}}
+  // expected-error@+1 {{inferred shape '[?]' is incompatible with return type of operation 'tensor<3x?xf32>'}}
   %0 = "stablehlo.dot"(%arg0, %arg1) : (tensor<?x3xf32>, tensor<3xf32>) -> tensor<3x?xf32>
   func.return %0 : tensor<3x?xf32>
 }
@@ -3295,7 +3295,7 @@ func.func @dot_general(%arg0: tensor<?x2x?xf32>, %arg1: tensor<?x3x?xf32>) {
 
 // CHECK-LABEL: func @dot_general
 func.func @dot_general(%arg0: tensor<2x3x4xf32>, %arg1: tensor<2x3x5xf32>) -> tensor<2x4x6xf32> {
-  // expected-error@+1 {{'stablehlo.dot_general' op inferred type(s) 'tensor<2x4x5xf32>' are incompatible with return type(s) of operation 'tensor<2x4x6xf32>'}}
+  // expected-error@+1 {{inferred shape '[2, 4, 5]' is incompatible with return type of operation 'tensor<2x4x6xf32>'}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
       lhs_batching_dimensions = [0],

--- a/stablehlo/tests/verify_conv.mlir
+++ b/stablehlo/tests/verify_conv.mlir
@@ -626,7 +626,7 @@ func.func @invalid_conv_window_attributes(%arg0: tensor<1x8x8x207xf32>,
 
 func.func @invalid_conv_return_type(%arg0: tensor<1x8x8x207xf32>,
     %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x16xf32> {
-  // expected-error @+1 {{inferred type(s) 'tensor<1x8x8x16xf32>' are incompatible with return type(s) of operation 'tensor<1x8x16xf32>'}}
+  // expected-error @+1 {{inferred shape '[1, 8, 8, 16]' is incompatible with return type of operation 'tensor<1x8x16xf32>'}}
   %0 = stablehlo.convolution(%arg0, %arg1)
          dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
          window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
@@ -647,7 +647,7 @@ func.func @invalid_conv_return_type(%arg0: tensor<1x8x8x207xf32>,
 
 func.func @invalid_conv_return_type(%arg0: tensor<1x8x8x207xf32>,
     %arg1: tensor<3x3x207x16xf32>) -> tensor<2x8x8x16xf32> {
-  // expected-error@+1 {{inferred type(s) 'tensor<1x8x8x16xf32>' are incompatible with return type(s) of operation 'tensor<2x8x8x16xf32>'}}
+  // expected-error@+1 {{inferred shape '[1, 8, 8, 16]' is incompatible with return type of operation 'tensor<2x8x8x16xf32>'}}
   %0 = stablehlo.convolution(%arg0, %arg1)
          dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
          window = {stride = [1, 1], pad = [[1, 1], [1,1]],
@@ -668,7 +668,7 @@ func.func @invalid_conv_return_type(%arg0: tensor<1x8x8x207xf32>,
 
 func.func @invalid_conv_return_type(%arg0: tensor<1x8x8x207xf32>,
     %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x32xf32> {
-  // expected-error@+1 {{inferred type(s) 'tensor<1x8x8x16xf32>' are incompatible with return type(s) of operation 'tensor<1x8x8x32xf32>'}}
+  // expected-error@+1 {{inferred shape '[1, 8, 8, 16]' is incompatible with return type of operation 'tensor<1x8x8x32xf32>'}}
   %0 = stablehlo.convolution(%arg0, %arg1)
          dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
          window = {stride = [1, 1], pad = [[1, 1], [1,1]],
@@ -691,7 +691,7 @@ func.func @invalid_conv_return_type(%arg0: tensor<1x8x8x207xf32>,
 // Dynamic input-batch-dimension
 func.func @invalid_conv_dynamic_shapes(%arg0: tensor<?x8x8x207xf32>,
     %arg1: tensor<3x3x207x16xf32>) -> tensor<1x1x1x1xf32> {
-  // expected-error@+1 {{inferred type(s) 'tensor<?x8x8x16xf32>' are incompatible with return type(s) of operation 'tensor<1x1x1x1xf32>'}}
+  // expected-error@+1 {{inferred shape '[?, 8, 8, 16]' is incompatible with return type of operation 'tensor<1x1x1x1xf32>'}}
   %0 = stablehlo.convolution(%arg0, %arg1)
          dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
          window = {stride = [1, 1], pad = [[1, 1], [1,1]],
@@ -710,7 +710,7 @@ func.func @invalid_conv_dynamic_shapes(%arg0: tensor<?x8x8x207xf32>,
 // Dynamic input-feature-dimension: No effect on output dimensions.
 func.func @invalid_conv_dynamic_shapes(%arg0: tensor<1x8x8x?xf32>,
     %arg1: tensor<3x3x207x16xf32>) -> tensor<1x1x1x1xf32> {
-  // expected-error@+1 {{inferred type(s) 'tensor<1x8x8x16xf32>' are incompatible with return type(s) of operation 'tensor<1x1x1x1xf32>'}}
+  // expected-error@+1 {{inferred shape '[1, 8, 8, 16]' is incompatible with return type of operation 'tensor<1x1x1x1xf32>'}}
   %0 = stablehlo.convolution(%arg0, %arg1)
          dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
          window = {stride = [1, 1], pad = [[1, 1], [1,1]],
@@ -729,7 +729,7 @@ func.func @invalid_conv_dynamic_shapes(%arg0: tensor<1x8x8x?xf32>,
 // Dynamic input-spatial-dimension
 func.func @invalid_conv_dynamic_shapes(%arg0: tensor<1x?x8x207xf32>,
     %arg1: tensor<3x3x207x16xf32>) -> tensor<1x1x1x1xf32> {
-  // expected-error@+1 {{inferred type(s) 'tensor<1x?x8x16xf32>' are incompatible with return type(s) of operation 'tensor<1x1x1x1xf32>'}}
+  // expected-error@+1 {{inferred shape '[1, ?, 8, 16]' is incompatible with return type of operation 'tensor<1x1x1x1xf32>'}}
   %0 = stablehlo.convolution(%arg0, %arg1)
          dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
          window = {stride = [1, 1], pad = [[1, 1], [1,1]],
@@ -748,7 +748,7 @@ func.func @invalid_conv_dynamic_shapes(%arg0: tensor<1x?x8x207xf32>,
 // Dynamic kernel-input-feature-dimension: No effect on output dimensions.
 func.func @invalid_conv_dynamic_shapes(%arg0: tensor<1x8x8x207xf32>,
     %arg1: tensor<3x3x?x16xf32>) -> tensor<1x1x1x1xf32> {
-  // expected-error@+1 {{inferred type(s) 'tensor<1x8x8x16xf32>' are incompatible with return type(s) of operation 'tensor<1x1x1x1xf32>'}}
+  // expected-error@+1 {{inferred shape '[1, 8, 8, 16]' is incompatible with return type of operation 'tensor<1x1x1x1xf32>'}}
   %0 = stablehlo.convolution(%arg0, %arg1)
          dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
          window = {stride = [1, 1], pad = [[1, 1], [1,1]],
@@ -767,7 +767,7 @@ func.func @invalid_conv_dynamic_shapes(%arg0: tensor<1x8x8x207xf32>,
 // Dynamic kernel-output-feature-dimension
 func.func @check_inferred_type_with_dynamic_input_dims(%arg0: tensor<1x8x8x207xf32>,
     %arg1: tensor<3x3x207x?xf32>) -> tensor<1x1x1x1xf32> {
-  // expected-error@+1 {{inferred type(s) 'tensor<1x8x8x?xf32>' are incompatible with return type(s) of operation 'tensor<1x1x1x1xf32>'}}
+  // expected-error@+1 {{inferred shape '[1, 8, 8, ?]' is incompatible with return type of operation 'tensor<1x1x1x1xf32>'}}
   %0 = stablehlo.convolution(%arg0, %arg1)
          dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
          window = {stride = [1, 1], pad = [[1, 1], [1,1]],
@@ -786,7 +786,7 @@ func.func @check_inferred_type_with_dynamic_input_dims(%arg0: tensor<1x8x8x207xf
 // Dynamic kernel-spatial-dimension
 func.func @check_inferred_type_with_dynamic_input_dims(%arg0: tensor<1x8x8x207xf32>,
     %arg1: tensor<3x?x207x16xf32>) -> tensor<1x1x1x1xf32> {
-  // expected-error@+1 {{inferred type(s) 'tensor<1x8x?x16xf32>' are incompatible with return type(s) of operation 'tensor<1x1x1x1xf32>'}}
+  // expected-error@+1 {{inferred shape '[1, 8, ?, 16]' is incompatible with return type of operation 'tensor<1x1x1x1xf32>'}}
   %0 = stablehlo.convolution(%arg0, %arg1)
          dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
          window = {stride = [1, 1], pad = [[1, 1], [1,1]],


### PR DESCRIPTION
In their current formulation, these ops cannot have shape functions because their lhs/rhs element types can be different from their result element type.

Perhaps in the future we will add the `preferred_element_type` attribute to these ops (see #600), and then shape functions will be feasible to write again, but today we have to disable them.