### PR TITLE
Remove "stablehlo" from "#stablehloadd" links

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -395,7 +395,7 @@ bytes is implementation-defined. String literals have type `string`.
 
 ## Ops
 
-## stablehlo.abs
+## abs
 
 ### Semantics
 
@@ -437,7 +437,7 @@ defined and one of the following:
 // %result: [2, 0, 2]
 ```
 
-## stablehlo.add
+## add
 
 ### Semantics
 
@@ -454,7 +454,7 @@ of the following:
 
 For floating-point element types, it implements the `addition` operation from
 the IEEE-754 specification. For boolean element type, the behavior is same as
-[stablehlo.or](#stablehloor).
+`or`.
 
 ### Inputs
 
@@ -484,7 +484,7 @@ the IEEE-754 specification. For boolean element type, the behavior is same as
 
 &nbsp;[More Examples](../stablehlo/tests/interpret_add.mlir)
 
-## stablehlo.after_all
+## after_all
 
 ### Semantics
 
@@ -510,7 +510,7 @@ it only exists to establish data dependencies from `result` to `inputs`.
 %result = "stablehlo.after_all"(%input0, %input1) : (!stablehlo.token, !stablehlo.token) -> !stablehlo.token
 ```
 
-## stablehlo.all_gather
+## all_gather
 
 ### Semantics
 
@@ -584,7 +584,7 @@ Afterwards, within each `process_group`:
 // %result@(1, 0): [[1.0, 2.0, 5.0, 6.0], [3.0, 4.0, 7.0, 8.0]]
 ```
 
-## stablehlo.all_reduce
+## all_reduce
 
 ### Semantics
 
@@ -671,7 +671,7 @@ Afterwards, within each `process_group`:
 // %result@(1, 0): [6.0, 8.0, 10.0, 12.0]
 ```
 
-## stablehlo.all_to_all
+## all_to_all
 
 ### Semantics
 
@@ -778,7 +778,7 @@ Afterwards, within each `process_group`:
 //                 ]
 ```
 
-## stablehlo.and
+## and
 
 ### Semantics
 
@@ -812,7 +812,7 @@ For boolean tensors, computes the logical operation.
 // %result: [[1, 2], [3, 0]]
 ```
 
-## stablehlo.atan2
+## atan2
 
 ### Semantics
 
@@ -847,13 +847,12 @@ with corner cases TBD. Numeric precision is implementation-defined.
 // %result: [0.0, 1.57079637, -1.57079637] // [0.0, pi/2, -pi/2]
 ```
 
-## stablehlo.batch_norm_grad
+## batch_norm_grad
 
 ### Semantics
 
-Computes gradients of several inputs of
-[batch_norm_training](#stablehlobatch_norm_training) backpropagating from
-`grad_output`, and produces `grad_operand`, `grad_scale` and `grad_offset`
+Computes gradients of several inputs of `batch_norm_training` backpropagating
+from `grad_output`, and produces `grad_operand`, `grad_scale` and `grad_offset`
 tensors. More formally, this operation can be expressed as a decomposition to
 existing StableHLO operations using Python-like syntax as follows:
 
@@ -967,7 +966,7 @@ def batch_norm_grad(operand, scale, mean, variance, grad_output, epsilon, featur
 // %grad_offset: [0.4, 0.4]
 ```
 
-## stablehlo.batch_norm_inference
+## batch_norm_inference
 
 ### Semantics
 
@@ -1045,7 +1044,7 @@ Numeric precision is implementation-defined.
 //          ]
 ```
 
-## stablehlo.batch_norm_training
+## batch_norm_training
 
 ### Semantics
 
@@ -1131,7 +1130,7 @@ Numeric precision is implementation-defined.
 // %batch_var: [1.0, 1.0]
 ```
 
-## stablehlo.bitcast_convert
+## bitcast_convert
 
 ### Semantics
 
@@ -1191,7 +1190,7 @@ representation of element types is implementation-defined as well.
 //          ]
 ```
 
-## stablehlo.broadcast_in_dim
+## broadcast_in_dim
 
 ### Semantics
 
@@ -1248,7 +1247,7 @@ dimensions `k` in `operand`.
 //          ]
 ```
 
-## stablehlo.case
+## case
 
 ### Semantics
 
@@ -1291,7 +1290,7 @@ returned.
 // %result: 11
 ```
 
-## stablehlo.cbrt
+## cbrt
 
 ### Semantics
 
@@ -1324,7 +1323,7 @@ corner cases TBD. Numeric precision is implementation-defined.
 // %result: [0.0, 1.0, 2.0, 3.0]
 ```
 
-## stablehlo.ceil
+## ceil
 
 ### Semantics
 
@@ -1358,7 +1357,7 @@ specification.
 
 &nbsp;[More Examples](../stablehlo/tests/interpret_ceil.mlir)
 
-## stablehlo.cholesky
+## cholesky
 
 ### Semantics
 
@@ -1411,7 +1410,7 @@ matrix, then the behavior is undefined.
 //          ]
 ```
 
-## stablehlo.clamp
+## clamp
 
 ### Semantics
 
@@ -1419,9 +1418,7 @@ Clamps every element of the `operand` tensor between a minimum and maximum
 value and produces a `result` tensor. More formally, `result[i0, ..., iR-1]` =
 `minimum(maximum(operand[i0, ..., iR-1], min_val), max_val)`,
 where `min_val = rank(min) == 0 ? min : min[i0, ..., iR-1]`,
-`max_val = rank(max) == 0 ? max : max[i0, ..., iR-1]`, `minimum` and `maximum`
-operations correspond to [stablehlo.minimum](#stablehlominimum) and
-[stablehlo.maximum](#stablehlomaximum).
+`max_val = rank(max) == 0 ? max : max[i0, ..., iR-1]`.
 
 ### Inputs
 
@@ -1454,7 +1451,7 @@ operations correspond to [stablehlo.minimum](#stablehlominimum) and
 // %result: [5, 13, 20]
 ```
 
