### PR TITLE
Create inferFooOp functions for some infeasible ops

### DIFF
--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -897,35 +897,6 @@ LogicalResult verifyConvolutionAttributes(
   return success();
 }
 
-LogicalResult inferDotShape(RankedTensorType lhs, RankedTensorType rhs,
-                            SmallVector<int64_t>& result) {
-  // vector dot vector
-  if (1 == lhs.getRank() && 1 == rhs.getRank() &&
-      verifyCompatibleDims(lhs.getDimSize(0), rhs.getDimSize(0))) {
-    return success();
-  }
-  // matrix dot vector
-  if (2 == lhs.getRank() && 1 == rhs.getRank() &&
-      verifyCompatibleDims(lhs.getDimSize(1), rhs.getDimSize(0))) {
-    result.push_back(lhs.getDimSize(0));
-    return success();
-  }
-  // vector dot matrix
-  if (1 == lhs.getRank() && 2 == rhs.getRank() &&
-      verifyCompatibleDims(lhs.getDimSize(0), rhs.getDimSize(0))) {
-    result.push_back(rhs.getDimSize(1));
-    return success();
-  }
-  // matrix dot matrix
-  if (2 == lhs.getRank() && 2 == rhs.getRank() &&
-      verifyCompatibleDims(lhs.getDimSize(1), rhs.getDimSize(0))) {
-    result.push_back(lhs.getDimSize(0));
-    result.push_back(rhs.getDimSize(1));
-    return success();
-  }
-  return failure();
-}
-
 /*
  * We intend to verify the following properties:
  * P1. The 'update_window_dims' must be valid indices of 'updates' tensor.
@@ -1256,6 +1227,36 @@ static LogicalResult inferGatherReturnTypeComponents(
   return success();
 }
 
+// Used by IfOp and CaseOp
+LogicalResult inferConditionalOp(Optional<Location> location,
+                                 RegionRange branches,
+                                 SmallVectorImpl<Type>& inferredReturnTypes) {
+  if (branches.empty())
+    return emitOptionalError(location, "expect at least one branch");
+  for (auto region : branches)
+    if (failed(verifyRegionNotEmpty(location, *region))) return failure();
+
+  ValueTypeRange<OperandRange> branch0ResultTypes =
+      branches[0]->front().getTerminator()->getOperandTypes();
+  for (unsigned i = 0; i < branches.size(); ++i) {
+    Twine branchName = "branch " + Twine(i);
+    Region* region = branches[i];
+    if (region->getNumArguments() != 0)
+      return emitOptionalError(location, branchName,
+                               " must have 0 arguments, but found ",
+                               region->getNumArguments());
+
+    auto branchResultTypes = region->front().getTerminator()->getOperandTypes();
+    if (!isCompatibleForHloTypeInference(branch0ResultTypes, branchResultTypes))
+      return emitOptionalError(location, "branch 0 and ", branchName,
+                               " have mismatched return types: ",
+                               branch0ResultTypes, " vs ", branchResultTypes);
+  }
+  for (auto resultType : branch0ResultTypes)
+    inferredReturnTypes.push_back(resultType);
+  return success();
+}
+
 //===----------------------------------------------------------------------===//
 // Shape functions for ops.
 //===----------------------------------------------------------------------===//
@@ -1407,36 +1408,6 @@ LogicalResult inferBroadcastOp(
   llvm::append_range(shapeValues, operandType.getShape());
 
   inferredReturnShapes.emplace_back(shapeValues, operandType.getElementType());
-  return success();
-}
-
-// Used by IfOp and CaseOp
-LogicalResult inferConditionalOp(Optional<Location> location,
-                                 RegionRange branches,
-                                 SmallVectorImpl<Type>& inferredReturnTypes) {
-  if (branches.empty())
-    return emitOptionalError(location, "expect at least one branch");
-  for (auto region : branches)
-    if (failed(verifyRegionNotEmpty(location, *region))) return failure();
-
-  ValueTypeRange<OperandRange> branch0ResultTypes =
-      branches[0]->front().getTerminator()->getOperandTypes();
-  for (unsigned i = 0; i < branches.size(); ++i) {
-    Twine branchName = "branch " + Twine(i);
-    Region* region = branches[i];
-    if (region->getNumArguments() != 0)
-      return emitOptionalError(location, branchName,
-                               " must have 0 arguments, but found ",
-                               region->getNumArguments());
-
-    auto branchResultTypes = region->front().getTerminator()->getOperandTypes();
-    if (!isCompatibleForHloTypeInference(branch0ResultTypes, branchResultTypes))
-      return emitOptionalError(location, "branch 0 and ", branchName,
-                               " have mismatched return types: ",
-                               branch0ResultTypes, " vs ", branchResultTypes);
-  }
-  for (auto resultType : branch0ResultTypes)
-    inferredReturnTypes.push_back(resultType);
   return success();
 }
 
@@ -1637,10 +1608,306 @@ LogicalResult inferConstantOp(Optional<Location>, ElementsAttr value,
   return success();
 }
 
+LogicalResult inferConvertOp(
+    Optional<Location> location, Value operand,
+    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
+  auto operandType = operand.getType().dyn_cast<ShapedType>();
+  inferredReturnShapes.emplace_back(
+      operandType.hasRank() ? operandType.getShape() : ArrayRef<int64_t>{});
+  return success();
+}
+
+/*
+ * We intend to verify the following properties
+ *  P1. Verify the input, kernel types.
+ *  P2. Verify the convolution atributes.
+ *  P3. Verify and collect the window atributes.
+ *  P4. Verify precision_config attribute.
+ *  P5. Verify the return shape.
+ *      TODO(b/232574102): Verify the element-type of return-value.
+ */
+LogicalResult inferConvolutionOp(
+    Optional<Location> location, Value lhs, Value rhs,
+    Optional<DenseIntElementsAttr> windowStrides,
+    Optional<DenseIntElementsAttr> padding,
+    Optional<DenseIntElementsAttr> lhsDilation,
+    Optional<DenseIntElementsAttr> rhsDilation,
+    Optional<DenseElementsAttr> windowReversal, int64_t inputBatchDimension,
+    int64_t inputFeatureDimension, ArrayRef<int64_t> inputSpatialDimensions,
+    int64_t kernelInputFeatureDimension, int64_t kernelOutputFeatureDimension,
+    ArrayRef<int64_t> kernelSpatialDimensions, int64_t outputBatchDimension,
+    int64_t outputFeatureDimension, ArrayRef<int64_t> outputSpatialDimensions,
+    int64_t featureGroupCount, int64_t batchGroupCount,
+    Optional<ArrayAttr> precisionConfig,
+    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
+  auto lhsType = lhs.getType().dyn_cast<RankedTensorType>();
+  auto rhsType = rhs.getType().dyn_cast<RankedTensorType>();
+  if (!lhsType || !rhsType) {
+    inferredReturnShapes.push_back({});
+    return success();
+  }
+
+  // P1.
+  int numDims = lhsType.getRank();
+  if (numDims != rhsType.getRank())
+    return emitOptionalError(location,
+                             "expects convolution arguments to have same "
+                             "number of dimensions. Got: ",
+                             lhsType, " and ", rhsType, ".");
+
+  if (numDims < 2)
+    return emitOptionalError(
+        location,
+        "expects convolution arguments to have >= 2 dimensions. Got: ", lhsType,
+        " and ", rhsType, ".");
+
+  // P2.
+  if (failed(verifyConvolutionAttributes(
+          location, lhs, rhs, inputBatchDimension, inputFeatureDimension,
+          inputSpatialDimensions, kernelInputFeatureDimension,
+          kernelOutputFeatureDimension, kernelSpatialDimensions,
+          outputBatchDimension, outputFeatureDimension, outputSpatialDimensions,
+          featureGroupCount, batchGroupCount, precisionConfig)))
+    return failure();
+
+  if ((size_t)numDims != inputSpatialDimensions.size() + 2)
+    return emitOptionalError(location, "expects convolution arguments to have ",
+                             inputSpatialDimensions.size() + 2,
+                             " dimensions. Got: ", numDims);
+
+  // P3.
+  SmallVector<int64_t> windowDimensions(kernelSpatialDimensions.size());
+  for (size_t i = 0; i < windowDimensions.size(); i++)
+    windowDimensions[i] = rhsType.getShape()[kernelSpatialDimensions[i]];
+
+  auto paddingOrErr = convertPaddingAttribute(padding, location);
+  if (failed(paddingOrErr)) return failure();
+
+  // TODO: add missing tests for ConvolutionOp.
+  auto windowStridesOrErr =
+      convert1DAttribute(windowStrides, location, "window_strides");
+  if (failed(windowStridesOrErr)) return failure();
+  auto lhsDilationOrErr =
+      convert1DAttribute(lhsDilation, location, "lhs_dilation");
+  if (failed(lhsDilationOrErr)) return failure();
+  auto rhsDilationOrErr =
+      convert1DAttribute(rhsDilation, location, "rhs_dilation");
+  if (failed(rhsDilationOrErr)) return failure();
+  auto windowReversalOrErr = convertWindowReversalAttribute(
+      windowReversal, location, "window_reversal");
+  if (failed(windowReversalOrErr)) return failure();
+
+  auto windowOrErr = verifyWindowAttributesAndInferWindowDimensions(
+      windowDimensions, *windowStridesOrErr, *paddingOrErr, *lhsDilationOrErr,
+      *rhsDilationOrErr, *windowReversalOrErr, location);
+  if (failed(windowOrErr)) return failure();
+
+  // P3.
+  if (failed(verifyPrecisionConfig(location, precisionConfig)))
+    return failure();
+
+  // P5.
+  SmallVector<int64_t> outputDimensions(lhsType.getShape().size(),
+                                        ShapedType::kDynamic);
+
+  // Infer the output spatial dimensions.
+  auto numSpatialDims = inputSpatialDimensions.size();
+  SmallVector<int64_t> inputSpatialDimVals(numSpatialDims);
+  for (int64_t i = 0; i < static_cast<int64_t>(numSpatialDims); ++i)
+    inputSpatialDimVals[i] = lhsType.getShape()[inputSpatialDimensions[i]];
+
+  auto windowOutputShape =
+      inferWindowOutputShape(inputSpatialDimVals, *windowOrErr);
+
+  for (int64_t i = 0; i < static_cast<int64_t>(windowOrErr->size()); ++i)
+    outputDimensions[outputSpatialDimensions[i]] = windowOutputShape[i];
+
+  // Infer the output-batch-dimension and output-feature-dimension.
+  const int64_t inputBatch = lhsType.getShape()[inputBatchDimension];
+  const int64_t kernelOutputFeatures =
+      rhsType.getShape()[kernelOutputFeatureDimension];
+
+  outputDimensions[outputBatchDimension] = isDynamicDimSize(inputBatch)
+                                               ? ShapedType::kDynamic
+                                               : inputBatch / batchGroupCount;
+  outputDimensions[outputFeatureDimension] = kernelOutputFeatures;
+
+  inferredReturnShapes.emplace_back(outputDimensions);
+  return success();
+}
+
 LogicalResult inferCreateTokenOp(Dialect* dialect, Optional<Location> location,
                                  SmallVectorImpl<Type>& inferredReturnTypes) {
   auto hloDialect = cast<HloDialectInterface>(dialect);
   inferredReturnTypes.push_back(hloDialect->createTokenType());
+  return success();
+}
+
+LogicalResult inferDotOp(
+    Optional<Location> location, Value lhs, Value rhs,
+    Optional<ArrayAttr> precisionConfig,
+    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
+  if (failed(verifyPrecisionConfig(location, precisionConfig)))
+    return failure();
+
+  auto lhsType = lhs.getType().dyn_cast<RankedTensorType>();
+  auto rhsType = rhs.getType().dyn_cast<RankedTensorType>();
+  if (!lhsType || !rhsType) {
+    inferredReturnShapes.push_back({});
+    return success();
+  }
+
+  SmallVector<int64_t> dimensions;
+  if (1 == lhsType.getRank() && 1 == rhsType.getRank() &&
+      // vector dot vector
+      verifyCompatibleDims(lhsType.getDimSize(0), rhsType.getDimSize(0))) {
+  } else if (2 == lhsType.getRank() && 1 == rhsType.getRank() &&
+             verifyCompatibleDims(lhsType.getDimSize(1),
+                                  rhsType.getDimSize(0))) {
+    // matrix dot vector
+    dimensions.push_back(lhsType.getDimSize(0));
+  } else if (1 == lhsType.getRank() && 2 == rhsType.getRank() &&
+             verifyCompatibleDims(lhsType.getDimSize(0),
+                                  rhsType.getDimSize(0))) {
+    // vector dot matrix
+    dimensions.push_back(rhsType.getDimSize(1));
+  } else if (2 == lhsType.getRank() && 2 == rhsType.getRank() &&
+             verifyCompatibleDims(lhsType.getDimSize(1),
+                                  rhsType.getDimSize(0))) {
+    // matrix dot matrix
+    dimensions.push_back(lhsType.getDimSize(0));
+    dimensions.push_back(rhsType.getDimSize(1));
+  } else {
+    return emitOptionalError(location,
+                             "expected both lhs/rhs ranks to be "
+                             "either 1 or 2");
+  }
+
+  inferredReturnShapes.emplace_back(dimensions);
+  return success();
+}
+
+LogicalResult inferDotGeneralOp(
+    Optional<Location> location, Value lhs, Value rhs,
+    ArrayRef<int64_t> lhsBatchingDimensions,
+    ArrayRef<int64_t> rhsBatchingDimensions,
+    ArrayRef<int64_t> lhsContractingDimensions,
+    ArrayRef<int64_t> rhsContractingDimensions,
+    Optional<ArrayAttr> precisionConfig,
+    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
+  if (failed(verifyPrecisionConfig(location, precisionConfig)))
+    return failure();
+
+  if (lhsBatchingDimensions.size() != rhsBatchingDimensions.size())
+    return emitOptionalError(location,
+                             "lhs and rhs should have the same "
+                             "number of batching dimensions");
+  if (lhsContractingDimensions.size() != rhsContractingDimensions.size())
+    return emitOptionalError(location,
+                             "lhs and rhs should have the same "
+                             "number of contracting dimensions");
+
+  llvm::SmallDenseSet<int64_t> dimSet;
+  auto checkDimsDistinct =
+      [&](ArrayRef<int64_t> batchingDims, ArrayRef<int64_t> contractingDims,
+          llvm::SmallDenseSet<int64_t>& dimSet, llvm::StringRef lhs,
+          llvm::StringRef rhs) -> LogicalResult {
+    auto dims = llvm::concat<const int64_t>(batchingDims, contractingDims);
+    for (auto dim : dims) {
+      auto [_, wasInserted] = dimSet.insert(dim);
+      if (!wasInserted)
+        return emitOptionalError(location, "has duplicated dimension from ",
+                                 lhs, " and ", rhs, ": ", dim);
+    }
+    return success();
+  };
+
+  if (failed(checkDimsDistinct(lhsBatchingDimensions, lhsContractingDimensions,
+                               dimSet, "lhs_batching_dimensions",
+                               "lhs_contracting_dimensions")))
+    return failure();
+
+  dimSet.clear();
+
+  if (failed(checkDimsDistinct(rhsBatchingDimensions, rhsContractingDimensions,
+                               dimSet, "rhs_batching_dimensions",
+                               "rhs_contracting_dimensions")))
+    return failure();
+
+  auto checkDimsInRange = [&](int64_t rank, ArrayRef<int64_t> dims,
+                              llvm::StringRef dimName) -> LogicalResult {
+    auto inRange = [&](int64_t i) -> bool { return 0 <= i && i < rank; };
+    const auto* dimsNotInRange =
+        std::find_if_not(dims.begin(), dims.end(), inRange);
+    if (dimsNotInRange != dims.end())
+      return emitOptionalError(location, dimName, " value: ", *dimsNotInRange,
+                               " is out of range: ", "[0, ", rank, ")");
+    return success();
+  };
+  auto lhsRankedType = lhs.getType().dyn_cast<RankedTensorType>();
+  auto rhsRankedType = rhs.getType().dyn_cast<RankedTensorType>();
+
+  if (lhsRankedType) {
+    if (failed(checkDimsInRange(lhsRankedType.getRank(), lhsBatchingDimensions,
+                                "lhs_batching_dimensions")) ||
+        failed(checkDimsInRange(lhsRankedType.getRank(),
+                                lhsContractingDimensions,
+                                "lhs_contracting_dimensions")))
+      return failure();
+  }
+  if (rhsRankedType) {
+    if (failed(checkDimsInRange(rhsRankedType.getRank(), rhsBatchingDimensions,
+                                "rhs_batching_dimensions")) ||
+        failed(checkDimsInRange(rhsRankedType.getRank(),
+                                rhsContractingDimensions,
+                                "rhs_contracting_dimensions")))
+      return failure();
+  }
+  if (lhsRankedType && rhsRankedType) {
+    // Dimension sizes must be compatible for lhs/rhs.
+    auto lhsShape = lhsRankedType.getShape();
+    auto rhsShape = rhsRankedType.getShape();
+
+    for (auto [lhs, rhs] :
+         llvm::zip(lhsBatchingDimensions, rhsBatchingDimensions)) {
+      if (!verifyCompatibleDims(lhsShape[lhs], rhsShape[rhs]))
+        return emitOptionalError(location,
+                                 "batching dimension sizes must "
+                                 "match for lhs/rhs");
+    }
+
+    for (auto [lhs, rhs] :
+         llvm::zip(lhsContractingDimensions, rhsContractingDimensions)) {
+      if (!verifyCompatibleDims(lhsShape[lhs], rhsShape[rhs]))
+        return emitOptionalError(location,
+                                 "contracting dimension sizes must "
+                                 "match for lhs/rhs");
+    }
+  }
+
+  auto lhsType = lhs.getType().dyn_cast<RankedTensorType>();
+  auto rhsType = rhs.getType().dyn_cast<RankedTensorType>();
+  if (!lhsType || !rhsType) {
+    inferredReturnShapes.push_back({});
+    return success();
+  }
+
+  // Infer the output dimensions of the operation.
+  auto lhsShape = lhsType.getShape();
+  auto rhsShape = rhsType.getShape();
+  SmallVector<int64_t> dimensions;
+  for (const int64_t lhsBatchingDim : lhsBatchingDimensions)
+    dimensions.push_back(lhsShape[lhsBatchingDim]);
+  for (int64_t i = 0; i < lhsType.getRank(); i++)
+    if (!llvm::is_contained(lhsBatchingDimensions, i) &&
+        !llvm::is_contained(lhsContractingDimensions, i))
+      dimensions.push_back(lhsShape[i]);
+  for (int64_t i = 0; i < rhsType.getRank(); i++)
+    if (!llvm::is_contained(rhsBatchingDimensions, i) &&
+        !llvm::is_contained(rhsContractingDimensions, i))
+      dimensions.push_back(rhsShape[i]);
+
+  inferredReturnShapes.emplace_back(dimensions);
   return success();
 }
 
