### PR TITLE
Handle bounds of Gather op

### DIFF
--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -31,6 +31,7 @@ limitations under the License.
 
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallSet.h"
@@ -1298,11 +1299,12 @@ static LogicalResult inferGatherReturnTypeComponents(
       startIndices.getType().cast<RankedTensorType>().getEncoding());
   SmallVector<int64_t> inferredBounds(resultRank, ShapedType::kDynamic);
   if (!startIndicesBounds.empty()) {
-    llvm::SmallDenseSet<int64_t> offsetDimSet(offsetDims.begin(),
-                                              offsetDims.end());
+    llvm::BitVector isOffsetDim(resultRank);
+    for (auto offsetDim : offsetDims) isOffsetDim.set(offsetDim);
+
     int64_t index = 0;
     for (int dim = 0; dim < resultRank; ++dim) {
-      if (offsetDimSet.count(dim)) continue;
+      if (isOffsetDim.test(dim)) continue;
 
       if (index == indexVectorDim) ++index;
       inferredBounds[dim] = startIndicesBounds[index];

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -169,7 +169,7 @@ func.func @gather(%operand : tensor<2x4x9xi32>, %start_indices : tensor<1x5x2xi3
 // -----
 
 // CHECK-LABEL: @gather_bounds
-func.func @gather_bounds(%operand : tensor<2x4x9xi32>, %start_indices : tensor<?x?x?xi32, #stablehlo.type_extensions<bounds = [16, 32, 64]>>) -> tensor<*xindex> {
+func.func @gather_bounds(%operand : tensor<?x?x?xi32, #stablehlo.type_extensions<bounds = [2, 4, 8]>>, %start_indices : tensor<?x?x?xi32, #stablehlo.type_extensions<bounds = [16, 32, 64]>>) -> tensor<*xindex> {
   %res = "stablehlo.gather"(%operand, %start_indices) {
     dimension_numbers = #stablehlo.gather<
       collapsed_slice_dims = [0, 1],
@@ -179,7 +179,7 @@ func.func @gather_bounds(%operand : tensor<2x4x9xi32>, %start_indices : tensor<?
     >,
     indices_are_sorted = false,
     slice_sizes = dense<[1, 1, 8]> : tensor<3xi64>
-  } : (tensor<2x4x9xi32>, tensor<?x?x?xi32, #stablehlo.type_extensions<bounds = [16, 32, 64]>>)
+  } : (tensor<?x?x?xi32, #stablehlo.type_extensions<bounds = [2, 4, 8]>>, tensor<?x?x?xi32, #stablehlo.type_extensions<bounds = [16, 32, 64]>>)
   -> tensor<?x?x8xi32>
 
   // CHECK: types0 = tensor<?x?x8xi32, #stablehlo.type_extensions<bounds = [32, 64, ?]>>

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -168,6 +168,27 @@ func.func @gather(%operand : tensor<2x4x9xi32>, %start_indices : tensor<1x5x2xi3
 
 // -----
 
+// CHECK-LABEL: @gather_bounds
+func.func @gather_bounds(%operand : tensor<2x4x9xi32>, %start_indices : tensor<?x?x?xi32, #stablehlo.type_extensions<bounds = [16, 32, 64]>>) -> tensor<*xindex> {
+  %res = "stablehlo.gather"(%operand, %start_indices) {
+    dimension_numbers = #stablehlo.gather<
+      collapsed_slice_dims = [0, 1],
+      index_vector_dim = 0,
+      offset_dims = [2],
+      start_index_map = [0, 1]
+    >,
+    indices_are_sorted = false,
+    slice_sizes = dense<[1, 1, 8]> : tensor<3xi64>
+  } : (tensor<2x4x9xi32>, tensor<?x?x?xi32, #stablehlo.type_extensions<bounds = [16, 32, 64]>>)
+  -> tensor<?x?x8xi32>
+
+  // CHECK: types0 = tensor<?x?x8xi32, #stablehlo.type_extensions<bounds = [32, 64, ?]>>
+  %1 = "hlo_test_infer.get_return_types"(%res) : (tensor<?x?x8xi32>) -> tensor<*xindex>
+  func.return %1 : tensor<*xindex>
+}
+
+// -----
+
 // CHECK-LABEL: @rng_normal
 func.func @rng_normal(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<7xindex> {
   %0 = "stablehlo.constant"() {value = dense<7> : tensor<1xi64>} : () -> tensor<1xi64>


### PR DESCRIPTION
The dimension sizes of result, corresponding to offset dimensions, depend on attributes (like `collapsed_slice_dims` and `slice_sizes`) and hence are always static. 

Whereas, the dimension sizes of result, corresponding to batch dimensions, depends on input `start_indices` and could be dynamic. The corresponding bounds, in that case,  are propagated from the `start_indices`.



Side notes:
I deliberately avoid making any changes in `inferGatherShape` which is currently shared by `GatherOp::inferReturnTypeComponents` and `GatherOp::reifyReturnTypeShapes`. The reason being I do not `reifyReturnTypeShapes` needs to handle the bounds. 

Because of the decision, we have  some duplicate code in line 1237 (duplicate of https://github.com/openxla/stablehlo/blob/afcbb953c12a2a3a8564cab73278f4b47021ec01/stablehlo/dialect/TypeInference.cpp#L1149).

PTAL @smit-hinsu 