-## stablehlo.collective_permute
+## collective_permute
 
 ### Semantics
 
@@ -1517,7 +1514,7 @@ Afterwards, `result@process` is given by:
 // %result@(1, 0): [[1, 2], [3, 4]]
 ```
 
-## stablehlo.compare
+## compare
 
 ### Semantics
 
@@ -1592,7 +1589,7 @@ performed using the provided `comparison_direction` and `compare_type`.
 // %result: [true, false]
 ```
 
-## stablehlo.complex
+## complex
 
 ### Semantics
 
@@ -1627,7 +1624,7 @@ imaginary values, `lhs` and `rhs`, and produces a `result` tensor.
 // %result: [(1.0, 2.0), (3.0, 4.0)]
 ```
 
-## stablehlo.concatenate
+## concatenate
 
 ### Semantics
 
@@ -1676,7 +1673,7 @@ tensor. More formally,
 // %result: [[1, 2], [3, 4], [5, 6], [7, 8]]
 ```
 
-## stablehlo.constant
+## constant
 
 ### Semantics
 
@@ -1709,7 +1706,7 @@ Produces an `output` tensor from a constant `value`.
 
 &nbsp;[More Examples](../stablehlo/tests/interpret_constant.mlir)
 
-## stablehlo.convert
+## convert
 
 ### Semantics
 
@@ -1778,7 +1775,7 @@ converted to zero, and the value `true` is converted to one. For
 // %result: [(1.0, 0.0), (2.0, 0.0), (3.0, 0.0)]
 ```
 
-## stablehlo.convolution
+## convolution
 
 ### Semantics
 
@@ -1959,7 +1956,7 @@ If `batch_group_count > 1`:
 //          ]]
 ```
 
-## stablehlo.cosine
+## cosine
 
 ### Semantics
 
@@ -1996,7 +1993,7 @@ specification. Numeric precision is implementation-defined.
 
 &nbsp;[More Examples](../stablehlo/tests/interpret_cosine.mlir)
 
-## stablehlo.count_leading_zeros
+## count_leading_zeros
 
 ### Semantics
 
@@ -2027,7 +2024,7 @@ tensor and produces a `result` tensor.
 // %result: [[8, 7], [1, 0]]
 ```
 
-## stablehlo.custom_call
+## custom_call
 
 ### Semantics
 
@@ -2065,7 +2062,7 @@ implementation-defined metadata.
 } : (tensor<f32>) -> tensor<f32>
 ```
 
-## stablehlo.divide
+## divide
 
 ### Semantics
 
@@ -2107,7 +2104,7 @@ produces an implementation-defined value.
 // %result: [5, -5, -5, 5]
 ```
 
-## stablehlo.dot_general
+## dot_general
 
 ### Semantics
 
@@ -2226,7 +2223,7 @@ computations on accelerator backends. This can be one of the following:
 
 &nbsp;[More Examples](../stablehlo/tests/interpret_dot_general.mlir)
 
-## stablehlo.dynamic_slice
+## dynamic_slice
 
 ### Semantics
 
@@ -2284,7 +2281,7 @@ More formally, `result[i0, ..., iR-1] = operand[j0, ..., jR-1]` where:
 //          ]
 ```
 
-## stablehlo.dynamic_update_slice
+## dynamic_update_slice
 
 ### Semantics
 
@@ -2347,7 +2344,7 @@ More formally, `result[i0, ..., iR-1]` is defined as:
 //          ]
 ```
 
-## stablehlo.exponential
+## exponential
 
 ### Semantics
 
@@ -2385,7 +2382,7 @@ implementation-defined.
 // %result: (-1.13120438, 2.47172667)
 ```
 
-## stablehlo.exponential_minus_one
+## exponential_minus_one
 
 ### Semantics
 
@@ -2419,7 +2416,7 @@ precision is implementation-defined.
 // %result: [0.0, 1.71828187]
 ```
 
-## stablehlo.fft
+## fft
 
 ### Semantics
 
@@ -2536,7 +2533,7 @@ for `fft_type = RFFT`. For example, for `L = 3`:
 // %result: [(1.0, 0.0), (1.0, 0.0), (1.0, 0.0), (1.0, 0.0)]
 ```
 
-## stablehlo.floor
+## floor
 
 ### Semantics
 
@@ -2570,7 +2567,7 @@ specification.
 
 &nbsp;[More Examples](../stablehlo/tests/interpret_floor.mlir)
 
-## stablehlo.gather
+## gather
 
 ### Semantics
 
@@ -2695,7 +2692,7 @@ behavior is undefined. More formally, for all `id < jd` from `indices(result)`,
 //          ]
 ```
 
-## stablehlo.get_dimension_size
+## get_dimension_size
 
 ### Semantics
 
@@ -2729,7 +2726,7 @@ Produces the size of the given `dimension` of the `operand`.
 // %result: 3
 ```
 
-## stablehlo.get_tuple_element
+## get_tuple_element
 
 ### Semantics
 
@@ -2764,7 +2761,7 @@ Extracts element at `index` position of the `operand` tuple and produces a
 // %result: [1.0, 2.0]
 ```
 
-## stablehlo.if
+## if
 
 ### Semantics
 
@@ -2807,7 +2804,7 @@ output of `true_branch` is returned, else if pred is `false`, output of
 // %result: 10
 ```
 
-## stablehlo.imag
+## imag
 
 ### Semantics
 
@@ -2843,7 +2840,7 @@ More formally, for each element `x`: `imag(x) = is_complex(x) ? x.imag : 0.0`.
 // %result: [2.0, 4.0]
 ```
 
-## stablehlo.infeed
+## infeed
 
 ### Semantics
 
@@ -2883,7 +2880,7 @@ as a value that other operations can take a data dependency on.
 } : (!stablehlo.token) -> (tensor<3x3x3xi32>, !stablehlo.token)
 ```
 
-## stablehlo.iota
+## iota
 
 ### Semantics
 
