### PR TITLE
Add "Constraints" column to Inputs/Outputs

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -409,15 +409,15 @@ tensor. Depending on the element type, does the following:
 
 #### Inputs
 
-| Name      | Type                                                      |
-|-----------|-----------------------------------------------------------|
-| `operand` | tensor of signed integer, floating-point, or complex type |
+| Name      | Type                                                      | Constraints |
+|-----------|-----------------------------------------------------------|-------------|
+| `operand` | tensor of signed integer, floating-point, or complex type | (C1), (C2)  |
 
 #### Outputs
 
-| Name     | Type                                                      |
-|----------|-----------------------------------------------------------|
-| `result` | tensor of signed integer, floating-point, or complex type |
+| Name     | Type                                                      | Constraints |
+|----------|-----------------------------------------------------------|-------------|
+| `result` | tensor of signed integer, floating-point, or complex type | (C1), (C2)  |
 
 #### Constraints
 
@@ -449,16 +449,16 @@ Performs element-wise addition of two tensors `lhs` and `rhs` and produces a
 
 #### Inputs
 
-| Name  | Type   |
-|-------|--------|
-| `lhs` | tensor |
-| `rhs` | tensor |
+| Name  | Type   | Constraints |
+|-------|--------|-------------|
+| `lhs` | tensor | (C1)        |
+| `rhs` | tensor | (C1)        |
 
 #### Outputs
 
-| Name     | Type   |
-|----------|--------|
-| `result` | tensor |
+| Name     | Type   | Constraints |
+|----------|--------|-------------|
+| `result` | tensor | (C1)        |
 
 #### Constraints
 
@@ -528,19 +528,19 @@ Afterwards, within each `process_group`:
 
 #### Inputs
 
-| Name                    | Type                                         |
-|-------------------------|----------------------------------------------|
-| `operand`               | tensor                                       |
-| `all_gather_dim`        | constant of type `si64`                      |
-| `replica_groups`        | 2-dimensional tensor constant of type `si64` |
-| `channel_id`            | constant of type `si64`                      |
-| `use_global_device_ids` | constant of type `i1`                        |
+| Name                    | Type                                         | Constraints |
+|-------------------------|----------------------------------------------|-------------|
+| `operand`               | tensor                                       | (C1), (C6)  |
+| `all_gather_dim`        | constant of type `si64`                      | (C1), (C6)  |
+| `replica_groups`        | 2-dimensional tensor constant of type `si64` | (C2-C4)     |
+| `channel_id`            | constant of type `si64`                      | (C5)        |
+| `use_global_device_ids` | constant of type `i1`                        | (C5)        |
 
 #### Outputs
 
-| Name     | Type   |
-|----------|--------|
-| `result` | tensor |
+| Name     | Type   | Constraints |
+|----------|--------|-------------|
+| `result` | tensor | (C6)        |
 
 #### Constraints
 
@@ -613,19 +613,19 @@ Afterwards, within each `process_group`:
 
 #### Inputs
 
-| Name                    | Type                                                             |
-|-------------------------|------------------------------------------------------------------|
-| `operand`               | tensor                                                           |
-| `replica_groups`        | variadic number of 1-dimensional tensor constants of type `si64` |
-| `channel_id`            | constant of type `si64`                                          |
-| `use_global_device_ids` | constant of type `i1`                                            |
-| `computation`           | function                                                         |
+| Name                    | Type                                                             | Constraints |
+|-------------------------|------------------------------------------------------------------|-------------|
+| `operand`               | tensor                                                           | (C5), (C6)  |
+| `replica_groups`        | variadic number of 1-dimensional tensor constants of type `si64` | (C1-C3)     |
+| `channel_id`            | constant of type `si64`                                          | (C4)        |
+| `use_global_device_ids` | constant of type `i1`                                            | (C4)        |
+| `computation`           | function                                                         | (C5)        |
 
 #### Outputs
 
-| Name     | Type   |
-|----------|--------|
-| `result` | tensor |
+| Name     | Type   | Constraints |
+|----------|--------|-------------|
+| `result` | tensor | (C6)        |
 
 #### Constraints
 
@@ -712,20 +712,20 @@ Afterwards, within each `process_group`:
 
 #### Inputs
 
-| Name               | Type                                         |
-|--------------------|----------------------------------------------|
-| `operand`          | tensor                                       |
-| `split_dimension`  | constant of type `si64`                      |
-| `concat_dimension` | constant of type `si64`                      |
-| `split_count`      | constant of type `si64`                      |
-| `replica_groups`   | 2-dimensional tensor constant of type `si64` |
-| `channel_id`       | constant of type `si64`                      |
+| Name               | Type                                         | Constraints      |
+|--------------------|----------------------------------------------|------------------|
+| `operand`          | tensor                                       | (C1)             |
+| `split_dimension`  | constant of type `si64`                      | (C1), (C2), (C8) |
+| `concat_dimension` | constant of type `si64`                      | (C3), (C8)       |
+| `split_count`      | constant of type `si64`                      | (C2), (C4), (C8) |
+| `replica_groups`   | 2-dimensional tensor constant of type `si64` | (C7)             |
+| `channel_id`       | constant of type `si64`                      |                  |
 
 #### Outputs
 
-| Name     | Type   |
-|----------|--------|
-| `result` | tensor |
+| Name     | Type   | Constraints |
+|----------|--------|-------------|
+| `result` | tensor | (C8)        |
 
 #### Constraints
 
@@ -790,16 +790,16 @@ tensor. Depending on the element type, does the following:
 
 #### Inputs
 
-| Name  | Type                              |
-|-------|-----------------------------------|
-| `lhs` | tensor of boolean or integer type |
-| `rhs` | tensor of boolean or integer type |
+| Name  | Type                              | Constraints |
+|-------|-----------------------------------|-------------|
+| `lhs` | tensor of boolean or integer type | (C1)        |
+| `rhs` | tensor of boolean or integer type | (C1)        |
 
 #### Outputs
 
-| Name     | Type                              |
-|----------|-----------------------------------|
-| `result` | tensor of boolean or integer type |
+| Name     | Type                              | Constraints |
+|----------|-----------------------------------|-------------|
+| `result` | tensor of boolean or integer type | (C1)        |
 
 #### Constraints
 
@@ -826,16 +826,16 @@ Performs element-wise atan2 operation on `lhs` and `rhs` tensor and produces a
 
 #### Inputs
 
-| Name  | Type                                     |
-|-------|------------------------------------------|
-| `lhs` | tensor of floating-point or complex type |
-| `rhs` | tensor of floating-point or complex type |
+| Name  | Type                                     | Constraints |
+|-------|------------------------------------------|-------------|
+| `lhs` | tensor of floating-point or complex type | (C1)        |
+| `rhs` | tensor of floating-point or complex type | (C1)        |
 
 #### Outputs
 
-| Name     | Type                                     |
-|----------|------------------------------------------|
-| `result` | tensor of floating-point or complex type |
+| Name     | Type                                     | Constraints |
+|----------|------------------------------------------|-------------|
+| `result` | tensor of floating-point or complex type | (C1)        |
 
 #### Constraints
 
