### PR TITLE
Update ODS to sync supported types to the spec

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -49,7 +49,7 @@ one of the following tracking labels.
 | all_reduce               | yes           | revisit      | yes            | no              | no          |
 | all_to_all               | yes           | revisit      | yes            | no              | no          |
 | and                      | yes           | yes          | yes            | yes             | yes         |
-| atan2                    | yes           | revisit      | yes            | yes             | no          |
+| atan2                    | yes           | yes          | yes            | yes             | no          |
 | batch_norm_grad          | yes           | revisit      | yes            | no              | no          |
 | batch_norm_inference     | yes           | revisit      | yes            | no              | no          |
 | batch_norm_training      | yes           | revisit      | yes            | no              | no          |
@@ -57,7 +57,7 @@ one of the following tracking labels.
 | broadcast                | no            | yes\*        | yes\*          | yes             | no          |
 | broadcast_in_dim         | yes           | yes          | infeasible     | yes             | no          |
 | case                     | yes           | revisit      | yes            | no              | no          |
-| cbrt                     | yes           | revisit      | yes            | yes             | no          |
+| cbrt                     | yes           | yes          | yes            | yes             | no          |
 | ceil                     | yes           | yes          | yes            | yes             | yes         |
 | cholesky                 | yes           | yes          | yes            | yes             | no          |
 | clamp                    | yes           | revisit      | yes            | yes             | no          |
@@ -114,7 +114,7 @@ one of the following tracking labels.
 | pad                      | yes           | yes          | yes            | yes             | no          |
 | partition_id             | yes           | yes          | yes            | yes             | no          |
 | popcnt                   | yes           | yes          | yes            | yes             | no          |
-| power                    | yes           | revisit      | yes            | yes             | no          |
+| power                    | yes           | yes          | yes            | yes             | no          |
 | real                     | yes           | yes          | yes            | yes             | no          |
 | real_dynamic_slice       | no            | revisit      | no             | yes             | no          |
 | recv                     | yes           | revisit      | infeasible     | no              | no          |

--- a/docs/status.md
+++ b/docs/status.md
@@ -137,9 +137,9 @@ one of the following tracking labels.
 | select_and_scatter       | yes           | revisit      | yes            | no              | no          |
 | send                     | yes           | revisit      | yes            | no              | no          |
 | set_dimension_size       | no            | yes\*        | yes\*          | yes             | no          |
-| shift_left               | yes           | revisit      | yes            | yes             | no          |
-| shift_right_arithmetic   | yes           | revisit      | yes            | yes             | no          |
-| shift_right_logical      | yes           | revisit      | yes            | yes             | no          |
+| shift_left               | yes           | yes          | yes            | yes             | no          |
+| shift_right_arithmetic   | yes           | yes          | yes            | yes             | no          |
+| shift_right_logical      | yes           | yes          | yes            | yes             | no          |
 | sign                     | yes           | yes          | yes            | yes             | no          |
 | sine                     | yes           | yes          | yes            | yes             | yes         |
 | slice                    | yes           | yes          | yes            | no              | no          |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -217,7 +217,7 @@ def StableHLO_AbsOp: StableHLO_UnaryElementwiseOp<"abs",
 }
 
 def StableHLO_CbrtOp: StableHLO_UnaryElementwiseOp<"cbrt",
