### PR TITLE
Fix clang-format lint action to skip deleted files

### DIFF
--- a/build_tools/github_actions/lint_clang_format.sh
+++ b/build_tools/github_actions/lint_clang_format.sh
@@ -35,7 +35,7 @@ if [[ $# -ne 0 ]] ; then
 fi
 
 echo "Gathering changed files..."
-CHANGED_FILES=$(git diff --name-only HEAD $BASE_BRANCH | grep '.*\.h\|.*\.cpp' | xargs)
+CHANGED_FILES=$(git diff $BASE_BRANCH HEAD --name-only --diff-filter=d | grep '.*\.h\|.*\.cpp' | xargs)
 if [[ -z "$CHANGED_FILES" ]]; then
   echo "No files to format."
   exit 0


### PR DESCRIPTION
Changed to `git diff $BASE_BRANCH HEAD --name-only --diff-filter=d`

In plain terms this reads:

Diff the base branch (`origin/main` by default) with `HEAD`, only show file names, and skip any deleted files.

The lint action was failing since `clang-format FileNotFound.cpp` exits with a bash error code.

I made the changes in #895 locally to test the fix. Should work after we merge this in.