### PR TITLE
Infer bounds for AllToAllOp.

### DIFF
--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -1332,19 +1332,31 @@ LogicalResult inferAllToAllOp(
 
   // If operand is ranked, size of split dimension should be a multiple of split
   // count.
-  auto splitDimSize = operandRankedType.getDimSize(splitDimension);
-  if (isStaticDimSize(splitDimSize) && splitDimSize % splitCount != 0)
-    return emitOptionalError(
-        location, "split dimension has size ", splitDimSize,
-        ", expected to be a multiple of split_count ", splitCount);
   SmallVector<int64_t> resultShape(operandRankedType.getShape().begin(),
                                    operandRankedType.getShape().end());
-  if (isStaticDimSize(resultShape[splitDimension]))
-    resultShape[splitDimension] /= splitCount;
-  if (isStaticDimSize(resultShape[concatDimension]))
-    resultShape[concatDimension] *= splitCount;
-  inferredReturnShapes.emplace_back(resultShape,
-                                    operandRankedType.getElementType());
+  if (!isDynamicDimSize(resultShape[splitDimension]) &&
+      resultShape[splitDimension] % splitCount != 0) {
+    return emitOptionalError(
+        location, "split dimension has size ", resultShape[splitDimension],
+        ", expected to be a multiple of split_count ", splitCount);
+  }
+  resultShape[splitDimension] /=
+      isDynamicDimSize(resultShape[splitDimension]) ? 1 : splitCount;
+  resultShape[concatDimension] *=
+      isDynamicDimSize(resultShape[concatDimension]) ? 1 : splitCount;
+
+  SmallVector<int64_t> resultBounds =
+      to_vector(encodingToBounds(operandRankedType.getEncoding()));
+  if (!resultBounds.empty()) {
+    resultBounds[splitDimension] /=
+        isDynamicDimSize(resultBounds[splitDimension]) ? 1 : splitCount;
+    resultBounds[concatDimension] *=
+        isDynamicDimSize(resultBounds[concatDimension]) ? 1 : splitCount;
+  }
+
+  inferredReturnShapes.emplace_back(
+      resultShape, operandRankedType.getElementType(),
+      boundsToEncoding(operandRankedType.getEncoding(), resultBounds));
   return success();
 }
 

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -111,6 +111,21 @@ func.func @alltoall(%data: tensor<4x16xf32>) -> tensor<16x4xindex> {
 
 // -----
 
+// CHECK-LABEL: func @alltoall_bounds
+func.func @alltoall_bounds(%data: tensor<16x?xf32, #stablehlo.type_extensions<bounds = [?, 5]>>) -> tensor<*xindex> {
+  %0 = "stablehlo.all_to_all"(%data) {
+    split_dimension = 0 : i64,
+    concat_dimension = 1 : i64,
+    split_count = 4 : i64,
+    replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>
+  } : (tensor<16x?xf32, #stablehlo.type_extensions<bounds = [?, 5]>>) -> tensor<*xf32>
+  // CHECK: types0 = tensor<4x?xf32, #stablehlo.type_extensions<bounds = [?, 20]>>
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xf32>) -> tensor<*xindex>
+  func.return %1 : tensor<*xindex>
+}
+
+// -----
+
 // CHECK-LABEL: func @abs
 func.func @abs(%arg0: tensor<1x2xf32>) -> tensor<1x2xindex> {
   %0 = "stablehlo.abs"(%arg0) {} : (tensor<1x2xf32>) -> tensor<1x2xf32>


### PR DESCRIPTION
closes #801

Infer bounds for `all_to_all` op
  * Infer bounds information from operand type and update the bounds and dimension sizes for split and concat dimensions
     according to the op logic.