### PR TITLE
Fix some typo in  dynamicUpdateSlice

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2416,7 +2416,7 @@ the slice starting at `start_indices` is updated with the values in `update`.
 More formally, `result[i0, ..., iR-1]` is defined as:
 
   * `update[j0, ..., jR-1]` if `jd = adjusted_start_indices[d][] + id` where
-    `adjusted_start_indices = clamp(0, start_indices, shape(operand) - update)`.
+    `adjusted_start_indices = clamp(0, start_indices, shape(operand) - shape(update))`.
   * `operand[i0, ..., iR-1]` otherwise.
 
 ### Inputs


### PR DESCRIPTION
The PR fixes a typo in the specification of `DynamicUpdateSliceOp` related to how `max` argument of `clampOp` is determined. 


As a side note:
Recommended one improvement related to dynamic_slice/dynamic_update_slice ops in https://github.com/openxla/stablehlo/issues/289#issuecomment-1363409092