@@ -1925,6 +2192,14 @@ LogicalResult inferGatherOp(
       collapsedSliceDims, startIndexMap, indexVectorDim, inferredReturnShapes);
 }
 
+LogicalResult inferGetDimensionSizeOp(
+    MLIRContext* context, Optional<Location> location,
+    SmallVectorImpl<Type>& inferredReturnTypes) {
+  inferredReturnTypes.push_back(
+      RankedTensorType::get({}, IntegerType::get(context, 32)));
+  return success();
+}
+
 LogicalResult inferGetTupleElementOp(
     Optional<Location> location, Value operand, int32_t index,
     SmallVectorImpl<Type>& inferredReturnTypes) {
@@ -1951,14 +2226,6 @@ LogicalResult inferIsFiniteOp(MLIRContext* context, Optional<Location>, Value x,
   auto argTy = x.getType().cast<TensorType>();
   Builder b(context);
   inferredReturnTypes.push_back(getSameShapeTensorType(argTy, b.getI1Type()));
-  return success();
-}
-
-LogicalResult inferGetDimensionSizeOp(
-    MLIRContext* context, Optional<Location> location,
-    SmallVectorImpl<Type>& inferredReturnTypes) {
-  inferredReturnTypes.push_back(
-      RankedTensorType::get({}, IntegerType::get(context, 32)));
   return success();
 }
 
@@ -2061,6 +2328,23 @@ LogicalResult inferMapOp(
   return success();
 }
 
+LogicalResult inferOptimizationBarrierOp(
+    Optional<Location> location, ValueRange operand,
+    SmallVectorImpl<Type>& inferredReturnTypes) {
+  for (auto inputArgType : operand.getTypes()) {
+    inferredReturnTypes.emplace_back(inputArgType);
+  }
+
+  return success();
+}
+
+LogicalResult inferOutfeedOp(Dialect* dialect, Optional<Location> location,
+                             SmallVectorImpl<Type>& inferredReturnTypes) {
+  auto hloDialect = cast<HloDialectInterface>(dialect);
+  inferredReturnTypes.push_back(hloDialect->createTokenType());
+  return success();
+}
+
 LogicalResult inferPadOp(Optional<Location> location, Value operand,
                          Value paddingValue,
                          DenseIntElementsAttr edgePaddingLow,
@@ -2129,23 +2413,6 @@ LogicalResult inferPadOp(Optional<Location> location, Value operand,
       resultShape, inputType.getElementType(),
       boundsToEncoding(inputType.getEncoding(), resultBounds)));
 
-  return success();
-}
-
-LogicalResult inferOptimizationBarrierOp(
-    Optional<Location> location, ValueRange operand,
-    SmallVectorImpl<Type>& inferredReturnTypes) {
-  for (auto inputArgType : operand.getTypes()) {
-    inferredReturnTypes.emplace_back(inputArgType);
-  }
-
-  return success();
-}
-
-LogicalResult inferOutfeedOp(Dialect* dialect, Optional<Location> location,
-                             SmallVectorImpl<Type>& inferredReturnTypes) {
-  auto hloDialect = cast<HloDialectInterface>(dialect);
-  inferredReturnTypes.push_back(hloDialect->createTokenType());
   return success();
 }
 
