### PR TITLE
Handle bounds for ScatterOp shape function

### DIFF
--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -472,7 +472,7 @@ func.func @scatter(%input_tensor: tensor<200x100x300xf32>,
 // -----
 
 // CHECK-LABEL: func @scatter_bounds
-func.func @scatter_bounds(%input_tensor: tensor<200x?x?xf32, #stablehlo.type_extensions<bounds = [?, 101, 301]>>,
+func.func @scatter_bounds(%input_tensor: tensor<200x?x?xf32, #stablehlo.type_extensions<bounds = [?, ?, 301]>>,
     %scatter_indices: tensor<10x2xi32>, %updates: tensor<10x300xf32>) ->
       tensor<*xindex> {
   %0 = "stablehlo.scatter" (%input_tensor, %scatter_indices, %updates) ({
@@ -488,11 +488,11 @@ func.func @scatter_bounds(%input_tensor: tensor<200x?x?xf32, #stablehlo.type_ext
     >,
     indices_are_sorted = true,
     unique_indices = true
-  } : (tensor<200x?x?xf32, #stablehlo.type_extensions<bounds = [?, 101, 301]>>, tensor<10x2xi32>, tensor<10x300xf32>) ->
+  } : (tensor<200x?x?xf32, #stablehlo.type_extensions<bounds = [?, ?, 301]>>, tensor<10x2xi32>, tensor<10x300xf32>) ->
       tensor<200x?x?xf32>
 
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<200x?x?xf32>) -> tensor<*xindex>
-  // CHECK: types0 = tensor<200x?x?xf32, #stablehlo.type_extensions<bounds = [?, 101, 301]>>
+  // CHECK: types0 = tensor<200x?x?xf32, #stablehlo.type_extensions<bounds = [?, ?, 301]>>
   func.return %1 : tensor<*xindex>
 }
 

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -471,6 +471,33 @@ func.func @scatter(%input_tensor: tensor<200x100x300xf32>,
 
 // -----
 
+// CHECK-LABEL: func @scatter_bounds
+func.func @scatter_bounds(%input_tensor: tensor<200x?x?xf32, #stablehlo.type_extensions<bounds = [?, 101, 301]>>,
+    %scatter_indices: tensor<10x2xi32>, %updates: tensor<10x300xf32>) ->
+      tensor<*xindex> {
+  %0 = "stablehlo.scatter" (%input_tensor, %scatter_indices, %updates) ({
+  ^bb0(%lhs: tensor<f32>, %rhs: tensor<f32>):
+    %add = stablehlo.add %lhs, %rhs : tensor<f32>
+    "stablehlo.return"(%add) : (tensor<f32>) -> ()
+  }) {
+    scatter_dimension_numbers = #stablehlo.scatter<
+      update_window_dims = [1],
+      inserted_window_dims = [0, 1],
+      scatter_dims_to_operand_dims = [0, 1],
+      index_vector_dim = 1
+    >,
+    indices_are_sorted = true,
+    unique_indices = true
+  } : (tensor<200x?x?xf32, #stablehlo.type_extensions<bounds = [?, 101, 301]>>, tensor<10x2xi32>, tensor<10x300xf32>) ->
+      tensor<200x?x?xf32>
+
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<200x?x?xf32>) -> tensor<*xindex>
+  // CHECK: types0 = tensor<200x?x?xf32, #stablehlo.type_extensions<bounds = [?, 101, 301]>>
+  func.return %1 : tensor<*xindex>
+}
+
+// -----
+
 // CHECK-LABEL: func @get_dimension_size
 func.func @get_dimension_size(%arg0: tensor<4x2xf32>) -> tensor<index> {
   %0 = "stablehlo.get_dimension_size"(%arg0) {dimension = 1 : i64} : (tensor<4x2xf32>) -> tensor<i32>


### PR DESCRIPTION
fixes #749 

For the ScatterOp, where the 
(C16) inputs[k] and result[k] have the same type for any k  [0, N)

and this is how the result type is inferred. 
(https://github.com/openxla/stablehlo/blob/81d520685c5cfe2620f995dbb09ac4399d000c9a/stablehlo/dialect/TypeInference.cpp#L2513).
 
IMO, we do not need to do anything special to handle the bounds as the bounds should get copied as part of copying the types. I wrote a test to check that input bounds are indeed propagated. Also I note that I do not have to use `inferReturnTypeComponents`  at all, for this case.