### PR TITLE
Add local code coverage generation tooling

### DIFF
--- a/build_tools/github_actions/ci_build_stablehlo_code_coverage.sh
+++ b/build_tools/github_actions/ci_build_stablehlo_code_coverage.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# Copyright 2023 The StableHLO Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+print_usage() {
+  echo "Usage:"
+  echo "$0 [-g][-o output_dir] <llvm_build_dir> <stablehlo_build_dir>"
+  echo "    -g               Generate HTML report (default false)"
+  echo "    -o <output_dir>  Set the output to generate report (default /tmp/ccov)"
+}
+
+OUTPUT_DIR="/tmp/ccov"
+GENERATE_HTML=false
+while getopts 'go:' flag; do
+  case "${flag}" in
+    g) GENERATE_HTML=true ;;
+    o) OUTPUT_DIR="$OPTARG" ;;
+    *) print_usage
+       exit 1 ;;
+  esac
+done
+shift $(( OPTIND - 1 ))
+
+if [[ $# -ne 2 ]] ; then
+  print_usage
+  exit 1
+fi
+
+LLVM_BUILD_DIR="$1"
+STABLEHLO_BUILD_DIR="$2"
+
+# Check for lcov
+if ! command -v lcov &> /dev/null
+then
+    echo "lcov could not be found"
+    echo "$ sudo apt install lcov"
+    exit
+fi
+
+# Configure StableHLO
+cmake -GNinja \
+  -B"$STABLEHLO_BUILD_DIR" \
+  -DLLVM_ENABLE_LLD=ON \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DLLVM_ENABLE_ASSERTIONS=On \
+  -DMLIR_DIR="$LLVM_BUILD_DIR/lib/cmake/mlir" \
+  -DCMAKE_CXX_COMPILER=clang++ \
+  -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+  -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -fprofile-instr-generate -fprofile-arcs -ftest-coverage -fcoverage-mapping" \
+  -DCMAKE_C_COMPILER=clang \
+  -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+  -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} -fprofile-instr-generate -fprofile-arcs -ftest-coverage -fcoverage-mapping"
+
+# Build and Check StableHLO
+(cd "$STABLEHLO_BUILD_DIR" && ninja check-stablehlo)
+
+BUILD_TOOLS_DIR="$(dirname "$(readlink -f "$0")")"
+
+REPORT_DATE="$(date +'%Y_%m_%d_%H-%M-%S')"
+REPORT_DIR="$OUTPUT_DIR/ccov_$REPORT_DATE"
+LCOV_DATA="$REPORT_DIR/cov.info"
+
+mkdir -p $REPORT_DIR
+
+lcov --directory "$STABLEHLO_BUILD_DIR"  \
+     --base-directory "stablehlo" \
+     --gcov-tool "$BUILD_TOOLS_DIR/llvm_gcov.sh" \
+     --capture -o "$LCOV_DATA" \
+     --no-external \
+     --exclude "*.inc" \
+     --exclude "llvm-project/*" \
+     --quiet
+
+# Capture code coverage output
+if [[ $GENERATE_HTML == true ]]; then
+  exec 5>&1
+  CCOV_OUT=$(genhtml $LCOV_DATA \
+      --output-directory $REPORT_DIR \
+      --ignore-errors source \
+      --show-details \
+      --sort \
+      --prefix $(pwd) | tee /dev/fd/5)
+  echo "HTML report at:"
+  echo "  $REPORT_DIR"
+fi
+
+echo "LCOV data at:"
+echo "  $LCOV_DATA"
+echo
+echo "Summary:"
+lcov -l "$LCOV_DATA"

--- a/build_tools/github_actions/llvm_gcov.sh
+++ b/build_tools/github_actions/llvm_gcov.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Copyright 2023 The StableHLO Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is a helper script used by lcov in
+# ci_build_stablehlo_code_coverage.sh
+exec llvm-cov-14 gcov "$@"


### PR DESCRIPTION
### LCOV Tooling

```
Usage:
$ ci_build_stablehlo_code_coverage.sh [-g][-o output_dir] <llvm_build_dir> <stablehlo_build_dir>
    -g               Generate HTML report (default false)
    -o <output_dir>  Set the output to generate report (default /tmp/ccov)
```

### Example:

```
./build_tools/github_actions/ci_build_stablehlo_code_coverage.sh ~/path-to/llvm-build/ ~/path-to/stablehlo-build/
-- Building StableHLO standalone
-- Using MLIRConfig.cmake in: /usr/local/google/home/gleasonk/Coding/llvm-build//lib/cmake/mlir
-- Using LLVMConfig.cmake in: /usr/local/google/home/gleasonk/Coding/llvm-build/lib/cmake/llvm
-- Building with -fPIC
-- Configuring done
-- Generating done
-- Build files have been written to: /usr/local/google/home/gleasonk/Coding/stablehlo-build
[0/1] Running the StableHLO regression tests

Testing Time: 1.01s
  Passed: 47
Subroutine read_intermediate_text redefined at /usr/bin/geninfo line 2637.
Subroutine read_intermediate_json redefined at /usr/bin/geninfo line 2669.
Subroutine intermediate_text_to_info redefined at /usr/bin/geninfo line 2717.
Subroutine intermediate_json_to_info redefined at /usr/bin/geninfo line 2806.
Subroutine get_output_fd redefined at /usr/bin/geninfo line 2886.
Subroutine print_gcov_warnings redefined at /usr/bin/geninfo line 2914.
Subroutine process_intermediate redefined at /usr/bin/geninfo line 2944.
LCOV data at:
  /tmp/ccov/ccov_2023_01_20_18-50-05/cov.info

Summary:
Reading tracefile /tmp/ccov/ccov_2023_01_20_18-50-05/cov.info
                                          |Lines       |Functions  |Branches    
Filename                                  |Rate     Num|Rate    Num|Rate     Num
================================================================================
[/usr/local/google/home/gleasonk/Coding/openxla/stablehlo/stablehlo/]
dialect/AssemblyFormat.cpp                |98.4%    247| 100%    32|    -      0
dialect/AssemblyFormat.h                  | 100%     14| 100%     6|    -      0
dialect/Base.cpp                          |96.4%    197| 100%    16|    -      0
dialect/Base.h                            |86.4%     66|84.8%   269|    -      0
dialect/BroadcastUtils.cpp                |70.3%     37| 100%     4|    -      0
dialect/ChloBytecode.cpp                  |72.4%     58|76.5%    17|    -      0
dialect/ChloOps.cpp                       |90.2%    307|76.1%    88|    -      0
dialect/ChloOps.h                         | 100%      1| 100%     2|    -      0
dialect/Register.cpp                      | 100%      4| 100%     1|    -      0
dialect/StablehloBytecode.cpp             |95.0%    317|96.9%    64|    -      0
dialect/StablehloOps.cpp                  |87.3%   2099|76.2%   277|    -      0
dialect/StablehloOps.h                    | 100%      1| 100%     3|    -      0
dialect/TypeInference.cpp                 |97.2%   2521|98.5%   130|    -      0
dialect/TypeInference.h                   | 100%      8| 100%     1|    -      0
dialect/Version.cpp                       |90.0%     30|71.4%     7|    -      0
dialect/Version.h                         | 100%      9| 100%     6|    -      0
dialect/VhloBytecode.cpp                  |87.6%    315|92.2%    64|    -      0
dialect/VhloOps.cpp                       |85.3%     34| 100%     5|    -      0
dialect/VhloOps.h                         | 100%      3| 100%     4|    -      0
reference/Element.cpp                     |84.8%    244|86.2%    80|    -      0
reference/Element.h                       | 100%      9| 100%     7|    -      0
reference/Errors.h                        | 0.0%      2| 0.0%     4|    -      0
reference/Index.cpp                       |77.4%     31|75.0%     4|    -      0
reference/Index.h                         |87.5%      8|80.0%     5|    -      0
reference/Interpreter.cpp                 |91.0%    122| 100%     3|    -      0
reference/Ops.cpp                         |98.8%    162| 100%    20|    -      0
reference/Tensor.cpp                      |96.5%    345|93.3%    30|    -      0
reference/Tensor.h                        | 100%      6| 100%     8|    -      0
reference/Types.cpp                       | 100%     20| 100%     6|    -      0
tests/TestUtils.cpp                       |97.7%     88| 100%    14|    -      0
tools/StablehloInterpreterMain.cpp        |90.9%     22| 100%     5|    -      0
tools/StablehloOptMain.cpp                | 100%     10| 100%     1|    -      0
transforms/StablehloLegalizeToVhlo.cpp    |96.0%    126|99.7%   352|    -      0
transforms/TypeConversion.cpp             | 100%     13| 100%     4|    -      0
transforms/TypeConversion.h               |88.1%     59|66.7%    21|    -      0
transforms/VhloLegalizeToStablehlo.cpp    |97.5%    120|99.7%   352|    -      0
transforms/VhloToVersion.cpp              |93.3%    150|83.8%    68|    -      0
================================================================================
                                    Total:|92.6%   7805|90.8%  1980|    -      0
```

If more specifics are required, use generated HTML files to figure out unhit lines:

```
./build_tools/github_actions/ci_build_stablehlo_code_coverage.sh -g ~/path-to/llvm-build/ ~/path-to/stablehlo-build/
...
Overall coverage rate:
  lines......: 92.6% (7228 of 7805 lines)
  functions..: 90.8% (1798 of 1980 functions)
HTML report at:
  /tmp/ccov/ccov_2023_01_20_18-49-10
LCOV data at:
  /tmp/ccov/ccov_2023_01_20_18-49-10/cov.info
...
```