@@ -913,23 +913,23 @@ def batch_norm_grad(operand, scale, mean, variance, grad_output, epsilon, featur
 
 #### Inputs
 
-| Name            | Type                                        |
-|-----------------|---------------------------------------------|
-| `operand`       | tensor of floating-point type               |
-| `scale`         | 1-dimensional tensor of floating-point type |
-| `mean`          | 1-dimensional tensor of floating-point type |
-| `variance`      | 1-dimensional tensor of floating-point type |
-| `grad_output`   | tensor of floating-point type               |
-| `epsilon`       | constant of type `f32`                      |
-| `feature_index` | constant of type `si64`                     |
+| Name            | Type                                        | Constraints      |
+|-----------------|---------------------------------------------|------------------|
+| `operand`       | tensor of floating-point type               | (C1-C3), (C5)    |
+| `scale`         | 1-dimensional tensor of floating-point type | (C2), (C4), (C5) |
+| `mean`          | 1-dimensional tensor of floating-point type | (C2), (C4)       |
+| `variance`      | 1-dimensional tensor of floating-point type | (C2), (C4)       |
+| `grad_output`   | tensor of floating-point type               | (C2), (C3)       |
+| `epsilon`       | constant of type `f32`                      |                  |
+| `feature_index` | constant of type `si64`                     | (C1), (C5)       |
 
 #### Outputs
 
-| Name           | Type                                        |
-|----------------|---------------------------------------------|
-| `grad_operand` | tensor of floating-point type               |
-| `grad_scale`   | 1-dimensional tensor of floating-point type |
-| `grad_offset`  | 1-dimensional tensor of floating-point type |
+| Name           | Type                                        | Constraints |
+|----------------|---------------------------------------------|-------------|
+| `grad_operand` | tensor of floating-point type               | (C2), (C3)  |
+| `grad_scale`   | 1-dimensional tensor of floating-point type | (C2), (C4)  |
+| `grad_offset`  | 1-dimensional tensor of floating-point type | (C2), (C4)  |
 
 #### Constraints
 
@@ -997,21 +997,21 @@ def batch_norm_inference(operand, scale, offset, mean, variance, epsilon, featur
 
 #### Inputs
 
-| Name            | Type                                        |
-|-----------------|---------------------------------------------|
-| `operand`       | tensor of floating-point type               |
-| `scale`         | 1-dimensional tensor of floating-point type |
-| `offset`        | 1-dimensional tensor of floating-point type |
-| `mean`          | 1-dimensional tensor of floating-point type |
-| `variance`      | 1-dimensional tensor of floating-point type |
-| `epsilon`       | constant of type `f32`                      |
-| `feature_index` | constant of type `si64`                     |
+| Name            | Type                                        | Constraints   |
+|-----------------|---------------------------------------------|---------------|
+| `operand`       | tensor of floating-point type               | (C1-C7)       |
+| `scale`         | 1-dimensional tensor of floating-point type | (C2), (C3)    |
+| `offset`        | 1-dimensional tensor of floating-point type | (C2), (C4)    |
+| `mean`          | 1-dimensional tensor of floating-point type | (C5)          |
+| `variance`      | 1-dimensional tensor of floating-point type | (C2), (C6)    |
+| `epsilon`       | constant of type `f32`                      |               |
+| `feature_index` | constant of type `si64`                     | (C1), (C3-C6) |
 
 #### Outputs
 
-| Name     | Type                          |
-|----------|-------------------------------|
-| `result` | tensor of floating-point type |
+| Name     | Type                          | Constraints |
+|----------|-------------------------------|-------------|
+| `result` | tensor of floating-point type | (C2), (C7)  |
 
 #### Constraints
 
@@ -1081,21 +1081,21 @@ def batch_norm_training(operand, scale, offset, epsilon, feature_index):
 
 #### Inputs
 
-| Name            | Type                                        |
-|-----------------|---------------------------------------------|
-| `operand`       | tensor of floating-point type               |
-| `scale`         | 1-dimensional tensor of floating-point type |
-| `offset`        | 1-dimensional tensor of floating-point type |
-| `epsilon`       | constant of type `f32`                      |
-| `feature_index` | constant of type `si64`                     |
+| Name            | Type                                        | Constraints   |
+|-----------------|---------------------------------------------|---------------|
+| `operand`       | tensor of floating-point type               | (C1)          |
+| `scale`         | 1-dimensional tensor of floating-point type | (C2), (C3)    |
+| `offset`        | 1-dimensional tensor of floating-point type | (C2), (C4)    |
+| `epsilon`       | constant of type `f32`                      | (C1), (C3-C6) |
+| `feature_index` | constant of type `si64`                     | (C1), (C3-C6) |
 
 #### Outputs
 
-| Name         | Type                                        |
-|--------------|---------------------------------------------|
-| `output`     | tensor of floating-point type               |
-| `batch_mean` | 1-dimensional tensor of floating-point type |
-| `batch_var`  | 1-dimensional tensor of floating-point type |
+| Name         | Type                                        | Constraints |
+|--------------|---------------------------------------------|-------------|
+| `output`     | tensor of floating-point type               | (C7)        |
+| `batch_mean` | 1-dimensional tensor of floating-point type | (C2), (C5)  |
+| `batch_var`  | 1-dimensional tensor of floating-point type | (C2), (C6)  |
 
 #### Constraints
 
@@ -1153,15 +1153,15 @@ representation of element types is implementation-defined as well.
 
 #### Inputs
 
-| Name      | Type   |
-|-----------|--------|
-| `operand` | tensor |
+| Name      | Type   | Constraints |
+|-----------|--------|-------------|
+| `operand` | tensor | (C1), (C2)  |
 
 #### Outputs
 
-| Name     | Type   |
-|----------|--------|
-| `result` | tensor |
+| Name     | Type   | Constraints |
+|----------|--------|-------------|
+| `result` | tensor | (C1), (C2)  |
 
 #### Constraints
 
@@ -1201,16 +1201,16 @@ dimensions `k` in `operand`.
 
 #### Inputs
 
-| Name                   | Type                                         |
-|------------------------|----------------------------------------------|
-| `operand`              | tensor                                       |
-| `broadcast_dimensions` | 1-dimensional tensor constant of type `si64` |
+| Name                   | Type                                         | Constraints   |
+|------------------------|----------------------------------------------|---------------|
+| `operand`              | tensor                                       | (C1-C3), (C5) |
+| `broadcast_dimensions` | 1-dimensional tensor constant of type `si64` | (C2-C5)       |
 
 #### Outputs
 
-| Name     | Type   |
-|----------|--------|
-| `result` | tensor |
+| Name     | Type   | Constraints      |
+|----------|--------|------------------|
+| `result` | tensor | (C1), (C3), (C5) |
 
 #### Constraints
 
@@ -1257,16 +1257,16 @@ returned.
 
 #### Inputs
 
-| Name       | Type                                |
-|------------|-------------------------------------|
-| `index`    | 1-dimensional tensor of type `si32` |
-| `branches` | variadic number of functions        |
+| Name       | Type                                | Constraints |
+|------------|-------------------------------------|-------------|
+| `index`    | 1-dimensional tensor of type `si32` |             |
+| `branches` | variadic number of functions        | (C1-C4)     |
 
 #### Outputs
 
-| Name      | Type                                 |
-|-----------|--------------------------------------|
-| `results` | variadic number of tensors or tokens |
+| Name      | Type                                 | Constraints |
+|-----------|--------------------------------------|-------------|
+| `results` | variadic number of tensors or tokens | (C4)        |
 
 #### Constraints
 
@@ -1301,15 +1301,15 @@ Performs element-wise cubic root operation on `operand` tensor and produces a
 
 #### Inputs
 
-| Name      | Type                                     |
-|-----------|------------------------------------------|
-| `operand` | tensor of floating-point or complex type |
+| Name      | Type                                     | Constraints |
+|-----------|------------------------------------------|-------------|
+| `operand` | tensor of floating-point or complex type | (C1)        |
 
 #### Outputs
 
-| Name     | Type                                     |
-|----------|------------------------------------------|
-| `result` | tensor of floating-point or complex type |
+| Name     | Type                                     | Constraints |
+|----------|------------------------------------------|-------------|
+| `result` | tensor of floating-point or complex type | (C1)        |
 
 #### Constraints
 
@@ -1333,15 +1333,15 @@ specification.
 
 #### Inputs
 
-| Name      | Type                          |
-|-----------|-------------------------------|
-| `operand` | tensor of floating-point type |
+| Name      | Type                          | Constraints |
+|-----------|-------------------------------|-------------|
+| `operand` | tensor of floating-point type | (C1)        |
 
 #### Outputs
 
-| Name     | Type                          |
-|----------|-------------------------------|
-| `result` | tensor of floating-point type |
+| Name     | Type                          | Constraints |
+|----------|-------------------------------|-------------|
+| `result` | tensor of floating-point type | (C1)        |
 
 #### Constraints
 
@@ -1375,16 +1375,16 @@ matrix, then the behavior is undefined.
 
 #### Inputs
 
-| Name    | Type                                       |
-|---------|--------------------------------------------|
-| `a`     | tensor of floating-point or complex type   |
-| `lower` | 0-dimensional tensor constant of type `i1` |
+| Name    | Type                                       | Constraints |
+|---------|--------------------------------------------|-------------|
+| `a`     | tensor of floating-point or complex type   | (C1-C3)     |
+| `lower` | 0-dimensional tensor constant of type `i1` |             |
 
 #### Outputs
 
-| Name     | Type                                     |
-|----------|------------------------------------------|
-| `result` | tensor of floating-point or complex type |
+| Name     | Type                                     | Constraints |
+|----------|------------------------------------------|-------------|
+| `result` | tensor of floating-point or complex type | (C1)        |
 
 #### Constraints
 
@@ -1422,17 +1422,17 @@ where `min_val = rank(min) == 0 ? min : min[i0, ..., iR-1]`,
 
 #### Inputs
 
-| Name      | Type   |
-|-----------|--------|
-| `min`     | tensor |
-| `operand` | tensor |
-| `max`     | tensor |
+| Name      | Type   | Constraints |
+|-----------|--------|-------------|
+| `min`     | tensor | (C1), (C3)  |
+| `operand` | tensor | (C1-C4)     |
+| `max`     | tensor | (C2), (C3)  |
 
 #### Outputs
 
-| Name     | Type   |
-|----------|--------|
-| `result` | tensor |
+| Name     | Type   | Constraints |
+|----------|--------|-------------|
+| `result` | tensor | (C4)        |
 
 #### Constraints
 
@@ -1475,17 +1475,17 @@ Afterwards, `result@process` is given by:
 
 #### Inputs
 
-| Name                  | Type                                         |
-|-----------------------|----------------------------------------------|
-| `operand`             | tensor                                       |
-| `source_target_pairs` | 2-dimensional tensor constant of type `si64` |
-| `channel_id`          | constant of type `si64`                      |
+| Name                  | Type                                         | Constraints |
+|-----------------------|----------------------------------------------|-------------|
+| `operand`             | tensor                                       | (C5)        |
+| `source_target_pairs` | 2-dimensional tensor constant of type `si64` | (C1-C4)     |
+| `channel_id`          | constant of type `si64`                      |             |
 
 #### Outputs
 
-| Name     | Type   |
-|----------|--------|
-| `result` | tensor |
+| Name     | Type   | Constraints |
+|----------|--------|-------------|
+| `result` | tensor | (C1)        |
 
 #### Constraints
 
@@ -1553,18 +1553,18 @@ performed using the provided `comparison_direction` and `compare_type`.
 
 #### Inputs
 
-| Name                   | Type                                                    |
-|------------------------|---------------------------------------------------------|
-| `lhs`                  | tensor                                                  |
-| `rhs`                  | tensor                                                  |
-| `comparison_direction` | enum of `EQ`, `NE`, `GE`, `GT`, `LE`, and `LT`          |
-| `compare_type`         | enum of `FLOAT`, `TOTALORDER`, `SIGNED`, and `UNSIGNED` |
+| Name                   | Type                                                    | Constraints |
+|------------------------|---------------------------------------------------------|-------------|
+| `lhs`                  | tensor                                                  | (C1-C3)     |
+| `rhs`                  | tensor                                                  | (C1), (C2)  |
+| `comparison_direction` | enum of `EQ`, `NE`, `GE`, `GT`, `LE`, and `LT`          |             |
+| `compare_type`         | enum of `FLOAT`, `TOTALORDER`, `SIGNED`, and `UNSIGNED` | (C3)        |
 
 #### Outputs
 
-| Name     | Type                   |
-|----------|------------------------|
-| `result` | tensor of boolean type |
+| Name     | Type                   | Constraints |
+|----------|------------------------|-------------|
+| `result` | tensor of boolean type | (C2)        |
 
 #### Constraints
 
@@ -1599,16 +1599,16 @@ imaginary values, `lhs` and `rhs`, and produces a `result` tensor.
 
 #### Inputs
 
-| Name  | Type                          |
-|-------|-------------------------------|
-| `lhs` | tensor of type `f32` or `f64` |
-| `rhs` | tensor of type `f32` or `f64` |
+| Name  | Type                          | Constraints |
+|-------|-------------------------------|-------------|
+| `lhs` | tensor of type `f32` or `f64` | (C1-C3)     |
+| `rhs` | tensor of type `f32` or `f64` | (C1)        |
 
 #### Outputs
 
-| Name     | Type                   |
-|----------|------------------------|
-| `result` | tensor of complex type |
+| Name     | Type                   | Constraints |
+|----------|------------------------|-------------|
+| `result` | tensor of complex type | (C2), (C3)  |
 
 #### Constraints
 
@@ -1640,16 +1640,16 @@ tensor. More formally,
 
 #### Inputs
 
-| Name        | Type                       |
-|-------------|----------------------------|
-| `inputs`    | variadic number of tensors |
-| `dimension` | constant of type `si64`    |
+| Name        | Type                       | Constraints      |
+|-------------|----------------------------|------------------|
+| `inputs`    | variadic number of tensors | (C1-C6)          |
+| `dimension` | constant of type `si64`    | (C2), (C4), (C6) |
 
 #### Outputs
 
-| Name     | Type   |
-|----------|--------|
-| `result` | tensor |
+| Name     | Type   | Constraints |
+|----------|--------|-------------|
+| `result` | tensor | (C5), (C6)  |
 
 #### Constraints
 
@@ -1682,15 +1682,15 @@ Produces an `output` tensor from a constant `value`.
 
 #### Inputs
 
-| Name    | Type     |
-|---------|----------|
-| `value` | constant |
+| Name    | Type     | Constraints |
+|---------|----------|-------------|
+| `value` | constant | (C1)        |
 
 #### Outputs
 
-| Name     | Type   |
-|----------|--------|
-| `output` | tensor |
+| Name     | Type   | Constraints |
+|----------|--------|-------------|
+| `output` | tensor | (C1)        |
 
 #### Constraints
 
@@ -1754,15 +1754,15 @@ converted to zero, and the value `true` is converted to one. For
 
 #### Inputs
 
-| Name      | Type   |
-|-----------|--------|
-| `operand` | tensor |
+| Name      | Type   | Constraints |
+|-----------|--------|-------------|
+| `operand` | tensor | (C1)        |
 
 #### Outputs
 
-| Name     | Type   |
-|----------|--------|
-| `result` | tensor |
+| Name     | Type   | Constraints |
+|----------|--------|-------------|
+| `result` | tensor | (C1)        |
 
 #### Constraints
 
@@ -1832,33 +1832,33 @@ If `batch_group_count > 1`:
 
 #### Inputs
 
-| Name                              | Type                                                        | Constraints                            |
-|-----------------------------------|-------------------------------------------------------------|----------------------------------------|
-| `lhs`                             | tensor                                                      | (C1), (C2), (C11), (C12), (C26), (C27) |
-| `rhs`                             | tensor                                                      | (C1), (C2), (C15), (C16), (C17), (C26) |
-| `window_strides`                  | 1-dimensional tensor constant of type `si64`                | (C3), (C4), (C26)                      |
-| `padding`                         | 2-dimensional tensor constant of type `si64`                | (C5), (C26)                            |
-| `lhs_dilation`                    | 1-dimensional tensor constant of type `si64`                | (C6), (C7), (C26)                      |
-| `rhs_dilation`                    | 1-dimensional tensor constant of type `si64`                | (C8), (C9), (C26)                      |
-| `window_reversal`                 | 1-dimensional tensor constant of type `i1`                  | (C10)                                  |
-| `input_batch_dimension`           | constant of type `si64`                                     | (C11), (C14), (C26)                    |
-| `input_feature_dimension`         | constant of type `si64`                                     | (C12), (C14)                           |
-| `input_spatial_dimensions`        | 1-dimensional tensor constant of type `si64`                | (C13), (C14), (C26)                    |
-| `kernel_input_feature_dimension`  | constant of type `si64`                                     | (C15), (C19)                           |
-| `kernel_output_feature_dimension` | constant of type `si64`                                     | (C16), (C17), (C19), (C26)             |
-| `kernel_spatial_dimensions`       | 1-dimensional tensor constant of type `si64`                | (C18), (C19), (C26)                    |
-| `output_batch_dimension`          | constant of type `si64`                                     | (C21), (C26)                           |
-| `output_feature_dimension`        | constant of type `si64`                                     | (C21),  (C26)                          |
-| `output_spatial_dimensions`       | 1-dimensional tensor constant of type `si64`                | (C20), (C21), (C26)                    |
-| `feature_group_count`             | constant of type `si64`                                     | (C12), (C15), (C17), (C22), (C24)      |
-| `batch_group_count`               | constant of type `si64`                                     | (C11), (C16), (C23), (C24), (C26)      |
-| `precision_config`                | variadic number of enum of `DEFAULT`, `HIGH`, and `HIGHEST` | (C25)                                  |
+| Name                              | Type                                                        | Constraints                                  |
+|-----------------------------------|-------------------------------------------------------------|----------------------------------------------|
+| `lhs`                             | tensor                                                      | (C1), (C2), (C11), (C12), (C15) (C26), (C27) |
+| `rhs`                             | tensor                                                      | (C1), (C2), (C15-C17), (C26)                 |
+| `window_strides`                  | 1-dimensional tensor constant of type `si64`                | (C3), (C4), (C26)                            |
+| `padding`                         | 2-dimensional tensor constant of type `si64`                | (C5), (C26)                                  |
+| `lhs_dilation`                    | 1-dimensional tensor constant of type `si64`                | (C6), (C7), (C26)                            |
+| `rhs_dilation`                    | 1-dimensional tensor constant of type `si64`                | (C8), (C9), (C26)                            |
+| `window_reversal`                 | 1-dimensional tensor constant of type `i1`                  | (C10)                                        |
+| `input_batch_dimension`           | constant of type `si64`                                     | (C11), (C14), (C26)                          |
+| `input_feature_dimension`         | constant of type `si64`                                     | (C12), (C14), (C15)                          |
+| `input_spatial_dimensions`        | 1-dimensional tensor constant of type `si64`                | (C13), (C14), (C26)                          |
+| `kernel_input_feature_dimension`  | constant of type `si64`                                     | (C15), (C19)                                 |
+| `kernel_output_feature_dimension` | constant of type `si64`                                     | (C16), (C17), (C19), (C26)                   |
+| `kernel_spatial_dimensions`       | 1-dimensional tensor constant of type `si64`                | (C18), (C19), (C26)                          |
+| `output_batch_dimension`          | constant of type `si64`                                     | (C21), (C26)                                 |
+| `output_feature_dimension`        | constant of type `si64`                                     | (C21), (C26)                                 |
+| `output_spatial_dimensions`       | 1-dimensional tensor constant of type `si64`                | (C20), (C21), (C26)                          |
+| `feature_group_count`             | constant of type `si64`                                     | (C12), (C15), (C17), (C22), (C24)            |
+| `batch_group_count`               | constant of type `si64`                                     | (C11), (C16), (C23), (C24), (C26)            |
+| `precision_config`                | variadic number of enum of `DEFAULT`, `HIGH`, and `HIGHEST` | (C25)                                        |
 
 #### Outputs
 
-| Name     | Type   | Constraints         |
-|----------|--------|---------------------|
-| `result` | tensor | (C26), (C27), (C28) |
+| Name     | Type   | Constraints |
+|----------|--------|-------------|
+| `result` | tensor | (C26-C28)   |
 
 #### Constraints
 
@@ -1969,15 +1969,15 @@ Performs element-wise cosine operation on `operand` tensor and produces a
 
 #### Inputs
 
-| Name      | Type                                     |
-|-----------|------------------------------------------|
-| `operand` | tensor of floating-point or complex type |
+| Name      | Type                                     | Constraints |
+|-----------|------------------------------------------|-------------|
+| `operand` | tensor of floating-point or complex type | (C1)        |
 
 #### Outputs
 
-| Name     | Type                                     |
-|----------|------------------------------------------|
-| `result` | tensor of floating-point or complex type |
+| Name     | Type                                     | Constraints |
+|----------|------------------------------------------|-------------|
+| `result` | tensor of floating-point or complex type | (C1)        |
 
 #### Constraints
 
@@ -2005,15 +2005,15 @@ tensor and produces a `result` tensor.
 
 #### Inputs
 
-| Name      | Type                   |
-|-----------|------------------------|
-| `operand` | tensor of integer type |
+| Name      | Type                   | Constraints |
+|-----------|------------------------|-------------|
+| `operand` | tensor of integer type | (C1)        |
 
 #### Outputs
 
-| Name     | Type                   |
-|----------|------------------------|
-| `result` | tensor of integer type |
+| Name     | Type                   | Constraints |
+|----------|------------------------|-------------|
+| `result` | tensor of integer type | (C1)        |
 
 #### Constraints
 
@@ -2078,16 +2078,16 @@ produces a `result` tensor. Depending on the element type, does the following:
 
 #### Inputs
 
-| Name  | Type                                              |
-|-------|---------------------------------------------------|
-| `lhs` | tensor of integer, floating-point or complex type |
-| `rhs` | tensor of integer, floating-point or complex type |
+| Name  | Type                                              | Constraints |
+|-------|---------------------------------------------------|-------------|
+| `lhs` | tensor of integer, floating-point or complex type | (C1)        |
+| `rhs` | tensor of integer, floating-point or complex type | (C1)        |
 
 #### Outputs
 
-| Name     | Type                                              |
-|----------|---------------------------------------------------|
-| `result` | tensor of integer, floating-point or complex type |
+| Name     | Type                                              | Constraints |
+|----------|---------------------------------------------------|-------------|
+| `result` | tensor of integer, floating-point or complex type | (C1)        |
 
 #### Constraints
 
@@ -2148,21 +2148,21 @@ computations on accelerator backends. This can be one of the following:
 
 #### Inputs
 
-| Name                         | Type                                                        |
-|------------------------------|-------------------------------------------------------------|
-| `lhs`                        | tensor                                                      |
-| `rhs`                        | tensor                                                      |
-| `lhs_batching_dimensions`    | 1-dimensional tensor constant of type `si64`                |
-| `rhs_batching_dimensions`    | 1-dimensional tensor constant of type `si64`                |
-| `lhs_contracting_dimensions` | 1-dimensional tensor constant of type `si64`                |
-| `rhs_contracting_dimensions` | 1-dimensional tensor constant of type `si64`                |
-| `precision_config`           | variadic number of enum of `DEFAULT`, `HIGH`, and `HIGHEST` |
+| Name                         | Type                                                        | Constraints                           |
+|------------------------------|-------------------------------------------------------------|---------------------------------------|
+| `lhs`                        | tensor                                                      | (C1), (C6), (C7), (C10), (C11), (C13) |
+| `rhs`                        | tensor                                                      | (C1), (C8), (C9), (C10), (C11), (C13) |
+| `lhs_batching_dimensions`    | 1-dimensional tensor constant of type `si64`                | (C2), (C4), (C6), (C10), (C13)        |
+| `rhs_batching_dimensions`    | 1-dimensional tensor constant of type `si64`                | (C2), (C5), (C8), (C10)               |
+| `lhs_contracting_dimensions` | 1-dimensional tensor constant of type `si64`                | (C3), (C4), (C7), (C11)               |
+| `rhs_contracting_dimensions` | 1-dimensional tensor constant of type `si64`                | (C3), (C5), (C9), (C11)               |
+| `precision_config`           | variadic number of enum of `DEFAULT`, `HIGH`, and `HIGHEST` | (C12)                                 |
 
 #### Outputs
 
-| Name     | Type   |
-|----------|--------|
-| `result` | tensor |
+| Name     | Type   | Constraints |
+|----------|--------|-------------|
+| `result` | tensor | (C13)       |
 
 #### Constraints
 
@@ -2243,17 +2243,17 @@ More formally, `result[i0, ..., iR-1] = operand[j0, ..., jR-1]` where:
 
 #### Inputs
 
-| Name            | Type                                                     |
-|-----------------|----------------------------------------------------------|
-| `operand`       | tensor                                                   |
-| `start_indices` | variadic number of 0-dimensional tensors of integer type |
-| `slice_sizes`   | 1-dimensional tensor constant of type `si64`             |
+| Name            | Type                                                     | Constraints      |
+|-----------------|----------------------------------------------------------|------------------|
+| `operand`       | tensor                                                   | (C1), (C2), (C4) |
+| `start_indices` | variadic number of 0-dimensional tensors of integer type | (C2), (C3)       |
+| `slice_sizes`   | 1-dimensional tensor constant of type `si64`             | (C2), (C4), (C5) |
 
 #### Outputs
 
-| Name     | Type   |
-|----------|--------|
-| `result` | tensor |
+| Name     | Type   | Constraints |
+|----------|--------|-------------|
+| `result` | tensor | (C1), (C5)  |
 
 #### Constraints
 
@@ -2300,17 +2300,17 @@ More formally, `result[i0, ..., iR-1]` is defined as:
 
 #### Inputs
 
-| Name            | Type                                                     |
-|-----------------|----------------------------------------------------------|
-| `operand`       | tensor                                                   |
-| `update`        | tensor                                                   |
-| `start_indices` | variadic number of 0-dimensional tensors of integer type |
+| Name            | Type                                                     | Constraints      |
+|-----------------|----------------------------------------------------------|------------------|
+| `operand`       | tensor                                                   | (C1-C4), (C6)    |
+| `update`        | tensor                                                   | (C3), (C3), (C6) |
+| `start_indices` | variadic number of 0-dimensional tensors of integer type | (C4), (C5)       |
 
 #### Outputs
 
-| Name     | Type   |
-|----------|--------|
-| `result` | tensor |
+| Name     | Type   | Constraints |
+|----------|--------|-------------|
+| `result` | tensor | (C1)        |
 
 #### Constraints
 
@@ -2359,15 +2359,15 @@ Performs element-wise exponential operation on `operand` tensor and produces a
 
 #### Inputs
 
-| Name      | Type                                     |
-|-----------|------------------------------------------|
-| `operand` | tensor of floating-point or complex type |
+| Name      | Type                                     | Constraints |
+|-----------|------------------------------------------|-------------|
+| `operand` | tensor of floating-point or complex type | (C1)        |
 
 #### Outputs
 
-| Name     | Type                                     |
-|----------|------------------------------------------|
-| `result` | tensor of floating-point or complex type |
+| Name     | Type                                     | Constraints |
+|----------|------------------------------------------|-------------|
+| `result` | tensor of floating-point or complex type | (C1)        |
 
 #### Constraints
 
@@ -2397,15 +2397,15 @@ produces a `result` tensor. Depending on the element type, does the following:
 
 #### Inputs
 
-| Name      | Type                                     |
-|-----------|------------------------------------------|
-| `operand` | tensor of floating-point or complex type |
+| Name      | Type                                     | Constraints |
+|-----------|------------------------------------------|-------------|
+| `operand` | tensor of floating-point or complex type | (C1)        |
 
 #### Outputs
 
-| Name     | Type                                     |
-|----------|------------------------------------------|
-| `result` | tensor of floating-point or complex type |
+| Name     | Type                                     | Constraints |
+|----------|------------------------------------------|-------------|
+| `result` | tensor of floating-point or complex type | (C1)        |
 
 #### Constraints
 
@@ -2490,17 +2490,17 @@ for `fft_type = RFFT`. For example, for `L = 3`:
 
 #### Inputs
 
-| Name         | Type                                         |
-|--------------|----------------------------------------------|
-| `operand`    | tensor of floating-point or complex type     |
-| `fft_type`   | enum of `FFT`, `IFFT`, `RFFT`, and `IRFFT`   |
-| `fft_length` | 1-dimensional tensor constant of type `si64` |
+| Name         | Type                                         | Constraints            |
+|--------------|----------------------------------------------|------------------------|
+| `operand`    | tensor of floating-point or complex type     | (C1), (C2), (C4), (C5) |
+| `fft_type`   | enum of `FFT`, `IFFT`, `RFFT`, and `IRFFT`   | (C2), (C5)             |
+| `fft_length` | 1-dimensional tensor constant of type `si64` | (C1), (C3), (C4)       |
 
 #### Outputs
 
-| Name     | Type                                     |
-|----------|------------------------------------------|
-| `result` | tensor of floating-point or complex type |
+| Name     | Type                                     | Constraints      |
+|----------|------------------------------------------|------------------|
+| `result` | tensor of floating-point or complex type | (C2), (C4), (C5) |
 
 #### Constraints
 
@@ -2546,15 +2546,15 @@ specification.
 
 #### Inputs
 
-| Name      | Type                          |
-|-----------|-------------------------------|
-| `operand` | tensor of floating-point type |
+| Name      | Type                          | Constraints |
+|-----------|-------------------------------|-------------|
+| `operand` | tensor of floating-point type | (C1)        |
 
 #### Outputs
 
-| Name     | Type                          |
-|----------|-------------------------------|
-| `result` | tensor of floating-point type |
+| Name     | Type                          | Constraints |
+|----------|-------------------------------|-------------|
+| `result` | tensor of floating-point type | (C1)        |
 
 #### Constraints
 
@@ -2610,22 +2610,22 @@ behavior is undefined. More formally, for all `id < jd` from `indices(result)`,
 
 #### Inputs
 
-| Name                   | Type                                         | Constraints                      |
-|------------------------|----------------------------------------------|----------------------------------|
-| `operand`              | tensor                                       | (C1), (C10), (C11), (C12), (C15) |
-| `start_indices`        | tensor of integer type                       | (C2), (C3), (C13)                |
-| `offset_dims`          | 1-dimensional tensor constant of type `si64` | (C1), (C4), (C5),                |
-| `collapsed_slice_dims` | 1-dimensional tensor constant of type `si64` | (C1), (C6), (C7), (C8), (C13)    |
-| `start_index_map`      | 1-dimensional tensor constant of type `si64` | (C3), (C9), (C10)                |
-| `index_vector_dim`     | constant of type `si64`                      | (C2), (C3), (C13)                |
-| `slice_sizes`          | 1-dimensional tensor constant of type `si64` | (C7), (C8), (C11), (C12), (C13)  |
-| `indices_are_sorted`   | constant of type `i1`                        |                                  |
+| Name                   | Type                                         | Constraints                   |
+|------------------------|----------------------------------------------|-------------------------------|
+| `operand`              | tensor                                       | (C1), (C10-C12), (C15)        |
+| `start_indices`        | tensor of integer type                       | (C2), (C3), (C13)             |
+| `offset_dims`          | 1-dimensional tensor constant of type `si64` | (C1), (C4), (C5), (C13)       |
+| `collapsed_slice_dims` | 1-dimensional tensor constant of type `si64` | (C1), (C6), (C7), (C8), (C13) |
+| `start_index_map`      | 1-dimensional tensor constant of type `si64` | (C3), (C9), (C10)             |
+| `index_vector_dim`     | constant of type `si64`                      | (C2), (C3), (C13)             |
+| `slice_sizes`          | 1-dimensional tensor constant of type `si64` | (C7), (C8), (C11-C13)         |
+| `indices_are_sorted`   | constant of type `i1`                        |                               |
 
 #### Outputs
 
-| Name     | Type   |
-|----------|--------|
-| `result` | tensor |
+| Name     | Type   | Constraints        |
+|----------|--------|--------------------|
+| `result` | tensor | (C5), (C13), (C15) |
 
 #### Constraints
 
@@ -2703,10 +2703,10 @@ Produces the size of the given `dimension` of the `operand`.
 
 #### Inputs
 
-| Name        | Type                    |
-|-------------|-------------------------|
-| `operand`   | tensor                  |
-| `dimension` | constant of type `si64` |
+| Name        | Type                    | Constraints |
+|-------------|-------------------------|-------------|
+| `operand`   | tensor                  | (C1)        |
+| `dimension` | constant of type `si64` | (C1)        |
 
 #### Outputs
 
@@ -2738,16 +2738,16 @@ Extracts element at `index` position of the `operand` tuple and produces a
 
 #### Inputs
 
-| Name      | Type                    |
-|-----------|-------------------------|
-| `operand` | tuple                   |
-| `index`   | constant of type `si32` |
+| Name      | Type                    | Constraints |
+|-----------|-------------------------|-------------|
+| `operand` | tuple                   | (C1), (C2)  |
+| `index`   | constant of type `si32` | (C1), (C2)  |
 
 #### Outputs
 
-| Name     | Type               |
-|----------|--------------------|
-| `result` | any supported type |
+| Name     | Type               | Constraints |
+|----------|--------------------|-------------|
+| `result` | any supported type | (C2)        |
 
 #### Constraints
 
@@ -2775,17 +2775,17 @@ output of `true_branch` is returned, else if pred is `false`, output of
 
 #### Inputs
 
-| Name           | Type                                       |
-|----------------|--------------------------------------------|
-| `pred`         | 1-dimensional tensor constant of type `i1` |
-| `true_branch`  | function                                   |
-| `false_branch` | function                                   |
+| Name           | Type                                       | Constraints |
+|----------------|--------------------------------------------|-------------|
+| `pred`         | 1-dimensional tensor constant of type `i1` |             |
+| `true_branch`  | function                                   | (C1-C3)     |
+| `false_branch` | function                                   | (C1), (C2)  |
 
 #### Outputs
 
-| Name      | Type                                 |
-|-----------|--------------------------------------|
-| `results` | variadic number of tensors or tokens |
+| Name      | Type                                 | Constraints |
+|-----------|--------------------------------------|-------------|
+| `results` | variadic number of tensors or tokens | (C3)        |
 
 #### Constraints
 
@@ -2817,15 +2817,15 @@ Extracts the imaginary part, element-wise, from the `operand` and produces a
 
 #### Inputs
 
-| Name      | Type                                     |
-|-----------|------------------------------------------|
-| `operand` | tensor of floating-point or complex type |
+| Name      | Type                                     | Constraints |
+|-----------|------------------------------------------|-------------|
+| `operand` | tensor of floating-point or complex type | (C1), (C2)  |
 
 #### Outputs
 
-| Name     | Type                          |
-|----------|-------------------------------|
-| `result` | tensor of floating-point type |
+| Name     | Type                          | Constraints |
+|----------|-------------------------------|-------------|
+| `result` | tensor of floating-point type | (C1), (C2)  |
 
 #### Constraints
 
@@ -2856,16 +2856,16 @@ as a value that other operations can take a data dependency on.
 
 #### Inputs
 
-| Name            | Type                      |
-|-----------------|---------------------------|
-| `token`         | `token`                   |
-| `infeed_config` | constant of type `string` |
+| Name            | Type                      | Constraints |
+|-----------------|---------------------------|-------------|
+| `token`         | `token`                   | (C2)        |
+| `infeed_config` | constant of type `string` |             |
 
 #### Outputs
 
-| Name      | Type                                 |
-|-----------|--------------------------------------|
-| `results` | variadic number of tensors or tokens |
+| Name      | Type                                 | Constraints |
+|-----------|--------------------------------------|-------------|
+| `results` | variadic number of tensors or tokens | (C1), (C2)  |
 
 #### Constraints
 
@@ -2892,15 +2892,15 @@ along the `iota_dimension` dimension. More formally,
 
 #### Inputs
 
-| Name             | Type   |
-|------------------|--------|
-| `iota_dimension` | `si64` |
+| Name             | Type   | Constraints |
+|------------------|--------|-------------|
+| `iota_dimension` | `si64` | (C1)        |
 
 #### Outputs
 
-| Name     | Type                                              |
-|----------|---------------------------------------------------|
-| `output` | tensor of integer, floating-point or complex type |
+| Name     | Type                                              | Constraints |
+|----------|---------------------------------------------------|-------------|
+| `output` | tensor of integer, floating-point or complex type | (C1)        |
 
 #### Constraints
 
@@ -2942,15 +2942,15 @@ operation from the IEEE-754 specification.
 
 #### Inputs
 
-| Name | Type                          |
-|------|-------------------------------|
-| `x`  | tensor of floating-point type |
+| Name | Type                          | Constraints |
+|------|-------------------------------|-------------|
+| `x`  | tensor of floating-point type | (C1)        |
 
 #### Outputs
 
-| Name | Type                   |
-|------|------------------------|
-| `y`  | tensor of boolean type |
+| Name | Type                   | Constraints |
+|------|------------------------|-------------|
+| `y`  | tensor of boolean type | (C1)        |
 
 #### Constraints
 
@@ -2977,15 +2977,15 @@ Performs element-wise logarithm operation on `operand` tensor and produces a
 
 #### Inputs
 
-| Name      | Type                                     |
-|-----------|------------------------------------------|
-| `operand` | tensor of floating-point or complex type |
+| Name      | Type                                     | Constraints |
+|-----------|------------------------------------------|-------------|
+| `operand` | tensor of floating-point or complex type | (C1)        |
 
 #### Outputs
 
-| Name     | Type                                     |
-|----------|------------------------------------------|
-| `result` | tensor of floating-point or complex type |
+| Name     | Type                                     | Constraints |
+|----------|------------------------------------------|-------------|
+| `result` | tensor of floating-point or complex type | (C1)        |
 
 #### Constraints
 
@@ -3015,15 +3015,15 @@ produces a `result` tensor. Depending on the element type, does the following:
 
 #### Inputs
 
-| Name      | Type                                     |
-|-----------|------------------------------------------|
-| `operand` | tensor of floating-point or complex type |
+| Name      | Type                                     | Constraints |
+|-----------|------------------------------------------|-------------|
+| `operand` | tensor of floating-point or complex type | (C1)        |
 
 #### Outputs
 
-| Name     | Type                                     |
-|----------|------------------------------------------|
-| `result` | tensor of floating-point or complex type |
+| Name     | Type                                     | Constraints |
+|----------|------------------------------------------|-------------|
+| `result` | tensor of floating-point or complex type | (C1)        |
 
 #### Constraints
 
@@ -3049,15 +3049,15 @@ Performs element-wise logistic operation on `operand` tensor and produces a
 
 #### Inputs
 
-| Name      | Type                                     |
-|-----------|------------------------------------------|
-| `operand` | tensor of floating-point or complex type |
+| Name      | Type                                     | Constraints |
+|-----------|------------------------------------------|-------------|
+| `operand` | tensor of floating-point or complex type | (C1)        |
 
 #### Outputs
 
-| Name     | Type                                     |
-|----------|------------------------------------------|
-| `result` | tensor of floating-point or complex type |
+| Name     | Type                                     | Constraints |
+|----------|------------------------------------------|-------------|
+| `result` | tensor of floating-point or complex type | (C1)        |
 
 #### Constraints
 
@@ -3087,17 +3087,17 @@ More formally, `result[i0, ..., iR-1] = computation(inputs[0][i0, ..., iR-1],`
 
 #### Inputs
 
-| Name          | Type                                         |
-|---------------|----------------------------------------------|
-| `inputs`      | variadic number of tensors                   |
-| `dimensions`  | 1-dimensional tensor constant of type `si64` |
-| `computation` | function                                     |
+| Name          | Type                                         | Constraints |
+|---------------|----------------------------------------------|-------------|
+| `inputs`      | variadic number of tensors                   | (C1-C4)     |
+| `dimensions`  | 1-dimensional tensor constant of type `si64` | (C3)        |
+| `computation` | function                                     | (C4)        |
 
 #### Outputs
 
-| Name     | Type   |
-|----------|--------|
-| `result` | tensor |
+| Name     | Type   | Constraints |
+|----------|--------|-------------|
+| `result` | tensor | (C1), (C4)  |
 
 #### Constraints
 
@@ -3137,16 +3137,16 @@ Performs element-wise max operation on tensors `lhs` and `rhs` and produces a
 
 #### Inputs
 
-| Name  | Type   |
-|-------|--------|
-| `lhs` | tensor |
-| `rhs` | tensor |
+| Name  | Type   | Constraints |
+|-------|--------|-------------|
+| `lhs` | tensor | (C1)        |
+| `rhs` | tensor | (C1)        |
 
 #### Outputs
 
-| Name     | Type   |
-|----------|--------|
-| `result` | tensor |
+| Name     | Type   | Constraints |
+|----------|--------|-------------|
+| `result` | tensor | (C1)        |
 
 #### Constraints
 
@@ -3177,16 +3177,16 @@ Performs element-wise min operation on tensors `lhs` and `rhs` and produces a
 
 #### Inputs
 
-| Name  | Type   |
-|-------|--------|
-| `lhs` | tensor |
-| `rhs` | tensor |
+| Name  | Type   | Constraints |
+|-------|--------|-------------|
+| `lhs` | tensor | (C1)        |
+| `rhs` | tensor | (C1)        |
 
 #### Outputs
 
-| Name     | Type   |
-|----------|--------|
-| `result` | tensor |
+| Name     | Type   | Constraints |
+|----------|--------|-------------|
+| `result` | tensor | (C1)        |
 
 #### Constraints
 
@@ -3217,16 +3217,16 @@ Performs element-wise product of two tensors `lhs` and `rhs` and produces a
 
 #### Inputs
 
-| Name  | Type   |
-|-------|--------|
-| `lhs` | tensor |
-| `rhs` | tensor |
+| Name  | Type   | Constraints |
+|-------|--------|-------------|
+| `lhs` | tensor | (C1)        |
+| `rhs` | tensor | (C1)        |
 
 #### Outputs
 
-| Name     | Type   |
-|----------|--------|
-| `result` | tensor |
+| Name     | Type   | Constraints |
+|----------|--------|-------------|
+| `result` | tensor | (C1)        |
 
 #### Constraints
 
@@ -3258,15 +3258,15 @@ tensor. Depending on the element type, does the following:
 
 #### Inputs
 
-| Name      | Type                                               |
-|-----------|----------------------------------------------------|
-| `operand` | tensor of integer, floating-point, or complex type |
+| Name      | Type                                               | Constraints |
+|-----------|----------------------------------------------------|-------------|
+| `operand` | tensor of integer, floating-point, or complex type | (C1)        |
 
 #### Outputs
 
-| Name     | Type                                               |
-|----------|----------------------------------------------------|
-| `result` | tensor of integer, floating-point, or complex type |
+| Name     | Type                                               | Constraints |
+|----------|----------------------------------------------------|-------------|
+| `result` | tensor of integer, floating-point, or complex type | (C1)        |
 
 #### Constraints
 
@@ -3300,15 +3300,15 @@ Depending on the element type, does the following:
 
 #### Arguments
 
-| Name      | Type                              |
-|-----------|-----------------------------------|
-| `operand` | tensor of boolean or integer type |
+| Name      | Type                              | Constraints |
+|-----------|-----------------------------------|-------------|
+| `operand` | tensor of boolean or integer type | (C1)        |
 
 #### Outputs
 
-| Name     | Type                              |
-|----------|-----------------------------------|
-| `result` | tensor of boolean or integer type |
+| Name     | Type                              | Constraints |
+|----------|-----------------------------------|-------------|
+| `result` | tensor of boolean or integer type | (C1)        |
 
 #### Constraints
 
@@ -3339,15 +3339,15 @@ an identity, i.e. `result` = `operand`.
 
 #### Arguments
 
-| Name      | Type                                 |
-|-----------|--------------------------------------|
-| `operand` | variadic number of tensors or tokens |
+| Name      | Type                                 | Constraints |
+|-----------|--------------------------------------|-------------|
+| `operand` | variadic number of tensors or tokens | (C1), (C2)  |
 
 #### Outputs
 
-| Name     | Type                                 |
-|----------|--------------------------------------|
-| `result` | variadic number of tensors or tokens |
+| Name     | Type                                 | Constraints |
+|----------|--------------------------------------|-------------|
+| `result` | variadic number of tensors or tokens | (C1), (C2)  |
 
 #### Constraints
 
@@ -3376,20 +3376,20 @@ tensor. Depending on the element type, does the following:
 
 #### Inputs
 
-| Name  | Type                              |
-|-------|-----------------------------------|
-| `lhs` | tensor of integer or boolean type |
-| `rhs` | tensor of integer or boolean type |
+| Name  | Type                              | Constraints |
+|-------|-----------------------------------|-------------|
+| `lhs` | tensor of integer or boolean type | (C1)        |
+| `rhs` | tensor of integer or boolean type | (C1)        |
 
 #### Outputs
 
-| Name     | Type                              |
-|----------|-----------------------------------|
-| `result` | tensor of integer or boolean type |
+| Name     | Type                              | Constraints |
+|----------|-----------------------------------|-------------|
+| `result` | tensor of integer or boolean type | (C1)        |
 
 #### Constraints
 
-* (C1) `operand` and `result` have the same type.
+* (C1) `lhs`, `rhs`, and `result` have the same type.
 
 #### Examples
 
@@ -3466,19 +3466,19 @@ More formally, `result[i0, ..., iR-1]` is equal to:
 
 #### Inputs
 
-| Name                | Type                                         |
-|---------------------|----------------------------------------------|
-| `operand`           | tensor                                       |
-| `padding_value`     | 0-dimensional tensor                         |
-| `edge_padding_low`  | 1-dimensional tensor constant of type `si64` |
-| `edge_padding_high` | 1-dimensional tensor constant of type `si64` |
-| `interior_padding`  | 1-dimensional tensor constant of type `si64` |
+| Name                | Type                                         | Constraints      |
+|---------------------|----------------------------------------------|------------------|
+| `operand`           | tensor                                       | (C1), (C2), (C4) |
+| `padding_value`     | 0-dimensional tensor                         | (C1)             |
+| `edge_padding_low`  | 1-dimensional tensor constant of type `si64` | (C2), (C4)       |
+| `edge_padding_high` | 1-dimensional tensor constant of type `si64` | (C2), (C4)       |
+| `interior_padding`  | 1-dimensional tensor constant of type `si64` | (C2-C4)          |
 
 #### Outputs
 
-| Name     | Type   |
-|----------|--------|
-| `result` | tensor |
+| Name     | Type   | Constraints |
+|----------|--------|-------------|
+| `result` | tensor | (C1)        |
 
 #### Constraints
 
@@ -3541,15 +3541,15 @@ and produces a `result` tensor.
 
 #### Inputs
 
-| Name      | Type                   |
-|-----------|------------------------|
-| `operand` | tensor of integer type |
+| Name      | Type                   | Constraints |
+|-----------|------------------------|-------------|
+| `operand` | tensor of integer type | (C1)        |
 
 #### Outputs
 
-| Name     | Type                   |
-|----------|------------------------|
-| `result` | tensor of integer type |
+| Name     | Type                   | Constraints |
+|----------|------------------------|-------------|
+| `result` | tensor of integer type | (C1)        |
 
 #### Constraints
 
@@ -3576,16 +3576,16 @@ produces a `result` tensor. Depending on the element type, does the following:
 
 #### Inputs
 
-| Name  | Type                                               |
-|-------|----------------------------------------------------|
-| `lhs` | tensor of integer, floating-point, or complex type |
-| `rhs` | tensor of integer, floating-point, or complex type |
+| Name  | Type                                               | Constraints |
+|-------|----------------------------------------------------|-------------|
+| `lhs` | tensor of integer, floating-point, or complex type | (C1)        |
+| `rhs` | tensor of integer, floating-point, or complex type | (C1)        |
 
 #### Outputs
 
-| Name     | Type                                               |
-|----------|----------------------------------------------------|
-| `result` | tensor of integer, floating-point, or complex type |
+| Name     | Type                                               | Constraints |
+|----------|----------------------------------------------------|-------------|
+| `result` | tensor of integer, floating-point, or complex type | (C1)        |
 
 #### Constraints
 
@@ -3610,15 +3610,15 @@ tensor. More formally, for each element `x`:
 
 #### Inputs
 
-| Name      | Type                                     |
-|-----------|------------------------------------------|
-| `operand` | tensor of floating-point or complex type |
+| Name      | Type                                     | Constraints |
+|-----------|------------------------------------------|-------------|
+| `operand` | tensor of floating-point or complex type | (C1), (C2)  |
 
 #### Outputs
 
-| Name     | Type                          |
-|----------|-------------------------------|
-| `result` | tensor of floating-point type |
+| Name     | Type                          | Constraints |
+|----------|-------------------------------|-------------|
+| `result` | tensor of floating-point type | (C1), (C2)  |
 
 #### Constraints
 
@@ -3651,18 +3651,18 @@ other operations can take a data dependency on.
 
 #### Inputs
 
-| Name               | Type                                            |
-|--------------------|-------------------------------------------------|
-| `token`            | `token`                                         |
-| `channel_id`       | constant of type `si64`                         |
-| `channel_type`     | enum of `DEVICE_TO_DEVICE` and `HOST_TO_DEVICE` |
-| `is_host_transfer` | constant of type `i1`                           |
+| Name               | Type                                            | Constraints |
+|--------------------|-------------------------------------------------|-------------|
+| `token`            | `token`                                         | (C3)        |
+| `channel_id`       | constant of type `si64`                         |             |
+| `channel_type`     | enum of `DEVICE_TO_DEVICE` and `HOST_TO_DEVICE` | (C1)        |
+| `is_host_transfer` | constant of type `i1`                           | (C1)        |
 
 #### Outputs
 
-| Name      | Type                                 |
-|-----------|--------------------------------------|
-| `results` | variadic number of tensors or tokens |
+| Name      | Type                                 | Constraints |
+|-----------|--------------------------------------|-------------|
+| `results` | variadic number of tensors or tokens | (C2), (C3)  |
 
 #### Constraints
 
@@ -3716,18 +3716,18 @@ More formally, `results[:][j0, ..., jR-1] = reduce(input_slices)` where:
 
 #### Inputs
 
-| Name          | Type                                         |
-|---------------|----------------------------------------------|
-| `inputs`      | variadic number of tensors                   |
-| `init_values` | variadic number of 0-dimensional tensors     |
-| `dimensions`  | 1-dimensional tensor constant of type `si64` |
-| `body`        | function                                     |
+| Name          | Type                                         | Constraints         |
+|---------------|----------------------------------------------|---------------------|
+| `inputs`      | variadic number of tensors                   | (C1-C4), (C6), (C7) |
+| `init_values` | variadic number of 0-dimensional tensors     | (C2), (C3)          |
+| `dimensions`  | 1-dimensional tensor constant of type `si64` | (C4), (C5), (C7)    |
+| `body`        | function                                     | (C6)                |
 
 #### Outputs
 
-| Name      | Type                       |
-|-----------|----------------------------|
-| `results` | variadic number of tensors |
+| Name      | Type                       | Constraints      |
+|-----------|----------------------------|------------------|
+| `results` | variadic number of tensors | (C2), (C3), (C7) |
 
 #### Constraints
 
@@ -3782,17 +3782,17 @@ More formally:
 
 #### Inputs
 
-| Name            | Type                          |
-|-----------------|-------------------------------|
-| `operand`       | tensor of floating-point type |
-| `exponent_bits` | constant of type `si32`       |
-| `mantissa_bits` | constant of type `si32`       |
+| Name            | Type                          | Constraints |
+|-----------------|-------------------------------|-------------|
+| `operand`       | tensor of floating-point type | (C1)        |
+| `exponent_bits` | constant of type `si32`       | (C2)        |
+| `mantissa_bits` | constant of type `si32`       | (C3)        |
 
 #### Outputs
 
-| Name     | Type                          |
-|----------|-------------------------------|
-| `result` | tensor of floating-point type |
+| Name     | Type                          | Constraints |
+|----------|-------------------------------|-------------|
+| `result` | tensor of floating-point type | (C1)        |
 
 #### Constraints
 
@@ -3845,20 +3845,20 @@ Afterwards, within each `process_group`:
 
 #### Inputs
 
-| Name                    | Type                                         |
-|-------------------------|----------------------------------------------|
-| `operand`               | tensor                                       |
-| `scatter_dimension`     | constant of type `si64`                      |
-| `replica_groups`        | 2-dimensional tensor constant of type `si64` |
-| `channel_id`            | constant of type `si64`                      |
-| `use_global_device_ids` | constant of type `i1`                        |
-| `computation`           | function                                     |
+| Name                    | Type                                         | Constraints            |
+|-------------------------|----------------------------------------------|------------------------|
+| `operand`               | tensor                                       | (C1), (C2), (C7), (C8) |
+| `scatter_dimension`     | constant of type `si64`                      | (C1), (C2), (C8)       |
+| `replica_groups`        | 2-dimensional tensor constant of type `si64` | (C3-C5)                |
+| `channel_id`            | constant of type `si64`                      | (C6)                   |
+| `use_global_device_ids` | constant of type `i1`                        | (C6)                   |
+| `computation`           | function                                     | (C7)                   |
 
 #### Outputs
 
-| Name     | Type   |
-|----------|--------|
-| `result` | tensor |
+| Name     | Type   | Constraints |
+|----------|--------|-------------|
+| `result` | tensor | (C8)        |
 
 #### Constraints
 
@@ -4026,16 +4026,16 @@ nearest to the exact value of `lhs/rhs` with ties to even.
 
 #### Inputs
 
-| Name  | Type                                              |
-|-------|---------------------------------------------------|
-| `lhs` | tensor of integer, floating-point or complex type |
-| `rhs` | tensor of integer, floating-point or complex type |
+| Name  | Type                                              | Constraints |
+|-------|---------------------------------------------------|-------------|
+| `lhs` | tensor of integer, floating-point or complex type | (C1)        |
+| `rhs` | tensor of integer, floating-point or complex type | (C1)        |
 
 #### Outputs
 
-| Name     | Type                                              |
-|----------|---------------------------------------------------|
-| `result` | tensor of integer, floating-point or complex type |
+| Name     | Type                                              | Constraints |
+|----------|---------------------------------------------------|-------------|
+| `result` | tensor of integer, floating-point or complex type | (C1)        |
 
 #### Constraints
 
@@ -4087,15 +4087,15 @@ spaces of `result` and `operand`.
 
 #### Inputs
 
-| Name      | Type   |
-|-----------|--------|
-| `operand` | tensor |
+| Name      | Type   | Constraints |
+|-----------|--------|-------------|
+| `operand` | tensor | (C1), (C2)  |
 
 #### Outputs
 
-| Name     | Type   |
-|----------|--------|
-| `result` | tensor |
+| Name     | Type   | Constraints |
+|----------|--------|-------------|
+| `result` | tensor | (C1), (C2)  |
 
 #### Constraints
 
@@ -4123,16 +4123,16 @@ and produces a `result` tensor. More formally,
 
 #### Inputs
 
-| Name         | Type                                         |
-|--------------|----------------------------------------------|
-| `operand`    | tensor                                       |
-| `dimensions` | 1-dimensional tensor constant of type `si64` |
+| Name         | Type                                         | Constraints |
+|--------------|----------------------------------------------|-------------|
+| `operand`    | tensor                                       | (C1)        |
+| `dimensions` | 1-dimensional tensor constant of type `si64` | (C2), (C3)  |
 
 #### Outputs
 
-| Name     | Type   |
-|----------|--------|
-| `result` | tensor |
+| Name     | Type   | Constraints |
+|----------|--------|-------------|
+| `result` | tensor | (C1), (C3)  |
 
 #### Constraints
 
@@ -4182,18 +4182,18 @@ hidden state.
 
 #### Inputs
 
-| Name               | Type                                                             |
-|--------------------|------------------------------------------------------------------|
-| `a`                | 0-dimensional tensor of integer, boolean, or floating-point type |
-| `b`                | 0-dimensional tensor of integer, boolean, or floating-point type |
-| `shape`            | 1-dimensional tensor constant of type `si64`                     |
-| `rng_distribution` | enum of `UNIFORM` and `NORMAL`                                   |
+| Name               | Type                                                             | Constraints |
+|--------------------|------------------------------------------------------------------|-------------|
+| `a`                | 0-dimensional tensor of integer, boolean, or floating-point type | (C1), (C2)  |
+| `b`                | 0-dimensional tensor of integer, boolean, or floating-point type | (C1), (C2)  |
+| `shape`            | 1-dimensional tensor constant of type `si64`                     | (C3)        |
+| `rng_distribution` | enum of `UNIFORM` and `NORMAL`                                   | (C2)        |
 
 #### Outputs
 
-| Name     | Type                                               |
-|----------|----------------------------------------------------|
-| `result` | tensor of integer, boolean, or floating-point type |
+| Name     | Type                                               | Constraints |
+|----------|----------------------------------------------------|-------------|
+| `result` | tensor of integer, boolean, or floating-point type | (C1-C3)     |
 
 #### Constraints
 
@@ -4239,17 +4239,17 @@ deterministic between implementations.
 
 #### Inputs
 
-| Name            | Type                                         |
-|-----------------|----------------------------------------------|
-| `initial_state` | 1-dimensional tensor of type `ui64`          |
-| `rng_algorithm` | enum of `DEFAULT`, `THREE_FRY`, and `PHILOX` |
+| Name            | Type                                         | Constraints |
+|-----------------|----------------------------------------------|-------------|
+| `initial_state` | 1-dimensional tensor of type `ui64`          | (C1), (C2)  |
+| `rng_algorithm` | enum of `DEFAULT`, `THREE_FRY`, and `PHILOX` | (C2)        |
 
 #### Outputs
 
-| Name           | Type                                     |
-|----------------|------------------------------------------|
-| `output_state` | 1-dimensional tensor of type `ui64`      |
-| `output`       | tensor of integer or floating-point type |
+| Name           | Type                                     | Constraints |
+|----------------|------------------------------------------|-------------|
+| `output_state` | 1-dimensional tensor of type `ui64`      | (C1)        |
+| `output`       | tensor of integer or floating-point type |             |
 
 #### Constraints
 
@@ -4283,15 +4283,15 @@ the `roundToIntegralTiesToAway` operation from the IEEE-754 specification.
 
 #### Inputs
 
-| Name      | Type                          |
-|-----------|-------------------------------|
-| `operand` | tensor of floating-point type |
+| Name      | Type                          | Constraints |
+|-----------|-------------------------------|-------------|
+| `operand` | tensor of floating-point type | (C1)        |
 
 #### Outputs
 
-| Name     | Type                          |
-|----------|-------------------------------|
-| `result` | tensor of floating-point type |
+| Name     | Type                          | Constraints |
+|----------|-------------------------------|-------------|
+| `result` | tensor of floating-point type | (C1)        |
 
 #### Constraints
 
@@ -4316,15 +4316,15 @@ specification.
 
 #### Inputs
 
-| Name      | Type                          |
-|-----------|-------------------------------|
-| `operand` | tensor of floating-point type |
+| Name      | Type                          | Constraints |
+|-----------|-------------------------------|-------------|
+| `operand` | tensor of floating-point type | (C1)        |
 
 #### Outputs
 
-| Name     | Type                          |
-|----------|-------------------------------|
-| `result` | tensor of floating-point type |
+| Name     | Type                          | Constraints |
+|----------|-------------------------------|-------------|
+| `result` | tensor of floating-point type | (C1)        |
 
 #### Constraints
 
@@ -4350,15 +4350,15 @@ produces a `result` tensor. Depending on the element type, does the following:
 
 #### Inputs
 
-| Name      | Type                                     |
-|-----------|------------------------------------------|
-| `operand` | tensor of floating-point or complex type |
+| Name      | Type                                     | Constraints |
+|-----------|------------------------------------------|-------------|
+| `operand` | tensor of floating-point or complex type | (C1)        |
 
 #### Outputs
 
-| Name     | Type                                     |
-|----------|------------------------------------------|
-| `result` | tensor of floating-point or complex type |
+| Name     | Type                                     | Constraints |
+|----------|------------------------------------------|-------------|
+| `result` | tensor of floating-point or complex type | (C1)        |
 
 #### Constraints
 
@@ -4432,24 +4432,24 @@ otherwise the behavior is undefined. More formally, for all `id < jd` from
 `indices(result)`, `full_start_index(id)` <= `full_start_index(jd)`.
 
 If `unique_indices` is `true` then the implementation can assume that all
-`result_index` indices being scattered to are unique. If `unique_indices`
-is `true` but the indices being scattered to are not unique then the behavior
-is undefined.
+`result_index` indices being scattered to are unique. If `unique_indices` is
+`true` but the indices being scattered to are not unique then the behavior is
+undefined.
 
 #### Inputs
 
-| Name                           | Type                                         | Constraints                                              |
-|--------------------------------|----------------------------------------------|----------------------------------------------------------|
-| `inputs`                       | variadic number of tensors                   | (C1), (C2), (C4), (C5), (C6), (C10), (C13), (C15), (C16) |
-| `scatter_indices`              | tensor of integer type                       | (C4), (C11), (C14)                                       |
-| `updates`                      | variadic number of tensors                   | (C3), (C4), (C5), (C6), (C8)                             |
-| `update_window_dims`           | 1-dimensional tensor constant of type `si64` | (C2), (C4), (C7), (C8)                                   |
-| `inserted_window_dims`         | 1-dimensional tensor constant of type `si64` | (C2), (C4), (C9), (C10)                                  |
-| `scatter_dims_to_operand_dims` | 1-dimensional tensor constant of type `si64` | (C11),(C12), (C13)                                       |
-| `index_vector_dim`             | constant of type `si64`                      | (C4), (C11), (C14)                                       |
-| `indices_are_sorted`           | constant of type `i1`                        |                                                          |
-| `unique_indices`               | constant of type `i1`                        |                                                          |
-| `update_computation`           | function                                     | (C15)                                                    |
+| Name                           | Type                                         | Constraints                                     |
+|--------------------------------|----------------------------------------------|-------------------------------------------------|
+| `inputs`                       | variadic number of tensors                   | (C1), (C2), (C4-C6), (C10), (C13), (C15), (C16) |
+| `scatter_indices`              | tensor of integer type                       | (C4), (C11), (C14)                              |
+| `updates`                      | variadic number of tensors                   | (C3-C6), (C8)                                   |
+| `update_window_dims`           | 1-dimensional tensor constant of type `si64` | (C2), (C4), (C7), (C8)                          |
+| `inserted_window_dims`         | 1-dimensional tensor constant of type `si64` | (C2), (C4), (C9), (C10)                         |
+| `scatter_dims_to_operand_dims` | 1-dimensional tensor constant of type `si64` | (C11-C13)                                       |
+| `index_vector_dim`             | constant of type `si64`                      | (C4), (C11), (C14)                              |
+| `indices_are_sorted`           | constant of type `i1`                        |                                                 |
+| `unique_indices`               | constant of type `i1`                        |                                                 |
+| `update_computation`           | function                                     | (C15)                                           |
 
 #### Outputs
 
@@ -4543,17 +4543,17 @@ where `pred_val = rank(pred) == 0 ? pred : pred[i0, ..., iR-1]`.
 
 #### Inputs
 
-| Name       | Type                |
-|------------|---------------------|
-| `pred`     | tensor of type `i1` |
-| `on_true`  | tensor              |
-| `on_false` | tensor              |
+| Name       | Type                | Constraints |
+|------------|---------------------|-------------|
+| `pred`     | tensor of type `i1` | (C1)        |
+| `on_true`  | tensor              | (C1), (C2)  |
+| `on_false` | tensor              | (C2)        |
 
 #### Outputs
 
-| Name     | Type   |
-|----------|--------|
-| `result` | tensor |
+| Name     | Type   | Constraints |
+|----------|--------|-------------|
+| `result` | tensor | (C2)        |
 
 #### Constraints
 
@@ -4613,16 +4613,16 @@ More formally:
 
 #### Inputs
 
-| Name                | Type                                         | Constraints                    |
-|---------------------|----------------------------------------------|--------------------------------|
-| `operand`           | tensor                                       | (C1-C5), (C7), (C9), (C10-C12) |
-| `source`            | tensor                                       | (C2), (C3)                     |
-| `init_value`        | 0-dimensional tensor                         | (C4)                           |
-| `window_dimensions` | 1-dimensional tensor constant of type `si64` | (C1), (C3), (C5), (C6)         |
-| `window_strides`    | 1-dimensional tensor constant of type `si64` | (C3), (C7), (C8)               |
-| `padding`           | 2-dimensional tensor constant of type `si64` | (C3), (C9)                     |
-| `select`            | function                                     | (C10)                          |
-| `scatter`           | function                                     | (C11)                          |
+| Name                | Type                                         | Constraints             |
+|---------------------|----------------------------------------------|-------------------------|
+| `operand`           | tensor                                       | (C1-C5), (C7), (C9-C12) |
+| `source`            | tensor                                       | (C2), (C3)              |
+| `init_value`        | 0-dimensional tensor                         | (C4)                    |
+| `window_dimensions` | 1-dimensional tensor constant of type `si64` | (C1), (C3), (C5), (C6)  |
+| `window_strides`    | 1-dimensional tensor constant of type `si64` | (C3), (C7), (C8)        |
+| `padding`           | 2-dimensional tensor constant of type `si64` | (C3), (C9)              |
+| `select`            | function                                     | (C10)                   |
+| `scatter`           | function                                     | (C11)                   |
 
 #### Outputs
 
@@ -4689,13 +4689,13 @@ implementation-defined.
 
 #### Inputs
 
-| Name               | Type                                            |
-|--------------------|-------------------------------------------------|
-| `inputs`           | variadic number of tensors                      |
-| `token`            | `token`                                         |
-| `channel_id`       | constant of type `si64`                         |
-| `channel_type`     | enum of `DEVICE_TO_DEVICE` and `DEVICE_TO_HOST` |
-| `is_host_transfer` | constant of type `i1`                           |
+| Name               | Type                                            | Constraints |
+|--------------------|-------------------------------------------------|-------------|
+| `inputs`           | variadic number of tensors                      |             |
+| `token`            | `token`                                         |             |
+| `channel_id`       | constant of type `si64`                         |             |
+| `channel_type`     | enum of `DEVICE_TO_DEVICE` and `DEVICE_TO_HOST` | (C1)        |
+| `is_host_transfer` | constant of type `i1`                           | (C1)        |
 
 #### Outputs
 
@@ -4730,16 +4730,16 @@ of bits and produces a `result` tensor.
 
 #### Inputs
 
-| Name  | Type                   |
-|-------|------------------------|
-| `lhs` | tensor of integer type |
-| `rhs` | tensor of integer type |
+| Name  | Type                   | Constraints |
+|-------|------------------------|-------------|
+| `lhs` | tensor of integer type | (C1)        |
+| `rhs` | tensor of integer type | (C1)        |
 
 #### Outputs
 
-| Name     | Type                   |
-|----------|------------------------|
-| `result` | tensor of integer type |
+| Name     | Type                   | Constraints |
+|----------|------------------------|-------------|
+| `result` | tensor of integer type | (C1)        |
 
 #### Constraints
 
@@ -4763,16 +4763,16 @@ Performs element-wise arithmetic right-shift operation on the `lhs` tensor by
 
 #### Inputs
 
-| Name  | Type                   |
-|-------|------------------------|
-| `lhs` | tensor of integer type |
-| `rhs` | tensor of integer type |
+| Name  | Type                   | Constraints |
+|-------|------------------------|-------------|
+| `lhs` | tensor of integer type | (C1)        |
+| `rhs` | tensor of integer type | (C1)        |
 
 #### Outputs
 
-| Name     | Type                   |
-|----------|------------------------|
-| `result` | tensor of integer type |
+| Name     | Type                   | Constraints |
+|----------|------------------------|-------------|
+| `result` | tensor of integer type | (C1)        |
 
 #### Constraints
 
@@ -4796,16 +4796,16 @@ number of bits and produces a `result` tensor.
 
 #### Inputs
 
-| Name  | Type                   |
-|-------|------------------------|
-| `lhs` | tensor of integer type |
-| `rhs` | tensor of integer type |
+| Name  | Type                   | Constraints |
+|-------|------------------------|-------------|
+| `lhs` | tensor of integer type | (C1)        |
+| `rhs` | tensor of integer type | (C1)        |
 
 #### Outputs
 
-| Name     | Type                   |
-|----------|------------------------|
-| `result` | tensor of integer type |
+| Name     | Type                   | Constraints |
+|----------|------------------------|-------------|
+| `result` | tensor of integer type | (C1)        |
 
 #### Constraints
 
@@ -4851,15 +4851,15 @@ def sign(x):
 
 #### Inputs
 
-| Name      | Type                                                      |
-|-----------|-----------------------------------------------------------|
-| `operand` | tensor of signed integer, floating-point, or complex type |
+| Name      | Type                                                      | Constraints |
+|-----------|-----------------------------------------------------------|-------------|
+| `operand` | tensor of signed integer, floating-point, or complex type | (C1)        |
 
 #### Outputs
 
-| Name     | Type                                                      |
-|----------|-----------------------------------------------------------|
-| `result` | tensor of signed integer, floating-point, or complex type |
+| Name     | Type                                                      | Constraints |
+|----------|-----------------------------------------------------------|-------------|
+| `result` | tensor of signed integer, floating-point, or complex type | (C1)        |
 
 #### Constraints
 
@@ -4886,15 +4886,15 @@ tensor. Depending on the element type, does the following:
 
 #### Inputs
 
-| Name      | Type                                     |
-|-----------|------------------------------------------|
-| `operand` | tensor of floating-point or complex type |
+| Name      | Type                                     | Constraints |
+|-----------|------------------------------------------|-------------|
+| `operand` | tensor of floating-point or complex type | (C1)        |
 
 #### Outputs
 
-| Name     | Type                                     |
-|----------|------------------------------------------|
-| `result` | tensor of floating-point or complex type |
+| Name     | Type                                     | Constraints |
+|----------|------------------------------------------|-------------|
+| `result` | tensor of floating-point or complex type | (C1)        |
 
 #### Constraints
 
@@ -4928,18 +4928,18 @@ More formally, `result[i0, ..., iR-1] = operand[j0, ..., jR-1]` where
 
 #### Inputs
 
-| Name            | Type                                         |
-|-----------------|----------------------------------------------|
-| `operand`       | tensor                                       |
-| `start_indices` | 1-dimensional tensor constant of type `si64` |
-| `limit_indices` | 1-dimensional tensor constant of type `si64` |
-| `strides`       | 1-dimensional tensor constant of type `si64` |
+| Name            | Type                                         | Constraints      |
+|-----------------|----------------------------------------------|------------------|
+| `operand`       | tensor                                       | (C1-C3), (C5)    |
+| `start_indices` | 1-dimensional tensor constant of type `si64` | (C2), (C3), (C5) |
+| `limit_indices` | 1-dimensional tensor constant of type `si64` | (C2), (C3), (C5) |
+| `strides`       | 1-dimensional tensor constant of type `si64` | (C2), (C4)       |
 
 #### Outputs
 
-| Name     | Type   |
-|----------|--------|
-| `result` | tensor |
+| Name     | Type   | Constraints |
+|----------|--------|-------------|
+| `result` | tensor | (C1), (C5)  |
 
 #### Constraints
 
@@ -5006,18 +5006,18 @@ More formally, for all `0 <= id < jd < dim(inputs[0], d)`, either
 
 #### Inputs
 
-| Name         | Type                       |
-|--------------|----------------------------|
-| `inputs`     | variadic number of tensors |
-| `dimension`  | constant of type `si64`    |
-| `is_stable`  | constant of type `i1`      |
-| `comparator` | function                   |
+| Name         | Type                       | Constraints |
+|--------------|----------------------------|-------------|
+| `inputs`     | variadic number of tensors | (C1)        |
+| `dimension`  | constant of type `si64`    | (C4)        |
+| `is_stable`  | constant of type `i1`      |             |
+| `comparator` | function                   | (C5)        |
 
 #### Outputs
 
-| Name      | Type                       |
-|-----------|----------------------------|
-| `results` | variadic number of tensors |
+| Name      | Type                       | Constraints |
+|-----------|----------------------------|-------------|
+| `results` | variadic number of tensors | (C2), (C3)  |
 
 #### Constraints
 
@@ -5080,15 +5080,15 @@ Performs element-wise square root operation on `operand` tensor and produces a
 
 #### Inputs
 
-| Name      | Type                                     |
-|-----------|------------------------------------------|
-| `operand` | tensor of floating-point or complex type |
+| Name      | Type                                     | Constraints |
+|-----------|------------------------------------------|-------------|
+| `operand` | tensor of floating-point or complex type | (C1)        |
 
 #### Outputs
 
-| Name     | Type                                     |
-|----------|------------------------------------------|
-| `result` | tensor of floating-point or complex type |
+| Name     | Type                                     | Constraints |
+|----------|------------------------------------------|-------------|
+| `result` | tensor of floating-point or complex type | (C1)        |
 
 #### Constraints
 
@@ -5119,16 +5119,16 @@ Performs element-wise subtraction of two tensors `lhs` and `rhs` and produces a
 
 #### Inputs
 
-| Name  | Type                                               |
-|-------|----------------------------------------------------|
-| `lhs` | tensor of integer, floating-point, or complex type |
-| `rhs` | tensor of integer, floating-point, or complex type |
+| Name  | Type                                               | Constraints |
+|-------|----------------------------------------------------|-------------|
+| `lhs` | tensor of integer, floating-point, or complex type | (C1)        |
+| `rhs` | tensor of integer, floating-point, or complex type | (C1)        |
 
 #### Outputs
 
-| Name     | Type                                               |
-|----------|----------------------------------------------------|
-| `result` | tensor of integer, floating-point, or complex type |
+| Name     | Type                                               | Constraints |
+|----------|----------------------------------------------------|-------------|
+| `result` | tensor of integer, floating-point, or complex type | (C1)        |
 
 #### Constraints
 
@@ -5157,15 +5157,15 @@ produces a `result` tensor. Depending on the element type, does the following:
 
 #### Inputs
 
-| Name      | Type                                     |
-|-----------|------------------------------------------|
-| `operand` | tensor of floating-point or complex type |
+| Name      | Type                                     | Constraints |
+|-----------|------------------------------------------|-------------|
+| `operand` | tensor of floating-point or complex type | (C1)        |
 
 #### Outputs
 
-| Name     | Type                                     |
-|----------|------------------------------------------|
-| `result` | tensor of floating-point or complex type |
+| Name     | Type                                     | Constraints |
+|----------|------------------------------------------|-------------|
+| `result` | tensor of floating-point or complex type | (C1)        |
 
 #### Constraints
 
@@ -5191,16 +5191,16 @@ where `i[d] = j[permutation[d]]`.
 
 #### Inputs
 
-| Name          | Type                                         |
-|---------------|----------------------------------------------|
-| `operand`     | tensor                                       |
-| `permutation` | 1-dimensional tensor constant of type `si64` |
+| Name          | Type                                         | Constraints |
+|---------------|----------------------------------------------|-------------|
+| `operand`     | tensor                                       | (C1-C3)     |
+| `permutation` | 1-dimensional tensor constant of type `si64` | (C2), (C3)  |
 
 #### Outputs
 
-| Name     | Type   |
-|----------|--------|
-| `result` | tensor |
+| Name     | Type   | Constraints |
+|----------|--------|-------------|
+| `result` | tensor | (C1), (C3)  |
 
 #### Constraints
 
@@ -5254,20 +5254,20 @@ elements of `a` are equal to 1, otherwise the behavior is undefined.
 
 #### Inputs
 
-| Name            | Type                                               |
-|-----------------|----------------------------------------------------|
-| `a`             | tensor of floating-point or complex type           |
-| `b`             | tensor of floating-point or complex type           |
-| `left_side`     | constant of type `i1`                              |
-| `lower`         | constant of type `i1`                              |
-| `unit_diagonal` | constant of type `i1`                              |
-| `transpose_a`   | enum of `NO_TRANSPOSE`, `TRANSPOSE`, and `ADJOINT` |
+| Name            | Type                                               | Constraints |
+|-----------------|----------------------------------------------------|-------------|
+| `a`             | tensor of floating-point or complex type           | (C1-C3)     |
+| `b`             | tensor of floating-point or complex type           | (C1-C4)     |
+| `left_side`     | constant of type `i1`                              | (C3)        |
+| `lower`         | constant of type `i1`                              |             |
+| `unit_diagonal` | constant of type `i1`                              |             |
+| `transpose_a`   | enum of `NO_TRANSPOSE`, `TRANSPOSE`, and `ADJOINT` |             |
 
 #### Outputs
 
-| Name     | Type                                     |
-|----------|------------------------------------------|
-| `result` | tensor of floating-point or complex type |
+| Name     | Type                                     | Constraints |
+|----------|------------------------------------------|-------------|
+| `result` | tensor of floating-point or complex type | (C1)        |
 
 #### Constraints
 
@@ -5312,15 +5312,15 @@ Produces a `result` tuple from values `val`.
 
 #### Inputs
 
-| Name  | Type                      |
-|-------|---------------------------|
-| `val` | variadic number of values |
+| Name  | Type                      | Constraints |
+|-------|---------------------------|-------------|
+| `val` | variadic number of values | (C1), (C2)  |
 
 #### Outputs
 
-| Name     | Type  |
-|----------|-------|
-| `result` | tuple |
+| Name     | Type  | Constraints |
+|----------|-------|-------------|
+| `result` | tuple | (C1), (C2)  |
 
 #### Constraints
 
@@ -5355,17 +5355,17 @@ The behavior of an infinite loop is TBD.
 
 #### Inputs
 
-| Name       | Type                                 |
-|------------|--------------------------------------|
-| `operands` | variadic number of tensors or tokens |
-| `cond`     | function                             |
-| `body`     | function                             |
+| Name       | Type                                 | Constraints |
+|------------|--------------------------------------|-------------|
+| `operands` | variadic number of tensors or tokens | (C1-C3)     |
+| `cond`     | function                             | (C1)        |
+| `body`     | function                             | (C2)        |
 
 #### Outputs
 
-| Name      | Type                                 |
-|-----------|--------------------------------------|
-| `results` | variadic number of tensors or tokens |
+| Name      | Type                                 | Constraints |
+|-----------|--------------------------------------|-------------|
+| `results` | variadic number of tensors or tokens | (C3)        |
 
 #### Constraints
 
@@ -5408,16 +5408,16 @@ tensor. Depending on the element type, does the following:
 
 #### Inputs
 
-| Name  | Type                              |
-|-------|-----------------------------------|
-| `lhs` | tensor of boolean or integer type |
-| `rhs` | tensor of boolean or integer type |
+| Name  | Type                              | Constraints |
+|-------|-----------------------------------|-------------|
+| `lhs` | tensor of boolean or integer type | (C1)        |
+| `rhs` | tensor of boolean or integer type | (C1)        |
 
 #### Outputs
 
-| Name     | Type                              |
-|----------|-----------------------------------|
-| `result` | tensor of boolean or integer type |
+| Name     | Type                              | Constraints |
+|----------|-----------------------------------|-------------|
+| `result` | tensor of boolean or integer type | (C1)        |
 
 #### Constraints
 


### PR DESCRIPTION
Some arguments are missing constraints as they are mentioned in the semantics section and/or are part of the Type column

Steps I followed to add the constraints for all ops (including ops that already have constraints column):
1. Add (missing) constraints for all instances of the Name occurring in the constraint
2. Abbreviate 3 or more consecutive constraints to save horizontal space
3. Omit adding Constraints column if none of the sections have constraints

Exception to the above steps:
* bitcast_convert: (C2) does not pertain to specific inputs/outputs

Other notes:
* Fixed typo in OrOp
* Minor formatting change in ScatterOp

closes #614