### PR TITLE
Handle bounds in the SelectAndScatterOp shape function

### DIFF
--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2546,15 +2546,7 @@ LogicalResult inferSelectOp(
 
 LogicalResult inferSelectAndScatterOp(
     Value operand, SmallVectorImpl<Type>& inferredReturnTypes) {
-  auto operandRankedType = operand.getType().dyn_cast<RankedTensorType>();
-  if (!operandRankedType) {
-    inferredReturnTypes.push_back(operand.getType());
-  } else {
-    auto bounds = encodingToBounds(operandRankedType.getEncoding()).vec();
-    inferredReturnTypes.push_back(RankedTensorType::get(
-        operandRankedType.getShape(), operandRankedType.getElementType(),
-        boundsToEncoding(operandRankedType.getEncoding(), bounds)));
-  }
+  inferredReturnTypes.push_back(operand.getType());
   return success();
 }
 

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2546,7 +2546,15 @@ LogicalResult inferSelectOp(
 
 LogicalResult inferSelectAndScatterOp(
     Value operand, SmallVectorImpl<Type>& inferredReturnTypes) {
-  inferredReturnTypes.push_back(operand.getType());
+  auto operandRankedType = operand.getType().dyn_cast<RankedTensorType>();
+  if (!operandRankedType) {
+    inferredReturnTypes.push_back(operand.getType());
+  } else {
+    auto bounds = encodingToBounds(operandRankedType.getEncoding()).vec();
+    inferredReturnTypes.push_back(RankedTensorType::get(
+        operandRankedType.getShape(), operandRankedType.getElementType(),
+        boundsToEncoding(operandRankedType.getEncoding(), bounds)));
+  }
   return success();
 }
 


### PR DESCRIPTION
SelectAndScatterOp's bound inference is very simple. There are two inputs: `operand` and `source`. The `source` contains the indices to the `result` tensor to place the reduced values from `operand`, so it does not affect the bound of the `result` tensor. As for `operand`, the type is equal to the `result` tensor. There is only a movement of values happening in this op (after reduction is applied, but this also does not affect the bounds), so we can propagate the bounds with no further inference done.

closes #754 