### PR TITLE
Handle bounds in the FftOp shape function

### DIFF
--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2181,7 +2181,7 @@ LogicalResult inferFftOp(
   }
 
   // P3. Check input shape and infer return shape
-  RankedTensorType operandRankedType = operandType.dyn_cast<RankedTensorType>();
+  auto operandRankedType = operandType.dyn_cast<RankedTensorType>();
   if (!operandRankedType) {
     inferredReturnShapes.emplace_back(resultElementType);
     return success();

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2249,10 +2249,17 @@ LogicalResult inferFftOp(
         resultShape, resultElementType,
         boundsToEncoding(operandRankedType.getEncoding(), bounds));
   } else if (isFftTypeRfft) {
-    bounds[bounds.size() - 1] = ShapedType::kDynamic;
-    inferredReturnShapes.emplace_back(
-        resultShape, resultElementType,
-        boundsToEncoding(operandRankedType.getEncoding(), bounds));
+    if (!bounds.empty()) {
+      bounds[bounds.size() - 1] = ShapedType::kDynamic;
+      inferredReturnShapes.emplace_back(
+          resultShape, resultElementType,
+          boundsToEncoding(operandRankedType.getEncoding(), bounds));
+    } else {
+      inferredReturnShapes.emplace_back(
+          resultShape, resultElementType,
+          boundsToEncoding(operandRankedType.getEncoding(),
+                           llvm::ArrayRef<int64_t>({})));
+    }
   } else {
     inferredReturnShapes.emplace_back(resultShape, resultElementType,
                                       operandRankedType.getEncoding());

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2236,8 +2236,8 @@ LogicalResult inferFftOp(
   if ((isFftTypeIrfft || isFftTypeRfft) && !resultBounds.empty())
     resultBounds[resultBounds.size() - 1] = ShapedType::kDynamic;
   inferredReturnShapes.emplace_back(
-        resultShape, resultElementType,
-        boundsToEncoding(operandRankedType.getEncoding(), resultBounds));
+      resultShape, resultElementType,
+      boundsToEncoding(operandRankedType.getEncoding(), resultBounds));
   return success();
 }
 

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2249,8 +2249,7 @@ LogicalResult inferFftOp(
         resultShape, resultElementType,
         boundsToEncoding(operandRankedType.getEncoding(), bounds));
   } else if (isFftTypeRfft) {
-    if (!bounds.empty())
-      bounds[bounds.size() - 1] = ShapedType::kDynamic;
+    if (!bounds.empty()) bounds[bounds.size() - 1] = ShapedType::kDynamic;
     inferredReturnShapes.emplace_back(
         resultShape, resultElementType,
         boundsToEncoding(operandRankedType.getEncoding(), bounds));

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2181,16 +2181,16 @@ LogicalResult inferFftOp(
   }
 
   // P3. Check input shape and infer return shape
-  operandType = operandType.dyn_cast<RankedTensorType>();
-  if (!operandType) {
+  RankedTensorType operandRankedType = operandType.dyn_cast<RankedTensorType>();
+  if (!operandRankedType) {
     inferredReturnShapes.emplace_back(resultElementType);
     return success();
   }
-  auto operandShape = operandType.getShape();
+  auto operandShape = operandRankedType.getShape();
   if (static_cast<int64_t>(operandShape.size()) < fftRank)
     return emitOptionalError(
         location, "operand rank must not be less than fft rank of ", fftRank,
-        " for operand of type ", operandType, ".");
+        " for operand of type ", operandRankedType, ".");
 
   SmallVector<int64_t> resultShape = to_vector(operandShape);
 
@@ -2233,7 +2233,8 @@ LogicalResult inferFftOp(
     resultShape[resultShape.size() - 1] = fftLengthValues[fftRank - 1];
   }
 
-  inferredReturnShapes.emplace_back(resultShape, resultElementType);
+  inferredReturnShapes.emplace_back(resultShape, resultElementType,
+                                    operandRankedType.getEncoding());
   return success();
 }
 

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2249,17 +2249,11 @@ LogicalResult inferFftOp(
         resultShape, resultElementType,
         boundsToEncoding(operandRankedType.getEncoding(), bounds));
   } else if (isFftTypeRfft) {
-    if (!bounds.empty()) {
+    if (!bounds.empty())
       bounds[bounds.size() - 1] = ShapedType::kDynamic;
-      inferredReturnShapes.emplace_back(
-          resultShape, resultElementType,
-          boundsToEncoding(operandRankedType.getEncoding(), bounds));
-    } else {
-      inferredReturnShapes.emplace_back(
-          resultShape, resultElementType,
-          boundsToEncoding(operandRankedType.getEncoding(),
-                           llvm::ArrayRef<int64_t>({})));
-    }
+    inferredReturnShapes.emplace_back(
+        resultShape, resultElementType,
+        boundsToEncoding(operandRankedType.getEncoding(), bounds));
   } else {
     inferredReturnShapes.emplace_back(resultShape, resultElementType,
                                       operandRankedType.getEncoding());

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2234,7 +2234,7 @@ LogicalResult inferFftOp(
   }
   auto resultBounds = encodingToBounds(operandRankedType.getEncoding()).vec();
   if ((isFftTypeIrfft || isFftTypeRfft) && !resultBounds.empty())
-    resultBounds[resultBounds.size() - 1] = ShapedType::kDynamic;
+    resultBounds.back() = ShapedType::kDynamic;
   inferredReturnShapes.emplace_back(
       resultShape, resultElementType,
       boundsToEncoding(operandRankedType.getEncoding(), resultBounds));

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2235,20 +2235,24 @@ LogicalResult inferFftOp(
   auto bounds = encodingToBounds(operandRankedType.getEncoding()).vec();
   if (isFftTypeIrfft) {
     if (!bounds.empty()) {
-      if (isStaticDimSize(bounds[bounds.size() - 1]) && bounds[bounds.size() - 1] < fftLengthValues[fftRank - 1])
-        return emitOptionalError(location,
-                               "IRFFT requires innermost dimension bound to be "
-                               "greater than or equal to fft_length[-1]. Got: ",
-                               bounds[bounds.size() - 1], " but fft_length is ",
-                               fftLengthValues, ".");
+      if (isStaticDimSize(bounds[bounds.size() - 1]) &&
+          bounds[bounds.size() - 1] < fftLengthValues[fftRank - 1])
+        return emitOptionalError(
+            location,
+            "IRFFT requires innermost dimension bound to be greater than or "
+            "equal to fft_length[-1]. Got: ",
+            bounds[bounds.size() - 1], " but fft_length is ", fftLengthValues,
+            ".");
       bounds[bounds.size() - 1] = ShapedType::kDynamic;
     }
-    inferredReturnShapes.emplace_back(resultShape, resultElementType,
-                                      boundsToEncoding(operandRankedType.getEncoding(), bounds));
-  } else if (isFftTypeRfft){
+    inferredReturnShapes.emplace_back(
+        resultShape, resultElementType,
+        boundsToEncoding(operandRankedType.getEncoding(), bounds));
+  } else if (isFftTypeRfft) {
     bounds[bounds.size() - 1] = ShapedType::kDynamic;
-    inferredReturnShapes.emplace_back(resultShape, resultElementType,
-                                      boundsToEncoding(operandRankedType.getEncoding(), bounds));
+    inferredReturnShapes.emplace_back(
+        resultShape, resultElementType,
+        boundsToEncoding(operandRankedType.getEncoding(), bounds));
   } else {
     inferredReturnShapes.emplace_back(resultShape, resultElementType,
                                       operandRankedType.getEncoding());

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -1531,60 +1531,24 @@ func.func @fft_bound(%arg0: tensor<?x9xcomplex<f32>, #stablehlo.type_extensions<
 
 // -----
 
-// CHECK-LABEL: func @rfft_without_bound
-func.func @rfft_without_bound(%arg0: tensor<?x?xf32, #stablehlo.type_extensions<bounds = [3, ?]>>) -> tensor<*xindex> {
-  %0 = "stablehlo.fft"(%arg0) {
-    fft_length = dense<9> : tensor<1xi64>, fft_type = #stablehlo<fft_type RFFT>
-  } : (tensor<?x?xf32, #stablehlo.type_extensions<bounds = [3, ?]>>) -> tensor<*xcomplex<f32>>
-  // CHECK: types0 = tensor<?x5xcomplex<f32>, #stablehlo.type_extensions<bounds = [3, ?]>>
-  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xcomplex<f32>>) -> tensor<*xindex>
-  func.return %1 : tensor<*xindex>
-}
-
-// -----
-
 // CHECK-LABEL: func @rfft_with_bound
-func.func @rfft_with_bound(%arg0: tensor<?x?xf32, #stablehlo.type_extensions<bounds = [3, 10]>>) -> tensor<*xindex> {
+func.func @rfft_with_bound(%arg0: tensor<3x?x?xf32, #stablehlo.type_extensions<bounds = [?, 3, 10]>>) -> tensor<*xindex> {
   %0 = "stablehlo.fft"(%arg0) {
     fft_length = dense<9> : tensor<1xi64>, fft_type = #stablehlo<fft_type RFFT>
-  } : (tensor<?x?xf32, #stablehlo.type_extensions<bounds = [3, 10]>>) -> tensor<*xcomplex<f32>>
-  // CHECK: types0 = tensor<?x5xcomplex<f32>, #stablehlo.type_extensions<bounds = [3, ?]>>
+  } : (tensor<3x?x?xf32, #stablehlo.type_extensions<bounds = [?, 3, 10]>>) -> tensor<*xcomplex<f32>>
+  // CHECK: types0 = tensor<3x?x5xcomplex<f32>, #stablehlo.type_extensions<bounds = [?, 3, ?]>>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xcomplex<f32>>) -> tensor<*xindex>
-  func.return %1 : tensor<*xindex>
-}
-
-// -----
-
-// CHECK-LABEL: func @rfft_with_bound
-func.func @rfft_with_bound(%arg0: tensor<3x?xf32, #stablehlo.type_extensions<bounds = [?, 10]>>) -> tensor<*xindex> {
-  %0 = "stablehlo.fft"(%arg0) {
-    fft_length = dense<9> : tensor<1xi64>, fft_type = #stablehlo<fft_type RFFT>
-  } : (tensor<3x?xf32, #stablehlo.type_extensions<bounds = [?, 10]>>) -> tensor<*xcomplex<f32>>
-  // CHECK: types0 = tensor<3x5xcomplex<f32>>
-  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xcomplex<f32>>) -> tensor<*xindex>
-  func.return %1 : tensor<*xindex>
-}
-
-// -----
-
-// CHECK-LABEL: func @irfft_without_bound
-func.func @irfft_without_bound(%arg0: tensor<?x?xcomplex<f32>, #stablehlo.type_extensions<bounds = [3, ?]>>) -> tensor<*xindex> {
-  %0 = "stablehlo.fft"(%arg0) {
-    fft_length = dense<9> : tensor<1xi64>, fft_type = #stablehlo<fft_type IRFFT>
-  } : (tensor<?x?xcomplex<f32>, #stablehlo.type_extensions<bounds = [3, ?]>>) -> tensor<*xf32>
-  // CHECK: types0 = tensor<?x9xf32, #stablehlo.type_extensions<bounds = [3, ?]>>
-  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xf32>) -> tensor<*xindex>
   func.return %1 : tensor<*xindex>
 }
 
 // -----
 
 // CHECK-LABEL: func @irfft_with_bound
-func.func @irfft_with_bound(%arg0: tensor<?x?xcomplex<f32>, #stablehlo.type_extensions<bounds = [3, 17]>>) -> tensor<*xindex> {
+func.func @irfft_with_bound(%arg0: tensor<3x?x?xcomplex<f32>, #stablehlo.type_extensions<bounds = [?, 3, 17]>>) -> tensor<*xindex> {
   %0 = "stablehlo.fft"(%arg0) {
     fft_length = dense<9> : tensor<1xi64>, fft_type = #stablehlo<fft_type IRFFT>
-  } : (tensor<?x?xcomplex<f32>, #stablehlo.type_extensions<bounds = [3, 17]>>) -> tensor<*xf32>
-  // CHECK: types0 = tensor<?x9xf32, #stablehlo.type_extensions<bounds = [3, ?]>>
+  } : (tensor<3x?x?xcomplex<f32>, #stablehlo.type_extensions<bounds = [?, 3, 17]>>) -> tensor<*xf32>
+  // CHECK: types0 = tensor<3x?x9xf32, #stablehlo.type_extensions<bounds = [?, 3, ?]>>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xf32>) -> tensor<*xindex>
   func.return %1 : tensor<*xindex>
 }

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -1520,11 +1520,11 @@ func.func @triangular_solve_bounds(
 //-----
 
 // CHECK-LABEL: func @fft_bound
-func.func @fft_bound(%arg0: tensor<3x9xcomplex<f32>, #stablehlo.type_extensions<bounds = [?, ?]>>) -> tensor<*xindex> {
+func.func @fft_bound(%arg0: tensor<?x9xcomplex<f32>, #stablehlo.type_extensions<bounds = [3, ?]>>) -> tensor<*xindex> {
   %0 = "stablehlo.fft"(%arg0) {
     fft_length = dense<9> : tensor<1xi64>, fft_type = #stablehlo<fft_type FFT>
-  } : (tensor<3x9xcomplex<f32>, #stablehlo.type_extensions<bounds = [?, ?]>>) -> tensor<*xcomplex<f32>>
-  // CHECK: types0 = tensor<3x9xcomplex<f32>, #stablehlo.type_extensions<bounds = [?, ?]>>
+  } : (tensor<?x9xcomplex<f32>, #stablehlo.type_extensions<bounds = [3, ?]>>) -> tensor<*xcomplex<f32>>
+  // CHECK: types0 = tensor<?x9xcomplex<f32>, #stablehlo.type_extensions<bounds = [3, ?]>>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xcomplex<f32>>) -> tensor<*xindex>
   func.return %1 : tensor<*xindex>
 }
@@ -1532,11 +1532,11 @@ func.func @fft_bound(%arg0: tensor<3x9xcomplex<f32>, #stablehlo.type_extensions<
 // -----
 
 // CHECK-LABEL: func @rfft_without_bound
-func.func @rfft_without_bound(%arg0: tensor<3x?xf32, #stablehlo.type_extensions<bounds = [?, ?]>>) -> tensor<*xindex> {
+func.func @rfft_without_bound(%arg0: tensor<?x?xf32, #stablehlo.type_extensions<bounds = [3, ?]>>) -> tensor<*xindex> {
   %0 = "stablehlo.fft"(%arg0) {
     fft_length = dense<9> : tensor<1xi64>, fft_type = #stablehlo<fft_type RFFT>
-  } : (tensor<3x?xf32, #stablehlo.type_extensions<bounds = [?, ?]>>) -> tensor<*xcomplex<f32>>
-  // CHECK: types0 = tensor<3x?xcomplex<f32>, #stablehlo.type_extensions<bounds = [?, ?]>>
+  } : (tensor<?x?xf32, #stablehlo.type_extensions<bounds = [3, ?]>>) -> tensor<*xcomplex<f32>>
+  // CHECK: types0 = tensor<?x5xcomplex<f32>, #stablehlo.type_extensions<bounds = [3, ?]>>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xcomplex<f32>>) -> tensor<*xindex>
   func.return %1 : tensor<*xindex>
 }
@@ -1544,11 +1544,11 @@ func.func @rfft_without_bound(%arg0: tensor<3x?xf32, #stablehlo.type_extensions<
 // -----
 
 // CHECK-LABEL: func @rfft_with_bound
-func.func @rfft_with_bound(%arg0: tensor<3x?xf32, #stablehlo.type_extensions<bounds = [?, 10]>>) -> tensor<*xindex> {
+func.func @rfft_with_bound(%arg0: tensor<?x?xf32, #stablehlo.type_extensions<bounds = [3, 10]>>) -> tensor<*xindex> {
   %0 = "stablehlo.fft"(%arg0) {
     fft_length = dense<9> : tensor<1xi64>, fft_type = #stablehlo<fft_type RFFT>
-  } : (tensor<3x?xf32, #stablehlo.type_extensions<bounds = [?, 10]>>) -> tensor<*xcomplex<f32>>
-  // CHECK: types0 = tensor<3x?xcomplex<f32>, #stablehlo.type_extensions<bounds = [?, ?]>>
+  } : (tensor<?x?xf32, #stablehlo.type_extensions<bounds = [3, 10]>>) -> tensor<*xcomplex<f32>>
+  // CHECK: types0 = tensor<?x5xcomplex<f32>, #stablehlo.type_extensions<bounds = [3, ?]>>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xcomplex<f32>>) -> tensor<*xindex>
   func.return %1 : tensor<*xindex>
 }
@@ -1556,11 +1556,11 @@ func.func @rfft_with_bound(%arg0: tensor<3x?xf32, #stablehlo.type_extensions<bou
 // -----
 
 // CHECK-LABEL: func @irfft_without_bound
-func.func @irfft_without_bound(%arg0: tensor<3x?xcomplex<f32>, #stablehlo.type_extensions<bounds = [?, ?]>>) -> tensor<*xindex> {
+func.func @irfft_without_bound(%arg0: tensor<?x?xcomplex<f32>, #stablehlo.type_extensions<bounds = [3, ?]>>) -> tensor<*xindex> {
   %0 = "stablehlo.fft"(%arg0) {
     fft_length = dense<9> : tensor<1xi64>, fft_type = #stablehlo<fft_type IRFFT>
-  } : (tensor<3x?xcomplex<f32>, #stablehlo.type_extensions<bounds = [?, ?]>>) -> tensor<*xf32>
-  // CHECK: types0 = tensor<3x?xcomplex<f32>, #stablehlo.type_extensions<bounds = [?, ?]>>
+  } : (tensor<?x?xcomplex<f32>, #stablehlo.type_extensions<bounds = [3, ?]>>) -> tensor<*xf32>
+  // CHECK: types0 = tensor<?x9xf32, #stablehlo.type_extensions<bounds = [3, ?]>>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xf32>) -> tensor<*xindex>
   func.return %1 : tensor<*xindex>
 }
@@ -1568,11 +1568,11 @@ func.func @irfft_without_bound(%arg0: tensor<3x?xcomplex<f32>, #stablehlo.type_e
 // -----
 
 // CHECK-LABEL: func @irfft_with_bound
-func.func @irfft_with_bound(%arg0: tensor<3x?xcomplex<f32>, #stablehlo.type_extensions<bounds = [?, 17]>>) -> tensor<*xindex> {
+func.func @irfft_with_bound(%arg0: tensor<?x?xcomplex<f32>, #stablehlo.type_extensions<bounds = [3, 17]>>) -> tensor<*xindex> {
   %0 = "stablehlo.fft"(%arg0) {
     fft_length = dense<9> : tensor<1xi64>, fft_type = #stablehlo<fft_type IRFFT>
-  } : (tensor<3x?xcomplex<f32>, #stablehlo.type_extensions<bounds = [?, 17]>>) -> tensor<*xf32>
-  // CHECK: types0 = tensor<3x?xcomplex<f32>, #stablehlo.type_extensions<bounds = [?, ?]>>
+  } : (tensor<?x?xcomplex<f32>, #stablehlo.type_extensions<bounds = [3, 17]>>) -> tensor<*xf32>
+  // CHECK: types0 = tensor<?x9xf32, #stablehlo.type_extensions<bounds = [3, ?]>>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xf32>) -> tensor<*xindex>
   func.return %1 : tensor<*xindex>
 }
@@ -1583,7 +1583,7 @@ func.func @irfft_invalid_bound(%arg0: tensor<3x?xcomplex<f32>, #stablehlo.type_e
   // expected-error@+1{{IRFFT requires innermost dimension bound to be greater than or equal to fft_length[-1]. Got: 8 but fft_length is 9.}}
   %0 = "stablehlo.fft"(%arg0) {
     fft_length = dense<9> : tensor<1xi64>, fft_type = #stablehlo<fft_type IRFFT>
-  } : (tensor<3x?xcomplex<f32>, #stablehlo.type_extensions<bounds = [?, 8]>>) -> tensor<*xcomplex<f32>>
-  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xcomplex<f32>>) -> tensor<*xindex>
+  } : (tensor<3x?xcomplex<f32>, #stablehlo.type_extensions<bounds = [?, 8]>>) -> tensor<*xf32>
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xf32>) -> tensor<*xindex>
   func.return %1 : tensor<*xindex>
 }

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -1555,6 +1555,18 @@ func.func @rfft_with_bound(%arg0: tensor<?x?xf32, #stablehlo.type_extensions<bou
 
 // -----
 
+// CHECK-LABEL: func @rfft_with_bound
+func.func @rfft_with_bound(%arg0: tensor<3x?xf32, #stablehlo.type_extensions<bounds = [?, 10]>>) -> tensor<*xindex> {
+  %0 = "stablehlo.fft"(%arg0) {
+    fft_length = dense<9> : tensor<1xi64>, fft_type = #stablehlo<fft_type RFFT>
+  } : (tensor<3x?xf32, #stablehlo.type_extensions<bounds = [?, 10]>>) -> tensor<*xcomplex<f32>>
+  // CHECK: types0 = tensor<3x5xcomplex<f32>>
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xcomplex<f32>>) -> tensor<*xindex>
+  func.return %1 : tensor<*xindex>
+}
+
+// -----
+
 // CHECK-LABEL: func @irfft_without_bound
 func.func @irfft_without_bound(%arg0: tensor<?x?xcomplex<f32>, #stablehlo.type_extensions<bounds = [3, ?]>>) -> tensor<*xindex> {
   %0 = "stablehlo.fft"(%arg0) {

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -1516,3 +1516,13 @@ func.func @triangular_solve_bounds(
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xf32>) -> tensor<*xindex>
   func.return %1 : tensor<*xindex>
 }
+
+//-----
+
+// CHECK-LABEL: func @fft_bound
+func.func @fft_bound(%arg0: tensor<?x9xcomplex<f32>, #stablehlo.type_extensions<bounds = [5, ?]>>) -> tensor<?x9xindex> {
+  %0 = "stablehlo.fft"(%arg0) {fft_length = dense<9> : tensor<1xi64>, fft_type = #stablehlo<fft_type FFT>} : (tensor<?x9xcomplex<f32>, #stablehlo.type_extensions<bounds = [5, ?]>>) -> tensor<?x9xcomplex<f32>>
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<?x9xcomplex<f32>>) -> tensor<?x9xindex>
+  // CHECK: %1 = "hlo_test_infer.return_types"(%0) {types0 = tensor<?x9xcomplex<f32>, #stablehlo.type_extensions<bounds = [5, ?]>>} : (tensor<?x9xcomplex<f32>>) -> tensor<?x9xindex>
+  func.return %1 : tensor<?x9xindex>
+}

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -1588,14 +1588,3 @@ func.func @irfft_with_bound(%arg0: tensor<?x?xcomplex<f32>, #stablehlo.type_exte
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xf32>) -> tensor<*xindex>
   func.return %1 : tensor<*xindex>
 }
-
-// -----
-
-func.func @irfft_invalid_bound(%arg0: tensor<3x?xcomplex<f32>, #stablehlo.type_extensions<bounds = [?, 8]>>) -> tensor<*xindex> {
-  // expected-error@+1{{IRFFT requires innermost dimension bound to be greater than or equal to fft_length[-1]. Got: 8 but fft_length is 9.}}
-  %0 = "stablehlo.fft"(%arg0) {
-    fft_length = dense<9> : tensor<1xi64>, fft_type = #stablehlo<fft_type IRFFT>
-  } : (tensor<3x?xcomplex<f32>, #stablehlo.type_extensions<bounds = [?, 8]>>) -> tensor<*xf32>
-  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xf32>) -> tensor<*xindex>
-  func.return %1 : tensor<*xindex>
-}

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -1520,9 +1520,11 @@ func.func @triangular_solve_bounds(
 //-----
 
 // CHECK-LABEL: func @fft_bound
-func.func @fft_bound(%arg0: tensor<?x9xcomplex<f32>, #stablehlo.type_extensions<bounds = [5, ?]>>) -> tensor<?x9xindex> {
-  %0 = "stablehlo.fft"(%arg0) {fft_length = dense<9> : tensor<1xi64>, fft_type = #stablehlo<fft_type FFT>} : (tensor<?x9xcomplex<f32>, #stablehlo.type_extensions<bounds = [5, ?]>>) -> tensor<?x9xcomplex<f32>>
-  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<?x9xcomplex<f32>>) -> tensor<?x9xindex>
-  // CHECK: %1 = "hlo_test_infer.return_types"(%0) {types0 = tensor<?x9xcomplex<f32>, #stablehlo.type_extensions<bounds = [5, ?]>>} : (tensor<?x9xcomplex<f32>>) -> tensor<?x9xindex>
-  func.return %1 : tensor<?x9xindex>
+func.func @fft_bound(%arg0: tensor<?x9xcomplex<f32>, #stablehlo.type_extensions<bounds = [5, ?]>>) -> tensor<*xindex> {
+  %0 = "stablehlo.fft"(%arg0) {
+    fft_length = dense<9> : tensor<1xi64>, fft_type = #stablehlo<fft_type FFT>
+  } : (tensor<?x9xcomplex<f32>, #stablehlo.type_extensions<bounds = [5, ?]>>) -> tensor<*xcomplex<f32>>
+  // CHECK: types0 = tensor<?x9xcomplex<f32>, #stablehlo.type_extensions<bounds = [5, ?]>>
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xcomplex<f32>>) -> tensor<*xindex>
+  func.return %1 : tensor<*xindex>
 }


### PR DESCRIPTION
Bounds of the result are inherited from the bounds of the operand, except for the bound of the last dimension for RFFT/IRFFT which is ? because it is computed statically.

closes #805