### PR TITLE
Infer bounds for SortOp.

### DIFF
--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2647,8 +2647,15 @@ LogicalResult inferSliceOp(Optional<Location> location, Value operand,
 LogicalResult inferSortOp(
     Optional<Location>, ValueRange inputs,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
-  for (auto resultType : inputs.getTypes())
-    inferredReturnShapes.emplace_back(resultType.cast<ShapedType>());
+  for (auto resultType : inputs.getTypes()) {
+    auto rankedResult = resultType.dyn_cast<RankedTensorType>();
+    if (rankedResult)
+      inferredReturnShapes.emplace_back(rankedResult.getShape(),
+                                        rankedResult.getElementType(),
+                                        rankedResult.getEncoding());
+    else
+      inferredReturnShapes.emplace_back(resultType.cast<ShapedType>());
+  }
   return success();
 }
 

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -1193,3 +1193,23 @@ func.func @dynamic_iota(%arg0: tensor<1xindex>) -> tensor<1xindex> {
   %1 = "hlo_test_infer.reify_return_type_shapes"(%result): (tensor<?xf32>) -> tensor<1xindex>
   func.return %1: tensor<1xindex>
 }
+
+// -----
+
+// CHECK-LABEL: @sort_bounds_and_unknown_rank
+func.func @sort_bounds_and_unknown_rank(%input0: tensor<*xf32>, %input1: tensor<5x?x?xi32, #stablehlo.type_extensions<bounds = [?, 7, 6]>>) {
+  %0, %1 = "stablehlo.sort"(%input0, %input1) ({
+  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>, %arg2: tensor<i32>, %arg3: tensor<i32>):
+    %pred = "stablehlo.compare"(%arg0, %arg1) {
+      comparison_direction = #stablehlo<comparison_direction GT>
+    } : (tensor<f32>, tensor<f32>) -> tensor<i1>
+    "stablehlo.return"(%pred) : (tensor<i1>) -> ()
+  }) { dimension = 1 : i64, is_stable = true } : (
+    tensor<*xf32>,
+    tensor<5x?x?xi32, #stablehlo.type_extensions<bounds = [?, 7, 6]>>
+  ) -> (tensor<*xf32>, tensor<*xi32>)
+  // CHECK: types0 = tensor<*xf32>
+  // CHECK-SAME: types1 = tensor<5x?x?xi32, #stablehlo.type_extensions<bounds = [?, 7, 6]>>
+  %2 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xf32>) -> tensor<*xindex>
+  func.return
+}


### PR DESCRIPTION
closes #885 

Infer bounds for `SortOp`
  * For ranked tensors infer bounds from corresponding tensors in `inputs` to` results`.
  * For unranked tensors copy the shape as is.

Additional context - A stricter inference can be implemented where we can infer the most specific shape from all tensors in the input, as of now having a simple solution that is standard across most ops tops the requirement of inferring most specific shape.