### PR TITLE
Make CHLO ops inlinable

### DIFF
--- a/stablehlo/dialect/CMakeLists.txt
+++ b/stablehlo/dialect/CMakeLists.txt
@@ -70,6 +70,7 @@ add_mlir_dialect_library(ChloOps
   MLIRInferTypeOpInterface
   MLIRIR
   MLIRQuantDialect
+  MLIRTransformUtils
 )
 
 target_include_directories(ChloOps INTERFACE

--- a/stablehlo/dialect/ChloOps.cpp
+++ b/stablehlo/dialect/ChloOps.cpp
@@ -529,8 +529,7 @@ struct ChloDialectInlinerInterface : public DialectInlinerInterface {
                        BlockAndValueMapping& valueMapping) const final {
     return true;
   }
-  // Operations in StableHLO dialect are always legal to inline since they are
-  // pure.
+  // Operations in CHLO dialect are always legal to inline since they are pure.
   bool isLegalToInline(Operation*, Region*, bool,
                        BlockAndValueMapping&) const final {
     return true;

--- a/stablehlo/dialect/ChloOps.cpp
+++ b/stablehlo/dialect/ChloOps.cpp
@@ -23,6 +23,7 @@ limitations under the License.
 #include "mlir/Dialect/Traits.h"
 #include "mlir/IR/Diagnostics.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/InliningUtils.h"
 #include "stablehlo/dialect/BroadcastUtils.h"
 #include "stablehlo/dialect/ChloBytecode.h"
 
@@ -513,6 +514,30 @@ LogicalResult ConstantOp::inferReturnTypes(
 namespace mlir {
 namespace chlo {
 
+namespace {
+struct ChloDialectInlinerInterface : public DialectInlinerInterface {
+  using DialectInlinerInterface::DialectInlinerInterface;
+
+  // Allow all call operations to be inlined.
+  bool isLegalToInline(Operation* call, Operation* callable,
+                       bool wouldBeCloned) const final {
+    return true;
+  }
+  // We don't have any special restrictions on what can be inlined into
+  // destination regions (e.g. while/conditional bodies). Always allow it.
+  bool isLegalToInline(Region* dest, Region* src, bool wouldBeCloned,
+                       BlockAndValueMapping& valueMapping) const final {
+    return true;
+  }
+  // Operations in StableHLO dialect are always legal to inline since they are
+  // pure.
+  bool isLegalToInline(Operation*, Region*, bool,
+                       BlockAndValueMapping&) const final {
+    return true;
+  }
+};
+}  // namespace
+
 //===----------------------------------------------------------------------===//
 // chlo Dialect Constructor
 //===----------------------------------------------------------------------===//
@@ -523,6 +548,7 @@ ChloDialect::ChloDialect(MLIRContext* context)
 #define GET_OP_LIST
 #include "stablehlo/dialect/ChloOps.cpp.inc"
       >();
+  addInterfaces<ChloDialectInlinerInterface>();
   addAttributes<
 #define GET_ATTRDEF_LIST
 #include "stablehlo/dialect/ChloAttrs.cpp.inc"

--- a/stablehlo/tests/transform_chlo.mlir
+++ b/stablehlo/tests/transform_chlo.mlir
@@ -1,0 +1,14 @@
+// RUN: stablehlo-opt --inline %s | FileCheck %s
+
+// CHECK: func.func @main
+func.func @main(%arg0 : tensor<f32>, %arg1 : tensor<f32>) -> tensor<f32> {
+  // CHECK-NEXT: chlo.broadcast_add
+  %0 = func.call @callee(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
+  return %0 : tensor<f32>
+}
+
+// CHECK-NOT: func.func private @callee
+func.func private @callee(%arg0 : tensor<f32>, %arg1 : tensor<f32>) -> tensor<f32> {
+  %0 = "chlo.broadcast_add"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
+  return %0 : tensor<f32>
+}


### PR DESCRIPTION
When working on #622, I discovered that functions with CHLO ops aren't getting inlined, which is a miss because there's no reason for these ops to not be inlinable. For comparison, StableHLO and MHLO both implement this interface.

This PR fixes that and adds tests to make sure that things stay this way in the future as well.