### PR TITLE
Remove remaining usages of llvm::Optional

### DIFF
--- a/stablehlo/dialect/Base.cpp
+++ b/stablehlo/dialect/Base.cpp
@@ -230,7 +230,7 @@ std::pair<int64_t, int64_t> inferConcatenatedDimAndBound(int64_t leftSize,
 //  c5:  ?              ?, B            ?, B
 //  c6:  ?, B           ?, C            ?, min(B, C)
 FailureOr<std::pair<int64_t, int64_t>> inferMergedDimAndBound(
-    Optional<Location> location, int64_t dim, int64_t leftSize,
+    std::optional<Location> location, int64_t dim, int64_t leftSize,
     int64_t rightSize, int64_t leftBound, int64_t rightBound) {
   bool isLeftStaticDim = !isDynamicDimSize(leftSize);
   bool isRightStaticDim = !isDynamicDimSize(rightSize);
@@ -263,7 +263,7 @@ FailureOr<std::pair<int64_t, int64_t>> inferMergedDimAndBound(
 
 // TODO(zhouxin) Refactor to better handle errors and return single type
 LogicalResult inferMostSpecificType(
-    Optional<Location> location, TypeRange inputTypes,
+    std::optional<Location> location, TypeRange inputTypes,
     SmallVectorImpl<Type>& inferredReturnTypes) {
   SmallVector<RankedTensorType> rankedTypes;
   for (auto inputType : inputTypes)
@@ -312,7 +312,7 @@ LogicalResult inferMostSpecificType(
 }
 
 LogicalResult inferMostSpecificTypeComponents(
-    Optional<Location> location, TypeRange inputTypes,
+    std::optional<Location> location, TypeRange inputTypes,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   SmallVector<Type> inferredReturnTypes;
   if (failed(hlo::inferMostSpecificType(location, inputTypes,

--- a/stablehlo/dialect/Base.h
+++ b/stablehlo/dialect/Base.h
@@ -18,6 +18,7 @@ limitations under the License.
 #define STABLEHLO_DIALECT_BASE_H
 
 #include <algorithm>
+#include <optional>
 
 #include "llvm/ADT/Sequence.h"
 #include "llvm/ADT/SmallVector.h"
@@ -74,18 +75,18 @@ std::pair<int64_t, int64_t> inferConcatenatedDimAndBound(int64_t leftSize,
                                                          int64_t rightBound);
 
 FailureOr<std::pair<int64_t, int64_t>> inferMergedDimAndBound(
-    Optional<Location> location, int64_t dim, int64_t leftSize,
+    std::optional<Location> location, int64_t dim, int64_t leftSize,
     int64_t rightSize, int64_t leftBound, int64_t rightBound);
 
 // Infer single most specific return type from inputTypes with support for
 // bounds. (Size, bound) of each dimension of the return type will be merged
 // from corresponding dimensions of every inputType by merging them.
-LogicalResult inferMostSpecificType(Optional<Location> location,
+LogicalResult inferMostSpecificType(std::optional<Location> location,
                                     TypeRange inputTypes,
                                     SmallVectorImpl<Type> &inferredReturnTypes);
 
 LogicalResult inferMostSpecificTypeComponents(
-    Optional<Location> location, TypeRange inputTypes,
+    std::optional<Location> location, TypeRange inputTypes,
     SmallVectorImpl<ShapedTypeComponents> &inferredReturnShapes);
 
 // Shape derivation function that computes the shape of the result based on an
@@ -230,7 +231,7 @@ class CompatibleOperandsAndResultType
   }
 
   static LogicalResult inferReturnTypes(
-      MLIRContext * /*context*/, Optional<Location> location,
+      MLIRContext * /*context*/, std::optional<Location> location,
       ValueRange operands, DictionaryAttr /*attributes*/,
       RegionRange /*regions*/, SmallVectorImpl<Type> &inferredReturnTypes) {
     // TODO(b/231358795): Review the use of InferTypeOpInterface for ops that
@@ -250,7 +251,7 @@ class CompatibleOperandsAndResultType
   // It needs to be paired with INFER_RETURN_TYPE_COMPONENTS_FROM_OPERANDS
   // (see examples in StablehloOps.cpp).
   static LogicalResult inferReturnTypeComponentsFromOperands(
-      MLIRContext *context, Optional<Location> location,
+      MLIRContext *context, std::optional<Location> location,
       ValueShapeRange operands, DictionaryAttr attributes, RegionRange regions,
       SmallVectorImpl<ShapedTypeComponents> &inferredReturnShapes) {
     SmallVector<Type> inferredReturnTypes;

--- a/stablehlo/dialect/ChloOps.cpp
+++ b/stablehlo/dialect/ChloOps.cpp
@@ -16,6 +16,8 @@ limitations under the License.
 
 #include "stablehlo/dialect/ChloOps.h"
 
+#include <optional>
+
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -43,7 +45,7 @@ namespace chlo {
 // support quantization or sparsity.
 #define INFER_RETURN_TYPE_COMPONENTS_FROM_OPERANDS(Op)                        \
   LogicalResult Op::inferReturnTypeComponents(                                \
-      MLIRContext* context, Optional<Location> location,                      \
+      MLIRContext* context, std::optional<Location> location,                 \
       ValueShapeRange operands, DictionaryAttr attributes,                    \
       RegionRange regions,                                                    \
       SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {          \
@@ -132,7 +134,7 @@ ShapedTypeComponents getBroadcastType(
 }
 
 LogicalResult InferBroadcastBinaryOpReturnTypeComponents(
-    MLIRContext* context, Optional<Location> location, ValueRange operands,
+    MLIRContext* context, std::optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, Type elementType,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   // Find broadcast_dimensions.
@@ -188,8 +190,9 @@ LogicalResult ReifyBroadcastBinaryOpReturnTypeShapes(
 //===----------------------------------------------------------------------===//
 
 LogicalResult BroadcastComplexOp::inferReturnTypeComponents(
-    MLIRContext* context, Optional<Location> location, ValueShapeRange operands,
-    DictionaryAttr attributes, RegionRange /*regions*/,
+    MLIRContext* context, std::optional<Location> location,
+    ValueShapeRange operands, DictionaryAttr attributes,
+    RegionRange /*regions*/,
     SmallVectorImpl<ShapedTypeComponents>& inferedReturnShapes) {
   ShapedType lhsType = operands[0].getType().dyn_cast<ShapedType>();
   if (!lhsType) {
@@ -223,8 +226,9 @@ void BroadcastCompareOp::build(OpBuilder& builder, OperationState& result,
 }
 
 LogicalResult BroadcastCompareOp::inferReturnTypeComponents(
-    MLIRContext* context, Optional<Location> location, ValueShapeRange operands,
-    DictionaryAttr attributes, RegionRange /*regions*/,
+    MLIRContext* context, std::optional<Location> location,
+    ValueShapeRange operands, DictionaryAttr attributes,
+    RegionRange /*regions*/,
     SmallVectorImpl<ShapedTypeComponents>& inferedReturnShapes) {
   Type elementType = IntegerType::get(context, 1);
   return InferBroadcastBinaryOpReturnTypeComponents(context, location, operands,
@@ -250,7 +254,7 @@ static Type getIsInfLikeReturnType(Value operand) {
 }
 
 LogicalResult IsInfOp::inferReturnTypes(
-    MLIRContext* /*ctx*/, Optional<Location>, ValueRange operands,
+    MLIRContext* /*ctx*/, std::optional<Location>, ValueRange operands,
     DictionaryAttr, RegionRange, SmallVectorImpl<Type>& inferredReturnTypes) {
   inferredReturnTypes.push_back(getIsInfLikeReturnType(operands.front()));
   return success();
@@ -261,7 +265,7 @@ LogicalResult IsInfOp::inferReturnTypes(
 //===----------------------------------------------------------------------===//
 
 LogicalResult IsNegInfOp::inferReturnTypes(
-    MLIRContext* /*ctx*/, Optional<Location>, ValueRange operands,
+    MLIRContext* /*ctx*/, std::optional<Location>, ValueRange operands,
     DictionaryAttr, RegionRange, SmallVectorImpl<Type>& inferredReturnTypes) {
   inferredReturnTypes.push_back(getIsInfLikeReturnType(operands.front()));
   return success();
@@ -272,7 +276,7 @@ LogicalResult IsNegInfOp::inferReturnTypes(
 //===----------------------------------------------------------------------===//
 
 LogicalResult IsPosInfOp::inferReturnTypes(
-    MLIRContext* /*ctx*/, Optional<Location>, ValueRange operands,
+    MLIRContext* /*ctx*/, std::optional<Location>, ValueRange operands,
     DictionaryAttr, RegionRange, SmallVectorImpl<Type>& inferredReturnTypes) {
   inferredReturnTypes.push_back(getIsInfLikeReturnType(operands.front()));
   return success();
@@ -284,7 +288,7 @@ LogicalResult IsPosInfOp::inferReturnTypes(
 
 #define BROADCAST_BINARY_OP_DEFS(Op)                                       \
   LogicalResult Op::inferReturnTypeComponents(                             \
-      MLIRContext* context, Optional<Location> location,                   \
+      MLIRContext* context, std::optional<Location> location,              \
       ValueShapeRange operands, DictionaryAttr attributes,                 \
       RegionRange regions,                                                 \
       SmallVectorImpl<ShapedTypeComponents>& inferedReturnShapes) {        \
@@ -346,7 +350,7 @@ LogicalResult MinimumBroadcastShapesOp::verify() {
 }
 
 LogicalResult ConstantLikeOp::inferReturnTypeComponents(
-    MLIRContext* /*context*/, Optional<Location> location,
+    MLIRContext* /*context*/, std::optional<Location> location,
     ValueShapeRange operands, DictionaryAttr attributes,
     RegionRange /*regions*/,
     SmallVectorImpl<ShapedTypeComponents>& inferedReturnShapes) {
@@ -380,7 +384,7 @@ OpFoldResult ConstantLikeOp::fold(ArrayRef<Attribute> /*operands*/) {
 }
 
 LogicalResult BroadcastSelectOp::inferReturnTypeComponents(
-    MLIRContext*, Optional<Location> location, ValueShapeRange operands,
+    MLIRContext*, std::optional<Location> location, ValueShapeRange operands,
     DictionaryAttr, RegionRange,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   BroadcastSelectOp::Adaptor op(operands.getValues());
@@ -418,7 +422,7 @@ LogicalResult BroadcastSelectOp::reifyReturnTypeShapes(
 //===----------------------------------------------------------------------===//
 
 void RankSpecializationClusterOp::getSuccessorRegions(
-    Optional<unsigned> index, ArrayRef<Attribute> /*operands*/,
+    std::optional<unsigned> index, ArrayRef<Attribute> /*operands*/,
     SmallVectorImpl<RegionSuccessor>& regions) {
   // RankSpecializationClusterOp has unconditional control flows into the region
   // and back to the parent, so return the correct RegionSuccessor purely based
@@ -455,8 +459,8 @@ LogicalResult RankSpecializationClusterOp::verify() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult TopKOp::inferReturnTypeComponents(
-    MLIRContext* context, Optional<Location> location, ValueShapeRange operands,
-    DictionaryAttr attributes, RegionRange regions,
+    MLIRContext* context, std::optional<Location> location,
+    ValueShapeRange operands, DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   Builder builder(context);
   TopKOp::Adaptor adaptor(operands, attributes, regions);
@@ -498,8 +502,9 @@ OpFoldResult ConstantOp::fold(ArrayRef<Attribute> /*operands*/) {
 }
 
 LogicalResult ConstantOp::inferReturnTypes(
-    MLIRContext*, Optional<Location>, ValueRange, DictionaryAttr attributes,
-    RegionRange, SmallVectorImpl<Type>& inferredReturnTypes) {
+    MLIRContext*, std::optional<Location>, ValueRange,
+    DictionaryAttr attributes, RegionRange,
+    SmallVectorImpl<Type>& inferredReturnTypes) {
   Type type = attributes.get("value").cast<TypedAttr>().getType();
   inferredReturnTypes.push_back(type);
   return success();

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -123,7 +123,7 @@ static LogicalResult verifyDimAttr(OpT op) {
 
 // Common shape function helper for RngNormal and RngUniform.
 static LogicalResult rngInferReturnTypeComponents(
-    MLIRContext* context, Optional<Location> location, ValueRange operands,
+    MLIRContext* context, std::optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   if (operands.size() != 3)
@@ -209,7 +209,7 @@ LogicalResult ReduceScatterOp::verify() {
 // support quantization or sparsity.
 #define INFER_RETURN_TYPE_COMPONENTS_FROM_OPERANDS(Op)                        \
   LogicalResult Op::inferReturnTypeComponents(                                \
-      MLIRContext* context, Optional<Location> location,                      \
+      MLIRContext* context, std::optional<Location> location,                 \
       ValueShapeRange operands, DictionaryAttr attributes,                    \
       RegionRange regions,                                                    \
       SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {          \
@@ -264,7 +264,7 @@ INFER_RETURN_TYPE_COMPONENTS_FROM_OPERANDS(XorOp)
 //===----------------------------------------------------------------------===//
 
 LogicalResult AfterAllOp::inferReturnTypes(
-    MLIRContext* context, Optional<Location> location, ValueRange operands,
+    MLIRContext* context, std::optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<Type>& inferredReturnTypes) {
   auto dialect = context->getLoadedDialect<StablehloDialect>();
@@ -309,7 +309,7 @@ void ConstantOp::build(OpBuilder& /*builder*/, OperationState& result,
 }
 
 LogicalResult ConstantOp::inferReturnTypes(
-    MLIRContext*, Optional<Location> location, ValueRange operands,
+    MLIRContext*, std::optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, RegionRange,
     SmallVectorImpl<Type>& inferredReturnTypes) {
   ConstantOpAdaptor adaptor(operands, attributes);
@@ -381,7 +381,7 @@ void ConstantOp::print(::mlir::OpAsmPrinter& p) {
 //===----------------------------------------------------------------------===//
 
 LogicalResult CreateTokenOp::inferReturnTypes(
-    MLIRContext* context, Optional<Location> location, ValueRange operands,
+    MLIRContext* context, std::optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<Type>& inferredReturnTypes) {
   auto dialect = context->getLoadedDialect<StablehloDialect>();
@@ -548,7 +548,7 @@ void CustomCallOp::getEffects(
 //===----------------------------------------------------------------------===//
 
 LogicalResult CholeskyOp::inferReturnTypeComponents(
-    MLIRContext*, Optional<Location> location, ValueShapeRange operands,
+    MLIRContext*, std::optional<Location> location, ValueShapeRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   CholeskyOp::Adaptor adaptor(operands, attributes, regions);
@@ -564,7 +564,7 @@ LogicalResult DotOp::verify() {
                           getResult());
 }
 
-// PrecisionConfig - Optional attribute, print the array as raw enums
+// PrecisionConfig - std::optional attribute, print the array as raw enums
 //
 // {precision_config = [#stablehlo<precision DEFAULT>,
 //                      #stablehlo<precision DEFAULT>]}
@@ -658,7 +658,7 @@ LogicalResult DotGeneralOp::reifyReturnTypeShapes(
 //===----------------------------------------------------------------------===//
 
 LogicalResult FftOp::inferReturnTypeComponents(
-    MLIRContext*, Optional<Location> location, ValueShapeRange operands,
+    MLIRContext*, std::optional<Location> location, ValueShapeRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   FftOp::Adaptor adaptor(operands, attributes, regions);
@@ -764,8 +764,8 @@ LogicalResult GatherOp::reifyReturnTypeShapes(
 }
 
 LogicalResult GatherOp::inferReturnTypeComponents(
-    MLIRContext* context, Optional<Location> location, ValueShapeRange operands,
-    DictionaryAttr attributes, RegionRange regions,
+    MLIRContext* context, std::optional<Location> location,
+    ValueShapeRange operands, DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   GatherOp::Adaptor adaptor(operands, attributes, regions);
   return hlo::inferGatherOp(
@@ -788,8 +788,8 @@ LogicalResult DynamicGatherOp::reifyReturnTypeShapes(
 }
 
 LogicalResult DynamicGatherOp::inferReturnTypeComponents(
-    MLIRContext* context, Optional<Location> location, ValueShapeRange operands,
-    DictionaryAttr attributes, RegionRange regions,
+    MLIRContext* context, std::optional<Location> location,
+    ValueShapeRange operands, DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   DynamicGatherOp::Adaptor adaptor(operands, attributes, regions);
   return hlo::inferDynamicGatherOp(
@@ -807,7 +807,7 @@ LogicalResult DynamicGatherOp::inferReturnTypeComponents(
 LogicalResult GetDimensionSizeOp::verify() { return verifyDimAttr(*this); }
 
 LogicalResult GetDimensionSizeOp::inferReturnTypes(
-    MLIRContext* context, Optional<Location> location, ValueRange,
+    MLIRContext* context, std::optional<Location> location, ValueRange,
     DictionaryAttr, RegionRange, SmallVectorImpl<Type>& inferredReturnTypes) {
   return hlo::inferGetDimensionSizeOp(context, location, inferredReturnTypes);
 }
@@ -846,7 +846,7 @@ LogicalResult DynamicIotaOp::reifyReturnTypeShapes(
 //===----------------------------------------------------------------------===//
 
 LogicalResult DynamicUpdateSliceOp::inferReturnTypeComponents(
-    MLIRContext*, Optional<Location> location, ValueShapeRange operands,
+    MLIRContext*, std::optional<Location> location, ValueShapeRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   DynamicUpdateSliceOp::Adaptor adaptor(operands, attributes, regions);
@@ -860,7 +860,7 @@ LogicalResult DynamicUpdateSliceOp::inferReturnTypeComponents(
 //===----------------------------------------------------------------------===//
 
 LogicalResult AbsOp::inferReturnTypes(
-    MLIRContext*, Optional<Location> location, ValueRange operands,
+    MLIRContext*, std::optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<Type>& inferredReturnTypes) {
   AbsOp::Adaptor adaptor(operands, attributes, regions);
@@ -917,7 +917,7 @@ void ConvertOp::build(OpBuilder& builder, OperationState& result, Value operand,
 //===----------------------------------------------------------------------===//
 
 LogicalResult AllToAllOp::inferReturnTypeComponents(
-    MLIRContext*, Optional<Location> location, ValueShapeRange operands,
+    MLIRContext*, std::optional<Location> location, ValueShapeRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   AllToAllOp::Adaptor adaptor(operands, attributes, regions);
@@ -961,8 +961,8 @@ LogicalResult AllReduceOp::verify() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult BatchNormGradOp::inferReturnTypeComponents(
-    MLIRContext* context, Optional<Location> location, ValueShapeRange operands,
-    DictionaryAttr attributes, RegionRange regions,
+    MLIRContext* context, std::optional<Location> location,
+    ValueShapeRange operands, DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   BatchNormGradOp::Adaptor adaptor(operands, attributes, regions);
   return hlo::inferBatchNormGradOp(
@@ -975,8 +975,8 @@ LogicalResult BatchNormGradOp::inferReturnTypeComponents(
 //===----------------------------------------------------------------------===//
 
 LogicalResult BatchNormTrainingOp::inferReturnTypeComponents(
-    MLIRContext* context, Optional<Location> location, ValueShapeRange operands,
-    DictionaryAttr attributes, RegionRange regions,
+    MLIRContext* context, std::optional<Location> location,
+    ValueShapeRange operands, DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   BatchNormTrainingOp::Adaptor adaptor(operands, attributes, regions);
   return hlo::inferBatchNormTrainingOp(
@@ -989,8 +989,8 @@ LogicalResult BatchNormTrainingOp::inferReturnTypeComponents(
 //===----------------------------------------------------------------------===//
 
 LogicalResult BatchNormInferenceOp::inferReturnTypeComponents(
-    MLIRContext* context, Optional<Location> location, ValueShapeRange operands,
-    DictionaryAttr attributes, RegionRange regions,
+    MLIRContext* context, std::optional<Location> location,
+    ValueShapeRange operands, DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   BatchNormInferenceOp::Adaptor adaptor(operands, attributes, regions);
   return hlo::inferBatchNormInferenceOp(
@@ -1033,7 +1033,7 @@ LogicalResult BitcastConvertOp::verify() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult BroadcastOp::inferReturnTypeComponents(
-    MLIRContext*, Optional<Location> location, ValueShapeRange operands,
+    MLIRContext*, std::optional<Location> location, ValueShapeRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   BroadcastOp::Adaptor adaptor(operands, attributes, regions);
@@ -1110,7 +1110,7 @@ LogicalResult DynamicBroadcastInDimOp::reifyReturnTypeShapes(
 //===----------------------------------------------------------------------===//
 
 LogicalResult ClampOp::inferReturnTypeComponents(
-    MLIRContext*, Optional<Location> location, ValueShapeRange operands,
+    MLIRContext*, std::optional<Location> location, ValueShapeRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   ClampOp::Adaptor adaptor(operands, attributes, regions);
@@ -1131,7 +1131,7 @@ LogicalResult ClampOp::reifyReturnTypeShapes(
 //===----------------------------------------------------------------------===//
 
 LogicalResult ComplexOp::inferReturnTypes(
-    MLIRContext*, Optional<Location> location, ValueRange operands,
+    MLIRContext*, std::optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<Type>& inferredReturnTypes) {
   ComplexOp::Adaptor adaptor(operands, attributes, regions);
@@ -1143,7 +1143,7 @@ LogicalResult ComplexOp::inferReturnTypes(
 //===----------------------------------------------------------------------===//
 
 LogicalResult ImagOp::inferReturnTypes(
-    MLIRContext*, Optional<Location> location, ValueRange operands,
+    MLIRContext*, std::optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<Type>& inferredReturnTypes) {
   ImagOp::Adaptor adaptor(operands, attributes, regions);
@@ -1155,7 +1155,7 @@ LogicalResult ImagOp::inferReturnTypes(
 //===----------------------------------------------------------------------===//
 
 LogicalResult IsFiniteOp::inferReturnTypes(
-    MLIRContext* ctx, Optional<Location> location, ValueRange operands,
+    MLIRContext* ctx, std::optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<Type>& inferredReturnTypes) {
   IsFiniteOp::Adaptor adaptor(operands, attributes, regions);
@@ -1168,7 +1168,7 @@ LogicalResult IsFiniteOp::inferReturnTypes(
 //===----------------------------------------------------------------------===//
 
 LogicalResult RealOp::inferReturnTypes(
-    MLIRContext*, Optional<Location> location, ValueRange operands,
+    MLIRContext*, std::optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<Type>& inferredReturnTypes) {
   RealOp::Adaptor adaptor(operands, attributes, regions);
@@ -1180,7 +1180,7 @@ LogicalResult RealOp::inferReturnTypes(
 //===----------------------------------------------------------------------===//
 
 LogicalResult ConcatenateOp::inferReturnTypes(
-    MLIRContext*, Optional<Location> location, ValueRange operands,
+    MLIRContext*, std::optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<Type>& inferredReturnTypes) {
   ConcatenateOp::Adaptor adaptor(operands, attributes, regions);
@@ -1264,7 +1264,7 @@ LogicalResult DynamicReshapeOp::reifyReturnTypeShapes(
 //===----------------------------------------------------------------------===//
 
 LogicalResult DynamicSliceOp::inferReturnTypeComponents(
-    MLIRContext*, Optional<Location> location, ValueShapeRange operands,
+    MLIRContext*, std::optional<Location> location, ValueShapeRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   DynamicSliceOp::Adaptor adaptor(operands, attributes, regions);
@@ -1343,7 +1343,7 @@ LogicalResult InfeedOp::verify() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult MapOp::inferReturnTypeComponents(
-    MLIRContext*, Optional<Location> location, ValueShapeRange operands,
+    MLIRContext*, std::optional<Location> location, ValueShapeRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   MapOp::Adaptor adaptor(operands, attributes, regions);
@@ -1363,7 +1363,7 @@ LogicalResult MapOp::reifyReturnTypeShapes(
 //===----------------------------------------------------------------------===//
 
 LogicalResult OutfeedOp::inferReturnTypes(
-    MLIRContext* context, Optional<Location> location, ValueRange operands,
+    MLIRContext* context, std::optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<Type>& inferredReturnTypes) {
   auto dialect = context->getLoadedDialect<StablehloDialect>();
@@ -1375,7 +1375,7 @@ LogicalResult OutfeedOp::inferReturnTypes(
 //===----------------------------------------------------------------------===//
 
 LogicalResult SendOp::inferReturnTypes(
-    MLIRContext* context, Optional<Location> location, ValueRange operands,
+    MLIRContext* context, std::optional<Location> location, ValueRange operands,
     DictionaryAttr, RegionRange, SmallVectorImpl<Type>& inferredReturnTypes) {
   auto dialect = context->getLoadedDialect<StablehloDialect>();
   return hlo::inferSendOp(dialect, location, inferredReturnTypes);
@@ -1395,7 +1395,7 @@ LogicalResult RecvOp::verify() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult ReduceWindowOp::inferReturnTypeComponents(
-    MLIRContext*, Optional<Location> location, ValueShapeRange operands,
+    MLIRContext*, std::optional<Location> location, ValueShapeRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   ReduceWindowOp::Adaptor adaptor(operands, attributes, regions);
@@ -1601,15 +1601,15 @@ ParseResult ReduceOp::parse(OpAsmParser& parser, OperationState& result) {
     SmallVector<OpAsmParser::UnresolvedOperand, 2> reducerInitOperands;
     SmallVector<Type, 2> reducerTypes;
     SmallVector<Type, 2> reducerInitTypes;
-    SmallVector<Optional<Location>, 2> reducerLocs;
-    SmallVector<Optional<Location>, 2> reducerInitLocs;
+    SmallVector<std::optional<Location>, 2> reducerLocs;
+    SmallVector<std::optional<Location>, 2> reducerInitLocs;
     auto parseBlockOperand =
         [&](SmallVectorImpl<OpAsmParser::UnresolvedOperand>& operands,
             SmallVectorImpl<Type>& types,
-            SmallVectorImpl<Optional<Location>>& locs) -> ParseResult {
+            SmallVectorImpl<std::optional<Location>>& locs) -> ParseResult {
       OpAsmParser::UnresolvedOperand operand;
       Type type;
-      Optional<Location> loc;
+      std::optional<Location> loc;
       if (parser.parseOperand(operand, /*allowResultNumber=*/false) ||
           parser.parseColon() || parser.parseType(type) ||
           parser.parseOptionalLocationSpecifier(loc))
@@ -1637,7 +1637,7 @@ ParseResult ReduceOp::parse(OpAsmParser& parser, OperationState& result) {
 
     // Derive the SSA-values for reduce-op's operands and parse the region, and
     // the optional trailing location.
-    Optional<Location> trailingLoc;
+    std::optional<Location> trailingLoc;
     if (parser.resolveOperands(operands, reduceOpFntype.getInputs(), loc,
                                result.operands) ||
         parser.parseRegion(*result.addRegion(), reducerArgs))
@@ -1677,7 +1677,7 @@ ParseResult ReduceOp::parse(OpAsmParser& parser, OperationState& result) {
     return success();
   };
 
-  Optional<Location> explicitLoc;
+  std::optional<Location> explicitLoc;
   FunctionType reduceOpFntype;
   if (parser.parseKeyword("across") || parser.parseKeyword("dimensions") ||
       parser.parseEqual() ||
@@ -1737,7 +1737,7 @@ ParseResult ReduceOp::parse(OpAsmParser& parser, OperationState& result) {
 }
 
 LogicalResult ReduceOp::inferReturnTypeComponents(
-    MLIRContext*, Optional<Location> location, ValueShapeRange operands,
+    MLIRContext*, std::optional<Location> location, ValueShapeRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   ReduceOp::Adaptor adaptor(operands, attributes, regions);
@@ -1798,7 +1798,7 @@ LogicalResult ReduceOp::reifyReturnTypeShapes(
 // OptimizationBarrierOp
 //===----------------------------------------------------------------------===//
 LogicalResult OptimizationBarrierOp::inferReturnTypes(
-    MLIRContext*, Optional<Location> location, ValueRange operands,
+    MLIRContext*, std::optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, RegionRange,
     SmallVectorImpl<Type>& inferredReturnTypes) {
   OptimizationBarrierOp::Adaptor adaptor(operands, attributes);
@@ -1810,7 +1810,7 @@ LogicalResult OptimizationBarrierOp::inferReturnTypes(
 // ReturnOp
 //===----------------------------------------------------------------------===//
 LogicalResult ReturnOp::inferReturnTypes(
-    MLIRContext*, Optional<Location> location, ValueRange operands,
+    MLIRContext*, std::optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, RegionRange,
     SmallVectorImpl<Type>& inferredReturnTypes) {
   ReturnOp::Adaptor adaptor(operands, attributes);
@@ -1844,8 +1844,8 @@ LogicalResult RngOp::verify() {
 }
 
 LogicalResult RngOp::inferReturnTypeComponents(
-    MLIRContext* context, Optional<Location> location, ValueShapeRange operands,
-    DictionaryAttr attributes, RegionRange regions,
+    MLIRContext* context, std::optional<Location> location,
+    ValueShapeRange operands, DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   return rngInferReturnTypeComponents(context, location, operands, attributes,
                                       regions, inferredReturnShapes);
@@ -1865,7 +1865,7 @@ LogicalResult RngOp::reifyReturnTypeShapes(
 //===----------------------------------------------------------------------===//
 
 LogicalResult SelectOp::inferReturnTypeComponents(
-    MLIRContext*, Optional<Location> location, ValueShapeRange operands,
+    MLIRContext*, std::optional<Location> location, ValueShapeRange operands,
     DictionaryAttr attributes, RegionRange,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   SelectOp::Adaptor op(operands, attributes);
@@ -1897,7 +1897,7 @@ LogicalResult SetDimensionSizeOp::verify() {
 // TODO(b/238903565): Switch to inferReturnTypeComponents after adding support
 // for the encoding upstream.
 LogicalResult SetDimensionSizeOp::inferReturnTypes(
-    MLIRContext* context, Optional<Location> location, ValueRange operands,
+    MLIRContext* context, std::optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<Type>& inferredReturnTypes) {
   Location loc = location.value_or(UnknownLoc::get(context));
@@ -1952,7 +1952,7 @@ LogicalResult SetDimensionSizeOp::inferReturnTypes(
 //===----------------------------------------------------------------------===//
 
 LogicalResult PadOp::inferReturnTypes(
-    MLIRContext*, Optional<Location> location, ValueRange operands,
+    MLIRContext*, std::optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<Type>& inferredReturnTypes) {
   PadOp::Adaptor adaptor(operands, attributes, regions);
@@ -2111,7 +2111,7 @@ LogicalResult ReshapeOp::verify() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult ReplicaIdOp::inferReturnTypes(
-    MLIRContext* context, Optional<Location> location, ValueRange operands,
+    MLIRContext* context, std::optional<Location> location, ValueRange operands,
     DictionaryAttr, RegionRange, SmallVectorImpl<Type>& inferredReturnTypes) {
   return hlo::inferReplicaIdOp(context, location, inferredReturnTypes);
 }
@@ -2121,8 +2121,9 @@ LogicalResult ReplicaIdOp::inferReturnTypes(
 //===----------------------------------------------------------------------===//
 
 LogicalResult PartitionIdOp::inferReturnTypes(
-    MLIRContext* context, Optional<Location> location, ValueRange /*operands*/,
-    DictionaryAttr, RegionRange, SmallVectorImpl<Type>& inferredReturnTypes) {
+    MLIRContext* context, std::optional<Location> location,
+    ValueRange /*operands*/, DictionaryAttr, RegionRange,
+    SmallVectorImpl<Type>& inferredReturnTypes) {
   return hlo::inferPartitionIdOp(context, location, inferredReturnTypes);
 }
 
@@ -2131,7 +2132,7 @@ LogicalResult PartitionIdOp::inferReturnTypes(
 //===----------------------------------------------------------------------===//
 
 LogicalResult IfOp::inferReturnTypes(
-    MLIRContext*, Optional<Location> location, ValueRange operands,
+    MLIRContext*, std::optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<Type>& inferredReturnTypes) {
   IfOp::Adaptor adaptor(operands, attributes, regions);
@@ -2143,7 +2144,7 @@ LogicalResult IfOp::inferReturnTypes(
 //===----------------------------------------------------------------------===//
 
 LogicalResult CaseOp::inferReturnTypes(
-    MLIRContext*, Optional<Location> location, ValueRange operands,
+    MLIRContext*, std::optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<Type>& inferredReturnTypes) {
   CaseOp::Adaptor adaptor(operands, attributes, regions);
@@ -2155,7 +2156,7 @@ LogicalResult CaseOp::inferReturnTypes(
 //===----------------------------------------------------------------------===//
 
 LogicalResult SliceOp::inferReturnTypes(
-    MLIRContext* context, Optional<Location> location, ValueRange operands,
+    MLIRContext* context, std::optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<Type>& inferredReturnTypes) {
   SliceOpAdaptor adaptor(operands, attributes);
@@ -2180,7 +2181,7 @@ void SortOp::build(OpBuilder& builder, OperationState& state,
 }
 
 LogicalResult SortOp::inferReturnTypeComponents(
-    MLIRContext*, Optional<Location> location, ValueShapeRange operands,
+    MLIRContext*, std::optional<Location> location, ValueShapeRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   SortOp::Adaptor adaptor(operands, attributes, regions);
@@ -2235,7 +2236,7 @@ LogicalResult TransposeOp::reifyReturnTypeShapes(
 }
 
 LogicalResult TransposeOp::inferReturnTypes(
-    MLIRContext*, Optional<Location> loc, ValueRange operands,
+    MLIRContext*, std::optional<Location> loc, ValueRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<Type>& inferredReturnTypes) {
   TransposeOp::Adaptor adaptor(operands, attributes, regions);
@@ -2248,7 +2249,7 @@ LogicalResult TransposeOp::inferReturnTypes(
 //===----------------------------------------------------------------------===//
 
 LogicalResult TriangularSolveOp::inferReturnTypeComponents(
-    MLIRContext*, Optional<Location> location, ValueShapeRange operands,
+    MLIRContext*, std::optional<Location> location, ValueShapeRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   TriangularSolveOp::Adaptor adaptor(operands, attributes, regions);
@@ -2264,7 +2265,7 @@ LogicalResult TriangularSolveOp::inferReturnTypeComponents(
 //===----------------------------------------------------------------------===//
 
 LogicalResult GetTupleElementOp::inferReturnTypes(
-    MLIRContext*, Optional<Location> location, ValueRange operands,
+    MLIRContext*, std::optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<Type>& inferredReturnTypes) {
   GetTupleElementOp::Adaptor adaptor(operands, attributes, regions);
@@ -2277,7 +2278,7 @@ LogicalResult GetTupleElementOp::inferReturnTypes(
 //===----------------------------------------------------------------------===//
 
 LogicalResult TupleOp::inferReturnTypes(
-    MLIRContext* context, Optional<Location> location, ValueRange operands,
+    MLIRContext* context, std::optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<Type>& inferredReturnTypes) {
   TupleOp::Adaptor adaptor(operands, attributes, regions);
@@ -2298,8 +2299,8 @@ void CompareOp::build(OpBuilder& builder, OperationState& result, Value lhs,
 }
 
 LogicalResult CompareOp::inferReturnTypeComponents(
-    MLIRContext* context, Optional<Location> location, ValueShapeRange operands,
-    DictionaryAttr attributes, RegionRange regions,
+    MLIRContext* context, std::optional<Location> location,
+    ValueShapeRange operands, DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   CompareOp::Adaptor adaptor(operands, attributes, regions);
   return hlo::inferCompareOp(context, location, adaptor.getLhs(),
@@ -2318,7 +2319,7 @@ LogicalResult CompareOp::reifyReturnTypeShapes(
 //===----------------------------------------------------------------------===//
 
 LogicalResult SelectAndScatterOp::inferReturnTypes(
-    MLIRContext*, Optional<Location> location, ValueRange operands,
+    MLIRContext*, std::optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<Type>& inferredReturnTypes) {
   SelectAndScatterOp::Adaptor adaptor(operands, attributes, regions);
@@ -2338,7 +2339,7 @@ LogicalResult SelectAndScatterOp::verify() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult ScatterOp::inferReturnTypes(
-    MLIRContext*, Optional<Location> location, ValueRange operands,
+    MLIRContext*, std::optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<Type>& inferredReturnTypes) {
   ScatterOp::Adaptor adaptor(operands, attributes, regions);
@@ -2360,7 +2361,7 @@ LogicalResult ScatterOp::verify() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult WhileOp::inferReturnTypes(
-    MLIRContext*, Optional<Location> location, ValueRange operands,
+    MLIRContext*, std::optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<Type>& inferredReturnTypes) {
   WhileOp::Adaptor adaptor(operands, attributes, regions);
@@ -2438,7 +2439,7 @@ ParseResult WhileOp::parse(OpAsmParser& parser, OperationState& result) {
 }
 
 LogicalResult UniformDequantizeOp::inferReturnTypeComponents(
-    MLIRContext*, Optional<Location> location, ValueShapeRange operands,
+    MLIRContext*, std::optional<Location> location, ValueShapeRange operands,
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   UniformDequantizeOp::Adaptor adaptor(operands, attributes, regions);
@@ -3288,11 +3289,11 @@ void printWindowAttribute(OpAsmPrinter& p, DenseElementsAttr attribute) {
 }  // namespace
 
 void printWindowAttributes(OpAsmPrinter& p, Operation* /*op*/,
-                           llvm::Optional<DenseIntElementsAttr> windowStrides,
-                           llvm::Optional<DenseIntElementsAttr> padding,
-                           llvm::Optional<DenseIntElementsAttr> lhsDilation,
-                           llvm::Optional<DenseIntElementsAttr> rhsDilation,
-                           llvm::Optional<DenseElementsAttr> windowReversal) {
+                           std::optional<DenseIntElementsAttr> windowStrides,
+                           std::optional<DenseIntElementsAttr> padding,
+                           std::optional<DenseIntElementsAttr> lhsDilation,
+                           std::optional<DenseIntElementsAttr> rhsDilation,
+                           std::optional<DenseElementsAttr> windowReversal) {
   using pair_t = std::pair<DenseElementsAttr, StringRef>;
   std::array<pair_t, 5> printedAttributes = {{
       {windowStrides ? *windowStrides : nullptr, "stride"},
@@ -3417,7 +3418,7 @@ ParseResult parseWindowAttributes(OpAsmParser& parser,
 // arguments.
 static void buildSortComparisonBody(llvm::ArrayRef<Type> elementTypes,
                                     ComparisonDirection direction,
-                                    llvm::Optional<StringRef> compareType,
+                                    std::optional<StringRef> compareType,
                                     Region* body, OpBuilder* builder) {
   OpBuilder::InsertionGuard insertionPointGurad(*builder);
 
@@ -3451,7 +3452,7 @@ SortOp createSortOp(PatternRewriter* rewriter, const Location& loc,
 
   // Use TOTALORDER comparison type instead of the default comparison if the
   // element type is of type float.
-  llvm::Optional<StringRef> compareType = std::nullopt;
+  std::optional<StringRef> compareType = std::nullopt;
   for (const auto& elementType : elementTypes) {
     if (elementType.isa<FloatType>()) {
       compareType.emplace("TOTALORDER");

--- a/stablehlo/dialect/StablehloOps.h
+++ b/stablehlo/dialect/StablehloOps.h
@@ -18,6 +18,7 @@ limitations under the License.
 #define STABLEHLO_DIALECT_STABLEHLO_OPS_H
 
 #include <algorithm>
+#include <optional>
 
 #include "llvm/ADT/StringRef.h"
 #include "mlir/Dialect/Quant/QuantTypes.h"
@@ -98,11 +99,11 @@ ParseResult parseConvolutionDimensions(AsmParser &parser,
 
 // Custom formatting for convolution window attributes.
 void printWindowAttributes(OpAsmPrinter &p, Operation *op,
-                           llvm::Optional<DenseIntElementsAttr> windowStrides,
-                           llvm::Optional<DenseIntElementsAttr> padding,
-                           llvm::Optional<DenseIntElementsAttr> lhsDilation,
-                           llvm::Optional<DenseIntElementsAttr> rhsDilation,
-                           llvm::Optional<DenseElementsAttr> windowReversal);
+                           std::optional<DenseIntElementsAttr> windowStrides,
+                           std::optional<DenseIntElementsAttr> padding,
+                           std::optional<DenseIntElementsAttr> lhsDilation,
+                           std::optional<DenseIntElementsAttr> rhsDilation,
+                           std::optional<DenseElementsAttr> windowReversal);
 
 ParseResult parseWindowAttributes(OpAsmParser &parser,
                                   DenseIntElementsAttr &windowStrides,

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -17,6 +17,8 @@ limitations under the License.
 #ifndef STABLEHLO_DIALECT_STABLEHLO_TYPE_INFERENCE_H
 #define STABLEHLO_DIALECT_STABLEHLO_TYPE_INFERENCE_H
 
+#include <optional>
+
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dialect.h"
@@ -42,7 +44,7 @@ void reifyGatherDimSizes(int64_t resultRank,
 
 // Convert a 1D dense bool attribute to a list of values.
 FailureOr<SmallVector<bool>> convertWindowReversalAttribute(
-    Optional<DenseElementsAttr> optionalAttr, Optional<Location> loc,
+    std::optional<DenseElementsAttr> optionalAttr, std::optional<Location> loc,
     StringRef attrName);
 
 // WindowDimension described how the kernel window moves across the base area
@@ -66,26 +68,26 @@ verifyWindowAttributesAndInferWindowDimensions(
     ArrayRef<int64_t> windowDimensions, ArrayRef<int64_t> windowStrides,
     ArrayRef<std::pair<int64_t, int64_t>> padding,
     ArrayRef<int64_t> lhsDilation, ArrayRef<int64_t> rhsDilation,
-    ArrayRef<bool> windowReversal, Optional<Location> loc);
+    ArrayRef<bool> windowReversal, std::optional<Location> loc);
 
 SmallVector<int64_t> inferWindowOutputShape(
     const ArrayRef<int64_t> baseShape, const ArrayRef<WindowDimension> window);
 
-LogicalResult verifyReplicaGroups(Optional<Location> location,
+LogicalResult verifyReplicaGroups(std::optional<Location> location,
                                   DenseIntElementsAttr replicaGroups,
                                   bool allGroupsMustHaveSameSize,
                                   bool useGlobalDeviceIds,
-                                  Optional<size_t> expectedGroupSize);
+                                  std::optional<size_t> expectedGroupSize);
 
 LogicalResult verifyConvolutionAttributes(
-    Optional<Location> location, Value lhs, Value rhs,
+    std::optional<Location> location, Value lhs, Value rhs,
     int64_t inputBatchDimension, int64_t inputFeatureDimension,
     ArrayRef<int64_t> inputSpatialDimensions,
     int64_t kernelInputFeatureDimension, int64_t kernelOutputFeatureDimension,
     ArrayRef<int64_t> kernelSpatialDimensions, int64_t outputBatchDimension,
     int64_t outputFeatureDimension, ArrayRef<int64_t> outputSpatialDimensions,
     int64_t featureGroupCount, int64_t batchGroupCount,
-    Optional<ArrayAttr> precisionConfig);
+    std::optional<ArrayAttr> precisionConfig);
 
 //===----------------------------------------------------------------------===//
 // Shape functions for ops.
@@ -99,158 +101,163 @@ LogicalResult verifyConvolutionAttributes(
 // These parameters have the same names as in the ODS and come in the same
 // order in which they are declared in the ODS.
 
-LogicalResult inferAbsOp(Optional<Location>, Value operand,
+LogicalResult inferAbsOp(std::optional<Location>, Value operand,
                          SmallVectorImpl<Type>& inferredReturnTypes);
 
-LogicalResult inferAfterAllOp(Dialect* dialect, Optional<Location> location,
+LogicalResult inferAfterAllOp(Dialect* dialect,
+                              std::optional<Location> location,
                               SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferAllToAllOp(
-    Optional<Location> location, Value operand, int64_t splitDimension,
+    std::optional<Location> location, Value operand, int64_t splitDimension,
     int64_t concatDimension, int64_t splitCount,
     DenseIntElementsAttr replicaGroups,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferBatchNormGradOp(
-    Optional<Location> location, Value operand, Value scale,
+    std::optional<Location> location, Value operand, Value scale,
     int64_t featureIndex,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferBatchNormInferenceOp(
-    Optional<Location> location, Value operand, Value scale,
+    std::optional<Location> location, Value operand, Value scale,
     int64_t featureIndex,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferBatchNormTrainingOp(
-    Optional<Location> location, Value operand, Value scale,
+    std::optional<Location> location, Value operand, Value scale,
     int64_t featureIndex,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferBroadcastOp(
-    Optional<Location> location, Value operand,
+    std::optional<Location> location, Value operand,
     DenseIntElementsAttr broadcastSizes,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
-LogicalResult inferCaseOp(Optional<Location> location, RegionRange branches,
+LogicalResult inferCaseOp(std::optional<Location> location,
+                          RegionRange branches,
                           SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferCholeskyOp(
-    Optional<Location> location, Value a,
+    std::optional<Location> location, Value a,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferClampOp(
-    Optional<Location> location, Value min, Value operand, Value max,
+    std::optional<Location> location, Value min, Value operand, Value max,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferCompareOp(
-    MLIRContext* context, Optional<Location>, Value lhs,
+    MLIRContext* context, std::optional<Location>, Value lhs,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
-LogicalResult inferComplexOp(Optional<Location> location, Value lhs,
+LogicalResult inferComplexOp(std::optional<Location> location, Value lhs,
                              SmallVectorImpl<Type>& inferredReturnTypes);
 
-LogicalResult inferConcatenateOp(Optional<Location> location, ValueRange inputs,
-                                 int64_t dimension,
+LogicalResult inferConcatenateOp(std::optional<Location> location,
+                                 ValueRange inputs, int64_t dimension,
                                  SmallVectorImpl<Type>& inferredReturnTypes);
 
-LogicalResult inferConstantOp(Optional<Location>, ElementsAttr value,
+LogicalResult inferConstantOp(std::optional<Location>, ElementsAttr value,
                               SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferConvertOp(
-    Optional<Location> location, Value operand,
+    std::optional<Location> location, Value operand,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferConvolutionOp(
-    Optional<Location> location, Value lhs, Value rhs,
-    Optional<DenseIntElementsAttr> windowStrides,
-    Optional<DenseIntElementsAttr> padding,
-    Optional<DenseIntElementsAttr> lhsDilation,
-    Optional<DenseIntElementsAttr> rhsDilation,
-    Optional<DenseElementsAttr> windowReversal, int64_t inputBatchDimension,
-    int64_t inputFeatureDimension, ArrayRef<int64_t> inputSpatialDimensions,
+    std::optional<Location> location, Value lhs, Value rhs,
+    std::optional<DenseIntElementsAttr> windowStrides,
+    std::optional<DenseIntElementsAttr> padding,
+    std::optional<DenseIntElementsAttr> lhsDilation,
+    std::optional<DenseIntElementsAttr> rhsDilation,
+    std::optional<DenseElementsAttr> windowReversal,
+    int64_t inputBatchDimension, int64_t inputFeatureDimension,
+    ArrayRef<int64_t> inputSpatialDimensions,
     int64_t kernelInputFeatureDimension, int64_t kernelOutputFeatureDimension,
     ArrayRef<int64_t> kernelSpatialDimensions, int64_t outputBatchDimension,
     int64_t outputFeatureDimension, ArrayRef<int64_t> outputSpatialDimensions,
     int64_t featureGroupCount, int64_t batchGroupCount,
-    Optional<ArrayAttr> precisionConfig,
+    std::optional<ArrayAttr> precisionConfig,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
-LogicalResult inferCreateTokenOp(Dialect* dialect, Optional<Location> location,
+LogicalResult inferCreateTokenOp(Dialect* dialect,
+                                 std::optional<Location> location,
                                  SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferDotOp(
-    Optional<Location> location, Value lhs, Value rhs,
-    Optional<ArrayAttr> precisionConfig,
+    std::optional<Location> location, Value lhs, Value rhs,
+    std::optional<ArrayAttr> precisionConfig,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferDotGeneralOp(
-    Optional<Location> location, Value lhs, Value rhs,
+    std::optional<Location> location, Value lhs, Value rhs,
     ArrayRef<int64_t> lhsBatchingDimensions,
     ArrayRef<int64_t> rhsBatchingDimensions,
     ArrayRef<int64_t> lhsContractingDimensions,
     ArrayRef<int64_t> rhsContractingDimensions,
-    Optional<ArrayAttr> precisionConfig,
+    std::optional<ArrayAttr> precisionConfig,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferDynamicGatherOp(
-    Optional<Location> location, Value operand, Value startIndices,
+    std::optional<Location> location, Value operand, Value startIndices,
     Value sliceSizes, ArrayRef<int64_t> offsetDims,
     ArrayRef<int64_t> collapsedSliceDims, ArrayRef<int64_t> startIndexMap,
     int64_t indexVectorDim,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferDynamicSliceOp(
-    Optional<Location> location, Value operand, ValueRange startIndices,
+    std::optional<Location> location, Value operand, ValueRange startIndices,
     DenseIntElementsAttr sliceSizes,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferDynamicUpdateSliceOp(
-    Optional<Location> location, Value operand, Value update,
+    std::optional<Location> location, Value operand, Value update,
     ValueRange startIndices,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferFftOp(
-    Optional<Location> location, Value operand, bool isFftTypeRfft,
+    std::optional<Location> location, Value operand, bool isFftTypeRfft,
     bool isFftTypeIrfft, DenseIntElementsAttr fftLength,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferGatherOp(
-    Optional<Location> location, Value operand, Value startIndices,
+    std::optional<Location> location, Value operand, Value startIndices,
     ArrayRef<int64_t> offsetDims, ArrayRef<int64_t> collapsedSliceDims,
     ArrayRef<int64_t> startIndexMap, int64_t indexVectorDim,
     DenseIntElementsAttr sliceSizes,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferGetDimensionSizeOp(
-    MLIRContext* context, Optional<Location> location,
+    MLIRContext* context, std::optional<Location> location,
     SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferGetTupleElementOp(
-    Optional<Location> location, Value operand, int32_t index,
+    std::optional<Location> location, Value operand, int32_t index,
     SmallVectorImpl<Type>& inferredReturnTypes);
 
-LogicalResult inferImagOp(Optional<Location> location, Value operand,
+LogicalResult inferImagOp(std::optional<Location> location, Value operand,
                           SmallVectorImpl<Type>& inferredReturnTypes);
 
-LogicalResult inferIsFiniteOp(MLIRContext* context, Optional<Location>, Value x,
+LogicalResult inferIsFiniteOp(MLIRContext* context, std::optional<Location>,
+                              Value x,
                               SmallVectorImpl<Type>& inferredReturnTypes);
 
-LogicalResult inferIfOp(Optional<Location> location, RegionRange branches,
+LogicalResult inferIfOp(std::optional<Location> location, RegionRange branches,
                         SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferMapOp(
-    Optional<Location> location, ValueRange inputs,
+    std::optional<Location> location, ValueRange inputs,
     DenseIntElementsAttr dimensions, Region& computation,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferOptimizationBarrierOp(
-    Optional<Location> location, ValueRange operand,
+    std::optional<Location> location, ValueRange operand,
     SmallVectorImpl<Type>& inferredReturnTypes);
 
-LogicalResult inferOutfeedOp(Dialect* dialect, Optional<Location> location,
+LogicalResult inferOutfeedOp(Dialect* dialect, std::optional<Location> location,
                              SmallVectorImpl<Type>& inferredReturnTypes);
 
-LogicalResult inferPadOp(Optional<Location> location, Value operand,
+LogicalResult inferPadOp(std::optional<Location> location, Value operand,
                          Value paddingValue,
                          DenseIntElementsAttr edgePaddingLow,
                          DenseIntElementsAttr edgePaddingHigh,
@@ -258,191 +265,198 @@ LogicalResult inferPadOp(Optional<Location> location, Value operand,
                          SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferPartitionIdOp(MLIRContext* context,
-                                 Optional<Location> location,
+                                 std::optional<Location> location,
                                  SmallVectorImpl<Type>& inferredReturnTypes);
 
-LogicalResult inferRealOp(Optional<Location> location, Value operand,
+LogicalResult inferRealOp(std::optional<Location> location, Value operand,
                           SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferReduceOp(
-    Optional<Location> location, ValueRange inputs, ValueRange initValues,
+    std::optional<Location> location, ValueRange inputs, ValueRange initValues,
     DenseIntElementsAttr dimensions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferReduceWindowOp(
-    Optional<Location> location, ValueRange inputs, ValueRange initValues,
+    std::optional<Location> location, ValueRange inputs, ValueRange initValues,
     DenseIntElementsAttr windowDimensions,
-    Optional<DenseIntElementsAttr> windowStrides,
-    Optional<DenseIntElementsAttr> baseDilations,
-    Optional<DenseIntElementsAttr> windowDilations,
-    Optional<DenseIntElementsAttr> padding,
+    std::optional<DenseIntElementsAttr> windowStrides,
+    std::optional<DenseIntElementsAttr> baseDilations,
+    std::optional<DenseIntElementsAttr> windowDilations,
+    std::optional<DenseIntElementsAttr> padding,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
-LogicalResult inferReplicaIdOp(MLIRContext* context, Optional<Location>,
+LogicalResult inferReplicaIdOp(MLIRContext* context, std::optional<Location>,
                                SmallVectorImpl<Type>& inferredReturnTypes);
 
-LogicalResult inferReturnOp(Optional<Location> location,
+LogicalResult inferReturnOp(std::optional<Location> location,
                             SmallVectorImpl<Type>& inferredReturnTypes);
 
-LogicalResult inferScatterOp(Optional<Location> location, ValueRange inputs,
+LogicalResult inferScatterOp(std::optional<Location> location,
+                             ValueRange inputs,
                              SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferSelectOp(
-    Optional<Location> location, Value pred, Value onTrue, Value onFalse,
+    std::optional<Location> location, Value pred, Value onTrue, Value onFalse,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferSelectAndScatterOp(
     Value operand, SmallVectorImpl<Type>& inferredReturnTypes);
 
-LogicalResult inferSendOp(Dialect* dialect, Optional<Location> location,
+LogicalResult inferSendOp(Dialect* dialect, std::optional<Location> location,
                           SmallVectorImpl<Type>& inferredReturnTypes);
 
-LogicalResult inferSliceOp(Optional<Location> location, Value operand,
+LogicalResult inferSliceOp(std::optional<Location> location, Value operand,
                            DenseIntElementsAttr startIndices,
                            DenseIntElementsAttr limitIndices,
                            DenseIntElementsAttr strides,
                            SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferSortOp(
-    Optional<Location> location, ValueRange inputs,
+    std::optional<Location> location, ValueRange inputs,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
-LogicalResult inferTransposeOp(Optional<Location> loc, Value operand,
+LogicalResult inferTransposeOp(std::optional<Location> loc, Value operand,
                                DenseIntElementsAttr permutation,
                                SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferTriangularSolveOp(
-    Optional<Location> location, Value a, Value b, bool leftSide,
+    std::optional<Location> location, Value a, Value b, bool leftSide,
     bool isTransposeAInvalid,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
-LogicalResult inferTupleOp(MLIRContext* context, Optional<Location> location,
-                           ValueRange val,
+LogicalResult inferTupleOp(MLIRContext* context,
+                           std::optional<Location> location, ValueRange val,
                            SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferUniformDequantizeOp(
-    Optional<Location> location, Value operand,
+    std::optional<Location> location, Value operand,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferUniformQuantizeOp(
-    Optional<Location> location, Value operand,
+    std::optional<Location> location, Value operand,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
-LogicalResult inferWhileOp(Optional<Location> location, ValueRange operand,
+LogicalResult inferWhileOp(std::optional<Location> location, ValueRange operand,
                            SmallVectorImpl<Type>& inferredReturnTypes);
 
 //===----------------------------------------------------------------------===//
 // Verifiers for ops.
 //===----------------------------------------------------------------------===//
 
-LogicalResult verifyAllGatherOp(Optional<Location> location, Value operand,
+LogicalResult verifyAllGatherOp(std::optional<Location> location, Value operand,
                                 int64_t allGatherDim,
                                 DenseIntElementsAttr replicaGroups,
                                 bool useGlobalDeviceIds, Value result);
 
-LogicalResult verifyAllReduceOp(Optional<Location> location, Value operand,
+LogicalResult verifyAllReduceOp(std::optional<Location> location, Value operand,
                                 DenseIntElementsAttr replicaGroups,
                                 bool useGlobalDeviceIds, Region& computation);
 
-LogicalResult verifyBitcastConvertOp(Optional<Location> location, Value operand,
-                                     Value result);
+LogicalResult verifyBitcastConvertOp(std::optional<Location> location,
+                                     Value operand, Value result);
 
-LogicalResult verifyBroadcastInDimOp(Optional<Location> location, Value operand,
+LogicalResult verifyBroadcastInDimOp(std::optional<Location> location,
+                                     Value operand,
                                      DenseIntElementsAttr broadcastDimensions,
                                      Value result);
 
-LogicalResult verifyCollectivePermuteOp(Optional<Location> location,
+LogicalResult verifyCollectivePermuteOp(std::optional<Location> location,
                                         DenseIntElementsAttr sourceTargetPairs);
 
 LogicalResult verifyConvolutionOp(
-    Optional<Location> location, Value lhs, Value rhs,
-    Optional<DenseIntElementsAttr> windowStrides,
-    Optional<DenseIntElementsAttr> padding,
-    Optional<DenseIntElementsAttr> lhsDilation,
-    Optional<DenseIntElementsAttr> rhsDilation,
-    Optional<DenseElementsAttr> windowReversal, int64_t inputBatchDimension,
-    int64_t inputFeatureDimension, ArrayRef<int64_t> inputSpatialDimensions,
+    std::optional<Location> location, Value lhs, Value rhs,
+    std::optional<DenseIntElementsAttr> windowStrides,
+    std::optional<DenseIntElementsAttr> padding,
+    std::optional<DenseIntElementsAttr> lhsDilation,
+    std::optional<DenseIntElementsAttr> rhsDilation,
+    std::optional<DenseElementsAttr> windowReversal,
+    int64_t inputBatchDimension, int64_t inputFeatureDimension,
+    ArrayRef<int64_t> inputSpatialDimensions,
     int64_t kernelInputFeatureDimension, int64_t kernelOutputFeatureDimension,
     ArrayRef<int64_t> kernelSpatialDimensions, int64_t outputBatchDimension,
     int64_t outputFeatureDimension, ArrayRef<int64_t> outputSpatialDimensions,
     int64_t featureGroupCount, int64_t batchGroupCount,
-    Optional<ArrayAttr> precisionConfig, Value result);
+    std::optional<ArrayAttr> precisionConfig, Value result);
 
-LogicalResult verifyDotOp(Optional<Location> location, Value lhs, Value rhs,
-                          Optional<ArrayAttr> precisionConfig, Value result);
+LogicalResult verifyDotOp(std::optional<Location> location, Value lhs,
+                          Value rhs, std::optional<ArrayAttr> precisionConfig,
+                          Value result);
 
-LogicalResult verifyDotGeneralOp(Optional<Location> location, Value lhs,
+LogicalResult verifyDotGeneralOp(std::optional<Location> location, Value lhs,
                                  Value rhs,
                                  ArrayRef<int64_t> lhsBatchingDimensions,
                                  ArrayRef<int64_t> rhsBatchingDimensions,
                                  ArrayRef<int64_t> lhsContractingDimensions,
                                  ArrayRef<int64_t> rhsContractingDimensions,
-                                 Optional<ArrayAttr> precisionConfig,
+                                 std::optional<ArrayAttr> precisionConfig,
                                  Value result);
 
 LogicalResult verifyDynamicBroadcastInDimOp(
-    Optional<Location> location, Value operand, Value outputDimensions,
+    std::optional<Location> location, Value operand, Value outputDimensions,
     DenseIntElementsAttr broadcastDimensions,
-    Optional<DenseIntElementsAttr> knownExpandingDimensions,
-    Optional<DenseIntElementsAttr> knownNonexpandingDimensions, Value result);
+    std::optional<DenseIntElementsAttr> knownExpandingDimensions,
+    std::optional<DenseIntElementsAttr> knownNonexpandingDimensions,
+    Value result);
 
-LogicalResult verifyDynamicPadOp(Optional<Location> location, Value operand,
-                                 Value paddingValue, Value edgePaddingLow,
-                                 Value edgePaddingHigh, Value interiorPadding,
-                                 Value result);
+LogicalResult verifyDynamicPadOp(std::optional<Location> location,
+                                 Value operand, Value paddingValue,
+                                 Value edgePaddingLow, Value edgePaddingHigh,
+                                 Value interiorPadding, Value result);
 
-LogicalResult verifyDynamicReshapeOp(Optional<Location> location,
+LogicalResult verifyDynamicReshapeOp(std::optional<Location> location,
                                      Value outputShape, Value result);
 
-LogicalResult verifyInfeedOp(Dialect* dialect, Optional<Location> location,
-                             Optional<ArrayAttr> layout, ValueRange results);
+LogicalResult verifyInfeedOp(Dialect* dialect, std::optional<Location> location,
+                             std::optional<ArrayAttr> layout,
+                             ValueRange results);
 
-LogicalResult verifyIotaOp(Optional<Location> location, int64_t iotaDimension,
-                           Value result);
+LogicalResult verifyIotaOp(std::optional<Location> location,
+                           int64_t iotaDimension, Value result);
 
-LogicalResult verifyRealDynamicSliceOp(Optional<Location> location,
+LogicalResult verifyRealDynamicSliceOp(std::optional<Location> location,
                                        Value operand, Value startIndices,
                                        Value limitIndices, Value strides);
 
-LogicalResult verifyRecvOp(Dialect* dialect, Optional<Location> location,
+LogicalResult verifyRecvOp(Dialect* dialect, std::optional<Location> location,
                            ValueRange results);
 
-LogicalResult verifyReduceOp(Optional<Location> location, ValueRange inputs,
-                             ValueRange initValues,
+LogicalResult verifyReduceOp(std::optional<Location> location,
+                             ValueRange inputs, ValueRange initValues,
                              DenseIntElementsAttr dimensions, Region& body);
 
-LogicalResult verifyReducePrecisionOp(Optional<Location> location,
+LogicalResult verifyReducePrecisionOp(std::optional<Location> location,
                                       int32_t exponentBits,
                                       int32_t mantissaBits);
 
-LogicalResult verifyReduceScatterOp(Optional<Location> location, Value operand,
-                                    int64_t scatterDimension,
+LogicalResult verifyReduceScatterOp(std::optional<Location> location,
+                                    Value operand, int64_t scatterDimension,
                                     DenseIntElementsAttr replicaGroups,
                                     bool useGlobalDeviceIds,
                                     Region& computation, Value result);
 
 LogicalResult verifyReduceWindowOp(
-    Optional<Location> location, ValueRange inputs, ValueRange initValues,
+    std::optional<Location> location, ValueRange inputs, ValueRange initValues,
     DenseIntElementsAttr windowDimensions,
-    Optional<DenseIntElementsAttr> windowStrides,
-    Optional<DenseIntElementsAttr> baseDilations,
-    Optional<DenseIntElementsAttr> windowDilations,
-    Optional<DenseIntElementsAttr> padding, Region& body);
+    std::optional<DenseIntElementsAttr> windowStrides,
+    std::optional<DenseIntElementsAttr> baseDilations,
+    std::optional<DenseIntElementsAttr> windowDilations,
+    std::optional<DenseIntElementsAttr> padding, Region& body);
 
-LogicalResult verifyReshapeOp(Optional<Location> location, Value operand,
+LogicalResult verifyReshapeOp(std::optional<Location> location, Value operand,
                               Value result);
 
-LogicalResult verifyReverseOp(Optional<Location> location, Value operand,
+LogicalResult verifyReverseOp(std::optional<Location> location, Value operand,
                               DenseIntElementsAttr dimensions);
 
-LogicalResult verifyRngOp(Optional<Location> location, Value a, Value b,
+LogicalResult verifyRngOp(std::optional<Location> location, Value a, Value b,
                           bool isRngDistributionUniform);
 
-LogicalResult verifyRngBitGeneratorOp(Optional<Location> location,
+LogicalResult verifyRngBitGeneratorOp(std::optional<Location> location,
                                       Value initialState, Value outputState);
 
-LogicalResult verifyScatterOp(Optional<Location> location, ValueRange inputs,
-                              Value scatterIndices, ValueRange updates,
+LogicalResult verifyScatterOp(std::optional<Location> location,
+                              ValueRange inputs, Value scatterIndices,
+                              ValueRange updates,
                               ArrayRef<int64_t> updateWindowDims,
                               ArrayRef<int64_t> insertedWindowDims,
                               ArrayRef<int64_t> scatterDimsToOperandDims,
@@ -450,16 +464,17 @@ LogicalResult verifyScatterOp(Optional<Location> location, ValueRange inputs,
                               Region& updateComputation);
 
 LogicalResult verifySelectAndScatterOp(
-    Optional<Location> location, Value operand, Value source, Value initValue,
-    Optional<DenseIntElementsAttr> windowDimensions,
-    Optional<DenseIntElementsAttr> windowStrides,
-    Optional<DenseIntElementsAttr> padding, Region& select, Region& scatter);
+    std::optional<Location> location, Value operand, Value source,
+    Value initValue, std::optional<DenseIntElementsAttr> windowDimensions,
+    std::optional<DenseIntElementsAttr> windowStrides,
+    std::optional<DenseIntElementsAttr> padding, Region& select,
+    Region& scatter);
 
-LogicalResult verifySortOp(Optional<Location> location, ValueRange inputs,
+LogicalResult verifySortOp(std::optional<Location> location, ValueRange inputs,
                            int64_t dimension, Region& comparator);
 
-LogicalResult verifyWhileOp(Optional<Location> location, ValueRange operand,
-                            Region& cond, Region& body);
+LogicalResult verifyWhileOp(std::optional<Location> location,
+                            ValueRange operand, Region& cond, Region& body);
 }  // end namespace hlo
 }  // end namespace mlir
 

--- a/stablehlo/integrations/c/ChloAttributes.cpp
+++ b/stablehlo/integrations/c/ChloAttributes.cpp
@@ -13,6 +13,8 @@ limitations under the License.
 
 #include "stablehlo/integrations/c/ChloAttributes.h"
 
+#include <optional>
+
 #include "mlir/CAPI/IR.h"
 #include "mlir/CAPI/Support.h"
 #include "stablehlo/dialect/ChloOps.h"
@@ -23,7 +25,7 @@ limitations under the License.
 
 MlirAttribute chloComparisonDirectionAttrGet(MlirContext ctx,
                                              MlirStringRef value) {
-  llvm::Optional<mlir::chlo::ComparisonDirection> comparisonDirection =
+  std::optional<mlir::chlo::ComparisonDirection> comparisonDirection =
       mlir::chlo::symbolizeComparisonDirection(unwrap(value));
   if (!comparisonDirection) llvm_unreachable("Invalid value.");
   return wrap(mlir::chlo::ComparisonDirectionAttr::get(
@@ -44,7 +46,7 @@ MlirStringRef chloComparisonDirectionAttrGetValue(MlirAttribute attr) {
 //===----------------------------------------------------------------------===//
 
 MlirAttribute chloComparisonTypeAttrGet(MlirContext ctx, MlirStringRef value) {
-  llvm::Optional<mlir::chlo::ComparisonType> comparisonType =
+  std::optional<mlir::chlo::ComparisonType> comparisonType =
       mlir::chlo::symbolizeComparisonType(unwrap(value));
   if (!comparisonType) llvm_unreachable("Invalid value.");
   return wrap(

--- a/stablehlo/integrations/c/StablehloAttributes.cpp
+++ b/stablehlo/integrations/c/StablehloAttributes.cpp
@@ -409,7 +409,7 @@ int64_t stablehloOutputOperandAliasGetOperandTupleIndicesElem(
 
 MlirAttribute stablehloComparisonDirectionAttrGet(MlirContext ctx,
                                                   MlirStringRef value) {
-  llvm::Optional<mlir::stablehlo::ComparisonDirection> comparisonDirection =
+  std::optional<mlir::stablehlo::ComparisonDirection> comparisonDirection =
       mlir::stablehlo::symbolizeComparisonDirection(unwrap(value));
   if (!comparisonDirection) llvm_unreachable("Invalid value.");
   return wrap(mlir::stablehlo::ComparisonDirectionAttr::get(
@@ -433,7 +433,7 @@ MlirStringRef stablehloComparisonDirectionAttrGetValue(MlirAttribute attr) {
 
 MlirAttribute stablehloComparisonTypeAttrGet(MlirContext ctx,
                                              MlirStringRef value) {
-  llvm::Optional<mlir::stablehlo::ComparisonType> comparisonType =
+  std::optional<mlir::stablehlo::ComparisonType> comparisonType =
       mlir::stablehlo::symbolizeComparisonType(unwrap(value));
   if (!comparisonType) llvm_unreachable("Invalid value.");
   return wrap(mlir::stablehlo::ComparisonTypeAttr::get(unwrap(ctx),
@@ -454,7 +454,7 @@ MlirStringRef stablehloComparisonTypeAttrGetValue(MlirAttribute attr) {
 //===----------------------------------------------------------------------===//
 
 MlirAttribute stablehloPrecisionAttrGet(MlirContext ctx, MlirStringRef value) {
-  llvm::Optional<mlir::stablehlo::Precision> precision =
+  std::optional<mlir::stablehlo::Precision> precision =
       mlir::stablehlo::symbolizePrecision(unwrap(value));
   if (!precision) llvm_unreachable("Invalid value.");
   return wrap(
@@ -475,7 +475,7 @@ MlirStringRef stablehloPrecisionAttrGetValue(MlirAttribute attr) {
 //===----------------------------------------------------------------------===//
 
 MlirAttribute stablehloFftTypeAttrGet(MlirContext ctx, MlirStringRef value) {
-  llvm::Optional<mlir::stablehlo::FftType> fftType =
+  std::optional<mlir::stablehlo::FftType> fftType =
       mlir::stablehlo::symbolizeFftType(unwrap(value));
   if (!fftType) llvm_unreachable("Invalid value.");
   return wrap(mlir::stablehlo::FftTypeAttr::get(unwrap(ctx), fftType.value()));
@@ -495,7 +495,7 @@ MlirStringRef stablehloFftTypeAttrGetValue(MlirAttribute attr) {
 //===----------------------------------------------------------------------===//
 
 MlirAttribute stablehloTransposeAttrGet(MlirContext ctx, MlirStringRef value) {
-  llvm::Optional<mlir::stablehlo::Transpose> transpose =
+  std::optional<mlir::stablehlo::Transpose> transpose =
       mlir::stablehlo::symbolizeTranspose(unwrap(value));
   if (!transpose) llvm_unreachable("Invalid value.");
   return wrap(
@@ -517,7 +517,7 @@ MlirStringRef stablehloTransposeAttrGetValue(MlirAttribute attr) {
 
 MlirAttribute stablehloRngDistributionAttrGet(MlirContext ctx,
                                               MlirStringRef value) {
-  llvm::Optional<mlir::stablehlo::RngDistribution> rngDistribution =
+  std::optional<mlir::stablehlo::RngDistribution> rngDistribution =
       mlir::stablehlo::symbolizeRngDistribution(unwrap(value));
   if (!rngDistribution) llvm_unreachable("Invalid value.");
   return wrap(mlir::stablehlo::RngDistributionAttr::get(
@@ -539,7 +539,7 @@ MlirStringRef stablehloRngDistributionAttrGetValue(MlirAttribute attr) {
 
 MlirAttribute stablehloRngAlgorithmAttrGet(MlirContext ctx,
                                            MlirStringRef value) {
-  llvm::Optional<mlir::stablehlo::RngAlgorithm> rngAlgorithm =
+  std::optional<mlir::stablehlo::RngAlgorithm> rngAlgorithm =
       mlir::stablehlo::symbolizeRngAlgorithm(unwrap(value));
   if (!rngAlgorithm) llvm_unreachable("Invalid value.");
   return wrap(mlir::stablehlo::RngAlgorithmAttr::get(unwrap(ctx),

--- a/stablehlo/integrations/c/StablehloAttributes.h
+++ b/stablehlo/integrations/c/StablehloAttributes.h
@@ -15,6 +15,8 @@ limitations under the License.
 
 #include <sys/types.h>
 
+#include <optional>
+
 #include "mlir-c/IR.h"
 #include "mlir-c/Support.h"
 

--- a/stablehlo/reference/Index.h
+++ b/stablehlo/reference/Index.h
@@ -17,9 +17,9 @@ limitations under the License.
 #define STABLEHLO_REFERENCE_INDEX_H_
 
 #include <cstdint>
+#include <optional>
 
 #include "llvm/ADT/ArrayRef.h"
-#include "llvm/ADT/Optional.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Error.h"
 #include "mlir/Support/LogicalResult.h"
@@ -42,7 +42,7 @@ class IndexSpaceIterator {
  public:
   /// \name Constructor
   IndexSpaceIterator(llvm::ArrayRef<int64_t> shape,
-                     llvm::Optional<llvm::SmallVector<int64_t>> index)
+                     std::optional<llvm::SmallVector<int64_t>> index)
       : shape_(shape), index_(index) {
     if (index && failed(verifyIndex(shape, (*index))))
       llvm::report_fatal_error(
@@ -78,7 +78,7 @@ class IndexSpaceIterator {
 
   /// Current multi-dimensional index.
   /// If the optional is empty, then we're at the end
-  llvm::Optional<llvm::SmallVector<int64_t>> index_;
+  std::optional<llvm::SmallVector<int64_t>> index_;
 };
 
 }  // namespace stablehlo


### PR DESCRIPTION
llvm::Optional has been replaced with a legacy alias of std::optional and is planned to be removed after LLVM 16. Let's migrate away.