-    [Pure, HLO_CompatibleOperandsAndResultType], HLO_FpTensor> {
+    [Pure, HLO_CompatibleOperandsAndResultType], HLO_FpOrComplexTensor> {
   let summary = "Cubic root operator";
   let description = [{
     Performs element-wise cubic root operation on `operand` tensor and produces
@@ -644,7 +644,8 @@ def StableHLO_TanhOp: StableHLO_UnaryElementwiseOp<"tanh",
 // See https://www.tensorflow.org/xla/operation_semantics#element-wise_binary_arithmetic_operations
 
 class StableHLO_BinaryElementwiseOp<string mnemonic, list<Trait> traits,
-    Type OperandType = HLO_Tensor, Type ResultType = OperandType> : StableHLO_Op<mnemonic, traits # [InferShapedTypeOpInterface, SameOperandsAndResultShape]> {
+    Type OperandType = HLO_Tensor, Type ResultType = OperandType> :
+    StableHLO_Op<mnemonic, traits # [InferShapedTypeOpInterface, SameOperandsAndResultShape]> {
   let arguments = (ins
     OperandType:$lhs,
     OperandType:$rhs
@@ -672,7 +673,7 @@ class StableHLO_BinaryElementwiseOp<string mnemonic, list<Trait> traits,
 }
 
 def StableHLO_AddOp : StableHLO_BinaryElementwiseOp<"add",
-      [Commutative, Pure, HLO_CompatibleOperandsAndResultType, Elementwise], HLO_Tensor> {
+      [Commutative, Pure, HLO_CompatibleOperandsAndResultType, Elementwise]> {
   let summary = "Addition operator";
   let description = [{
     Performs element-wise addition of two tensors `lhs` and `rhs` and produces a
@@ -748,7 +749,7 @@ def StableHLO_DivOp : StableHLO_BinaryElementwiseOp<"divide",
 }
 
 def StableHLO_MaxOp : StableHLO_BinaryElementwiseOp<"maximum",
-      [Commutative, Pure, HLO_CompatibleOperandsAndResultType, Elementwise], HLO_Tensor> {
+      [Commutative, Pure, HLO_CompatibleOperandsAndResultType, Elementwise]> {
   let summary = "Maximum operator";
   let description = [{
     Performs element-wise max operation on tensors `lhs` and `rhs` and produces
@@ -765,7 +766,7 @@ def StableHLO_MaxOp : StableHLO_BinaryElementwiseOp<"maximum",
 }
 
 def StableHLO_MinOp : StableHLO_BinaryElementwiseOp<"minimum",
-      [Commutative, Pure, HLO_CompatibleOperandsAndResultType, Elementwise], HLO_Tensor> {
+      [Commutative, Pure, HLO_CompatibleOperandsAndResultType, Elementwise]> {
   let summary = "Minimum operator";
   let description = [{
     Performs element-wise min operation on tensors `lhs` and `rhs` and produces a
@@ -782,7 +783,7 @@ def StableHLO_MinOp : StableHLO_BinaryElementwiseOp<"minimum",
 }
 
 def StableHLO_MulOp : StableHLO_BinaryElementwiseOp<"multiply",
-      [Commutative, Pure, HLO_CompatibleOperandsAndResultType, Elementwise], HLO_Tensor> {
+      [Commutative, Pure, HLO_CompatibleOperandsAndResultType, Elementwise]> {
   let summary = "Multiplication operator";
   let description = [{
     Performs element-wise product of two tensors `lhs` and `rhs` and produces a

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -645,7 +645,8 @@ def StableHLO_TanhOp: StableHLO_UnaryElementwiseOp<"tanh",
 
 class StableHLO_BinaryElementwiseOp<string mnemonic, list<Trait> traits,
     Type OperandType = HLO_Tensor, Type ResultType = OperandType> :
-    StableHLO_Op<mnemonic, traits # [InferShapedTypeOpInterface, SameOperandsAndResultShape]> {
+    StableHLO_Op<mnemonic, traits # [InferShapedTypeOpInterface,
+    SameOperandsAndResultShape, Elementwise]> {
   let arguments = (ins
     OperandType:$lhs,
     OperandType:$rhs
@@ -673,7 +674,7 @@ class StableHLO_BinaryElementwiseOp<string mnemonic, list<Trait> traits,
 }
 
 def StableHLO_AddOp : StableHLO_BinaryElementwiseOp<"add",
-      [Commutative, Pure, HLO_CompatibleOperandsAndResultType, Elementwise]> {
+      [Commutative, Pure, HLO_CompatibleOperandsAndResultType]> {
   let summary = "Addition operator";
   let description = [{
     Performs element-wise addition of two tensors `lhs` and `rhs` and produces a
@@ -690,7 +691,7 @@ def StableHLO_AddOp : StableHLO_BinaryElementwiseOp<"add",
 }
 
 def StableHLO_Atan2Op : StableHLO_BinaryElementwiseOp<"atan2",
-      [Pure, HLO_CompatibleOperandsAndResultType, Elementwise], HLO_FpOrComplexTensor> {
+      [Pure, HLO_CompatibleOperandsAndResultType], HLO_FpOrComplexTensor> {
   let summary = "Atan2 operator";
   let description = [{
     Performs element-wise atan2 operation on `lhs` and `rhs` tensor and produces
@@ -708,7 +709,7 @@ def StableHLO_Atan2Op : StableHLO_BinaryElementwiseOp<"atan2",
 
 def StableHLO_ComplexOp: StableHLO_BinaryElementwiseOp<"complex", [Pure,
     SameOperandsElementType, SameOperandsAndResultShape,
-    DeclareOpInterfaceMethods<InferTypeOpInterface>, Elementwise]> {
+    DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
   let summary = "Complex operator";
   let description = [{
     Performs element-wise conversion to a complex value from a pair of real and
@@ -732,7 +733,7 @@ def StableHLO_ComplexOp: StableHLO_BinaryElementwiseOp<"complex", [Pure,
 }
 
 def StableHLO_DivOp : StableHLO_BinaryElementwiseOp<"divide",
-      [Pure, HLO_CompatibleOperandsAndResultType, Elementwise], HLO_IntFpOrComplexTensor> {
+      [Pure, HLO_CompatibleOperandsAndResultType], HLO_IntFpOrComplexTensor> {
   let summary = "Division operator";
   let description = [{
     Performs element-wise division of dividend `lhs` and divisor `rhs` tensors
@@ -749,7 +750,7 @@ def StableHLO_DivOp : StableHLO_BinaryElementwiseOp<"divide",
 }
 
 def StableHLO_MaxOp : StableHLO_BinaryElementwiseOp<"maximum",
-      [Commutative, Pure, HLO_CompatibleOperandsAndResultType, Elementwise]> {
+      [Commutative, Pure, HLO_CompatibleOperandsAndResultType]> {
   let summary = "Maximum operator";
   let description = [{
     Performs element-wise max operation on tensors `lhs` and `rhs` and produces
@@ -766,7 +767,7 @@ def StableHLO_MaxOp : StableHLO_BinaryElementwiseOp<"maximum",
 }
 
 def StableHLO_MinOp : StableHLO_BinaryElementwiseOp<"minimum",
-      [Commutative, Pure, HLO_CompatibleOperandsAndResultType, Elementwise]> {
+      [Commutative, Pure, HLO_CompatibleOperandsAndResultType]> {
   let summary = "Minimum operator";
   let description = [{
     Performs element-wise min operation on tensors `lhs` and `rhs` and produces a
@@ -783,7 +784,7 @@ def StableHLO_MinOp : StableHLO_BinaryElementwiseOp<"minimum",
 }
 
 def StableHLO_MulOp : StableHLO_BinaryElementwiseOp<"multiply",
-      [Commutative, Pure, HLO_CompatibleOperandsAndResultType, Elementwise]> {
+      [Commutative, Pure, HLO_CompatibleOperandsAndResultType]> {
   let summary = "Multiplication operator";
   let description = [{
     Performs element-wise product of two tensors `lhs` and `rhs` and produces a
@@ -800,7 +801,7 @@ def StableHLO_MulOp : StableHLO_BinaryElementwiseOp<"multiply",
 }
 
 def StableHLO_PowOp : StableHLO_BinaryElementwiseOp<"power",
-      [Pure, HLO_CompatibleOperandsAndResultType, Elementwise], HLO_IntFpOrComplexTensor> {
+      [Pure, HLO_CompatibleOperandsAndResultType], HLO_IntFpOrComplexTensor> {
   let summary = "Power operator";
   let description = [{
     Performs element-wise exponentiation of `lhs` tensor by `rhs` tensor and
@@ -817,7 +818,7 @@ def StableHLO_PowOp : StableHLO_BinaryElementwiseOp<"power",
 }
 
 def StableHLO_RemOp : StableHLO_BinaryElementwiseOp<"remainder",
-      [Pure, HLO_CompatibleOperandsAndResultType, Elementwise], HLO_IntFpOrComplexTensor> {
+      [Pure, HLO_CompatibleOperandsAndResultType], HLO_IntFpOrComplexTensor> {
   let summary = "Remainder operator";
   let description = [{
     Performs element-wise remainder of dividend `lhs` and divisor `rhs` tensors
@@ -834,7 +835,7 @@ def StableHLO_RemOp : StableHLO_BinaryElementwiseOp<"remainder",
 }
 
 def StableHLO_ShiftLeftOp : StableHLO_BinaryElementwiseOp<"shift_left",
-      [Pure, HLO_CompatibleOperandsAndResultType, Elementwise], HLO_IntTensor> {
+      [Pure, HLO_CompatibleOperandsAndResultType], HLO_IntTensor> {
   let summary = "Shift Left operator";
   let description = [{
     Performs element-wise left-shift operation on the `lhs` tensor by `rhs`
@@ -851,7 +852,7 @@ def StableHLO_ShiftLeftOp : StableHLO_BinaryElementwiseOp<"shift_left",
 }
 
 def StableHLO_ShiftRightArithmeticOp : StableHLO_BinaryElementwiseOp<"shift_right_arithmetic",
-      [Pure, HLO_CompatibleOperandsAndResultType, Elementwise], HLO_IntTensor> {
+      [Pure, HLO_CompatibleOperandsAndResultType], HLO_IntTensor> {
   let summary = "Shift right arithmetic operator";
   let description = [{
     Performs element-wise arithmetic right-shift operation on the `lhs` tensor
@@ -868,7 +869,7 @@ def StableHLO_ShiftRightArithmeticOp : StableHLO_BinaryElementwiseOp<"shift_righ
 }
 
 def StableHLO_ShiftRightLogicalOp : StableHLO_BinaryElementwiseOp<"shift_right_logical",
-      [Pure, HLO_CompatibleOperandsAndResultType, Elementwise], HLO_IntTensor> {
+      [Pure, HLO_CompatibleOperandsAndResultType], HLO_IntTensor> {
   let summary = "Shift right logical operator";
   let description = [{
     Performs element-wise logical right-shift operation on the `lhs` tensor by
@@ -885,7 +886,7 @@ def StableHLO_ShiftRightLogicalOp : StableHLO_BinaryElementwiseOp<"shift_right_l
 }
 
 def StableHLO_SubtractOp : StableHLO_BinaryElementwiseOp<"subtract",
-      [Pure, HLO_CompatibleOperandsAndResultType, Elementwise], HLO_IntFpOrComplexTensor> {
+      [Pure, HLO_CompatibleOperandsAndResultType], HLO_IntFpOrComplexTensor> {
   let summary = "Subtraction operator";
   let description = [{
     Performs element-wise subtraction of two tensors `lhs` and `rhs` and

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -643,12 +643,11 @@ def StableHLO_TanhOp: StableHLO_UnaryElementwiseOp<"tanh",
 //===----------------------------------------------------------------------===//
 // See https://www.tensorflow.org/xla/operation_semantics#element-wise_binary_arithmetic_operations
 
-class StableHLO_BinaryElementwiseOp<string mnemonic, list<Trait> traits> :
-    StableHLO_Op<mnemonic, traits # [InferShapedTypeOpInterface,
-    SameOperandsAndResultShape, Elementwise]> {
+class StableHLO_BinaryElementwiseOp<string mnemonic, list<Trait> traits,
+    Type OperandType = HLO_Tensor, Type ResultType = OperandType> : StableHLO_Op<mnemonic, traits # [InferShapedTypeOpInterface, SameOperandsAndResultShape]> {
   let arguments = (ins
-    HLO_Tensor:$lhs,
-    HLO_Tensor:$rhs
+    OperandType:$lhs,
+    OperandType:$rhs
   );
 
   let extraClassDeclaration = [{
@@ -664,7 +663,7 @@ class StableHLO_BinaryElementwiseOp<string mnemonic, list<Trait> traits> :
     }
   }];
 
-  let results = (outs HLO_Tensor:$result);
+  let results = (outs ResultType:$result);
 
   let assemblyFormat = [{
     $lhs `,` $rhs attr-dict
@@ -673,7 +672,7 @@ class StableHLO_BinaryElementwiseOp<string mnemonic, list<Trait> traits> :
 }
 
 def StableHLO_AddOp : StableHLO_BinaryElementwiseOp<"add",
-      [Commutative, Pure, HLO_CompatibleOperandsAndResultType]> {
+      [Commutative, Pure, HLO_CompatibleOperandsAndResultType, Elementwise], HLO_Tensor> {
   let summary = "Addition operator";
   let description = [{
     Performs element-wise addition of two tensors `lhs` and `rhs` and produces a
@@ -690,7 +689,7 @@ def StableHLO_AddOp : StableHLO_BinaryElementwiseOp<"add",
 }
 
 def StableHLO_Atan2Op : StableHLO_BinaryElementwiseOp<"atan2",
-      [Pure, HLO_CompatibleOperandsAndResultType]> {
+      [Pure, HLO_CompatibleOperandsAndResultType, Elementwise], HLO_FpOrComplexTensor> {
   let summary = "Atan2 operator";
   let description = [{
     Performs element-wise atan2 operation on `lhs` and `rhs` tensor and produces
@@ -707,7 +706,8 @@ def StableHLO_Atan2Op : StableHLO_BinaryElementwiseOp<"atan2",
 }
 
 def StableHLO_ComplexOp: StableHLO_BinaryElementwiseOp<"complex", [Pure,
-    SameOperandsElementType, DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
+    SameOperandsElementType, DeclareOpInterfaceMethods<InferTypeOpInterface>],
+    HLO_Fp32Or64Tensor, HLO_ComplexTensor> {
   let summary = "Complex operator";
   let description = [{
     Performs element-wise conversion to a complex value from a pair of real and
@@ -731,7 +731,7 @@ def StableHLO_ComplexOp: StableHLO_BinaryElementwiseOp<"complex", [Pure,
 }
 
 def StableHLO_DivOp : StableHLO_BinaryElementwiseOp<"divide",
-      [Pure, HLO_CompatibleOperandsAndResultType]> {
+      [Pure, HLO_CompatibleOperandsAndResultType, Elementwise], HLO_FpOrComplexTensor> {
   let summary = "Division operator";
   let description = [{
     Performs element-wise division of dividend `lhs` and divisor `rhs` tensors
@@ -748,7 +748,7 @@ def StableHLO_DivOp : StableHLO_BinaryElementwiseOp<"divide",
 }
 
 def StableHLO_MaxOp : StableHLO_BinaryElementwiseOp<"maximum",
-      [Commutative, Pure, HLO_CompatibleOperandsAndResultType]> {
+      [Commutative, Pure, HLO_CompatibleOperandsAndResultType, Elementwise], HLO_Tensor> {
   let summary = "Maximum operator";
   let description = [{
     Performs element-wise max operation on tensors `lhs` and `rhs` and produces
@@ -765,7 +765,7 @@ def StableHLO_MaxOp : StableHLO_BinaryElementwiseOp<"maximum",
 }
 
 def StableHLO_MinOp : StableHLO_BinaryElementwiseOp<"minimum",
-      [Commutative, Pure, HLO_CompatibleOperandsAndResultType]> {
+      [Commutative, Pure, HLO_CompatibleOperandsAndResultType, Elementwise], HLO_Tensor> {
   let summary = "Minimum operator";
   let description = [{
     Performs element-wise min operation on tensors `lhs` and `rhs` and produces a
@@ -782,7 +782,7 @@ def StableHLO_MinOp : StableHLO_BinaryElementwiseOp<"minimum",
 }
 
 def StableHLO_MulOp : StableHLO_BinaryElementwiseOp<"multiply",
-      [Commutative, Pure, HLO_CompatibleOperandsAndResultType]> {
+      [Commutative, Pure, HLO_CompatibleOperandsAndResultType, Elementwise], HLO_Tensor> {
   let summary = "Multiplication operator";
   let description = [{
     Performs element-wise product of two tensors `lhs` and `rhs` and produces a
@@ -798,8 +798,8 @@ def StableHLO_MulOp : StableHLO_BinaryElementwiseOp<"multiply",
   }];
 }
 
-def StableHLO_PowOp : StableHLO_Op<"power",
-      [Pure, HLO_CompatibleOperandsAndResultType]> {
+def StableHLO_PowOp : StableHLO_BinaryElementwiseOp<"power",
+      [Pure, HLO_CompatibleOperandsAndResultType, Elementwise], HLO_IntFpOrComplexTensor> {
   let summary = "Power operator";
   let description = [{
     Performs element-wise exponentiation of `lhs` tensor by `rhs` tensor and
@@ -813,35 +813,10 @@ def StableHLO_PowOp : StableHLO_Op<"power",
     %result = stablehlo.power %lhs, %rhs : tensor<6xf32>
     ```
   }];
-
-  let arguments = (ins
-    HLO_IntFpOrComplexTensor:$lhs,
-    HLO_IntFpOrComplexTensor:$rhs
-  );
-
-  let results = (outs HLO_IntFpOrComplexTensor:$result);
-
-  let extraClassDeclaration = [{
-    LogicalResult reifyReturnTypeShapes(
-        OpBuilder& builder, ValueRange operands,
-        SmallVectorImpl<Value>& reifiedReturnShapes) {
-      return ::mlir::hlo::deriveShapeFromOperand(&builder, getOperation(),
-                                                 operands.front(),
-                                                 &reifiedReturnShapes);
-    }
-    static bool isCompatibleReturnTypes(TypeRange l, TypeRange r) {
-      return mlir::hlo::isCompatibleForHloTypeInference(l, r);
-    }
-  }];
-
-  let assemblyFormat = [{
-    $lhs `,` $rhs attr-dict
-      `:` custom<SameOperandsAndResultType>(type($lhs), type($rhs), type($result))
-  }];
 }
 
 def StableHLO_RemOp : StableHLO_BinaryElementwiseOp<"remainder",
-      [Pure, HLO_CompatibleOperandsAndResultType]> {
+      [Pure, HLO_CompatibleOperandsAndResultType, Elementwise], HLO_IntFpOrComplexTensor> {
   let summary = "Remainder operator";
   let description = [{
     Performs element-wise remainder of dividend `lhs` and divisor `rhs` tensors
@@ -858,7 +833,7 @@ def StableHLO_RemOp : StableHLO_BinaryElementwiseOp<"remainder",
 }
 
 def StableHLO_ShiftLeftOp : StableHLO_BinaryElementwiseOp<"shift_left",
-      [Pure, HLO_CompatibleOperandsAndResultType]> {
+      [Pure, HLO_CompatibleOperandsAndResultType, Elementwise], HLO_IntTensor> {
   let summary = "Shift Left operator";
   let description = [{
     Performs element-wise left-shift operation on the `lhs` tensor by `rhs`
@@ -875,7 +850,7 @@ def StableHLO_ShiftLeftOp : StableHLO_BinaryElementwiseOp<"shift_left",
 }
 
 def StableHLO_ShiftRightArithmeticOp : StableHLO_BinaryElementwiseOp<"shift_right_arithmetic",
-      [Pure, HLO_CompatibleOperandsAndResultType]> {
+      [Pure, HLO_CompatibleOperandsAndResultType, Elementwise], HLO_IntTensor> {
   let summary = "Shift right arithmetic operator";
   let description = [{
     Performs element-wise arithmetic right-shift operation on the `lhs` tensor
@@ -892,7 +867,7 @@ def StableHLO_ShiftRightArithmeticOp : StableHLO_BinaryElementwiseOp<"shift_righ
 }
 
 def StableHLO_ShiftRightLogicalOp : StableHLO_BinaryElementwiseOp<"shift_right_logical",
-      [Pure, HLO_CompatibleOperandsAndResultType]> {
+      [Pure, HLO_CompatibleOperandsAndResultType, Elementwise], HLO_IntTensor> {
   let summary = "Shift right logical operator";
   let description = [{
     Performs element-wise logical right-shift operation on the `lhs` tensor by
@@ -909,7 +884,7 @@ def StableHLO_ShiftRightLogicalOp : StableHLO_BinaryElementwiseOp<"shift_right_l
 }
 
 def StableHLO_SubtractOp : StableHLO_BinaryElementwiseOp<"subtract",
-      [Pure, HLO_CompatibleOperandsAndResultType]> {
+      [Pure, HLO_CompatibleOperandsAndResultType, Elementwise], HLO_IntFpOrComplexTensor> {
   let summary = "Subtraction operator";
   let description = [{
     Performs element-wise subtraction of two tensors `lhs` and `rhs` and

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -799,8 +799,7 @@ def StableHLO_MulOp : StableHLO_BinaryElementwiseOp<"multiply",
 }
 
 def StableHLO_PowOp : StableHLO_Op<"power",
-      [Pure, HLO_CompatibleOperandsAndResultType, InferShapedTypeOpInterface,
-       SameOperandsAndResultShape, Elementwise]> {
+      [Pure, HLO_CompatibleOperandsAndResultType]> {
   let summary = "Power operator";
   let description = [{
     Performs element-wise exponentiation of `lhs` tensor by `rhs` tensor and
@@ -816,11 +815,11 @@ def StableHLO_PowOp : StableHLO_Op<"power",
   }];
 
   let arguments = (ins
-    HLO_FpOrComplexTensor:$lhs,
-    HLO_FpOrComplexTensor:$rhs
+    HLO_IntFpOrComplexTensor:$lhs,
+    HLO_IntFpOrComplexTensor:$rhs
   );
 
-  let results = (outs HLO_FpOrComplexTensor:$result);
+  let results = (outs HLO_IntFpOrComplexTensor:$result);
 
   let extraClassDeclaration = [{
     LogicalResult reifyReturnTypeShapes(

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -798,8 +798,9 @@ def StableHLO_MulOp : StableHLO_BinaryElementwiseOp<"multiply",
   }];
 }
 
-def StableHLO_PowOp : StableHLO_BinaryElementwiseOp<"power",
-      [Pure, HLO_CompatibleOperandsAndResultType]> {
+def StableHLO_PowOp : StableHLO_Op<"power",
+      [Pure, HLO_CompatibleOperandsAndResultType, InferShapedTypeOpInterface,
+       SameOperandsAndResultShape, Elementwise]> {
   let summary = "Power operator";
   let description = [{
     Performs element-wise exponentiation of `lhs` tensor by `rhs` tensor and
@@ -812,6 +813,31 @@ def StableHLO_PowOp : StableHLO_BinaryElementwiseOp<"power",
     ```mlir
     %result = stablehlo.power %lhs, %rhs : tensor<6xf32>
     ```
+  }];
+
+  let arguments = (ins
+    HLO_FpOrComplexTensor:$lhs,
+    HLO_FpOrComplexTensor:$rhs
+  );
+
+  let results = (outs HLO_FpOrComplexTensor:$result);
+
+  let extraClassDeclaration = [{
+    LogicalResult reifyReturnTypeShapes(
+        OpBuilder& builder, ValueRange operands,
+        SmallVectorImpl<Value>& reifiedReturnShapes) {
+      return ::mlir::hlo::deriveShapeFromOperand(&builder, getOperation(),
+                                                 operands.front(),
+                                                 &reifiedReturnShapes);
+    }
+    static bool isCompatibleReturnTypes(TypeRange l, TypeRange r) {
+      return mlir::hlo::isCompatibleForHloTypeInference(l, r);
+    }
+  }];
+
+  let assemblyFormat = [{
+    $lhs `,` $rhs attr-dict
+      `:` custom<SameOperandsAndResultType>(type($lhs), type($rhs), type($result))
   }];
 }
 

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -707,8 +707,8 @@ def StableHLO_Atan2Op : StableHLO_BinaryElementwiseOp<"atan2",
 }
 
 def StableHLO_ComplexOp: StableHLO_BinaryElementwiseOp<"complex", [Pure,
-    SameOperandsElementType, DeclareOpInterfaceMethods<InferTypeOpInterface>],
-    HLO_Fp32Or64Tensor, HLO_ComplexTensor> {
+    SameOperandsElementType, SameOperandsAndResultShape,
+    DeclareOpInterfaceMethods<InferTypeOpInterface>, Elementwise]> {
   let summary = "Complex operator";
   let description = [{
     Performs element-wise conversion to a complex value from a pair of real and
@@ -732,7 +732,7 @@ def StableHLO_ComplexOp: StableHLO_BinaryElementwiseOp<"complex", [Pure,
 }
 
 def StableHLO_DivOp : StableHLO_BinaryElementwiseOp<"divide",
-      [Pure, HLO_CompatibleOperandsAndResultType, Elementwise], HLO_FpOrComplexTensor> {
+      [Pure, HLO_CompatibleOperandsAndResultType, Elementwise], HLO_IntFpOrComplexTensor> {
   let summary = "Division operator";
   let description = [{
     Performs element-wise division of dividend `lhs` and divisor `rhs` tensors

--- a/stablehlo/tests/ops_stablehlo_roundtrip.mlir
+++ b/stablehlo/tests/ops_stablehlo_roundtrip.mlir
@@ -678,12 +678,11 @@ func.func @test_set_dimension_size(%arg: tensor<4x4xf32>, %size: tensor<i32>) ->
   func.return %0 : tensor<4x4xf32>
 }
 
-func.func @test_shift(%arg0: tensor<4xi32>, %arg1: tensor<4xi32>) -> (tensor<4xi32>, tensor<4xi32>, tensor<4xi32>, tensor<4xi32>) {
-  %0 = stablehlo.atan2 %arg0, %arg1 : tensor<4xi32>
-  %1 = stablehlo.shift_left %arg0, %arg1 : tensor<4xi32>
-  %2 = stablehlo.shift_right_arithmetic %arg0, %arg1 : tensor<4xi32>
-  %3 = stablehlo.shift_right_logical %arg0, %arg1 : tensor<4xi32>
-  func.return %0, %1, %2, %3 : tensor<4xi32>, tensor<4xi32>, tensor<4xi32>, tensor<4xi32>
+func.func @test_shift(%arg0: tensor<4xi32>, %arg1: tensor<4xi32>) -> (tensor<4xi32>, tensor<4xi32>, tensor<4xi32>) {
+  %0 = stablehlo.shift_left %arg0, %arg1 : tensor<4xi32>
+  %1 = stablehlo.shift_right_arithmetic %arg0, %arg1 : tensor<4xi32>
+  %2 = stablehlo.shift_right_logical %arg0, %arg1 : tensor<4xi32>
+  func.return %0, %1, %2 : tensor<4xi32>, tensor<4xi32>, tensor<4xi32>
 }
 
 func.func @test_slice(%arg: tensor<3x4xi32>) -> tensor<1x2xi32> {

--- a/stablehlo/tests/print_stablehlo.mlir
+++ b/stablehlo/tests/print_stablehlo.mlir
@@ -84,35 +84,35 @@ func.func @unary_ops(%arg0 : tensor<2xi32>, %arg1 : tensor<2xf32>) -> () {
 }
 
 // CHECK-LABEL: func @binary_ops
-func.func @binary_ops(%arg0: tensor<2xi1>, %arg1 : tensor<2xf32>) -> tensor<2xi1> {
+func.func @binary_ops(%arg0: tensor<2xi1>, %arg1 : tensor<2xf32>, %arg2 : tensor<2xi32>) -> tensor<2xi1> {
   // CHECK:      %0 = stablehlo.add %arg0, %arg0 : tensor<2xi1>
   // CHECK-NEXT: %1 = stablehlo.and %arg0, %arg0 : tensor<2xi1>
-  // CHECK-NEXT: %2 = stablehlo.atan2 %arg0, %arg0 : tensor<2xi1>
-  // CHECK-NEXT: %3 = stablehlo.divide %arg0, %arg0 : tensor<2xi1>
+  // CHECK-NEXT: %2 = stablehlo.atan2 %arg1, %arg1 : tensor<2xf32>
+  // CHECK-NEXT: %3 = stablehlo.divide %arg1, %arg1 : tensor<2xf32>
   // CHECK-NEXT: %4 = stablehlo.maximum %arg1, %arg1 : tensor<2xf32>
   // CHECK-NEXT: %5 = stablehlo.minimum %arg1, %arg1 : tensor<2xf32>
   // CHECK-NEXT: %6 = stablehlo.multiply %arg1, %arg1 : tensor<2xf32>
   // CHECK-NEXT: %7 = stablehlo.or %arg0, %arg0 : tensor<2xi1>
   // CHECK-NEXT: %8 = stablehlo.power %arg1, %arg1 : tensor<2xf32>
   // CHECK-NEXT: %9 = stablehlo.remainder %arg1, %arg1 : tensor<2xf32>
-  // CHECK-NEXT: %10 = stablehlo.shift_left %arg1, %arg1 : tensor<2xf32>
-  // CHECK-NEXT: %11 = stablehlo.shift_right_arithmetic %arg1, %arg1 : tensor<2xf32>
-  // CHECK-NEXT: %12 = stablehlo.shift_right_logical %arg1, %arg1 : tensor<2xf32>
+  // CHECK-NEXT: %10 = stablehlo.shift_left %arg2, %arg2 : tensor<2xi32>
+  // CHECK-NEXT: %11 = stablehlo.shift_right_arithmetic %arg2, %arg2 : tensor<2xi32>
+  // CHECK-NEXT: %12 = stablehlo.shift_right_logical %arg2, %arg2 : tensor<2xi32>
   // CHECK-NEXT: %13 = stablehlo.subtract %arg1, %arg1 : tensor<2xf32>
   // CHECK-NEXT: %14 = stablehlo.xor %arg0, %arg0 : tensor<2xi1>
   %0 = "stablehlo.add"(%arg0, %arg0) : (tensor<2xi1>, tensor<2xi1>) -> tensor<2xi1>
   %1 = "stablehlo.and"(%arg0, %arg0) : (tensor<2xi1>, tensor<2xi1>) -> tensor<2xi1>
-  %2 = "stablehlo.atan2"(%arg0, %arg0) : (tensor<2xi1>, tensor<2xi1>) -> tensor<2xi1>
-  %3 = "stablehlo.divide"(%arg0, %arg0) : (tensor<2xi1>, tensor<2xi1>) -> tensor<2xi1>
+  %2 = "stablehlo.atan2"(%arg1, %arg1) : (tensor<2xf32>, tensor<2xf32>) -> tensor<2xf32>
+  %3 = "stablehlo.divide"(%arg1, %arg1) : (tensor<2xf32>, tensor<2xf32>) -> tensor<2xf32>
   %4 = "stablehlo.maximum"(%arg1, %arg1) : (tensor<2xf32>, tensor<2xf32>) -> tensor<2xf32>
   %5 = "stablehlo.minimum"(%arg1, %arg1) : (tensor<2xf32>, tensor<2xf32>) -> tensor<2xf32>
   %6 = "stablehlo.multiply"(%arg1, %arg1) : (tensor<2xf32>, tensor<2xf32>) -> tensor<2xf32>
   %7 = "stablehlo.or"(%arg0, %arg0) : (tensor<2xi1>, tensor<2xi1>) -> tensor<2xi1>
   %8 = "stablehlo.power"(%arg1, %arg1) : (tensor<2xf32>, tensor<2xf32>) -> tensor<2xf32>
   %9 = "stablehlo.remainder"(%arg1, %arg1) : (tensor<2xf32>, tensor<2xf32>) -> tensor<2xf32>
-  %10 = "stablehlo.shift_left"(%arg1, %arg1) : (tensor<2xf32>, tensor<2xf32>) -> tensor<2xf32>
-  %11 = "stablehlo.shift_right_arithmetic"(%arg1, %arg1) : (tensor<2xf32>, tensor<2xf32>) -> tensor<2xf32>
-  %12 = "stablehlo.shift_right_logical"(%arg1, %arg1) : (tensor<2xf32>, tensor<2xf32>) -> tensor<2xf32>
+  %10 = "stablehlo.shift_left"(%arg2, %arg2) : (tensor<2xi32>, tensor<2xi32>) -> tensor<2xi32>
+  %11 = "stablehlo.shift_right_arithmetic"(%arg2, %arg2) : (tensor<2xi32>, tensor<2xi32>) -> tensor<2xi32>
+  %12 = "stablehlo.shift_right_logical"(%arg2, %arg2) : (tensor<2xi32>, tensor<2xi32>) -> tensor<2xi32>
   %13 = "stablehlo.subtract"(%arg1, %arg1) : (tensor<2xf32>, tensor<2xf32>) -> tensor<2xf32>
   %14 = "stablehlo.xor"(%arg0, %arg0) : (tensor<2xi1>, tensor<2xi1>) -> tensor<2xi1>
   func.return %0 : tensor<2xi1>


### PR DESCRIPTION
Notes:
* Atan2: As discussed in #500, [shape_inference.cc](https://github.com/tensorflow/tensorflow/blob/2c1b3efe573befdda3f3db399eebb875e690082c/tensorflow/compiler/xla/service/shape_inference.cc#L1028-L1043) does allow integers, but our spec doesn't. However, since the ODS is now in sync with StableHLO spec, I'm marking the verification status to `yes`.

closes #262 
closes #499
closes #512 
closes #513 
closes #587 