### PR TITLE
Verify dimension in GetDimensionSizeOp

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2716,7 +2716,7 @@ Produces the size of the given `dimension` of the `operand`.
 
 ### Constraints
 
-  * (C1) 0 $\le$ `dimension` $\lt$ `rank(operand)`.
+* (C1) 0 $\le$ `dimension` $\lt$ `rank(operand)`.
 
 ### Examples
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2716,8 +2716,7 @@ Produces the size of the given `dimension` of the `operand`.
 
 ### Constraints
 
-* (C1) 0 $\le$ `dimension` $\lt$ `rank(operand)`.
-  [todo](https://github.com/openxla/stablehlo/issues/790)
+  * (C1) 0 $\le$ `dimension` $\lt$ `rank(operand)`.
 
 ### Examples
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -92,7 +92,7 @@ one of the following tracking labels.
 | fft                      | yes           | revisit      | yes            | yes             | no          |
 | floor                    | yes           | yes          | yes            | yes             | yes         |
 | gather                   | yes           | yes          | yes            | no              | no          |
-| get_dimension_size       | yes           | revisit      | yes            | yes             | no          |
+| get_dimension_size       | yes           | yes          | yes            | yes             | no          |
 | get_tuple_element        | yes           | yes          | yes            | yes             | no          |
 | if                       | yes           | revisit      | yes            | no              | no          |
 | imag                     | yes           | yes          | yes            | yes             | no          |

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -4177,6 +4177,14 @@ func.func @get_dimension_size(%I: tensor<1x128x512xf32>) -> tensor<i32> {
 
 // -----
 
+func.func @get_dimension_size_invalid_dimension(%I: tensor<1x128x512xf32>) -> tensor<i32> {
+  // expected-error@+1 {{requires dimension attribute in range [0, 3); found (-1)}}
+  %size = "stablehlo.get_dimension_size"(%I) {dimension = -1 : i64} : (tensor<1x128x512xf32>) -> tensor<i32>
+  func.return %size : tensor<i32>
+}
+
+// -----
+
 func.func @set_dimension_size(%I: tensor<1x128x512xf32>) -> tensor<1x128x512xf32> {
   %dim = stablehlo.constant dense<512> : tensor<1xi32>
 

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -4177,9 +4177,17 @@ func.func @get_dimension_size(%I: tensor<1x128x512xf32>) -> tensor<i32> {
 
 // -----
 
-func.func @get_dimension_size_invalid_dimension(%I: tensor<1x128x512xf32>) -> tensor<i32> {
-  // expected-error@+1 {{requires dimension attribute in range [0, 3); found (-1)}}
+func.func @get_dimension_size_negative_dimension(%I: tensor<1x128x512xf32>) -> tensor<i32> {
+  // expected-error@+1 {{requires non-negative dimension attribute; found (-1)}}
   %size = "stablehlo.get_dimension_size"(%I) {dimension = -1 : i64} : (tensor<1x128x512xf32>) -> tensor<i32>
+  func.return %size : tensor<i32>
+}
+
+// -----
+
+func.func @get_dimension_size_invalid_dimension(%I: tensor<1x128x512xf32>) -> tensor<i32> {
+  // expected-error@+1 {{requires dimension attribute in range [0, 3); found (3)}}
+  %size = "stablehlo.get_dimension_size"(%I) {dimension = 3 : i64} : (tensor<1x128x512xf32>) -> tensor<i32>
   func.return %size : tensor<i32>
 }
 
@@ -4195,9 +4203,17 @@ func.func @set_dimension_size(%I: tensor<1x128x512xf32>) -> tensor<1x128x512xf32
 
 // -----
 
-func.func @set_dimension_size(%I: tensor<1x128x512xf32>) -> tensor<1x128x512xf32> {
+func.func @set_dimension_size_negative_dimension(%I: tensor<1x128x512xf32>) -> tensor<1x128x512xf32> {
   %dim = stablehlo.constant dense<512> : tensor<i32>
+  // expected-error@+1 {{requires non-negative dimension attribute; found (-1)}}
+  %result = "stablehlo.set_dimension_size"(%I, %dim) {dimension =-1 : i64} : (tensor<1x128x512xf32>, tensor<i32>) -> tensor<1x128x512xf32>
+  func.return %result : tensor<1x128x512xf32>
+}
 
+// -----
+
+func.func @set_dimension_size_invalid_dimension(%I: tensor<1x128x512xf32>) -> tensor<1x128x512xf32> {
+  %dim = stablehlo.constant dense<512> : tensor<i32>
   // expected-error@+1 {{requires dimension attribute in range [0, 3); found (3)}}
   %result = "stablehlo.set_dimension_size"(%I, %dim) {dimension = 3 : i64} : (tensor<1x128x512xf32>, tensor<i32>) -> tensor<1x128x512xf32>
   func.return %result : tensor<1x128x512xf32>
@@ -5619,9 +5635,17 @@ func.func @is_finite_mismatch_return_shape(%arg0: tensor<3xf32>) -> tensor<4xi1>
 
 // -----
 
-func.func @invalid_dimension_attr(%arg0: tensor<?x?xf32, #stablehlo.type_extensions<bounds = [3, -1]>>, %arg1: tensor<i32>) -> tensor<*xf32> {
-  // expected-error@+1 {{requires dimension attribute in range [0, 2); found (-1)}}
+func.func @negative_dimension_attr(%arg0: tensor<?x?xf32, #stablehlo.type_extensions<bounds = [3, -1]>>, %arg1: tensor<i32>) -> tensor<*xf32> {
+  // expected-error@+1 {{requires non-negative dimension attribute; found (-1)}}
   %result = "stablehlo.set_dimension_size"(%arg0, %arg1) {dimension = -1 : i64} : (tensor<?x?xf32, #stablehlo.type_extensions<bounds = [3, -1]>>, tensor<i32>) -> tensor<*xf32>
+  func.return %result : tensor<*xf32>
+}
+
+// -----
+
+func.func @invalid_dimension_attr(%arg0: tensor<?x?xf32, #stablehlo.type_extensions<bounds = [3, -1]>>, %arg1: tensor<i32>) -> tensor<*xf32> {
+  // expected-error@+1 {{requires dimension attribute in range [0, 2); found (2)}}
+  %result = "stablehlo.set_dimension_size"(%arg0, %arg1) {dimension = 2 : i64} : (tensor<?x?xf32, #stablehlo.type_extensions<bounds = [3, -1]>>, tensor<i32>) -> tensor<*xf32>
   func.return %result : tensor<*xf32>
 }
 


### PR DESCRIPTION
Of the two constraints mentioned in #790:
* (C1) is already checked by [verifyDimAttr](https://github.com/openxla/stablehlo/blob/main/stablehlo/dialect/StablehloOps.cpp#L117-L120), but have added a negative test
* (C2) is not added per discussion [here](https://github.com/openxla/stablehlo/pull/791#discussion_r1053899143)

closes #790