@@ -2943,7 +2940,7 @@ defined and one of the following:
 
 &nbsp;[More Examples](../stablehlo/tests/interpret_iota.mlir)
 
-## stablehlo.is_finite
+## is_finite
 
 ### Semantics
 
@@ -2976,7 +2973,7 @@ operation from the IEEE-754 specification.
 // %y: [false, false, false, true, true, true, true]
 ```
 
-## stablehlo.log
+## log
 
 ### Semantics
 
@@ -3014,7 +3011,7 @@ implementation-defined.
 // %result: (0.80471896, 1.10714871)
 ```
 
-## stablehlo.log_plus_one
+## log_plus_one
 
 ### Semantics
 
@@ -3048,7 +3045,7 @@ implementation-defined.
 // %result: [-nan, 0.0, -6.90776825, 2.07944155, 2.0, 2.77258873]
 ```
 
-## stablehlo.logistic
+## logistic
 
 ### Semantics
 
@@ -3087,7 +3084,7 @@ function, with corner cases TBD. Numeric precision is implementation-defined.
 // %result: (1.02141536, 0.40343871)
 ```
 
-## stablehlo.map
+## map
 
 ### Semantics
 
@@ -3135,7 +3132,7 @@ More formally, `result[i0, ..., iR-1] = computation(inputs[0][i0, ..., iR-1],`
 // %result: [[0, 5], [12, 21]]
 ```
 
-## stablehlo.maximum
+## maximum
 
 ### Semantics
 
@@ -3143,7 +3140,7 @@ Performs element-wise max operation on tensors `lhs` and `rhs` and produces a
 `result` tensor. For floating-point element types, it implements the `maximum`
 operation from the IEEE-754 specification. For complex element types, it performs
 lexicographic comparison on the (real, imaginary) pairs with corner cases TBD.
-For boolean element type, the behavior is same as [stablehlo.or](#stablehloor).
+For boolean element type, the behavior is same as `or`.
 
 ### Inputs
 
@@ -3173,7 +3170,7 @@ For boolean element type, the behavior is same as [stablehlo.or](#stablehloor).
 
 &nbsp;[More Examples](../stablehlo/tests/interpret_maximum.mlir)
 
-## stablehlo.minimum
+## minimum
 
 ### Semantics
 
@@ -3181,8 +3178,7 @@ Performs element-wise min operation on tensors `lhs` and `rhs` and produces a
 `result` tensor. For floating-point element types, it implements the `minimum`
 operation from the IEEE-754 specification. For complex element types, it performs
 lexicographic comparison on the (real, imaginary) pairs with corner cases TBD.
-For boolean element type, the behavior is same as
-[stablehlo.and](#stablehloand).
+For boolean element type, the behavior is same as `and`.
 
 ### Inputs
 
@@ -3212,7 +3208,7 @@ For boolean element type, the behavior is same as
 
 &nbsp;[More Examples](../stablehlo/tests/interpret_minimum.mlir)
 
-## stablehlo.multiply
+## multiply
 
 ### Semantics
 
@@ -3233,8 +3229,7 @@ from the IEEE-754 specification.
 For complex element types, it computes a complex multiplication, with corner
 cases TBD.
 
-For boolean element type, the behavior is same as
-[stablehlo.and](#stablehloand).
+For boolean element type, the behavior is same as `and`.
 
 ### Inputs
 
@@ -3264,7 +3259,7 @@ For boolean element type, the behavior is same as
 
 &nbsp;[More Examples](../stablehlo/tests/interpret_multiply.mlir)
 
-## stablehlo.negate
+## negate
 
 ### Semantics
 
@@ -3313,7 +3308,7 @@ unsigned integer type.
 
 &nbsp;[More Examples](../stablehlo/tests/interpret_negate.mlir)
 
-## stablehlo.not
+## not
 
 ### Semantics
 
@@ -3350,7 +3345,7 @@ produces a `result` tensor. For boolean tensors, it computes the logical NOT.
 // %result: [false, true]
 ```
 
-## stablehlo.optimization_barrier
+## optimization_barrier
 
 ### Semantics
 
@@ -3386,7 +3381,7 @@ an identity, i.e. `result` = `operand`.
 // %result1: 1.0
 ```
 
-## stablehlo.or
+## or
 
 ### Semantics
 
@@ -3427,7 +3422,7 @@ operation.
 // %result: [[false, true], [true, true]]
 ```
 
-## stablehlo.outfeed
+## outfeed
 
 ### Semantics
 
@@ -3460,7 +3455,7 @@ as a value that other operations can take a data dependency on.
 } : (tensor<3x3x3xi32>, !stablehlo.token) -> !stablehlo.token
 ```
 
-## stablehlo.pad
+## pad
 
 ### Semantics
 
@@ -3534,7 +3529,7 @@ More formally, `result[i0, ..., iR-1]` is equal to:
 //          ]
 ```
 
-## stablehlo.partition_id
+## partition_id
 
 ### Semantics
 
@@ -3552,7 +3547,7 @@ Produces `partition_id` of the current process.
 %result = "stablehlo.partition_id"() : () -> tensor<ui32>
 ```
 
-## stablehlo.popcnt
+## popcnt
 
 ### Semantics
 
@@ -3583,7 +3578,7 @@ and produces a `result` tensor.
 // %result: [0, 1, 1, 7]
 ```
 
-## stablehlo.power
+## power
 
 ### Semantics
 
@@ -3637,7 +3632,7 @@ implementation-defined.
 // %result: [4.0, 0.0, -nan, 25.0, 0.333333343, inf]
 ```
 
-## stablehlo.real
+## real
 
 ### Semantics
 
@@ -3673,7 +3668,7 @@ More formally, for each element `x`: `real(x) = is_complex(x) ? x.real : x`.
 // %result: [1.0, 3.0]
 ```
 
-## stablehlo.recv
+## recv
 
 ### Semantics
 