@@ -2503,6 +2770,15 @@ LogicalResult inferUniformDequantizeOp(
   return success();
 }
 
+LogicalResult inferUniformQuantizeOp(
+    Optional<Location> location, Value operand,
+    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
+  auto operandType = operand.getType().dyn_cast<ShapedType>();
+  inferredReturnShapes.emplace_back(
+      operandType.hasRank() ? operandType.getShape() : ArrayRef<int64_t>{});
+  return success();
+}
+
 LogicalResult inferWhileOp(Optional<Location>, ValueRange operand,
                            SmallVectorImpl<Type>& inferredReturnTypes) {
   for (const auto& resultType : operand.getType())
@@ -2773,14 +3049,6 @@ LogicalResult verifyCollectivePermuteOp(
   return success();
 }
 
-/*
- * We intend to verify the following properties
- *  P1. Verify the input, kernel types.
- *  P2. Verify the convolution atributes.
- *  P3. Verify and collect the window atributes.
- *  P4. Verify precision_config attribute.
- *  P5. Verify the return shape.
- */
 LogicalResult verifyConvolutionOp(
     Optional<Location> location, Value lhs, Value rhs,
     Optional<DenseIntElementsAttr> windowStrides,
@@ -2794,121 +3062,45 @@ LogicalResult verifyConvolutionOp(
     int64_t outputFeatureDimension, ArrayRef<int64_t> outputSpatialDimensions,
     int64_t featureGroupCount, int64_t batchGroupCount,
     Optional<ArrayAttr> precisionConfig, Value result) {
-  auto lhsType = lhs.getType().dyn_cast<RankedTensorType>();
-  auto rhsType = rhs.getType().dyn_cast<RankedTensorType>();
-  if (!lhsType || !rhsType) return success();
-
-  // P1.
-  int numDims = lhsType.getRank();
-  if (numDims != rhsType.getRank())
-    return emitOptionalError(location,
-                             "expects convolution arguments to have same "
-                             "number of dimensions. Got: ",
-                             lhsType, " and ", rhsType, ".");
-
-  if (numDims < 2)
-    return emitOptionalError(
-        location,
-        "expects convolution arguments to have >= 2 dimensions. Got: ", lhsType,
-        " and ", rhsType, ".");
-
-  // P2.
-  if (failed(verifyConvolutionAttributes(
-          location, lhs, rhs, inputBatchDimension, inputFeatureDimension,
+  SmallVector<ShapedTypeComponents> inferredReturnShapes;
+  if (failed(inferConvolutionOp(
+          location, lhs, rhs, windowStrides, padding, lhsDilation, rhsDilation,
+          windowReversal, inputBatchDimension, inputFeatureDimension,
           inputSpatialDimensions, kernelInputFeatureDimension,
           kernelOutputFeatureDimension, kernelSpatialDimensions,
           outputBatchDimension, outputFeatureDimension, outputSpatialDimensions,
-          featureGroupCount, batchGroupCount, precisionConfig)))
+          featureGroupCount, batchGroupCount, precisionConfig,
+          inferredReturnShapes)))
     return failure();
 
-  if ((size_t)numDims != inputSpatialDimensions.size() + 2)
-    return emitOptionalError(location, "expects convolution arguments to have ",
-                             inputSpatialDimensions.size() + 2,
-                             " dimensions. Got: ", numDims);
-
-  // P3.
-  SmallVector<int64_t> windowDimensions(kernelSpatialDimensions.size());
-  for (size_t i = 0; i < windowDimensions.size(); i++)
-    windowDimensions[i] = rhsType.getShape()[kernelSpatialDimensions[i]];
-
-  auto paddingOrErr = convertPaddingAttribute(padding, location);
-  if (failed(paddingOrErr)) return failure();
-
-  // TODO: add missing tests for ConvolutionOp.
-  auto windowStridesOrErr =
-      convert1DAttribute(windowStrides, location, "window_strides");
-  if (failed(windowStridesOrErr)) return failure();
-  auto lhsDilationOrErr =
-      convert1DAttribute(lhsDilation, location, "lhs_dilation");
-  if (failed(lhsDilationOrErr)) return failure();
-  auto rhsDilationOrErr =
-      convert1DAttribute(rhsDilation, location, "rhs_dilation");
-  if (failed(rhsDilationOrErr)) return failure();
-  auto windowReversalOrErr = convertWindowReversalAttribute(
-      windowReversal, location, "window_reversal");
-  if (failed(windowReversalOrErr)) return failure();
-
-  auto windowOrErr = verifyWindowAttributesAndInferWindowDimensions(
-      windowDimensions, *windowStridesOrErr, *paddingOrErr, *lhsDilationOrErr,
-      *rhsDilationOrErr, *windowReversalOrErr, location);
-  if (failed(windowOrErr)) return failure();
-
-  // P4.
-  SmallVector<int64_t> outputDimensions(lhsType.getShape().size(),
-                                        ShapedType::kDynamic);
-
-  // Infer the output spatial dimensions.
-  auto numSpatialDims = inputSpatialDimensions.size();
-  SmallVector<int64_t> inputSpatialDimVals(numSpatialDims);
-  for (int64_t i = 0; i < static_cast<int64_t>(numSpatialDims); ++i)
-    inputSpatialDimVals[i] = lhsType.getShape()[inputSpatialDimensions[i]];
-
-  auto windowOutputShape =
-      inferWindowOutputShape(inputSpatialDimVals, *windowOrErr);
-
-  for (int64_t i = 0; i < static_cast<int64_t>(windowOrErr->size()); ++i)
-    outputDimensions[outputSpatialDimensions[i]] = windowOutputShape[i];
-
-  // Infer the output-batch-dimension and output-feature-dimension.
-  const int64_t inputBatch = lhsType.getShape()[inputBatchDimension];
-  const int64_t kernelOutputFeatures =
-      rhsType.getShape()[kernelOutputFeatureDimension];
-
-  outputDimensions[outputBatchDimension] = isDynamicDimSize(inputBatch)
-                                               ? ShapedType::kDynamic
-                                               : inputBatch / batchGroupCount;
-  outputDimensions[outputFeatureDimension] = kernelOutputFeatures;
-
-  auto resultType = result.getType().dyn_cast<RankedTensorType>();
-  if (!resultType) return success();
-
-  if (failed(verifyCompatibleShape(outputDimensions, resultType.getShape())))
+  auto inferredShape = inferredReturnShapes[0];
+  auto resultType = result.getType().dyn_cast<ShapedType>();
+  if (inferredShape.hasRank() && resultType.hasRank() &&
+      failed(verifyCompatibleShape(inferredShape.getDims(),
+                                   resultType.getShape())))
     return emitOptionalError(
-        location, "inferred shape '", dimSizesToString(outputDimensions), "' ",
-        "is incompatible with return type of operation ", resultType, "");
+        location, "inferred shape '", dimSizesToString(inferredShape.getDims()),
+        "' ", "is incompatible with return type of operation ", resultType, "");
 
   return success();
 }
 
 LogicalResult verifyDotOp(Optional<Location> location, Value lhs, Value rhs,
                           Optional<ArrayAttr> precisionConfig, Value result) {
-  auto lhsType = lhs.getType().dyn_cast<RankedTensorType>();
-  auto rhsType = rhs.getType().dyn_cast<RankedTensorType>();
-  auto resultType = result.getType().dyn_cast<RankedTensorType>();
-  if (!lhsType || !rhsType) return success();
+  SmallVector<ShapedTypeComponents> inferredReturnShapes;
+  if (failed(inferDotOp(location, lhs, rhs, precisionConfig,
+                        inferredReturnShapes)))
+    return failure();
 
-  SmallVector<int64_t> inferredShape;
-  if (failed(inferDotShape(lhsType, rhsType, inferredShape)))
-    return emitOptionalError(location, "failed to infer shape for lhs ",
-                             lhsType, " and rhs ", rhsType);
-
-  if (resultType &&
-      failed(verifyCompatibleShape(inferredShape, resultType.getShape())))
+  auto inferredShape = inferredReturnShapes[0];
+  auto resultType = result.getType().dyn_cast<ShapedType>();
+  if (inferredShape.hasRank() && resultType.hasRank() &&
+      failed(verifyCompatibleShape(inferredShape.getDims(),
+                                   resultType.getShape())))
     return emitOptionalError(
-        location, "inferred shape '", dimSizesToString(inferredShape), "' ",
-        "is incompatible with return type of operation ", resultType, "");
-
-  return verifyPrecisionConfig(location, precisionConfig);
+        location, "inferred shape '", dimSizesToString(inferredShape.getDims()),
+        "' ", "is incompatible with return type of operation ", resultType, "");
+  return success();
 }
 
 LogicalResult verifyDotGeneralOp(Optional<Location> location, Value lhs,
@@ -2919,123 +3111,21 @@ LogicalResult verifyDotGeneralOp(Optional<Location> location, Value lhs,
                                  ArrayRef<int64_t> rhsContractingDimensions,
                                  Optional<ArrayAttr> precisionConfig,
                                  Value result) {
-  if (failed(verifyPrecisionConfig(location, precisionConfig)))
+  SmallVector<ShapedTypeComponents> inferredReturnShapes;
+  if (failed(inferDotGeneralOp(location, lhs, rhs, lhsBatchingDimensions,
+                               rhsBatchingDimensions, lhsContractingDimensions,
+                               rhsContractingDimensions, precisionConfig,
+                               inferredReturnShapes)))
     return failure();
 
-  if (lhsBatchingDimensions.size() != rhsBatchingDimensions.size())
-    return emitOptionalError(location,
-                             "lhs and rhs should have the same "
-                             "number of batching dimensions");
-  if (lhsContractingDimensions.size() != rhsContractingDimensions.size())
-    return emitOptionalError(location,
-                             "lhs and rhs should have the same "
-                             "number of contracting dimensions");
-
-  llvm::SmallDenseSet<int64_t> dimSet;
-  auto checkDimsDistinct =
-      [&](ArrayRef<int64_t> batchingDims, ArrayRef<int64_t> contractingDims,
-          llvm::SmallDenseSet<int64_t>& dimSet, llvm::StringRef lhs,
-          llvm::StringRef rhs) -> LogicalResult {
-    auto dims = llvm::concat<const int64_t>(batchingDims, contractingDims);
-    for (auto dim : dims) {
-      auto [_, wasInserted] = dimSet.insert(dim);
-      if (!wasInserted)
-        return emitOptionalError(location, "has duplicated dimension from ",
-                                 lhs, " and ", rhs, ": ", dim);
-    }
-    return success();
-  };
-
-  if (failed(checkDimsDistinct(lhsBatchingDimensions, lhsContractingDimensions,
-                               dimSet, "lhs_batching_dimensions",
-                               "lhs_contracting_dimensions")))
-    return failure();
-
-  dimSet.clear();
-
-  if (failed(checkDimsDistinct(rhsBatchingDimensions, rhsContractingDimensions,
-                               dimSet, "rhs_batching_dimensions",
-                               "rhs_contracting_dimensions")))
-    return failure();
-
-  auto checkDimsInRange = [&](int64_t rank, ArrayRef<int64_t> dims,
-                              llvm::StringRef dimName) -> LogicalResult {
-    auto inRange = [&](int64_t i) -> bool { return 0 <= i && i < rank; };
-    const auto* dimsNotInRange =
-        std::find_if_not(dims.begin(), dims.end(), inRange);
-    if (dimsNotInRange != dims.end())
-      return emitOptionalError(location, dimName, " value: ", *dimsNotInRange,
-                               " is out of range: ", "[0, ", rank, ")");
-    return success();
-  };
-  auto lhsRankedType = lhs.getType().dyn_cast<RankedTensorType>();
-  auto rhsRankedType = rhs.getType().dyn_cast<RankedTensorType>();
-
-  if (lhsRankedType) {
-    if (failed(checkDimsInRange(lhsRankedType.getRank(), lhsBatchingDimensions,
-                                "lhs_batching_dimensions")) ||
-        failed(checkDimsInRange(lhsRankedType.getRank(),
-                                lhsContractingDimensions,
-                                "lhs_contracting_dimensions")))
-      return failure();
-  }
-  if (rhsRankedType) {
-    if (failed(checkDimsInRange(rhsRankedType.getRank(), rhsBatchingDimensions,
-                                "rhs_batching_dimensions")) ||
-        failed(checkDimsInRange(rhsRankedType.getRank(),
-                                rhsContractingDimensions,
-                                "rhs_contracting_dimensions")))
-      return failure();
-  }
-  if (lhsRankedType && rhsRankedType) {
-    // Dimension sizes must be compatible for lhs/rhs.
-    auto lhsShape = lhsRankedType.getShape();
-    auto rhsShape = rhsRankedType.getShape();
-
-    for (auto [lhs, rhs] :
-         llvm::zip(lhsBatchingDimensions, rhsBatchingDimensions)) {
-      if (!verifyCompatibleDims(lhsShape[lhs], rhsShape[rhs]))
-        return emitOptionalError(location,
-                                 "batching dimension sizes must "
-                                 "match for lhs/rhs");
-    }
-
-    for (auto [lhs, rhs] :
-         llvm::zip(lhsContractingDimensions, rhsContractingDimensions)) {
-      if (!verifyCompatibleDims(lhsShape[lhs], rhsShape[rhs]))
-        return emitOptionalError(location,
-                                 "contracting dimension sizes must "
-                                 "match for lhs/rhs");
-    }
-  }
-
-  auto lhsType = lhs.getType().dyn_cast<RankedTensorType>();
-  auto rhsType = rhs.getType().dyn_cast<RankedTensorType>();
-  auto resultType = result.getType().dyn_cast<RankedTensorType>();
-  if (!lhsType || !rhsType || !resultType) return success();
-
-  auto lhsShape = lhsType.getShape();
-  auto rhsShape = rhsType.getShape();
-  auto resultShape = resultType.getShape();
-
-  // Infer the output dimensions of the operation.
-  SmallVector<int64_t> dimensions;
-  for (const int64_t lhsBatchingDim : lhsBatchingDimensions)
-    dimensions.push_back(lhsShape[lhsBatchingDim]);
-  for (int64_t i = 0; i < lhsType.getRank(); i++)
-    if (!llvm::is_contained(lhsBatchingDimensions, i) &&
-        !llvm::is_contained(lhsContractingDimensions, i))
-      dimensions.push_back(lhsShape[i]);
-  for (int64_t i = 0; i < rhsType.getRank(); i++)
-    if (!llvm::is_contained(rhsBatchingDimensions, i) &&
-        !llvm::is_contained(rhsContractingDimensions, i))
-      dimensions.push_back(rhsShape[i]);
-
-  if (failed(verifyCompatibleShape(dimensions, resultShape)))
+  auto inferredShape = inferredReturnShapes[0];
+  auto resultType = result.getType().dyn_cast<ShapedType>();
+  if (inferredShape.hasRank() && resultType.hasRank() &&
+      failed(verifyCompatibleShape(inferredShape.getDims(),
+                                   resultType.getShape())))
     return emitOptionalError(
-        location, "inferred shape '", dimSizesToString(dimensions), "' ",
-        "is incompatible with return type of operation ", resultType, "");
-
+        location, "inferred shape '", dimSizesToString(inferredShape.getDims()),
+        "' ", "is incompatible with return type of operation ", resultType, "");
   return success();
 }
 

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -156,8 +156,41 @@ LogicalResult inferConcatenateOp(Optional<Location> location, ValueRange inputs,
 LogicalResult inferConstantOp(Optional<Location>, ElementsAttr value,
                               SmallVectorImpl<Type>& inferredReturnTypes);
 
+LogicalResult inferConvertOp(
+    Optional<Location> location, Value operand,
+    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
+
+LogicalResult inferConvolutionOp(
+    Optional<Location> location, Value lhs, Value rhs,
+    Optional<DenseIntElementsAttr> windowStrides,
+    Optional<DenseIntElementsAttr> padding,
+    Optional<DenseIntElementsAttr> lhsDilation,
+    Optional<DenseIntElementsAttr> rhsDilation,
+    Optional<DenseElementsAttr> windowReversal, int64_t inputBatchDimension,
+    int64_t inputFeatureDimension, ArrayRef<int64_t> inputSpatialDimensions,
+    int64_t kernelInputFeatureDimension, int64_t kernelOutputFeatureDimension,
+    ArrayRef<int64_t> kernelSpatialDimensions, int64_t outputBatchDimension,
+    int64_t outputFeatureDimension, ArrayRef<int64_t> outputSpatialDimensions,
+    int64_t featureGroupCount, int64_t batchGroupCount,
+    Optional<ArrayAttr> precisionConfig,
+    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
+
 LogicalResult inferCreateTokenOp(Dialect* dialect, Optional<Location> location,
                                  SmallVectorImpl<Type>& inferredReturnTypes);
+
+LogicalResult inferDotOp(
+    Optional<Location> location, Value lhs, Value rhs,
+    Optional<ArrayAttr> precisionConfig,
+    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
+
+LogicalResult inferDotGeneralOp(
+    Optional<Location> location, Value lhs, Value rhs,
+    ArrayRef<int64_t> lhsBatchingDimensions,
+    ArrayRef<int64_t> rhsBatchingDimensions,
+    ArrayRef<int64_t> lhsContractingDimensions,
+    ArrayRef<int64_t> rhsContractingDimensions,
+    Optional<ArrayAttr> precisionConfig,
+    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferDynamicGatherOp(
     Optional<Location> location, Value operand, Value startIndices,
@@ -188,6 +221,10 @@ LogicalResult inferGatherOp(
     DenseIntElementsAttr sliceSizes,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
+LogicalResult inferGetDimensionSizeOp(
+    MLIRContext* context, Optional<Location> location,
+    SmallVectorImpl<Type>& inferredReturnTypes);
+
 LogicalResult inferGetTupleElementOp(
     Optional<Location> location, Value operand, int32_t index,
     SmallVectorImpl<Type>& inferredReturnTypes);
@@ -198,10 +235,6 @@ LogicalResult inferImagOp(Optional<Location> location, Value operand,
 LogicalResult inferIsFiniteOp(MLIRContext* context, Optional<Location>, Value x,
                               SmallVectorImpl<Type>& inferredReturnTypes);
 
-LogicalResult inferGetDimensionSizeOp(
-    MLIRContext* context, Optional<Location> location,
-    SmallVectorImpl<Type>& inferredReturnTypes);
-
 LogicalResult inferIfOp(Optional<Location> location, RegionRange branches,
                         SmallVectorImpl<Type>& inferredReturnTypes);
 
@@ -210,19 +243,19 @@ LogicalResult inferMapOp(
     DenseIntElementsAttr dimensions, Region& computation,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
-LogicalResult inferPadOp(Optional<Location> location, Value operand,
-                         Value paddingValue,
-                         DenseIntElementsAttr edgePaddingLow,
-                         DenseIntElementsAttr edgePaddingHigh,
-                         DenseIntElementsAttr interiorPadding,
-                         SmallVectorImpl<Type>& inferredReturnTypes);
-
 LogicalResult inferOptimizationBarrierOp(
     Optional<Location> location, ValueRange operand,
     SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferOutfeedOp(Dialect* dialect, Optional<Location> location,
                              SmallVectorImpl<Type>& inferredReturnTypes);
+
+LogicalResult inferPadOp(Optional<Location> location, Value operand,
+                         Value paddingValue,
+                         DenseIntElementsAttr edgePaddingLow,
+                         DenseIntElementsAttr edgePaddingHigh,
+                         DenseIntElementsAttr interiorPadding,
+                         SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferPartitionIdOp(MLIRContext* context,
                                  Optional<Location> location,
@@ -288,6 +321,10 @@ LogicalResult inferTupleOp(MLIRContext* context, Optional<Location> location,
                            SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferUniformDequantizeOp(
+    Optional<Location> location, Value operand,
+    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
+
+LogicalResult inferUniformQuantizeOp(
     Optional<Location> location, Value operand,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -1506,7 +1506,7 @@ func.func @dot_more_dynamic_output_type(%arg0: tensor<3xf32>, %arg1: tensor<?x3x
 // -----
 
 func.func @dot_cannot_infer_type(%arg0: tensor<?x?x3xf32>, %arg1: tensor<?x3x?xf32>) -> tensor<*xf32> {
-  // expected-error@+1 {{failed to infer shape for lhs 'tensor<?x?x3xf32>' and rhs 'tensor<?x3x?xf32>'}}
+  // expected-error@+1 {{expected both lhs/rhs ranks to be either 1 or 2}}
   %0 = "stablehlo.dot"(%arg0, %arg1) : (tensor<?x?x3xf32>, tensor<?x3x?xf32>) -> tensor<*xf32>
   func.return %0 : tensor<*xf32>
 }


### PR DESCRIPTION
In this PR, we introduce inferFooOp functions for ops where result's element type is load-bearing: convert, convolution, dot, dot_general, uniform_quantize.

These functions return SmallVectorImpl<ShapedTypeComponents>& and only fill in the shape part. Even though these functions aren't be usable from the existing type inference framework (missing element types will mean that type inference will fail), they will allow sharing shape inference logic with #622.

bitcast_convert is an odd one. It does belong in this category, but its shape curiously depends on the relationship between the operand type and the result type, so implementing inferBitcastConvertOp is not possible, even if it returns ShapedTypeComponents.