### PR TITLE
Interpreter implementation and review guidelines

### DIFF
--- a/docs/interpreter_checklist.md
+++ b/docs/interpreter_checklist.md
@@ -7,27 +7,26 @@ those fronts alongside the interpreter implementation.
 
 1. While implementing the interpreter for an op, double check with related
    implementations (e.g.
-   <!-- markdownlint-disable line-length -->
    [hlo_interpreter](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/xla/hlo/evaluator)
-   <!-- markdownlint-enable line-length -->
    and
-   <!-- markdownlint-disable line-length -->
    [mlir_interpreter](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/compiler/xla/mlir_hlo/tools/mlir_interpreter)).
-   <!-- markdownlint-enable line-length -->
    This action item will allow mutual improvements.
+1. Make sure that the ODS follows standard [summary](https://github.com/openxla/stablehlo/issues/611).
 1. Replace the comments, related to input/output constraints, in
    the implementations, specifically for verifiers and type inference, with
-   "constraint-labels" (e.g. `Cn` in
-   <!-- markdownlint-disable line-length -->
-   [here](https://github.com/openxla/stablehlo/blob/main/docs/spec.md#constraints-2) )
-   <!-- markdownlint-enable line-length -->
-   used in the
-   <!-- markdownlint-disable line-length -->
+   some unique identifier containing "constraint-labels", e.g. `Cn` in
+   [here](https://github.com/openxla/stablehlo/blob/main/docs/spec.md#constraints-2)
+   , used in the
    [specification](https://github.com/openxla/stablehlo/blob/main/docs/spec.md).
-   <!-- markdownlint-enable line-length -->
+   The unique identifier should have the format `<op_name>_Cn`.
    This is to explicitly align all the implementations with the specification:
    the single source of truth, and help to track gaps in those implementations
    back to the spec.
+
+   **Why Unique**: The fact that the spec will be augmented with Dynamism,
+   Quantization can affect the suffix number in the constraint label or might
+   change it to something else. A unique identifier will enable faster updates
+   to comments we are planning to add here.
    1. It is OK to have a comment with multiple constraint-labels or to have
       multiple comments with the same constraint-label. It all depends on how
       the constraint-label(s) are coded in the implementations.
@@ -37,19 +36,32 @@ those fronts alongside the interpreter implementation.
 1. Make sure that the there are sufficient tests to cover for the
    implementations (e.g. verifiers, type inference, interpreter) of the
    specification. Specifically,
-   1. Write tests for an op interpreter following the
-      <!-- markdownlint-disable line-length -->
-      [testing guidelines](https://github.com/openxla/stablehlo/blob/main/docs/reference.md#testing-guidelines).
-      <!-- markdownlint-enable line-length -->
-   1. Double check that there is at least one test for each constraint in
-      verifier and type inference methods.
+   1. Regarding interpreter tests
+      1. For interpreter: Write tests following the
+         [testing guidelines](https://github.com/openxla/stablehlo/blob/main/docs/reference.md#testing-guidelines).
+      1. Add a link of the test file in the spec (e.g.
+         [More Examples](https://github.com/openxla/stablehlo/blob/main/docs/spec.md#add)).
+   1. For verifier and type inference: Affecting [this file](https://github.com/openxla/stablehlo/blob/main/stablehlo/tests/ops_stablehlo.mlir).
+      1. Make sure that there is at least one test for each constraint in
+         verifier and type inference methods. These tests will mostly be
+         negative tests exercising the fact that the constraints are not met.
+         Make sure to add at least one positive tests in case there are none.
+         Note that it is out of scope to revisit the correctness of type
+         inference as in
+         [file](https://github.com/openxla/stablehlo/blob/main/stablehlo/tests/infer_stablehlo.mlir).
+      1. Make sure that all the tests related to the op under test, are placed
+         together.
+      1. Make sure that all the tests related to the op under test, are
+         prepended with `CHECK-LABEL` lit macro.
+      1. Chose the function name of the tests using the format
+         `op_name_Cn1_Cn2_...` for a function testing constraints `Cn1`, `Cn2`
+         for op `op_name`. In cases when the proposed format does not apply,
+         keep the existing name.
 1. Locally run the
-   <!-- markdownlint-disable line-length -->
    [ccov](https://github.com/openxla/stablehlo/blob/main/build_tools/github_actions/ci_build_stablehlo_code_coverage.sh)
-   <!-- markdownlint-enable line-length -->
    tool to make sure that the followings yield >= 90% coverage. If not, then add
    tests to achieve the goal.
    1. Code and tests introduced for implementing the interpreter.
    1. The existing code and tests for verifier and type inference.
-1. Cross validate the test results of the interpreter implementation against
-   hardware. TBD
+1. Once all the items are finsihed, update the interpreter column in status.md
+   to `yes`.

--- a/docs/interpreter_checklist.md
+++ b/docs/interpreter_checklist.md
@@ -25,7 +25,6 @@ After implementing the interpreter:
    and [StablehloOps.cpp](https://github.com/openxla/stablehlo/blob/main/stablehlo/dialect/StablehloOps.cpp):
     1. Delete comments that say things like "Verify the following properties:
        ...".
-
     1. Add comments that reference constraint labels from the spec in the format
        `<op_name>_Cn`, e.g. `SliceOp_C1`, to identify which parts of verifiers
        and shape functions correspond to which constraints in the specification.
@@ -35,11 +34,9 @@ After implementing the interpreter:
         1. In case there is a mismatch between the constraints in the
            implementation VS those in the specification, make sure there is an
            open issue reflecting that discrepancy.
-
 1. In [interpreter tests](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests):
     1. Add file called `interpret_<op_mnemonic>.mlir`.
     1. Write tests following the [testing guidelines](https://github.com/openxla/stablehlo/blob/main/docs/reference.md#testing-guidelines).
-
 1. In [ops_stablehlo.mlir](https://github.com/openxla/stablehlo/blob/main/stablehlo/tests/ops_stablehlo.mlir):
     1. Make sure that there is at least one test for each constraint in
        verifier and type inference methods. These tests will mostly be
@@ -53,9 +50,9 @@ After implementing the interpreter:
     1. Make sure that all the tests related to the op under test, are
        prepended with `CHECK-LABEL` lit macro.
     1. Chose the function name of the tests using the format
-       `op_mnemonic_Cn1_Cn2_...` for a function testing constraints `Cn1`, `Cn2`
-       for op `op_mnemonic`. In cases when the proposed format does not apply,
-       keep the existing name.
+       `op_mnemonic_C1_C2_...` for a function testing constraints `C1`, `C2`,
+       etc. for op `op_mnemonic`. In cases when the proposed format does not
+       apply, keep the existing name.
     1. Once the above step is complete, sort all the tests related to the op
        under test alphabetically based on the function name.
     1. Keep adding tests until the [ccov](https://github.com/openxla/stablehlo/blob/main/build_tools/github_actions/ci_build_stablehlo_code_coverage.sh)
@@ -63,6 +60,8 @@ After implementing the interpreter:
 1. In [spec.md](link):
     1. Add a link to `interpret_<op_mnemonic>.mlir` to the "Examples" section
        (e.g. [More Examples](https://github.com/openxla/stablehlo/blob/main/docs/spec.md#add)).
-
+    1. Make sure the spec only has 1 example
+    1. Make sure the spec example test is interpretable.
+    1. The spec example is the same as what is in the ODS.
 1. In [status.md](https://github.com/openxla/stablehlo/blob/main/docs/status.md):
     1. Update the "Interpreter" column to `yes`.

--- a/docs/interpreter_checklist.md
+++ b/docs/interpreter_checklist.md
@@ -1,0 +1,55 @@
+# StableHLO Interpreter Checklist
+
+In this document, we summarize the guidelines while implementing and reviewing
+interpreter for an op. We have intentionally tied a few auxiliary action items,
+related to verifier and type inference, with the idea of making progress in
+those fronts alongside the interpreter implementation.
+
+1. While implementing the interpreter for an op, double check with related
+   implementations (e.g.
+   <!-- markdownlint-disable line-length -->
+   [hlo_interpreter](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/xla/hlo/evaluator)
+   <!-- markdownlint-enable line-length -->
+   and
+   <!-- markdownlint-disable line-length -->
+   [mlir_interpreter](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/compiler/xla/mlir_hlo/tools/mlir_interpreter)).
+   <!-- markdownlint-enable line-length -->
+   This action item will allow mutual improvements.
+1. Replace the comments, related to input/output constraints, in
+   the implementations, specifically for verifiers and type inference, with
+   "constraint-labels" (e.g. `Cn` in
+   <!-- markdownlint-disable line-length -->
+   [here](https://github.com/openxla/stablehlo/blob/main/docs/spec.md#constraints-2) )
+   <!-- markdownlint-enable line-length -->
+   used in the
+   <!-- markdownlint-disable line-length -->
+   [specification](https://github.com/openxla/stablehlo/blob/main/docs/spec.md).
+   <!-- markdownlint-enable line-length -->
+   This is to explicitly align all the implementations with the specification:
+   the single source of truth, and help to track gaps in those implementations
+   back to the spec.
+   1. It is OK to have a comment with multiple constraint-labels or to have
+      multiple comments with the same constraint-label. It all depends on how
+      the constraint-label(s) are coded in the implementations.
+   1. In case there is a mismatch between the constraints in the
+      implementation VS those in the specification, make sure there is an
+      open issue reflecting that discrepancy.
+1. Make sure that the there are sufficient tests to cover for the
+   implementations (e.g. verifiers, type inference, interpreter) of the
+   specification. Specifically,
+   1. Write tests for an op interpreter following the
+      <!-- markdownlint-disable line-length -->
+      [testing guidelines](https://github.com/openxla/stablehlo/blob/main/docs/reference.md#testing-guidelines).
+      <!-- markdownlint-enable line-length -->
+   1. Double check that there is at least one test for each constraint in
+      verifier and type inference methods.
+1. Locally run the
+   <!-- markdownlint-disable line-length -->
+   [ccov](https://github.com/openxla/stablehlo/blob/main/build_tools/github_actions/ci_build_stablehlo_code_coverage.sh)
+   <!-- markdownlint-enable line-length -->
+   tool to make sure that the followings yield >= 90% coverage. If not, then add
+   tests to achieve the goal.
+   1. Code and tests introduced for implementing the interpreter.
+   1. The existing code and tests for verifier and type inference.
+1. Cross validate the test results of the interpreter implementation against
+   hardware. TBD

--- a/docs/interpreter_checklist.md
+++ b/docs/interpreter_checklist.md
@@ -5,63 +5,64 @@ interpreter for an op. We have intentionally tied a few auxiliary action items,
 related to verifier and type inference, with the idea of making progress in
 those fronts alongside the interpreter implementation.
 
-1. While implementing the interpreter for an op, double check with related
-   implementations (e.g.
-   [hlo_interpreter](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/xla/hlo/evaluator)
-   and
-   [mlir_interpreter](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/compiler/xla/mlir_hlo/tools/mlir_interpreter)).
-   This action item will allow mutual improvements.
-1. Make sure that the ODS follows standard [summary](https://github.com/openxla/stablehlo/issues/611).
-1. Replace the comments, related to input/output constraints, in
-   the implementations, specifically for verifiers and type inference, with
-   some unique identifier containing "constraint-labels", e.g. `Cn` in
-   [here](https://github.com/openxla/stablehlo/blob/main/docs/spec.md#constraints-2)
-   , used in the
-   [specification](https://github.com/openxla/stablehlo/blob/main/docs/spec.md).
-   The unique identifier should have the format `<op_name>_Cn`.
-   This is to explicitly align all the implementations with the specification:
-   the single source of truth, and help to track gaps in those implementations
-   back to the spec.
+While implementing the interpreter:
 
-   **Why Unique**: The fact that the spec will be augmented with Dynamism,
-   Quantization can affect the suffix number in the constraint label or might
-   change it to something else. A unique identifier will enable faster updates
-   to comments we are planning to add here.
-   1. It is OK to have a comment with multiple constraint-labels or to have
-      multiple comments with the same constraint-label. It all depends on how
-      the constraint-label(s) are coded in the implementations.
-   1. In case there is a mismatch between the constraints in the
-      implementation VS those in the specification, make sure there is an
-      open issue reflecting that discrepancy.
-1. Make sure that the there are sufficient tests to cover for the
-   implementations (e.g. verifiers, type inference, interpreter) of the
-   specification. Specifically,
-   1. Regarding interpreter tests
-      1. For interpreter: Write tests following the
-         [testing guidelines](https://github.com/openxla/stablehlo/blob/main/docs/reference.md#testing-guidelines).
-      1. Add a link of the test file in the spec (e.g.
-         [More Examples](https://github.com/openxla/stablehlo/blob/main/docs/spec.md#add)).
-   1. For verifier and type inference: Affecting [this file](https://github.com/openxla/stablehlo/blob/main/stablehlo/tests/ops_stablehlo.mlir).
-      1. Make sure that there is at least one test for each constraint in
-         verifier and type inference methods. These tests will mostly be
-         negative tests exercising the fact that the constraints are not met.
-         Make sure to add at least one positive tests in case there are none.
-         Note that it is out of scope to revisit the correctness of type
-         inference as in
-         [file](https://github.com/openxla/stablehlo/blob/main/stablehlo/tests/infer_stablehlo.mlir).
-      1. Make sure that all the tests related to the op under test, are placed
-         together.
-      1. Make sure that all the tests related to the op under test, are
-         prepended with `CHECK-LABEL` lit macro.
-      1. Chose the function name of the tests using the format
-         `op_name_Cn1_Cn2_...` for a function testing constraints `Cn1`, `Cn2`
-         for op `op_name`. In cases when the proposed format does not apply,
-         keep the existing name.
-1. Locally run the
-   [ccov](https://github.com/openxla/stablehlo/blob/main/build_tools/github_actions/ci_build_stablehlo_code_coverage.sh)
-   tool to make sure that the followings yield >= 90% coverage. If not, then add
-   tests to achieve the goal.
-   1. Code and tests introduced for implementing the interpreter.
-   1. The existing code and tests for verifier and type inference.
-1. Once all the items are finsihed, update the interpreter column in status.md
-   to `yes`.
+1. Consult
+   [hlo_evaluator](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/xla/hlo/evaluator)
+   and
+   [mlir_interpreter](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/compiler/xla/mlir_hlo/tools/mlir_interpreter)
+   to identify tricky implementation details and potential functionality gaps.
+1. File tickets for the corresponding software components if you find any bugs
+   or missing functionality.
+
+After implementing the interpreter:
+
+1. In [StablehloOps.td](https://github.com/openxla/stablehlo/blob/main/stablehlo/dialect/StablehloOps.td):
+    1. Make sure that the `summary` in op's ODS follows the standard format.
+       (related [ticket](https://github.com/openxla/stablehlo/issues/611))
+
+1. In [TypeInference.cpp](https://github.com/openxla/stablehlo/blob/main/stablehlo/dialect/TypeInference.cpp)
+   and [StablehloOps.cpp](https://github.com/openxla/stablehlo/blob/main/stablehlo/dialect/StablehloOps.cpp):
+    1. Delete comments that say things like "Verify the following properties:
+       ...".
+
+    1. Add comments that reference constraint labels from the spec in the format
+       `<op_name>_Cn`, e.g. `SliceOp_C1`, to identify which parts of verifiers
+       and shape functions correspond to which constraints in the specification.
+        1. It is OK to have a comment with multiple constraint labels or to have
+           multiple comments with the same constraint label. It all depends on
+           how the constraints are implemented.
+        1. In case there is a mismatch between the constraints in the
+           implementation VS those in the specification, make sure there is an
+           open issue reflecting that discrepancy.
+
+1. In [interpreter tests](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests):
+    1. Add file called `interpret_<op_mnemonic>.mlir`.
+    1. Write tests following the [testing guidelines](https://github.com/openxla/stablehlo/blob/main/docs/reference.md#testing-guidelines).
+
+1. In [ops_stablehlo.mlir](https://github.com/openxla/stablehlo/blob/main/stablehlo/tests/ops_stablehlo.mlir):
+    1. Make sure that there is at least one test for each constraint in
+       verifier and type inference methods. These tests will mostly be
+       negative tests exercising the fact that the constraints are not met.
+       Make sure to add at least one positive tests in case there are none.
+       Note that it is out of scope to revisit the correctness of type
+       inference as in
+       [file](https://github.com/openxla/stablehlo/blob/main/stablehlo/tests/infer_stablehlo.mlir).
+    1. Make sure that all the tests related to the op under test, are placed
+       together.
+    1. Make sure that all the tests related to the op under test, are
+       prepended with `CHECK-LABEL` lit macro.
+    1. Chose the function name of the tests using the format
+       `op_mnemonic_Cn1_Cn2_...` for a function testing constraints `Cn1`, `Cn2`
+       for op `op_mnemonic`. In cases when the proposed format does not apply,
+       keep the existing name.
+    1. Once the above step is complete, sort all the tests related to the op
+       under test alphabetically based on the function name.
+    1. Keep adding tests until the [ccov](https://github.com/openxla/stablehlo/blob/main/build_tools/github_actions/ci_build_stablehlo_code_coverage.sh)
+       shows >= 90% coverage for the op.
+1. In [spec.md](link):
+    1. Add a link to `interpret_<op_mnemonic>.mlir` to the "Examples" section
+       (e.g. [More Examples](https://github.com/openxla/stablehlo/blob/main/docs/spec.md#add)).
+
+1. In [status.md](https://github.com/openxla/stablehlo/blob/main/docs/status.md):
+    1. Update the "Interpreter" column to `yes`.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -196,3 +196,9 @@ different precision than what is mentioned in the lit CHECK directives. As a
 quick-fix, we allow the lit checks to measure the accuracy up to an arbitrary
 places after the decimal point. But the solution is far from ideal. We plan to
 resolve it using [ticket](https://github.com/openxla/stablehlo/issues/268).
+
+**(G6) Anything about the coding-style of the tests?**
+
+1. Make sure to use the actual name of the inputs/outputs instead of defaulting
+   to SSA values (e.g. %0, %1, etc.)
+1. Make sure the tests use pretty-printed format, if it exists.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -153,10 +153,10 @@ We can use a combination of following rules to decide it:
    representative test. To avoid ambiguity in selecting the representative, we
    should use the following guidelines:
 
-     - If all the types, handled uniformaly, have the same primitive type
+     - If all the types, handled uniformly, have the same primitive type
        (i.e., if all are integer, or floating-point, or complex types), then
        choose the one with maximum bit-width.
-     - If all the types, handled uniformaly, have a mix of primitive types, then
+     - If all the types, handled uniformly, have a mix of primitive types, then
        choose the one with the following primitive type, in decreasing order of
        preference: integer, floating-point, boolean, complex.
 
@@ -202,3 +202,6 @@ resolve it using [ticket](https://github.com/openxla/stablehlo/issues/268).
 1. Make sure to use the actual name of the inputs/outputs instead of defaulting
    to SSA values (e.g. %0, %1, etc.)
 1. Make sure the tests use pretty-printed format, if it exists.
+
+**(G7) Should we include the example already provided in the spec?**
+Yes (for completeness of testing).


### PR DESCRIPTION
Provides a doc to be followed while introducing the interpreter implementation of an op. 

Added @GleasonK.
Can you please take a look the the item related to running the `ccov`. 