@@ -3722,7 +3717,7 @@ other operations can take a data dependency on.
 } : (!stablehlo.token) -> (tensor<3x4xi32>, !stablehlo.token)
 ```
 
-## stablehlo.reduce
+## reduce
 
 ### Semantics
 
@@ -3799,7 +3794,7 @@ More formally, `results[:][j0, ..., jR-1] = reduce(input_slices)` where:
 // %result = [15]
 ```
 
-## stablehlo.reduce_precision
+## reduce_precision
 
 ### Semantics
 
@@ -3852,7 +3847,7 @@ More formally:
 // %result: [0xFF800000, 0x7F800000, 0x7FFFFFFF, 0.0, 1024.0, 0x7F800000]
 ```
 
-## stablehlo.reduce_scatter
+## reduce_scatter
 
 ### Semantics
 
@@ -3953,7 +3948,7 @@ Afterwards, within each `process_group`:
 //                 ]
 ```
 
-## stablehlo.reduce_window
+## reduce_window
 
 ### Semantics
 
@@ -4042,7 +4037,7 @@ where:
 // %result = [[0, 0], [3, 4]]
 ```
 
-## stablehlo.remainder
+## remainder
 
 ### Semantics
 
@@ -4088,7 +4083,7 @@ implementation-defined value.
 // %result: [2, -2, 2, -2]
 ```
 
-## stablehlo.replica_id
+## replica_id
 
 ### Semantics
 
@@ -4106,7 +4101,7 @@ Produces `replica_id` of the current process.
 %result = "stablehlo.replica_id"() : () -> tensor<ui32>
 ```
 
-## stablehlo.reshape
+## reshape
 
 ### Semantics
 
@@ -4145,7 +4140,7 @@ spaces of `result` and `operand`.
 
 &nbsp;[More Examples](../stablehlo/tests/interpret_reshape.mlir)
 
-## stablehlo.reverse
+## reverse
 
 ### Semantics
 
@@ -4194,7 +4189,7 @@ and produces a `result` tensor. More formally,
 // %result: [[2, 1], [4, 3], [6, 5]]
 ```
 
-## stablehlo.rng
+## rng
 
 ### Semantics
 
@@ -4251,7 +4246,7 @@ hidden state.
 //          ]
 ```
 
-## stablehlo.rng_bit_generator
+## rng_bit_generator
 
 ### Semantics
 
@@ -4306,7 +4301,7 @@ deterministic between implementations.
 //          ]
 ```
 
-## stablehlo.round_nearest_afz
+## round_nearest_afz
 
 ### Semantics
 
@@ -4338,7 +4333,7 @@ the `roundToIntegralTiesToAway` operation from the IEEE-754 specification.
 // %result: [-3.0, 0.0, 1.0, 1.0, 3.0]
 ```
 
-## stablehlo.round_nearest_even
+## round_nearest_even
 
 ### Semantics
 
@@ -4371,7 +4366,7 @@ specification.
 // %result: [-2.0, 0.0, 0.0, 1.0, 2.0]
 ```
 
-## stablehlo.rsqrt
+## rsqrt
 
 ### Semantics
 
@@ -4407,7 +4402,7 @@ specification. Numeric precision is implementation-defined.
 // %result: [(0.56886448, -0.35157758)]
 ```
 
-## stablehlo.scatter
+## scatter
 
 ### Semantics
 
@@ -4560,7 +4555,7 @@ is undefined.
 //          ]
 ```
 
-## stablehlo.select
+## select
 
 ### Semantics
 
@@ -4601,7 +4596,7 @@ where `pred_val = rank(pred) == 0 ? pred : pred[i0, ..., iR-1]`.
 // %result: [[5, 2], [3, 8]]
 ```
 
-## stablehlo.select_and_scatter
+## select_and_scatter
 
 ### Semantics
 
@@ -4702,7 +4697,7 @@ More formally:
 // %result: [[0, 0], [0, 0], [5, 14], [7, 0]]
 ```
 
-## stablehlo.send
+## send
 
 ### Semantics
 
@@ -4749,7 +4744,7 @@ implementation-defined.
 } : (tensor<3x4xi32>, !stablehlo.token) -> !stablehlo.token
 ```
 
-## stablehlo.shift_left
+## shift_left
 
 ### Semantics
 
@@ -4782,7 +4777,7 @@ of bits and produces a `result` tensor.
 // %result: [-2, -8, 24, 0, -128, 0]
 ```
 
-## stablehlo.shift_right_arithmetic
+## shift_right_arithmetic
 
 ### Semantics
 
@@ -4815,7 +4810,7 @@ Performs element-wise arithmetic right-shift operation on the `lhs` tensor by
 // %result: [-1, -32, -5, 1, 1, 0]
 ```
 
-## stablehlo.shift_right_logical
+## shift_right_logical
 
 ### Semantics
 
@@ -4848,7 +4843,7 @@ number of bits and produces a `result` tensor.
 // %result: [127, 32, 27, 1, 1, 0]
 ```
 
-## stablehlo.sign
+## sign
 
 ### Semantics
 
@@ -4902,7 +4897,7 @@ def sign(x):
 // %result: [-1.0, 1.0, 0x7FFFFFFF, -1.0, -0.0, 0.0, 1.0]
 ```
 
-## stablehlo.sine
+## sine
 
 ### Semantics
 
@@ -4939,7 +4934,7 @@ Numeric precision is implementation-defined.
 
 &nbsp;[More Examples](../stablehlo/tests/interpret_sine.mlir)
 
-## stablehlo.slice
+## slice
 
 ### Semantics
 
@@ -5010,7 +5005,7 @@ More formally, `result[i0, ..., iR-1] = operand[j0, ..., jR-1]` where
 //           ]
 ```
 
-## stablehlo.sort
+## sort
 
 ### Semantics
 
@@ -5094,7 +5089,7 @@ More formally, for all `0 <= id < jd < dim(inputs[0], d)`, either
 // %result1 = [[1, 2, 3], [1, 2, 3]]
 ```
 
-## stablehlo.sqrt
+## sqrt
 
 ### Semantics
 
@@ -5130,7 +5125,7 @@ specification.
 // %result: [(1.27201965, 0.78615138)]
 ```
 
