### PR TITLE
Consistently use HLO_StaticShapeTensor

### DIFF
--- a/stablehlo/dialect/Base.td
+++ b/stablehlo/dialect/Base.td
@@ -135,11 +135,6 @@ def HLO_DimensionValue : AnyTypeOf<[Index, HLO_Int]>;
 // Dynamic representation of a shape vector as a tensor.
 def HLO_DimensionTensor : 1DTensorOf<[HLO_DimensionValue]>;
 
-// In general, static shaped tensor constraints should be avoided unless
-// it is for a legacy op which is only correct with static shapes.
-def HLO_StaticShapeTensor : StaticShapeTensorOf<[
-      HLO_Float, HLO_Pred, HLO_Int, HLO_Complex, HLO_QuantizedInt]>;
-
 //===----------------------------------------------------------------------===//
 // HLO combined type definitions.
 //===----------------------------------------------------------------------===//
@@ -158,6 +153,22 @@ def HLO_IntFpOrComplexTensor : TensorOf<[HLO_Int, HLO_Float, HLO_Complex]>;
 
 // Any pred, int or floating-point tensor types
 def HLO_PredIntOrFpTensor : TensorOf<[HLO_Pred, HLO_Int, HLO_Float]>;
+
+//===----------------------------------------------------------------------===//
+// HLO static shape type definitions.
+//===----------------------------------------------------------------------===//
+
+// In general, static shaped tensor constraints should be avoided unless
+// it is for a legacy op which is only correct with static shapes.
+def HLO_StaticShapeTensor : StaticShapeTensorOf<[
+      HLO_Float, HLO_Pred, HLO_Int, HLO_Complex, HLO_QuantizedInt]>;
+
+def HLO_StaticShapeTensorOrToken : AnyTypeOf<[HLO_StaticShapeTensor, HLO_Token]>;
+
+def HLO_StaticShapeIntOrFpTensor : StaticShapeTensorOf<[HLO_Int, HLO_Float]>;
+
+def HLO_StaticShapeIntFpOrComplexTensor :
+  StaticShapeTensorOf<[HLO_Int, HLO_Float, HLO_Complex]>;
 
 //===----------------------------------------------------------------------===//
 // HLO traits

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -116,7 +116,7 @@ def StableHLO_IotaOp : StableHLO_Op<"iota", [Pure]> {
   }];
   let arguments = (ins I64Attr:$iota_dimension);
 
-  let results = (outs HLO_IntFpOrComplexTensor:$output);
+  let results = (outs HLO_StaticShapeIntFpOrComplexTensor:$output);
 
   let hasVerifier = 1;
 
@@ -966,8 +966,6 @@ def StableHLO_XorOp : StableHLO_BinaryBiwiseOrLogicalElementwiseOp<"xor"> {
 // StableHLO communication op definitions.
 //===----------------------------------------------------------------------===//
 
-// InfeedOp corresponds to 'InfeedWithToken' xla client API and not 'Infeed'.
-// InfeedWithToken allows ordering of infeed HLO instructions using tokens.
 def StableHLO_InfeedOp : StableHLO_Op<"infeed", []> {
 
   let summary = "Infeed operator";
@@ -991,12 +989,10 @@ def StableHLO_InfeedOp : StableHLO_Op<"infeed", []> {
     DefaultValuedStrAttr<StrAttr, "">:$infeed_config,
     OptionalAttr<ArrayAttr>:$layout
   );
-  let results = (outs Variadic<HLO_TensorOrToken>);
+  let results = (outs Variadic<HLO_StaticShapeTensorOrToken>);
   let hasVerifier = 1;
 }
 
-// OutfeedOp corresponds to 'OutfeedWithToken' xla client API and not 'Outfeed'.
-// OutfeedWithToken allows ordering of outfeed HLO instructions using tokens.
 def StableHLO_OutfeedOp : StableHLO_Op<"outfeed",
     [DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
 
@@ -1083,7 +1079,7 @@ def StableHLO_RecvOp : StableHLO_Op<"recv", []> {
     DefaultValuedOptionalAttr<BoolAttr, "false">:$is_host_transfer
   );
 
-  let results = (outs Variadic<HLO_TensorOrToken>);
+  let results = (outs Variadic<HLO_StaticShapeTensorOrToken>);
   let hasVerifier = 1;
 }
 
@@ -2995,7 +2991,7 @@ def StableHLO_RngBitGeneratorOp : StableHLO_Op<"rng_bit_generator", [Pure]> {
 
   let results = (outs
     HLO_IntOrFpTensor:$output_state,
-    HLO_IntOrFpTensor:$output
+    HLO_StaticShapeIntOrFpTensor:$output
   );
 
   let hasVerifier = 1;


### PR DESCRIPTION
Some ops in the StableHLO dialect have "load-bearing" result shapes, meaning that these shapes cannot be inferred from op's operands, attributes and regions.

For these ops, the current design philosophy involves one of the two approaches:
  1) The shape is specified statically in the result type, e.g. see
     ReshapeOp.
  2) The shape is passed dynamically as an operand (or can be computed
     indirectly from shape-related operands), e.g. see DynamicReshapeOp.

In the future (#8), we want to have one unified approach in these situations, but we're not there yet, and this PR is about an incremental improvement to the state of the art.

One important piece of the design philosophy for 1) is that these ops need to be restricted to produce HLO_StaticShapeTensor, otherwise it is unclear what their semantics is.

  %1 = "stablehlo.reshape"(%0) : (tensor<2x4xf32>) -> tensor<?x?xf32>

For example, the code snippet above doesn't make sense because we need an actual shape to execute the op - either passed at compile time or passed at runtime - and neither is happening here.

When working on #622, I discovered that there are some ops which fall into 1) but don't have their result types restricted to be static: InfeedOp, IotaOp, RecvOp and RngBitGeneratorOp.

This means that StableHLO producers can currently produce these ops with dynamic result types, which would be unsound. This PR fixes this issue by changing the result types to HLO_StaticShapeTensor or equivalent.