### PR TITLE
Handle bounds in the SortOp shape function

### DIFF
--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2393,7 +2393,7 @@ LogicalResult inferSliceOp(Optional<Location> location, Value operand,
 LogicalResult inferSortOp(
     Optional<Location> location, ValueRange inputs,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
-  // Infermost specific type from all operands
+  // Infer most specific type from all operands
   SmallVector<Type> mostSpecificType;
   if (failed(hlo::inferMostSpecificType(location, inputs.getTypes(),
                                         mostSpecificType)))

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -1228,8 +1228,7 @@ func.func @sort_unknown_rank(%input0: tensor<*xf32>, %input1: tensor<*xi32>) {
 // -----
 
 // CHECK-LABEL: @sort_bounds_and_unknown_rank
-func.func @sort_bounds_and_unknown_rank(%input0: tensor<*xf32>, %input1: tensor<5x?x?xi32, #stablehlo.type_extensions<bounds = [?, 7, 6]>>
-) {
+func.func @sort_bounds_and_unknown_rank(%input0: tensor<*xf32>, %input1: tensor<5x?x?xi32, #stablehlo.type_extensions<bounds = [?, 7, 6]>>) {
   %0, %1 = "stablehlo.sort"(%input0, %input1) ({
   ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>, %arg2: tensor<i32>, %arg3: tensor<i32>):
     %pred = "stablehlo.compare"(%arg0, %arg1) {

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -1184,3 +1184,64 @@ func.func @dynamic_iota(%arg0: tensor<1xindex>) -> tensor<1xindex> {
   %1 = "hlo_test_infer.reify_return_type_shapes"(%result): (tensor<?xf32>) -> tensor<1xindex>
   func.return %1: tensor<1xindex>
 }
+
+// -----
+
+// CHECK-LABEL: @sort_bounds
+func.func @sort_bounds(
+  %input0: tensor<5x?x?xf32, #stablehlo.type_extensions<bounds = [?, 5, ?]>>,
+  %input1: tensor<?x?x?xi32, #stablehlo.type_extensions<bounds = [?, 7, 6]>>
+) {
+  %0, %1 = "stablehlo.sort"(%input0, %input1) ({
+  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>, %arg2: tensor<i32>, %arg3: tensor<i32>):
+    %pred = "stablehlo.compare"(%arg0, %arg1) {
+      comparison_direction = #stablehlo<comparison_direction GT>
+    } : (tensor<f32>, tensor<f32>) -> tensor<i1>
+    "stablehlo.return"(%pred) : (tensor<i1>) -> ()
+  }) { dimension = 1 : i64, is_stable = true } : (
+    tensor<5x?x?xf32, #stablehlo.type_extensions<bounds = [?, 5, ?]>>,
+    tensor<?x?x?xi32, #stablehlo.type_extensions<bounds = [?, 7, 6]>>
+  ) -> (tensor<*xf32>, tensor<*xi32>)
+  // CHECK: types0 = tensor<5x?x?xf32, #stablehlo.type_extensions<bounds = [?, 5, 6]>>
+  // CHECK-SAME: types1 = tensor<5x?x?xi32, #stablehlo.type_extensions<bounds = [?, 5, 6]>>
+  %2 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xf32>) -> tensor<*xindex>
+  func.return
+}
+
+// -----
+
+// CHECK-LABEL: @sort_unknown_rank
+func.func @sort_unknown_rank(%input0: tensor<*xf32>, %input1: tensor<*xi32>) {
+  %0, %1 = "stablehlo.sort"(%input0, %input1) ({
+  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>, %arg2: tensor<i32>, %arg3: tensor<i32>):
+    %pred = "stablehlo.compare"(%arg0, %arg1) {
+      comparison_direction = #stablehlo<comparison_direction GT>
+    } : (tensor<f32>, tensor<f32>) -> tensor<i1>
+    "stablehlo.return"(%pred) : (tensor<i1>) -> ()
+  }) { dimension = 1 : i64, is_stable = true } : (tensor<*xf32>, tensor<*xi32>) -> (tensor<*xf32>, tensor<*xi32>)
+  // CHECK: types0 = tensor<*xf32>
+  // CHECK-SAME: types1 = tensor<*xi32>
+  %2 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xf32>) -> tensor<*xindex>
+  func.return
+}
+
+// -----
+
+// CHECK-LABEL: @sort_bounds_and_unknown_rank
+func.func @sort_bounds_and_unknown_rank(%input0: tensor<*xf32>, %input1: tensor<5x?x?xi32, #stablehlo.type_extensions<bounds = [?, 7, 6]>>
+) {
+  %0, %1 = "stablehlo.sort"(%input0, %input1) ({
+  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>, %arg2: tensor<i32>, %arg3: tensor<i32>):
+    %pred = "stablehlo.compare"(%arg0, %arg1) {
+      comparison_direction = #stablehlo<comparison_direction GT>
+    } : (tensor<f32>, tensor<f32>) -> tensor<i1>
+    "stablehlo.return"(%pred) : (tensor<i1>) -> ()
+  }) { dimension = 1 : i64, is_stable = true } : (
+    tensor<*xf32>,
+    tensor<5x?x?xi32, #stablehlo.type_extensions<bounds = [?, 7, 6]>>
+  ) -> (tensor<*xf32>, tensor<*xi32>)
+  // CHECK: types0 = tensor<5x?x?xf32, #stablehlo.type_extensions<bounds = [?, 7, 6]>>
+  // CHECK-SAME: types1 = tensor<5x?x?xi32, #stablehlo.type_extensions<bounds = [?, 7, 6]>>
+  %2 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xf32>) -> tensor<*xindex>
+  func.return
+}


### PR DESCRIPTION
Closes #803

Infer the most specific type from all input tensors and use the most specific type for every result tensor with the element type of the corresponding input tensor.