-## stablehlo.subtract
+## subtract
 
 ### Semantics
 
@@ -5176,7 +5171,7 @@ the IEEE-754 specification.
 
 &nbsp;[More Examples](../stablehlo/tests/interpret_subtract.mlir)
 
-## stablehlo.tanh
+## tanh
 
 ### Semantics
 
@@ -5210,7 +5205,7 @@ Numeric precision is implementation-defined.
 
 &nbsp;[More Examples](../stablehlo/tests/interpret_tanh.mlir)
 
-## stablehlo.transpose
+## transpose
 
 ### Semantics
 
@@ -5257,7 +5252,7 @@ where `i[d] = j[permutation[d]]`.
 
 &nbsp;[More Examples](../stablehlo/tests/interpret_transpose.mlir)
 
-## stablehlo.triangular_solve
+## triangular_solve
 
 ### Semantics
 
@@ -5333,7 +5328,7 @@ elements of `a` are equal to 1, otherwise the behavior is undefined.
 //          ]
 ```
 
-## stablehlo.tuple
+## tuple
 
 ### Semantics
 
@@ -5365,7 +5360,7 @@ Produces a `result` tuple from values `val`.
 // %result: ([1.0, 2.0], (3))
 ```
 
-## stablehlo.while
+## while
 
 ### Semantics
 
@@ -5425,7 +5420,7 @@ The behavior of an infinite loop is TBD.
 // %results1: 10
 ```
 
-## stablehlo.xor
+## xor
 
 ### Semantics
 

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -74,7 +74,7 @@ def StableHLO_ConstantOp : StableHLO_Op<"constant",
     Produces an `output` tensor from a constant `value`.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloconstant
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#constant
 
     Example:
     ```mlir
