### PR TITLE
Fix Reduce op bounds inference for scalar results

### DIFF
--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -452,7 +452,10 @@ LogicalResult verifyReduceOpInputsAndInferShape(
         }
       }
     }
-    if (!inputBounds.empty()) {
+
+    // Set encoding based on the bounds only if the bounds is not empty.
+    encoding = nullptr;
+    if (!newBounds.empty()) {
       encoding = boundsToEncoding(rankedInput.getEncoding(), newBounds);
     }
   }

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -627,6 +627,27 @@ func.func @reduce_with_bounds(%arg0: tensor<?x?x5xf32, #stablehlo.type_extension
   func.return %2: tensor<*xindex>
 }
 
+// Verifies that bounds are not set for scalar types.
+
+// CHECK-LABEL: func @reduce_with_scalar_result
+func.func @reduce_with_scalar_result(%arg0: tensor<?xf32, #stablehlo.type_extensions<bounds = [3]>>, %arg1 : tensor<f32>)
+    -> (tensor<*xindex>) {
+  %0 = "stablehlo.reduce"(%arg0, %arg1) ({
+
+  ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32> ):
+    %1 = "stablehlo.add"(%arg2, %arg3) : (tensor<f32>, tensor<f32>) -> tensor<f32>
+    "stablehlo.return"(%1) : (tensor<f32>) -> ()
+
+  }) {dimensions = dense<[0]> : tensor<1xi64>}
+      : (tensor<?xf32, #stablehlo.type_extensions<bounds = [3]>>, tensor<f32>)
+          -> tensor<*xf32>
+
+  // CHECK: types0 = tensor<f32>
+  %2 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xf32>) -> tensor<*xindex>
+
+  func.return %2: tensor<*xindex>
+}
+
 // -----
 
 // CHECK-LABEL: func @unranked_reduce


### PR DESCRIPTION
encoding attribute is not required if the result is a scalar but the current code will end up incorrectly setting it to the input encoding attribute.

For the added test, the inferred result type was `tensor<f32, #stablehlo.type_extensions<bounds = [3]>>` but scalar tensors shouldn't have a bounds attributes. This was happening because boundsToEncoding returns the original encoding if the provided bounds are empty. boundsToEncoding doesn't differentiate between bounds being empty for scalars or bounds being empty for unbounded tensors.

I also checked that the other inference functions are not having a similar issue. (May have missed recently submitted shape functions.)

Reduce op inference also doesn't deal with sparse encoding attribute so we don't have to worry about that here.

cc @zhouxin913 