### PR TITLE
Update spec status for convolution op: `revisit` to `yes`

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -68,7 +68,7 @@ one of the following tracking labels.
 | concatenate              | yes           | yes          | yes            | yes             | no          |
 | constant                 | yes           | yes          | yes            | yes             | yes         |
 | convert                  | yes           | yes          | infeasible     | yes             | no          |
-| convolution              | revisit       | yes          | infeasible     | revisit         | no          |
+| convolution              | yes           | yes          | infeasible     | revisit         | no          |
 | cosine                   | yes           | yes          | yes            | yes             | yes         |
 | count_leading_zeros      | yes           | yes          | yes            | yes             | no          |
 | create_token             | no            | yes\*        | yes\*          | yes             | no          |


### PR DESCRIPTION
As per https://github.com/openxla/stablehlo/pull/441#discussion_r1041744301, the spec should be a `revisit` for #730 which is now  fixed. 