@@ -107,7 +107,7 @@ def StableHLO_IotaOp : StableHLO_Op<"iota", [Pure]> {
     along the `iota_dimension` dimension.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloiota
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#iota
 
     Example:
     ```mlir
@@ -207,7 +207,7 @@ def StableHLO_AbsOp: StableHLO_UnaryElementwiseOp<"abs",
     `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloabs
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#abs
 
     Example:
     ```mlir
@@ -225,7 +225,7 @@ def StableHLO_CbrtOp: StableHLO_UnaryElementwiseOp<"cbrt",
     IEEE-754 specification.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlocbrt
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#cbrt
 
     Example:
     ```mlir
@@ -241,7 +241,7 @@ def StableHLO_CeilOp: StableHLO_UnaryElementwiseOp<"ceil",
     Performs element-wise ceil of `operand` tensor and produces a `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloceil
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#ceil
 
     Example:
     ```mlir
@@ -258,7 +258,7 @@ def StableHLO_ConvertOp : StableHLO_UnaryElementwiseOp<"convert",
     `operand` tensor and produces a `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloconvert
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#convert
 
     Example:
     ```mlir
@@ -277,7 +277,7 @@ def StableHLO_ClzOp: StableHLO_UnaryElementwiseOp<"count_leading_zeros",
     `operand` tensor and produces a `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlocount_leading_zeros
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#count_leading_zeros
 
     Example:
     ```mlir
@@ -295,7 +295,7 @@ def StableHLO_CosineOp: StableHLO_UnaryElementwiseOp<"cosine",
     specification.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlocosine
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#cosine
 
     Example:
     ```mlir
@@ -312,7 +312,7 @@ def StableHLO_ExpOp: StableHLO_UnaryElementwiseOp<"exponential",
     a `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloexponential
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#exponential
 
     Example:
     ```mlir
@@ -329,7 +329,7 @@ def StableHLO_Expm1Op: StableHLO_UnaryElementwiseOp<"exponential_minus_one",
     and produces a `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloexponential_minus_one
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#exponential_minus_one
 
     Example:
     ```mlir
@@ -346,7 +346,7 @@ def StableHLO_FloorOp: StableHLO_UnaryElementwiseOp<"floor",
     tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlofloor
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#floor
 
     Example:
     ```mlir
@@ -364,7 +364,7 @@ def StableHLO_ImagOp: StableHLO_UnaryElementwiseOp<"imag",
     `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloimag
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#imag
 
     Example:
     ```mlir
@@ -381,7 +381,7 @@ def StableHLO_IsFiniteOp: StableHLO_UnaryElementwiseOp<"is_finite", [Pure,
     neither +Inf, -Inf, nor NaN) and produces a `y` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlois_finite
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#is_finite
 
     Example:
     ```mlir
@@ -404,7 +404,7 @@ def StableHLO_LogOp: StableHLO_UnaryElementwiseOp<"log",
     `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlolog
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#log
 
     Example:
     ```mlir
@@ -421,7 +421,7 @@ def StableHLO_Log1pOp: StableHLO_UnaryElementwiseOp<"log_plus_one",
     `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlolog_plus_one
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#log_plus_one
 
     Example:
     ```mlir
@@ -438,7 +438,7 @@ def StableHLO_LogisticOp: StableHLO_UnaryElementwiseOp<"logistic",
     produces a `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlologistic
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#logistic
 
     Example:
     ```mlir
@@ -455,7 +455,7 @@ def StableHLO_NotOp: StableHLO_UnaryElementwiseOp<"not",
     produces a `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlonot
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#not
 
     Example:
     ```mlir
@@ -472,7 +472,7 @@ def StableHLO_NegOp: StableHLO_UnaryElementwiseOp<"negate",
     tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlonegate
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#negate
 
     Example:
     ```mlir
@@ -489,7 +489,7 @@ def StableHLO_PopulationCountOp: StableHLO_UnaryElementwiseOp<"popcnt",
     tensor and produces a `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlopopcnt
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#popcnt
 
     Example:
     ```mlir
@@ -507,7 +507,7 @@ def StableHLO_RealOp: StableHLO_UnaryElementwiseOp<"real",
     `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloreal
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#real
 
     Example:
     ```mlir
@@ -524,7 +524,7 @@ def StableHLO_RoundOp: StableHLO_UnaryElementwiseOp<"round_nearest_afz",
     away from zero, on the `operand` tensor and produces a `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloround_nearest_afz
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#round_nearest_afz
 
     Example:
     ```mlir
@@ -542,7 +542,7 @@ def StableHLO_RoundNearestEvenOp: StableHLO_UnaryElementwiseOp<"round_nearest_ev
     tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloround_nearest_even
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#round_nearest_even
 
     Example:
 
@@ -561,7 +561,7 @@ def StableHLO_RsqrtOp: StableHLO_UnaryElementwiseOp<"rsqrt",
     IEEE-754 specification.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlorsqrt
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#rsqrt
 
     Example:
     ```mlir
@@ -579,7 +579,7 @@ def StableHLO_SignOp: StableHLO_UnaryElementwiseOp<"sign",
     tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlosign
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#sign
 
     Example:
     ```mlir
@@ -597,7 +597,7 @@ def StableHLO_SineOp: StableHLO_UnaryElementwiseOp<"sine",
     specification.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlosine
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#sine
 
     Example:
     ```mlir
@@ -615,7 +615,7 @@ def StableHLO_SqrtOp: StableHLO_UnaryElementwiseOp<"sqrt",
     specification.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlosqrt
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#sqrt
 
     Example:
     ```mlir
@@ -634,7 +634,7 @@ def StableHLO_TanhOp: StableHLO_UnaryElementwiseOp<"tanh",
     specification.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlotanh
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#tanh
 
     Example:
     ```mlir
@@ -685,7 +685,7 @@ def StableHLO_AddOp : StableHLO_BinaryElementwiseOp<"add",
     `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloadd
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#add
 
     Example:
     ```mlir
@@ -703,7 +703,7 @@ def StableHLO_Atan2Op : StableHLO_BinaryElementwiseOp<"atan2",
     specification.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloatan2
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#atan2
 
     Example:
     ```mlir
@@ -720,7 +720,7 @@ def StableHLO_ComplexOp: StableHLO_BinaryElementwiseOp<"complex", [Pure,
     imaginary values, `lhs` and `rhs`, and produces a `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlocomplex
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#complex
 
     Example:
     ```mlir
@@ -744,7 +744,7 @@ def StableHLO_DivOp : StableHLO_BinaryElementwiseOp<"divide",
     and produces a `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlodivide
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#divide
 
     Example:
     ```mlir
@@ -761,7 +761,7 @@ def StableHLO_MaxOp : StableHLO_BinaryElementwiseOp<"maximum",
     a `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlomaximum
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#maximum
 
     Example:
     ```mlir
@@ -778,7 +778,7 @@ def StableHLO_MinOp : StableHLO_BinaryElementwiseOp<"minimum",
     `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlominimum
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#minimum
 
     Example:
     ```mlir
@@ -795,7 +795,7 @@ def StableHLO_MulOp : StableHLO_BinaryElementwiseOp<"multiply",
     `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlomultiply
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#multiply
 
     Example:
     ```mlir
@@ -812,7 +812,7 @@ def StableHLO_PowOp : StableHLO_BinaryElementwiseOp<"power",
     produces a `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlopower
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#power
 
     Example:
     ```mlir
@@ -829,7 +829,7 @@ def StableHLO_RemOp : StableHLO_BinaryElementwiseOp<"remainder",
     and produces a `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloremainder
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#remainder
 
     Example:
     ```mlir
@@ -846,7 +846,7 @@ def StableHLO_ShiftLeftOp : StableHLO_BinaryElementwiseOp<"shift_left",
     number of bits and produces a `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloshift_left
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#shift_left
 
     Example:
     ```mlir
@@ -863,7 +863,7 @@ def StableHLO_ShiftRightArithmeticOp : StableHLO_BinaryElementwiseOp<"shift_righ
     by `rhs` number of bits and produces a `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloshift_right_arithmetic
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#shift_right_arithmetic
 
     Example:
     ```mlir
@@ -880,7 +880,7 @@ def StableHLO_ShiftRightLogicalOp : StableHLO_BinaryElementwiseOp<"shift_right_l
     `rhs` number of bits and produces a `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloshift_right_logical
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#shift_right_logical
 
     Example:
     ```mlir
@@ -897,7 +897,7 @@ def StableHLO_SubtractOp : StableHLO_BinaryElementwiseOp<"subtract",
     produces a `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlosubtract
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#subtract
 
     Example:
     ```mlir
@@ -927,7 +927,7 @@ def StableHLO_AndOp: StableHLO_BinaryBiwiseOrLogicalElementwiseOp<"and"> {
     and produces a `result` tensor
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloand
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#and
 
     Example:
     ```mlir
@@ -943,7 +943,7 @@ def StableHLO_OrOp: StableHLO_BinaryBiwiseOrLogicalElementwiseOp<"or"> {
     and produces a `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloor
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#or
 
     Example:
     ```mlir
@@ -959,7 +959,7 @@ def StableHLO_XorOp : StableHLO_BinaryBiwiseOrLogicalElementwiseOp<"xor"> {
     types and produces a `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloxor
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#xor
 
     Example:
     ```mlir
@@ -982,7 +982,7 @@ def StableHLO_InfeedOp : StableHLO_Op<"infeed", []> {
     Reads data from the infeed and produces `results`.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloinfeed
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#infeed
 
     Example:
     ```mlir
@@ -1012,7 +1012,7 @@ def StableHLO_OutfeedOp : StableHLO_Op<"outfeed",
     Writes `inputs` to the outfeed and produces a `result` token.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlooutfeed
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#outfeed
 
     Example:
     ```mlir
@@ -1039,7 +1039,7 @@ def StableHLO_SendOp : StableHLO_Op<"send",
     Sends `inputs` to a channel `channel_id` and produces a `result` token.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlosend
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#send
 
     Example:
     ```mlir
@@ -1070,7 +1070,7 @@ def StableHLO_RecvOp : StableHLO_Op<"recv", []> {
     Receives data from a channel with `channel_id` and produces `results`.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlorecv
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#recv
 
     Example:
     ```mlir
@@ -1104,7 +1104,7 @@ def StableHLO_ReplicaIdOp : StableHLO_Op<"replica_id", [Pure,
     Produces `replica_id` of the current process.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloreplica_id
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#replica_id
 
     Example:
     ```mlir
@@ -1123,7 +1123,7 @@ def StableHLO_PartitionIdOp : StableHLO_Op<"partition_id", [Pure,
     Produces `partition_id` of the current process.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlopartition_id
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#partition_id
 
     Example:
     ```mlir
@@ -1149,7 +1149,7 @@ def StableHLO_AfterAllOp : StableHLO_Op<"after_all", [Pure,
     operations that depend on `result`.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloafter_all
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#after_all
 
     Example:
 
@@ -1181,7 +1181,7 @@ def StableHLO_IfOp: StableHLO_Op<"if", [
     `false_branch` depending on the value of `pred`.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloif
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#if
 
     Example:
     %result = "stablehlo.if"(%pred) ({
@@ -1215,7 +1215,7 @@ def StableHLO_CaseOp: StableHLO_Op<"case", [
     depending on the value of `index`.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlocase
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#case
 
     Example:
     ```mlir
@@ -1249,7 +1249,7 @@ def StableHLO_WhileOp: StableHLO_Op<"while", [
     `cond` function outputs `true`.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlowhile
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#while
 
     Example:
     %results:2 = "stablehlo.while"(%input0, %input1) ({
@@ -1301,7 +1301,7 @@ def StableHLO_AllGatherOp : StableHLO_Op<"all_gather", [SameOperandsAndResultEle
     `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloall_gather
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#all_gather
 
     Example:
     ```mlir
@@ -1335,7 +1335,7 @@ def StableHLO_AllReduceOp : StableHLO_Op<"all_reduce",
     produces a `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloall_reduce
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#all_reduce
 
     Example:
     ```mlir
@@ -1380,7 +1380,7 @@ def StableHLO_ReduceScatterOp : StableHLO_Op<"reduce_scatter",
      scatters the split parts between the processes to produce the `result`.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloreduce_scatter
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#reduce_scatter
 
     Example:
     ```mlir
@@ -1420,7 +1420,7 @@ def StableHLO_AllToAllOp : StableHLO_Op<"all_to_all",
     and produces a `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloall_to_all
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#all_to_all
 
     Example:
     ```mlir
@@ -1466,7 +1466,7 @@ def StableHLO_ReduceOp: StableHLO_ShapedInterfaceOp<"reduce", [
     `dimensions` and produces a `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloreduce
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#reduce
 
     Example:
     ```mlir
@@ -1507,7 +1507,7 @@ def StableHLO_GetTupleElementOp: StableHLO_Op<"get_tuple_element", [Pure,
     `result`.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloget_tuple_element
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#get_tuple_element
 
     Example:
     ```mlir
@@ -1533,7 +1533,7 @@ def StableHLO_TupleOp : StableHLO_Op<"tuple", [Pure,
     Produces a `result` tuple from values `val`.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlotuple
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#tuple
 
     Example:
     ```mlir
@@ -1557,7 +1557,7 @@ def StableHLO_CompareOp: StableHLO_Op<"compare", [Pure, SameOperandsElementType,
     `comparison_direction` and `compare_type`, and produces a `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlocompare
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#compare
 
     Example:
     ```mlir
@@ -1600,7 +1600,7 @@ def StableHLO_SliceOp: StableHLO_Op<
     indices and produces a `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloslice
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#slice
 
     Example:
     ```mlir
@@ -1631,7 +1631,7 @@ def StableHLO_DynamicSliceOp: StableHLO_Op<"dynamic_slice",
     indices and produces a `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlodynamic_slice
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#dynamic_slice
 
     Example:
     ```mlir
@@ -1664,7 +1664,7 @@ def StableHLO_DynamicUpdateSliceOp: StableHLO_Op<"dynamic_update_slice",
     `update`.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlodynamic_update_slice
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#dynamic_update_slice
 
     Example:
     ```mlir
@@ -1701,7 +1701,7 @@ def StableHLO_BatchNormGradOp : StableHLO_Op<"batch_norm_grad", [Pure,
     `grad_offset` tensors.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlobatch_norm_grad
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#batch_norm_grad
 
     Example:
     ```mlir
@@ -1740,7 +1740,7 @@ def StableHLO_BatchNormInferenceOp : StableHLO_Op<"batch_norm_inference",
     `feature_index` dimension and produces a `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlobatch_norm_inference
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#batch_norm_inference
 
     Example:
     ```mlir
@@ -1776,7 +1776,7 @@ def StableHLO_BatchNormTrainingOp : StableHLO_Op<"batch_norm_training",
     dimension and produces `output`, `batch_mean` and `batch_var` tensors.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlobatch_norm_training
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#batch_norm_training
 
     Example:
     ```mlir
@@ -1810,7 +1810,7 @@ def StableHLO_BitcastConvertOp : StableHLO_ShapedInterfaceOp<"bitcast_convert",
     the type of the `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlobitcast_convert
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#bitcast_convert
 
     Example:
     ```mlir
@@ -1866,7 +1866,7 @@ def StableHLO_BroadcastInDimOp : StableHLO_Op<"broadcast_in_dim",
     data in the `operand` tensor and produces a `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlobroadcast_in_dim
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#broadcast_in_dim
 
     Example:
 
@@ -1943,7 +1943,7 @@ def StableHLO_CholeskyOp : StableHLO_Op<"cholesky",
     Computes the Cholesky decomposition of a batch of matrices.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlocholesky
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#cholesky
 
     Example:
     ```mlir
@@ -1971,7 +1971,7 @@ def StableHLO_ClampOp : StableHLO_ShapedInterfaceOp<"clamp", [Pure,
     value and produces a `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloclamp
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#clamp
 
     Example:
     ```mlir
@@ -2002,7 +2002,7 @@ def StableHLO_ConcatenateOp : StableHLO_ShapedInterfaceOp<"concatenate",
     tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloconcatenate
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#concatenate
 
     Example:
     ```mlir
@@ -2031,7 +2031,7 @@ def StableHLO_CollectivePermuteOp: StableHLO_Op<"collective_permute",
     a `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlocollective_permute
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#collective_permute
 
     Example:
     ```mlir
@@ -2066,7 +2066,7 @@ def StableHLO_ConvolutionOp : StableHLO_Op<"convolution", [Pure]> {
     produces `result`.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloconvolution
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#convolution
 
     Example:
     ```mlir
@@ -2141,7 +2141,7 @@ def StableHLO_CustomCallOp: StableHLO_Op<"custom_call",
     takes `inputs` and `called_computations` and produces `results`.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlocustom_call
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#custom_call
 
     Example:
     ```mlir
@@ -2221,7 +2221,7 @@ def StableHLO_DotGeneralOp: StableHLO_ShapedInterfaceOp<"dot_general", [Pure]> {
     produces a `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlodot_general
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#dot_general
 
     Example:
     ```mlir
@@ -2295,7 +2295,7 @@ def StableHLO_FftOp: StableHLO_Op<"fft", [InferTensorType, Pure]> {
     inputs/outputs.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlofft
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#fft
 
     Example:
     ```mlir
@@ -2323,7 +2323,7 @@ def StableHLO_GatherOp: StableHLO_Op<"gather", [InferTensorTypeWithReify, Pure]>
     `start_indices` and produces a `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlogather
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#gather
 
     Example:
     ```mlir
@@ -2357,7 +2357,7 @@ def StableHLO_GetDimensionSizeOp: StableHLO_Op<"get_dimension_size", [Pure,
     Produces the size of the given `dimension` of the `operand`.
 
     See
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloget_dimension_size
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#get_dimension_size
 
     Example:
 
@@ -2390,7 +2390,7 @@ def StableHLO_MapOp: StableHLO_ShapedInterfaceOp<"map",
     produces a `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlomap
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#map
 
     Example:
     ```mlir
@@ -2418,7 +2418,7 @@ def StableHLO_ReshapeOp: StableHLO_Op<"reshape",
     Performs reshape of `operand` tensor to a `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloreshape
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#reshape
 
     Example:
     ```mlir
@@ -2470,7 +2470,7 @@ def StableHLO_ScatterOp: StableHLO_Op<"scatter",
     `updates` using `update_computation`.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloscatter
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#scatter
 
    Example:
 
@@ -2515,7 +2515,7 @@ def StableHLO_SelectOp: StableHLO_Op<"select", [Pure, HLO_BroadcastingElementwis
     `on_false` tensor based on the value of the corresponding element of `pred`.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloselect
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#select
 
     Example:
     ```mlir
@@ -2545,7 +2545,7 @@ def StableHLO_SelectAndScatterOp: StableHLO_Op<"select_and_scatter",
     a `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloselect_and_scatter
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#select_and_scatter
 
     Example:
     ```mlir
@@ -2622,7 +2622,7 @@ def StableHLO_SortOp : StableHLO_Op<"sort",
     number of tensors as `results`.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloreverse
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#reverse
 
     Example:
     %result0, %result1 = "stablehlo.sort"(%input0, %input1) ({
@@ -2661,7 +2661,7 @@ def StableHLO_ReverseOp: StableHLO_Op<"reverse",
     `dimensions` and produces a `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloreverse
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#reverse
 
     Example:
     ```mlir
@@ -2690,7 +2690,7 @@ def StableHLO_PadOp: StableHLO_ShapedInterfaceOp<"pad",
     elements of the tensor with the given `padding_value`.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlopad
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#pad
 
     Example:
     ```mlir
@@ -2744,7 +2744,7 @@ def StableHLO_TransposeOp: StableHLO_ShapedInterfaceOp<"transpose",
     a `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlotranspose
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#transpose
 
     Example:
     ```mlir
@@ -2771,7 +2771,7 @@ def StableHLO_TriangularSolveOp: StableHLO_Op<"triangular_solve",
     coefficient matrices.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlotriangular_solve
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#triangular_solve
 
     Example:
     ```mlir
@@ -2806,7 +2806,7 @@ def StableHLO_ReduceWindowOp: StableHLO_Op<"reduce_window", [
     and produces `results`.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloreduce_window
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#reduce_window
 
     Example:
     ```mlir
@@ -2920,7 +2920,7 @@ def StableHLO_OptimizationBarrierOp : StableHLO_Op<"optimization_barrier",
     an identity, i.e. `result` = `operand`.
 
     See
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlooptimization_barrier
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#optimization_barrier
 
     Example:
     ```mlir
@@ -2955,7 +2955,7 @@ def StableHLO_RngOp : StableHLO_Op<"rng", [InferTensorTypeWithReify, AllElementT
     a `result` tensor of a given shape `shape`.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlorng
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#rng
 
     Example:
     ```mlir
@@ -2987,7 +2987,7 @@ def StableHLO_RngBitGeneratorOp : StableHLO_Op<"rng_bit_generator", [Pure]> {
     pseudorandom number generator algorithm `rng_algorithm`.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehlorng_bit_generator
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#rng_bit_generator
 
     Example:
     ```mlir
@@ -3058,7 +3058,7 @@ def StableHLO_ReducePrecisionOp :
     floating-point type and produces a `result` tensor.
 
     See:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#stablehloreduce_precision
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#reduce_precision
 
     Example:
     ```mlir


### PR DESCRIPTION
The "stablehlo" part of spec sections and spec permalinks is redundant.
It's a StableHLO spec, so it is reasonable to assume that it specs
StableHLO ops.