### PR TITLE
Make precision config optional in VHLO

### DIFF
--- a/stablehlo/dialect/VhloAttrs.td
+++ b/stablehlo/dialect/VhloAttrs.td
@@ -199,7 +199,7 @@ def VHLO_ConvolutionAttributes {
     VHLO_AnyAttr:$dimension_numbers,
     VHLO_AnyAttr:$feature_group_count,
     VHLO_AnyAttr:$batch_group_count,
-    VHLO_AnyAttr:$precision_config
+    OptionalAttr<VHLO_AnyAttr>:$precision_config
   );
 }
 

--- a/stablehlo/dialect/VhloOps.td
+++ b/stablehlo/dialect/VhloOps.td
@@ -670,7 +670,7 @@ def VHLO_DotOpV1 : VHLO_Op<"dot"> {
   let arguments = (
     ins VHLO_AnyType:$lhs,
     VHLO_AnyType:$rhs,
-    VHLO_AnyAttr:$precision_config
+    OptionalAttr<VHLO_AnyAttr>:$precision_config
   );
   let results = (outs VHLO_AnyType);
 }
@@ -680,7 +680,7 @@ def VHLO_DotGeneralOpV1 : VHLO_Op<"dot_general"> {
     VHLO_AnyType:$lhs,
     VHLO_AnyType:$rhs,
     VHLO_AnyAttr:$dot_dimension_numbers,
-    VHLO_AnyAttr:$precision_config
+    OptionalAttr<VHLO_AnyAttr>:$precision_config
   );
   let results = (outs VHLO_AnyType);
 }

--- a/stablehlo/tests/legalize_stablehlo_to_vhlo.mlir
+++ b/stablehlo/tests/legalize_stablehlo_to_vhlo.mlir
@@ -729,6 +729,9 @@ func.func @op_dot(%arg0: tensor<8x16xf32>, %arg1: tensor<16x8xf32>) -> tensor<8x
   %0 = "stablehlo.dot"(%arg0, %arg1) {
     precision_config = []
   } : (tensor<8x16xf32>, tensor<16x8xf32>) -> tensor<8x8xf32>
+  //      CHECK: "vhlo.dot"(%arg0, %arg1)
+  // CHECK-SAME: : (tensor<8x16xf32>, tensor<16x8xf32>) -> tensor<8x8xf32>
+  %1 = "stablehlo.dot"(%arg0, %arg1) : (tensor<8x16xf32>, tensor<16x8xf32>) -> tensor<8x8xf32>
   func.return %0 : tensor<8x8xf32>
 }
 // CHECK-LABEL: "op_dot"


### PR DESCRIPTION
Found this while converting some models to VHLO. `PrecisionConfigAttr` in stablehlo is an optional attribute. Missed this since it appears without the `OptionalAttr` tag in op definitions, because the attribute itself is defined using it.