### PR TITLE
Remove InferReturnTypeComponents test pattern from hlo_test_infer.

### DIFF
--- a/stablehlo/tests/TestUtils.cpp
+++ b/stablehlo/tests/TestUtils.cpp
@@ -74,49 +74,6 @@ struct InferReturnTypesPattern : public RewritePattern {
   }
 };
 
-struct InferReturnTypeComponentsPattern : public RewritePattern {
-  explicit InferReturnTypeComponentsPattern(MLIRContext *context)
-      : RewritePattern("hlo_test_infer.get_return_type_components", 1,
-                       context) {}
-  LogicalResult matchAndRewrite(Operation *op,
-                                PatternRewriter &rewriter) const override {
-    if (op->getNumOperands() != 1) return failure();
-    auto *definingOp = op->getOperand(0).getDefiningOp();
-    auto definingOpInt =
-        llvm::dyn_cast_or_null<InferShapedTypeOpInterface>(definingOp);
-    if (!definingOpInt) return failure();
-    SmallVector<ShapedTypeComponents, 4> components;
-    if (failed(definingOpInt.inferReturnTypeComponents(
-            op->getContext(), op->getLoc(), definingOp->getOperands(),
-            definingOp->getAttrDictionary(), definingOp->getRegions(),
-            components))) {
-      return failure();
-    }
-
-    // Replace the op with another pass-through op with attributes added.
-    OperationState state(op->getLoc(), "hlo_test_infer.return_type_components",
-                         op->getOperands(), op->getResultTypes(),
-                         op->getAttrs());
-    auto *newOp = rewriter.create(state);
-    for (const auto &it : llvm::enumerate(components)) {
-      if (it.value().hasRank()) {
-        newOp->setAttr(
-            (StringRef("dims") + Twine(it.index())).str(),
-            rewriter.getStringAttr(dimSizesToString(it.value().getDims())));
-        if (it.value().getAttribute())
-          newOp->setAttr((StringRef("bounds") + Twine(it.index())).str(),
-                         it.value().getAttribute());
-      }
-      if (it.value().getElementType()) {
-        newOp->setAttr((Twine("element_type") + Twine(it.index())).str(),
-                       TypeAttr::get(it.value().getElementType()));
-      }
-    }
-    rewriter.replaceOp(op, {newOp->getResults()});
-    return success();
-  }
-};
-
 struct ReifyReturnTypeShapesPattern : public RewritePattern {
   explicit ReifyReturnTypeShapesPattern(MLIRContext *context)
       : RewritePattern("hlo_test_infer.reify_return_type_shapes", 1, context) {}
@@ -143,7 +100,6 @@ struct HloTestInferPass : public impl::HloTestInferPassBase<HloTestInferPass> {
   void runOnOperation() override {
     RewritePatternSet patterns(&getContext());
     patterns.add<InferReturnTypesPattern>(&getContext());
-    patterns.add<InferReturnTypeComponentsPattern>(&getContext());
     patterns.add<ReifyReturnTypeShapesPattern>(&getContext());
     if (failed(applyPatternsAndFoldGreedily(getOperation(),
                                             std::move(patterns)))) {

--- a/stablehlo/tests/infer_chlo.mlir
+++ b/stablehlo/tests/infer_chlo.mlir
@@ -19,8 +19,8 @@ func.func @broadcast_add_reify(%arg0: tensor<?xf32>, %arg1: tensor<?xf32>) -> te
 // CHECK-LABEL: @broadcast_add_different_operand_size
 func.func @broadcast_add_different_operand_size(%arg1: tensor<1xi32>, %arg2: tensor<1x2xi32>) -> tensor<1x2xi32> {
   %0 = "chlo.broadcast_add"(%arg1, %arg2) {broadcast_dimensions = dense<1> : tensor<i64>} : (tensor<1xi32>, tensor<1x2xi32>) -> tensor<1x2xi32>
-  // CHECK: "hlo_test_infer.return_type_components"(%0) {dims0 = "[1, 2]", element_type0 = i32}
-  %1 = "hlo_test_infer.get_return_type_components"(%0) : (tensor<1x2xi32>) -> tensor<1x2xi32>
+  // CHECK: {types0 = tensor<1x2xi32>}
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<1x2xi32>) -> tensor<1x2xi32>
   return %1: tensor<1x2xi32>
 }
 
@@ -28,8 +28,8 @@ func.func @broadcast_add_different_operand_size(%arg1: tensor<1xi32>, %arg2: ten
 // CHECK-LABEL: @broadcast_complex_ranked_components
 func.func @broadcast_complex_ranked_components(%arg0: tensor<?xf32>, %arg1: tensor<?x?xf32>) -> tensor<?x?xcomplex<f32>> {
   %0 = chlo.broadcast_complex %arg0, %arg1 : (tensor<?xf32>, tensor<?x?xf32>) -> tensor<?x?xcomplex<f32>>
-  // CHECK: "hlo_test_infer.return_type_components"(%0) {dims0 = "[?, ?]", element_type0 = complex<f32>}
-  %1 = "hlo_test_infer.get_return_type_components"(%0) : (tensor<?x?xcomplex<f32>>) -> tensor<?x?xcomplex<f32>>
+  // CHECK: {types0 = tensor<?x?xcomplex<f32>>}
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<?x?xcomplex<f32>>) -> tensor<?x?xcomplex<f32>>
   func.return %1 : tensor<?x?xcomplex<f32>>
 }
 
@@ -48,7 +48,7 @@ func.func @broadcast_complex_reify(%arg0: tensor<?xf32>, %arg1: tensor<?x?xf32>)
 func.func @broadcast_complex_mismatch(%arg0: tensor<2xf64>, %arg1: tensor<2xf32>) -> tensor<2xcomplex<f32>> {
   // expected-error @+1 {{mismatched operand types}}
   %0 = "chlo.broadcast_complex"(%arg0, %arg1) : (tensor<2xf64>, tensor<2xf32>) -> tensor<2xcomplex<f32>>
-  %1 = "hlo_test_infer.get_return_type_components"(%0) : (tensor<2xcomplex<f32>>) -> tensor<2xcomplex<f32>>
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<2xcomplex<f32>>) -> tensor<2xcomplex<f32>>
   return %0: tensor<2xcomplex<f32>>
 }
 
@@ -56,8 +56,8 @@ func.func @broadcast_complex_mismatch(%arg0: tensor<2xf64>, %arg1: tensor<2xf32>
 // CHECK-LABEL: @broadcast_compare_ranked_components
 func.func @broadcast_compare_ranked_components(%arg0: tensor<?xf32>, %arg1: tensor<?x?xf32>) -> tensor<?x?xi1> {
   %0 = chlo.broadcast_compare %arg0, %arg1 {comparison_direction = #chlo<comparison_direction EQ>} : (tensor<?xf32>, tensor<?x?xf32>) -> tensor<?x?xi1>
-  // CHECK: "hlo_test_infer.return_type_components"(%0) {dims0 = "[?, ?]", element_type0 = i1}
-  %1 = "hlo_test_infer.get_return_type_components"(%0) : (tensor<?x?xi1>) -> tensor<?x?xi1>
+  // CHECK: {types0 = tensor<?x?xi1>}
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<?x?xi1>) -> tensor<?x?xi1>
   func.return %0 : tensor<?x?xi1>
 }
 
@@ -93,8 +93,8 @@ func.func @broadcast_add_ranked_components_r1(%arg0: tensor<?xf32>, %arg1: tenso
 // CHECK-LABEL: @broadcast_add_ranked_components_r1x2
 func.func @broadcast_add_ranked_components_r1x2(%arg0: tensor<?xf32>, %arg1: tensor<?x3xf32>) -> tensor<?x3xf32> {
   %0 = chlo.broadcast_add %arg0, %arg1 : (tensor<?xf32>, tensor<?x3xf32>) -> tensor<?x3xf32>
-  // CHECK: "hlo_test_infer.return_type_components"(%0) {dims0 = "[?, 3]", element_type0 = f32}
-  %1 = "hlo_test_infer.get_return_type_components"(%0) : (tensor<?x3xf32>) -> tensor<?x3xf32>
+  // CHECK: {types0 = tensor<?x3xf32>}
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<?x3xf32>) -> tensor<?x3xf32>
   func.return %1 : tensor<?x3xf32>
 }
 
@@ -102,8 +102,8 @@ func.func @broadcast_add_ranked_components_r1x2(%arg0: tensor<?xf32>, %arg1: ten
 // CHECK-LABEL: @broadcast_add_ranked_components_with_zero_r1x2
 func.func @broadcast_add_ranked_components_with_zero_r1x2(%arg0: tensor<0xf32>, %arg1: tensor<?x1xf32>) -> tensor<?x0xf32> {
   %0 = chlo.broadcast_add %arg0, %arg1 : (tensor<0xf32>, tensor<?x1xf32>) -> tensor<?x0xf32>
-  // CHECK: "hlo_test_infer.return_type_components"(%0) {dims0 = "[?, 0]", element_type0 = f32}
-  %1 = "hlo_test_infer.get_return_type_components"(%0) : (tensor<?x0xf32>) -> tensor<?x0xf32>
+  // CHECK: {types0 = tensor<?x0xf32>}
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<?x0xf32>) -> tensor<?x0xf32>
   func.return %1 : tensor<?x0xf32>
 }
 
@@ -111,7 +111,7 @@ func.func @broadcast_add_ranked_components_with_zero_r1x2(%arg0: tensor<0xf32>, 
 func.func @broadcast_select_branch_mismatch(%arg0: tensor<2xi1>, %arg1: tensor<2xi32>, %arg2: tensor<2xf32>) -> tensor<2xi32> {
   // expected-error @+1 {{mismatched operand types}}
   %0 = "chlo.broadcast_select"(%arg0, %arg1, %arg2) : (tensor<2xi1>, tensor<2xi32>, tensor<2xf32>) -> tensor<2xi32>
-  %1 = "hlo_test_infer.get_return_type_components"(%0) : (tensor<2xi32>) -> tensor<2xi32>
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<2xi32>) -> tensor<2xi32>
   return %0: tensor<2xi32>
 }
 
@@ -140,8 +140,8 @@ func.func @constant_ranked() -> (tensor<i32>) {
 // CHECK-LABEL: @constant_like_ranked
 func.func @constant_like_ranked(%arg0: tensor<1x?xi64>) -> (tensor<1x?xf32>) {
   %0 = "chlo.constant_like"(%arg0) { value = 3.2 : f32 } : (tensor<1x?xi64>) -> tensor<1x?xf32>
-  // CHECK: "hlo_test_infer.return_type_components"(%0) {dims0 = "[1, ?]", element_type0 = f32}
-  %1 = "hlo_test_infer.get_return_type_components"(%0) : (tensor<1x?xf32>) -> tensor<1x?xf32>
+  // CHECK: {types0 = tensor<1x?xf32>}
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<1x?xf32>) -> tensor<1x?xf32>
   func.return %1 : tensor<1x?xf32>
 }
 
@@ -149,8 +149,8 @@ func.func @constant_like_ranked(%arg0: tensor<1x?xi64>) -> (tensor<1x?xf32>) {
 // CHECK-LABEL: @constant_like_unranked
 func.func @constant_like_unranked(%arg0: tensor<*xi64>) -> (tensor<*xf32>) {
   %0 = "chlo.constant_like"(%arg0) { value = 3.2 : f32 } : (tensor<*xi64>) -> tensor<*xf32>
-  // CHECK: "hlo_test_infer.return_type_components"(%0) {element_type0 = f32}
-  %1 = "hlo_test_infer.get_return_type_components"(%0) : (tensor<*xf32>) -> tensor<*xf32>
+  // CHECK: {types0 = tensor<*xf32>}
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xf32>) -> tensor<*xf32>
   func.return %1 : tensor<*xf32>
 }
 
@@ -199,41 +199,41 @@ func.func @infer_type_components_from_operands(%arg : tensor<2xf32>) -> tensor<2
   %15 = "chlo.sinh"(%14) : (tensor<2xf32>) -> tensor<2xf32>
   %16 = "chlo.tan"(%15) : (tensor<2xf32>) -> tensor<2xf32>
   %17 = "chlo.zeta"(%16, %16) : (tensor<2xf32>, tensor<2xf32>) -> tensor<2xf32>
-  // CHECK:      "hlo_test_infer.return_type_components"(%0) {dims0 = "[2]", element_type0 = f32}
-  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%1) {dims0 = "[2]", element_type0 = f32}
-  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%2) {dims0 = "[2]", element_type0 = f32}
-  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%3) {dims0 = "[2]", element_type0 = f32}
-  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%4) {dims0 = "[2]", element_type0 = f32}
-  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%5) {dims0 = "[2]", element_type0 = f32}
-  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%6) {dims0 = "[2]", element_type0 = f32}
-  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%7) {dims0 = "[2]", element_type0 = f32}
-  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%8) {dims0 = "[2]", element_type0 = f32}
-  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%9) {dims0 = "[2]", element_type0 = f32}
-  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%10) {dims0 = "[2]", element_type0 = f32}
-  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%11) {dims0 = "[2]", element_type0 = f32}
-  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%12) {dims0 = "[2]", element_type0 = f32}
-  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%13) {dims0 = "[2]", element_type0 = f32}
-  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%14) {dims0 = "[2]", element_type0 = f32}
-  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%15) {dims0 = "[2]", element_type0 = f32}
-  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%16) {dims0 = "[2]", element_type0 = f32}
-  // CHECK-NEXT: "hlo_test_infer.return_type_components"(%17) {dims0 = "[2]", element_type0 = f32}
-  %r0 = "hlo_test_infer.get_return_type_components"(%0) : (tensor<2xf32>) -> tensor<2xf32>
-  %r1 = "hlo_test_infer.get_return_type_components"(%1) : (tensor<2xf32>) -> tensor<2xf32>
-  %r2 = "hlo_test_infer.get_return_type_components"(%2) : (tensor<2xf32>) -> tensor<2xf32>
-  %r3 = "hlo_test_infer.get_return_type_components"(%3) : (tensor<2xf32>) -> tensor<2xf32>
-  %r4 = "hlo_test_infer.get_return_type_components"(%4) : (tensor<2xf32>) -> tensor<2xf32>
-  %r5 = "hlo_test_infer.get_return_type_components"(%5) : (tensor<2xf32>) -> tensor<2xf32>
-  %r6 = "hlo_test_infer.get_return_type_components"(%6) : (tensor<2xf32>) -> tensor<2xf32>
-  %r7 = "hlo_test_infer.get_return_type_components"(%7) : (tensor<2xf32>) -> tensor<2xf32>
-  %r8 = "hlo_test_infer.get_return_type_components"(%8) : (tensor<2xf32>) -> tensor<2xf32>
-  %r9 = "hlo_test_infer.get_return_type_components"(%9) : (tensor<2xf32>) -> tensor<2xf32>
-  %r10 = "hlo_test_infer.get_return_type_components"(%10) : (tensor<2xf32>) -> tensor<2xf32>
-  %r11 = "hlo_test_infer.get_return_type_components"(%11) : (tensor<2xf32>) -> tensor<2xf32>
-  %r12 = "hlo_test_infer.get_return_type_components"(%12) : (tensor<2xf32>) -> tensor<2xf32>
-  %r13 = "hlo_test_infer.get_return_type_components"(%13) : (tensor<2xf32>) -> tensor<2xf32>
-  %r14 = "hlo_test_infer.get_return_type_components"(%14) : (tensor<2xf32>) -> tensor<2xf32>
-  %r15 = "hlo_test_infer.get_return_type_components"(%15) : (tensor<2xf32>) -> tensor<2xf32>
-  %r16 = "hlo_test_infer.get_return_type_components"(%16) : (tensor<2xf32>) -> tensor<2xf32>
-  %r17 = "hlo_test_infer.get_return_type_components"(%17) : (tensor<2xf32>) -> tensor<2xf32>
+  // CHECK: {types0 = tensor<2xf32>}
+  // CHECK-NEXT: {types0 = tensor<2xf32>}
+  // CHECK-NEXT: {types0 = tensor<2xf32>}
+  // CHECK-NEXT: {types0 = tensor<2xf32>}
+  // CHECK-NEXT: {types0 = tensor<2xf32>}
+  // CHECK-NEXT: {types0 = tensor<2xf32>}
+  // CHECK-NEXT: {types0 = tensor<2xf32>}
+  // CHECK-NEXT: {types0 = tensor<2xf32>}
+  // CHECK-NEXT: {types0 = tensor<2xf32>}
+  // CHECK-NEXT: {types0 = tensor<2xf32>}
+  // CHECK-NEXT: {types0 = tensor<2xf32>}
+  // CHECK-NEXT: {types0 = tensor<2xf32>}
+  // CHECK-NEXT: {types0 = tensor<2xf32>}
+  // CHECK-NEXT: {types0 = tensor<2xf32>}
+  // CHECK-NEXT: {types0 = tensor<2xf32>}
+  // CHECK-NEXT: {types0 = tensor<2xf32>}
+  // CHECK-NEXT: {types0 = tensor<2xf32>}
+  // CHECK-NEXT: {types0 = tensor<2xf32>}
+  %r0 = "hlo_test_infer.get_return_types"(%0) : (tensor<2xf32>) -> tensor<2xf32>
+  %r1 = "hlo_test_infer.get_return_types"(%1) : (tensor<2xf32>) -> tensor<2xf32>
+  %r2 = "hlo_test_infer.get_return_types"(%2) : (tensor<2xf32>) -> tensor<2xf32>
+  %r3 = "hlo_test_infer.get_return_types"(%3) : (tensor<2xf32>) -> tensor<2xf32>
+  %r4 = "hlo_test_infer.get_return_types"(%4) : (tensor<2xf32>) -> tensor<2xf32>
+  %r5 = "hlo_test_infer.get_return_types"(%5) : (tensor<2xf32>) -> tensor<2xf32>
+  %r6 = "hlo_test_infer.get_return_types"(%6) : (tensor<2xf32>) -> tensor<2xf32>
+  %r7 = "hlo_test_infer.get_return_types"(%7) : (tensor<2xf32>) -> tensor<2xf32>
+  %r8 = "hlo_test_infer.get_return_types"(%8) : (tensor<2xf32>) -> tensor<2xf32>
+  %r9 = "hlo_test_infer.get_return_types"(%9) : (tensor<2xf32>) -> tensor<2xf32>
+  %r10 = "hlo_test_infer.get_return_types"(%10) : (tensor<2xf32>) -> tensor<2xf32>
+  %r11 = "hlo_test_infer.get_return_types"(%11) : (tensor<2xf32>) -> tensor<2xf32>
+  %r12 = "hlo_test_infer.get_return_types"(%12) : (tensor<2xf32>) -> tensor<2xf32>
+  %r13 = "hlo_test_infer.get_return_types"(%13) : (tensor<2xf32>) -> tensor<2xf32>
+  %r14 = "hlo_test_infer.get_return_types"(%14) : (tensor<2xf32>) -> tensor<2xf32>
+  %r15 = "hlo_test_infer.get_return_types"(%15) : (tensor<2xf32>) -> tensor<2xf32>
+  %r16 = "hlo_test_infer.get_return_types"(%16) : (tensor<2xf32>) -> tensor<2xf32>
+  %r17 = "hlo_test_infer.get_return_types"(%17) : (tensor<2xf32>) -> tensor<2xf32>
   func.return %r17 : tensor<2xf32>
 }

--- a/stablehlo/tests/infer_chlo.mlir
+++ b/stablehlo/tests/infer_chlo.mlir
@@ -19,7 +19,7 @@ func.func @broadcast_add_reify(%arg0: tensor<?xf32>, %arg1: tensor<?xf32>) -> te
 // CHECK-LABEL: @broadcast_add_different_operand_size
 func.func @broadcast_add_different_operand_size(%arg1: tensor<1xi32>, %arg2: tensor<1x2xi32>) -> tensor<1x2xi32> {
   %0 = "chlo.broadcast_add"(%arg1, %arg2) {broadcast_dimensions = dense<1> : tensor<i64>} : (tensor<1xi32>, tensor<1x2xi32>) -> tensor<1x2xi32>
-  // CHECK: {types0 = tensor<1x2xi32>}
+  // CHECK: types0 = tensor<1x2xi32>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<1x2xi32>) -> tensor<1x2xi32>
   return %1: tensor<1x2xi32>
 }
@@ -28,7 +28,7 @@ func.func @broadcast_add_different_operand_size(%arg1: tensor<1xi32>, %arg2: ten
 // CHECK-LABEL: @broadcast_complex_ranked_components
 func.func @broadcast_complex_ranked_components(%arg0: tensor<?xf32>, %arg1: tensor<?x?xf32>) -> tensor<?x?xcomplex<f32>> {
   %0 = chlo.broadcast_complex %arg0, %arg1 : (tensor<?xf32>, tensor<?x?xf32>) -> tensor<?x?xcomplex<f32>>
-  // CHECK: {types0 = tensor<?x?xcomplex<f32>>}
+  // CHECK: types0 = tensor<?x?xcomplex<f32>>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<?x?xcomplex<f32>>) -> tensor<?x?xcomplex<f32>>
   func.return %1 : tensor<?x?xcomplex<f32>>
 }
@@ -56,7 +56,7 @@ func.func @broadcast_complex_mismatch(%arg0: tensor<2xf64>, %arg1: tensor<2xf32>
 // CHECK-LABEL: @broadcast_compare_ranked_components
 func.func @broadcast_compare_ranked_components(%arg0: tensor<?xf32>, %arg1: tensor<?x?xf32>) -> tensor<?x?xi1> {
   %0 = chlo.broadcast_compare %arg0, %arg1 {comparison_direction = #chlo<comparison_direction EQ>} : (tensor<?xf32>, tensor<?x?xf32>) -> tensor<?x?xi1>
-  // CHECK: {types0 = tensor<?x?xi1>}
+  // CHECK: types0 = tensor<?x?xi1>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<?x?xi1>) -> tensor<?x?xi1>
   func.return %0 : tensor<?x?xi1>
 }
@@ -93,7 +93,7 @@ func.func @broadcast_add_ranked_components_r1(%arg0: tensor<?xf32>, %arg1: tenso
 // CHECK-LABEL: @broadcast_add_ranked_components_r1x2
 func.func @broadcast_add_ranked_components_r1x2(%arg0: tensor<?xf32>, %arg1: tensor<?x3xf32>) -> tensor<?x3xf32> {
   %0 = chlo.broadcast_add %arg0, %arg1 : (tensor<?xf32>, tensor<?x3xf32>) -> tensor<?x3xf32>
-  // CHECK: {types0 = tensor<?x3xf32>}
+  // CHECK: types0 = tensor<?x3xf32>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<?x3xf32>) -> tensor<?x3xf32>
   func.return %1 : tensor<?x3xf32>
 }
@@ -102,7 +102,7 @@ func.func @broadcast_add_ranked_components_r1x2(%arg0: tensor<?xf32>, %arg1: ten
 // CHECK-LABEL: @broadcast_add_ranked_components_with_zero_r1x2
 func.func @broadcast_add_ranked_components_with_zero_r1x2(%arg0: tensor<0xf32>, %arg1: tensor<?x1xf32>) -> tensor<?x0xf32> {
   %0 = chlo.broadcast_add %arg0, %arg1 : (tensor<0xf32>, tensor<?x1xf32>) -> tensor<?x0xf32>
-  // CHECK: {types0 = tensor<?x0xf32>}
+  // CHECK: types0 = tensor<?x0xf32>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<?x0xf32>) -> tensor<?x0xf32>
   func.return %1 : tensor<?x0xf32>
 }
@@ -131,7 +131,7 @@ func.func @broadcast_select_reify(%arg0: tensor<2xi1>, %arg1: tensor<?xi32>, %ar
 // CHECK-LABEL: @constant_ranked
 func.func @constant_ranked() -> (tensor<i32>) {
   %0 = "chlo.constant"() { value = dense<1> : tensor<i32> } : () -> tensor<i32>
-  // CHECK: "hlo_test_infer.return_types"(%0) {types0 = tensor<i32>}
+  // CHECK: types0 = tensor<i32>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<i32>) -> tensor<i32>
   func.return %1 : tensor<i32>
 }
@@ -140,7 +140,7 @@ func.func @constant_ranked() -> (tensor<i32>) {
 // CHECK-LABEL: @constant_like_ranked
 func.func @constant_like_ranked(%arg0: tensor<1x?xi64>) -> (tensor<1x?xf32>) {
   %0 = "chlo.constant_like"(%arg0) { value = 3.2 : f32 } : (tensor<1x?xi64>) -> tensor<1x?xf32>
-  // CHECK: {types0 = tensor<1x?xf32>}
+  // CHECK: types0 = tensor<1x?xf32>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<1x?xf32>) -> tensor<1x?xf32>
   func.return %1 : tensor<1x?xf32>
 }
@@ -149,7 +149,7 @@ func.func @constant_like_ranked(%arg0: tensor<1x?xi64>) -> (tensor<1x?xf32>) {
 // CHECK-LABEL: @constant_like_unranked
 func.func @constant_like_unranked(%arg0: tensor<*xi64>) -> (tensor<*xf32>) {
   %0 = "chlo.constant_like"(%arg0) { value = 3.2 : f32 } : (tensor<*xi64>) -> tensor<*xf32>
-  // CHECK: {types0 = tensor<*xf32>}
+  // CHECK: types0 = tensor<*xf32>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xf32>) -> tensor<*xf32>
   func.return %1 : tensor<*xf32>
 }
@@ -169,9 +169,9 @@ func.func @is_inf_ops_return_types(%arg : tensor<f32>) -> tensor<i1> {
   %0 = chlo.is_inf %arg : tensor<f32> -> tensor<i1>
   %1 = chlo.is_neg_inf %arg : tensor<f32> -> tensor<i1>
   %2 = chlo.is_pos_inf %arg : tensor<f32> -> tensor<i1>
-  // CHECK:      "hlo_test_infer.return_types"(%0) {types0 = tensor<i1>}
-  // CHECK-NEXT: "hlo_test_infer.return_types"(%1) {types0 = tensor<i1>}
-  // CHECK-NEXT: "hlo_test_infer.return_types"(%2) {types0 = tensor<i1>}
+  // CHECK:      types0 = tensor<i1>
+  // CHECK-NEXT: types0 = tensor<i1>
+  // CHECK-NEXT: types0 = tensor<i1>
   %3 = "hlo_test_infer.get_return_types"(%0) : (tensor<i1>) -> tensor<i1>
   %4 = "hlo_test_infer.get_return_types"(%1) : (tensor<i1>) -> tensor<i1>
   %5 = "hlo_test_infer.get_return_types"(%2) : (tensor<i1>) -> tensor<i1>
@@ -199,24 +199,24 @@ func.func @infer_type_components_from_operands(%arg : tensor<2xf32>) -> tensor<2
   %15 = "chlo.sinh"(%14) : (tensor<2xf32>) -> tensor<2xf32>
   %16 = "chlo.tan"(%15) : (tensor<2xf32>) -> tensor<2xf32>
   %17 = "chlo.zeta"(%16, %16) : (tensor<2xf32>, tensor<2xf32>) -> tensor<2xf32>
-  // CHECK: {types0 = tensor<2xf32>}
-  // CHECK-NEXT: {types0 = tensor<2xf32>}
-  // CHECK-NEXT: {types0 = tensor<2xf32>}
-  // CHECK-NEXT: {types0 = tensor<2xf32>}
-  // CHECK-NEXT: {types0 = tensor<2xf32>}
-  // CHECK-NEXT: {types0 = tensor<2xf32>}
-  // CHECK-NEXT: {types0 = tensor<2xf32>}
-  // CHECK-NEXT: {types0 = tensor<2xf32>}
-  // CHECK-NEXT: {types0 = tensor<2xf32>}
-  // CHECK-NEXT: {types0 = tensor<2xf32>}
-  // CHECK-NEXT: {types0 = tensor<2xf32>}
-  // CHECK-NEXT: {types0 = tensor<2xf32>}
-  // CHECK-NEXT: {types0 = tensor<2xf32>}
-  // CHECK-NEXT: {types0 = tensor<2xf32>}
-  // CHECK-NEXT: {types0 = tensor<2xf32>}
-  // CHECK-NEXT: {types0 = tensor<2xf32>}
-  // CHECK-NEXT: {types0 = tensor<2xf32>}
-  // CHECK-NEXT: {types0 = tensor<2xf32>}
+  // CHECK: types0 = tensor<2xf32>
+  // CHECK-NEXT: types0 = tensor<2xf32>
+  // CHECK-NEXT: types0 = tensor<2xf32>
+  // CHECK-NEXT: types0 = tensor<2xf32>
+  // CHECK-NEXT: types0 = tensor<2xf32>
+  // CHECK-NEXT: types0 = tensor<2xf32>
+  // CHECK-NEXT: types0 = tensor<2xf32>
+  // CHECK-NEXT: types0 = tensor<2xf32>
+  // CHECK-NEXT: types0 = tensor<2xf32>
+  // CHECK-NEXT: types0 = tensor<2xf32>
+  // CHECK-NEXT: types0 = tensor<2xf32>
+  // CHECK-NEXT: types0 = tensor<2xf32>
+  // CHECK-NEXT: types0 = tensor<2xf32>
+  // CHECK-NEXT: types0 = tensor<2xf32>
+  // CHECK-NEXT: types0 = tensor<2xf32>
+  // CHECK-NEXT: types0 = tensor<2xf32>
+  // CHECK-NEXT: types0 = tensor<2xf32>
+  // CHECK-NEXT: types0 = tensor<2xf32>
   %r0 = "hlo_test_infer.get_return_types"(%0) : (tensor<2xf32>) -> tensor<2xf32>
   %r1 = "hlo_test_infer.get_return_types"(%1) : (tensor<2xf32>) -> tensor<2xf32>
   %r2 = "hlo_test_infer.get_return_types"(%2) : (tensor<2xf32>) -> tensor<2xf32>

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -423,8 +423,8 @@ func.func @outfeed(%arg0: tensor<3x3x3xi32>, %arg1: !stablehlo.token) -> !stable
   %0 = "stablehlo.outfeed"(%arg0, %arg1) {
     outfeed_config = ""
   } : (tensor<3x3x3xi32>, !stablehlo.token) -> !stablehlo.token
-  %1 = "hlo_test_infer.get_return_types"(%0) : (!stablehlo.token) -> !stablehlo.token
   // CHECK: %1 = "hlo_test_infer.return_types"(%0) {types0 = !stablehlo.token} : (!stablehlo.token) -> !stablehlo.token
+  %1 = "hlo_test_infer.get_return_types"(%0) : (!stablehlo.token) -> !stablehlo.token
   func.return %1 : !stablehlo.token
 }
 
@@ -474,8 +474,8 @@ func.func @dynamic_update_slice(%input: tensor<3x?x?xi64, #stablehlo.type_extens
 // CHECK-LABEL: func @create_token
 func.func @create_token() -> !stablehlo.token {
   %0 = "stablehlo.create_token"() : () -> !stablehlo.token
-  %1 = "hlo_test_infer.get_return_types"(%0) : (!stablehlo.token) -> !stablehlo.token
   // CHECK: %1 = "hlo_test_infer.return_types"(%0) {types0 = !stablehlo.token} : (!stablehlo.token) -> !stablehlo.token
+  %1 = "hlo_test_infer.get_return_types"(%0) : (!stablehlo.token) -> !stablehlo.token
   func.return %1 : !stablehlo.token
 }
 
@@ -484,8 +484,8 @@ func.func @create_token() -> !stablehlo.token {
 // CHECK-LABEL: func @after_all_empty_arg
 func.func @after_all_empty_arg() -> !stablehlo.token {
   %0 = "stablehlo.after_all"() : () -> !stablehlo.token
-  %1 = "hlo_test_infer.get_return_types"(%0) : (!stablehlo.token) -> !stablehlo.token
   // CHECK: %1 = "hlo_test_infer.return_types"(%0) {types0 = !stablehlo.token} : (!stablehlo.token) -> !stablehlo.token
+  %1 = "hlo_test_infer.get_return_types"(%0) : (!stablehlo.token) -> !stablehlo.token
   func.return %1 : !stablehlo.token
 }
 
@@ -494,8 +494,8 @@ func.func @after_all_empty_arg() -> !stablehlo.token {
 // CHECK-LABEL: func @after_all
 func.func @after_all(%arg0: !stablehlo.token, %arg1: !stablehlo.token) -> !stablehlo.token {
   %0 = "stablehlo.after_all"(%arg0, %arg1) : (!stablehlo.token, !stablehlo.token) -> !stablehlo.token
-  %1 = "hlo_test_infer.get_return_types"(%0) : (!stablehlo.token) -> !stablehlo.token
   // CHECK: %1 = "hlo_test_infer.return_types"(%0) {types0 = !stablehlo.token} : (!stablehlo.token) -> !stablehlo.token
+  %1 = "hlo_test_infer.get_return_types"(%0) : (!stablehlo.token) -> !stablehlo.token
   func.return %1 : !stablehlo.token
 }
 
@@ -523,8 +523,8 @@ func.func @select_and_scatter(
     window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>
   } : (tensor<10x24x24x64xf32>, tensor<10x12x12x64xf32>, tensor<f32>) ->
         tensor<10x24x24x64xf32>
+  // CHECK: %2 = "hlo_test_infer.return_types"(%1) {types0 = tensor<10x24x24x64xf32>} : (tensor<10x24x24x64xf32>) -> tensor<10x24x24x64xindex>
   %3 = "hlo_test_infer.get_return_types"(%1) : (tensor<10x24x24x64xf32>) -> tensor<10x24x24x64xindex>
-   // CHECK: %2 = "hlo_test_infer.return_types"(%1) {types0 = tensor<10x24x24x64xf32>} : (tensor<10x24x24x64xf32>) -> tensor<10x24x24x64xindex>
   func.return %3 : tensor<10x24x24x64xindex>
 }
 
@@ -549,8 +549,8 @@ func.func @scatter(%input_tensor: tensor<200x100x300xf32>,
     unique_indices = true
   } : (tensor<200x100x300xf32>, tensor<10x2xi32>, tensor<10x300xf32>) ->
       tensor<200x100x300xf32>
-  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<200x100x300xf32>) -> tensor<200x100x300xindex>
   // CHECK: %1 = "hlo_test_infer.return_types"(%0) {types0 = tensor<200x100x300xf32>} : (tensor<200x100x300xf32>) -> tensor<200x100x300xindex>
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<200x100x300xf32>) -> tensor<200x100x300xindex>
   func.return %1 : tensor<200x100x300xindex>
 }
 
@@ -575,9 +575,8 @@ func.func @scatter_bounds(%input_tensor: tensor<200x?x?xf32, #stablehlo.type_ext
     unique_indices = true
   } : (tensor<200x?x?xf32, #stablehlo.type_extensions<bounds = [?, ?, 301]>>, tensor<10x2xi32>, tensor<10x300xf32>) ->
       tensor<200x?x?xf32>
-
-  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<200x?x?xf32>) -> tensor<*xindex>
   // CHECK: types0 = tensor<200x?x?xf32, #stablehlo.type_extensions<bounds = [?, ?, 301]>>
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<200x?x?xf32>) -> tensor<*xindex>
   func.return %1 : tensor<*xindex>
 }
 
@@ -586,8 +585,8 @@ func.func @scatter_bounds(%input_tensor: tensor<200x?x?xf32, #stablehlo.type_ext
 // CHECK-LABEL: func @get_dimension_size
 func.func @get_dimension_size(%arg0: tensor<4x2xf32>) -> tensor<index> {
   %0 = "stablehlo.get_dimension_size"(%arg0) {dimension = 1 : i64} : (tensor<4x2xf32>) -> tensor<i32>
-  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<i32>) -> tensor<index>
   // CHECK: %1 = "hlo_test_infer.return_types"(%0) {types0 = tensor<i32>} : (tensor<i32>) -> tensor<index>
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<i32>) -> tensor<index>
   func.return %1 : tensor<index>
 }
 
@@ -604,9 +603,8 @@ func.func @get_dimension_size(%arg0: tensor<4x2xf32>) -> tensor<index> {
 // CHECK-LABEL: @tanh_sparsity
 func.func @tanh_sparsity(%arg0: tensor<10x10xf32, #CSR>) -> tensor<10x10xindex> {
   %0 = "stablehlo.tanh"(%arg0) : (tensor<10x10xf32, #CSR>) -> tensor<10x10xf32>
-  %1 = "hlo_test_infer.get_return_types"(%0)
-      : (tensor<10x10xf32>) -> tensor<10x10xindex>
   // CHECK: %1 = "hlo_test_infer.return_types"(%0) {types0 = tensor<10x10xf32, {{.*}}>} : (tensor<10x10xf32>) -> tensor<10x10xindex>
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<10x10xf32>) -> tensor<10x10xindex>
   func.return %1 : tensor<10x10xindex>
 }
 
@@ -619,9 +617,8 @@ func.func @tanh_sparsity(%arg0: tensor<10x10xf32, #CSR>) -> tensor<10x10xindex> 
 // CHECK-LABEL: @abs_sparsity
 func.func @abs_sparsity(%arg0: tensor<10x10xf32, #CSR>) -> tensor<10x10xindex> {
   %0 = "stablehlo.abs"(%arg0) : (tensor<10x10xf32, #CSR>) -> tensor<10x10xf32>
-  %1 = "hlo_test_infer.get_return_types"(%0)
-      : (tensor<10x10xf32>) -> tensor<10x10xindex>
   // CHECK: %1 = "hlo_test_infer.return_types"(%0) {types0 = tensor<10x10xf32, {{.*}}>} : (tensor<10x10xf32>) -> tensor<10x10xindex>
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<10x10xf32>) -> tensor<10x10xindex>
   func.return %1 : tensor<10x10xindex>
 }
 
@@ -634,9 +631,8 @@ func.func @abs_sparsity(%arg0: tensor<10x10xf32, #CSR>) -> tensor<10x10xindex> {
 // CHECK-LABEL: @real_sparsity
 func.func @real_sparsity(%arg0: tensor<10x10xcomplex<f32>, #CSR>) -> tensor<10x10xindex> {
   %0 = "stablehlo.real"(%arg0) : (tensor<10x10xcomplex<f32>, #CSR>) -> tensor<10x10xf32>
-  %1 = "hlo_test_infer.get_return_types"(%0)
-      : (tensor<10x10xf32>) -> tensor<10x10xindex>
   // CHECK: %1 = "hlo_test_infer.return_types"(%0) {types0 = tensor<10x10xf32, {{.*}}>} : (tensor<10x10xf32>) -> tensor<10x10xindex>
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<10x10xf32>) -> tensor<10x10xindex>
   func.return %1 : tensor<10x10xindex>
 }
 
@@ -649,9 +645,8 @@ func.func @real_sparsity(%arg0: tensor<10x10xcomplex<f32>, #CSR>) -> tensor<10x1
 // CHECK-LABEL: @imag_sparsity
 func.func @imag_sparsity(%arg0: tensor<10x10xcomplex<f32>, #CSR>) -> tensor<10x10xindex> {
   %0 = "stablehlo.imag"(%arg0) : (tensor<10x10xcomplex<f32>, #CSR>) -> tensor<10x10xf32>
-  %1 = "hlo_test_infer.get_return_types"(%0)
-      : (tensor<10x10xf32>) -> tensor<10x10xindex>
   // CHECK: %1 = "hlo_test_infer.return_types"(%0) {types0 = tensor<10x10xf32, {{.*}}>} : (tensor<10x10xf32>) -> tensor<10x10xindex>
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<10x10xf32>) -> tensor<10x10xindex>
   func.return %1 : tensor<10x10xindex>
 }
 
@@ -664,9 +659,8 @@ func.func @imag_sparsity(%arg0: tensor<10x10xcomplex<f32>, #CSR>) -> tensor<10x1
 // CHECK-LABEL: @complex_sparsity
 func.func @complex_sparsity(%arg0: tensor<10x10xf32, #CSR>, %arg1: tensor<10x10xf32, #CSR>) -> tensor<10x10xindex> {
   %0 = "stablehlo.complex"(%arg0, %arg1) : (tensor<10x10xf32, #CSR>, tensor<10x10xf32, #CSR>) -> tensor<10x10xcomplex<f32>>
-  %1 = "hlo_test_infer.get_return_types"(%0)
-      : (tensor<10x10xcomplex<f32>>) -> tensor<10x10xindex>
   // CHECK: %1 = "hlo_test_infer.return_types"(%0) {types0 = tensor<10x10xcomplex<f32>, {{.*}}>} : (tensor<10x10xcomplex<f32>>) -> tensor<10x10xindex>
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<10x10xcomplex<f32>>) -> tensor<10x10xindex>
   func.return %1 : tensor<10x10xindex>
 }
 

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -19,7 +19,7 @@ func.func @select(%pred : tensor<i1>, %a : tensor<?x2x3xf32>, %b : tensor<1x?x3x
     -> tensor<1x2x3xindex> {
   %0 = "stablehlo.select"(%pred, %a, %b)
       : (tensor<i1>, tensor<?x2x3xf32>, tensor<1x?x3xf32>) -> tensor<*xf32>
-  // CHECK: {types0 = tensor<1x2x3xf32>}
+  // CHECK: types0 = tensor<1x2x3xf32>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xf32>) -> tensor<1x2x3xindex>
   func.return %1 : tensor<1x2x3xindex>
 }
@@ -30,7 +30,7 @@ func.func @select(%pred : tensor<i1>, %a : tensor<?x2x3xf32>, %b : tensor<1x?x3x
 func.func @compare(%a : tensor<2x2xf32>, %b : tensor<2x2xf32>) -> tensor<2x2xindex> {
   %0 = "stablehlo.compare"(%a, %b) {comparison_direction = #stablehlo<comparison_direction NE>}
       : (tensor<2x2xf32>, tensor<2x2xf32>) -> tensor<2x2xi1>
-  // CHECK: {types0 = tensor<2x2xi1>}
+  // CHECK: types0 = tensor<2x2xi1>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<2x2xi1>) -> tensor<2x2xindex>
   func.return %1 : tensor<2x2xindex>
 }
@@ -41,7 +41,7 @@ func.func @compare(%a : tensor<2x2xf32>, %b : tensor<2x2xf32>) -> tensor<2x2xind
 func.func @broadcast(%a : tensor<3xi32>) -> tensor<1x2x3xindex> {
   %0 = "stablehlo.broadcast"(%a) {broadcast_sizes = dense<[1, 2]> : tensor<2xi64>}
       : (tensor<3xi32>) -> tensor<1x2x3xi32>
-  // CHECK: {types0 = tensor<1x2x3xi32>}
+  // CHECK: types0 = tensor<1x2x3xi32>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<1x2x3xi32>) -> tensor<1x2x3xindex>
   func.return %1 : tensor<1x2x3xindex>
 }
@@ -60,7 +60,7 @@ func.func @broadcast(%a : tensor<3xi32>) -> tensor<1x2x3xi32> {
 // CHECK-LABEL: @dynamic_slice
 func.func @dynamic_slice(%arg0: tensor<3x4xi32>, %arg1: tensor<i64>, %arg2: tensor<i64>) -> tensor<1x4xindex> {
   %0 = "stablehlo.dynamic_slice"(%arg0, %arg1, %arg2) {slice_sizes = dense<[1, 4]> : tensor<2xi64>} : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xi32>
-  // CHECK: {types0 = tensor<1x4xi32>}
+  // CHECK: types0 = tensor<1x4xi32>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<1x4xi32>) -> tensor<1x4xindex>
   func.return %1 : tensor<1x4xindex>
 }
@@ -74,7 +74,7 @@ func.func @pad(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x4x7xind
     edge_padding_low = dense<[0, 1, 2]> : tensor<3xi64>,
     interior_padding = dense<[0, 0, 1]> : tensor<3xi64>
   } : (tensor<1x2x3xf16>, tensor<f16>) -> tensor<2x4x7xf16>
-  // CHECK: %1 = "hlo_test_infer.return_types"(%0) {types0 = tensor<2x4x7xf16>} : (tensor<2x4x7xf16>) -> tensor<2x4x7xindex>
+  // CHECK: types0 = tensor<2x4x7xf16>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<2x4x7xf16>) -> tensor<2x4x7xindex>
   func.return %1 : tensor<2x4x7xindex>
 }
@@ -84,7 +84,7 @@ func.func @pad(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x4x7xind
 // CHECK-LABEL: @cholesky
 func.func @cholesky(%arg0: tensor<1x2x2xf32>) -> tensor<1x2x2xindex> {
   %0 = "stablehlo.cholesky"(%arg0) { lower = true } : (tensor<1x2x2xf32>) -> tensor<1x2x2xf32>
-  // CHECK: {types0 = tensor<1x2x2xf32>}
+  // CHECK: types0 = tensor<1x2x2xf32>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<1x2x2xf32>) -> tensor<1x2x2xindex>
   func.return %1: tensor<1x2x2xindex>
 }
@@ -99,7 +99,7 @@ func.func @alltoall(%data: tensor<4x16xf32>) -> tensor<16x4xindex> {
     split_count = 4 : i64,
     replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>
   } : (tensor<4x16xf32>) -> tensor<16x4xf32>
-  // CHECK: {types0 = tensor<16x4xf32>}
+  // CHECK: types0 = tensor<16x4xf32>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<16x4xf32>) -> tensor<16x4xindex>
   func.return %1 : tensor<16x4xindex>
 }
@@ -124,7 +124,7 @@ func.func @alltoall_bounds(%data: tensor<16x?xf32, #stablehlo.type_extensions<bo
 // CHECK-LABEL: func @abs
 func.func @abs(%arg0: tensor<1x2xf32>) -> tensor<1x2xindex> {
   %0 = "stablehlo.abs"(%arg0) {} : (tensor<1x2xf32>) -> tensor<1x2xf32>
-  // CHECK: {types0 = tensor<1x2xf32>}
+  // CHECK: types0 = tensor<1x2xf32>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<1x2xf32>) -> tensor<1x2xindex>
   func.return %1: tensor<1x2xindex>
 }
@@ -134,7 +134,7 @@ func.func @abs(%arg0: tensor<1x2xf32>) -> tensor<1x2xindex> {
 // CHECK-LABEL: @concat
 func.func @concat(%arg0: tensor<1xi32>, %arg1: tensor<2xi32>)  -> tensor<3xindex> {
   %0 = "stablehlo.concatenate"(%arg0, %arg1) { dimension = 0 : i64 } : (tensor<1xi32>, tensor<2xi32>) -> tensor<3xi32>
-  // CHECK: {types0 = tensor<3xi32>}
+  // CHECK: types0 = tensor<3xi32>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<3xi32>) -> tensor<3xindex>
   func.return %1 : tensor<3xindex>
 }
@@ -153,7 +153,7 @@ func.func @gather(%operand : tensor<2x4x9xi32>, %start_indices : tensor<1x5x2xi3
     indices_are_sorted = false,
     slice_sizes = dense<[1, 1, 8]> : tensor<3xi64>
   } : (tensor<2x4x9xi32>, tensor<1x5x2xi32>) -> tensor<1x5x8xi32>
-  // CHECK: {types0 = tensor<1x5x8xi32>}
+  // CHECK: types0 = tensor<1x5x8xi32>
   %1 = "hlo_test_infer.get_return_types"(%res) : (tensor<1x5x8xi32>) -> tensor<1x5x8xindex>
   func.return %1 : tensor<1x5x8xindex>
 }
@@ -185,7 +185,7 @@ func.func @gather_bounds(%operand : tensor<?x?x?xi32, #stablehlo.type_extensions
 func.func @rng_normal(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<7xindex> {
   %0 = "stablehlo.constant"() {value = dense<7> : tensor<1xi64>} : () -> tensor<1xi64>
   %1 = "stablehlo.rng"(%arg0, %arg1, %0) {rng_distribution = #stablehlo<rng_distribution NORMAL>} : (tensor<f32>, tensor<f32>, tensor<1xi64>) -> tensor<7xf32>
-  // CHECK: {types0 = tensor<7xf32>}
+  // CHECK: types0 = tensor<7xf32>
   %2 = "hlo_test_infer.get_return_types"(%1) : (tensor<7xf32>) -> tensor<7xindex>
   func.return %2 : tensor<7xindex>
 }
@@ -196,7 +196,7 @@ func.func @rng_normal(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<7xindex>
 func.func @rng_uniform(%a: tensor<f32>, %b: tensor<f32>) -> tensor<2x3x5xindex> {
   %0 = stablehlo.constant dense<[2, 3, 5]> : tensor<3xi64>
   %1 = "stablehlo.rng"(%a, %b, %0) {rng_distribution = #stablehlo<rng_distribution UNIFORM>} : (tensor<f32>, tensor<f32>, tensor<3xi64>) -> tensor<2x3x5xf32>
-  // CHECK: {types0 = tensor<2x3x5xf32>}
+  // CHECK: types0 = tensor<2x3x5xf32>
   %2 = "hlo_test_infer.get_return_types"(%1) : (tensor<2x3x5xf32>) -> tensor<2x3x5xindex>
   func.return %2 : tensor<2x3x5xindex>
 }
@@ -206,7 +206,7 @@ func.func @rng_uniform(%a: tensor<f32>, %b: tensor<f32>) -> tensor<2x3x5xindex> 
 // CHECK-LABEL: func @slice
 func.func @slice(%arg0: tensor<3x4xi32>) -> tensor<1x2xindex> {
   %0 = "stablehlo.slice"(%arg0) {start_indices = dense<[1, 0]> : tensor<2xi64>, limit_indices = dense<[2, 4]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<3x4xi32>) -> tensor<1x2xi32>
-  // CHECK: {types0 = tensor<1x2xi32>}
+  // CHECK: types0 = tensor<1x2xi32>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<1x2xi32>) -> tensor<1x2xindex>
   func.return %1 : tensor<1x2xindex>
 }
@@ -216,7 +216,7 @@ func.func @slice(%arg0: tensor<3x4xi32>) -> tensor<1x2xindex> {
 // CHECK-LABEL: func @clamp
 func.func @clamp(%arg0: tensor<1xi32>) -> tensor<1xindex> {
   %0 = "stablehlo.clamp"(%arg0, %arg0, %arg0) : (tensor<1xi32>, tensor<1xi32>, tensor<1xi32>) -> tensor<1xi32>
-  // CHECK: {types0 = tensor<1xi32>}
+  // CHECK: types0 = tensor<1xi32>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<1xi32>) -> tensor<1xindex>
   func.return %1 : tensor<1xindex>
 }
@@ -226,7 +226,7 @@ func.func @clamp(%arg0: tensor<1xi32>) -> tensor<1xindex> {
 // CHECK: func @uniform_dequantize
 func.func @uniform_dequantize(%arg: tensor<16x16x!quant.uniform<i8:f32, 34.0:16>>) -> tensor<16x16xindex> {
   %0 = stablehlo.uniform_dequantize %arg : (tensor<16x16x!quant.uniform<i8:f32, 34.0:16>>) -> tensor<16x16xf32>
-  // CHECK: {types0 = tensor<16x16xf32>}
+  // CHECK: types0 = tensor<16x16xf32>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<16x16xf32>) -> tensor<16x16xindex>
   func.return %1 : tensor<16x16xindex>
 }
@@ -236,7 +236,7 @@ func.func @uniform_dequantize(%arg: tensor<16x16x!quant.uniform<i8:f32, 34.0:16>
 // CHECK-LABEL: func @fft
 func.func @fft(%arg0: tensor<3x9xcomplex<f32>>) -> tensor<3x9xindex> {
   %0 = "stablehlo.fft"(%arg0) { fft_length = dense<9> : tensor<1xi64>, fft_type = #stablehlo<fft_type FFT> } : (tensor<3x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>>
-  // CHECK: {types0 = tensor<3x9xcomplex<f32>>}
+  // CHECK: types0 = tensor<3x9xcomplex<f32>>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<3x9xcomplex<f32>>) -> tensor<3x9xindex>
   func.return %1 : tensor<3x9xindex>
 }
@@ -359,7 +359,7 @@ func.func @map(%arg0: tensor<4x5xf32>, %arg1: tensor<4x5xf32>) -> tensor<4x5xind
     %1 = stablehlo.constant dense<2.0> : tensor<f32>
     "stablehlo.return"(%1) : (tensor<f32>) -> ()
   }) {dimensions = dense<[0, 1]> : tensor<2xi64>} : (tensor<4x5xf32>, tensor<4x5xf32>) -> tensor<4x5xf32>
-  // CHECK: {types0 = tensor<4x5xf32>}
+  // CHECK: types0 = tensor<4x5xf32>
   %2 = "hlo_test_infer.get_return_types"(%0) : (tensor<4x5xf32>) -> tensor<4x5xindex>
   func.return %2 : tensor<4x5xindex>
 }
@@ -369,7 +369,7 @@ func.func @map(%arg0: tensor<4x5xf32>, %arg1: tensor<4x5xf32>) -> tensor<4x5xind
 // CHECK-LABEL: func @triangular_solve
 func.func @triangular_solve(%arg0: tensor<10x5x4x4xf32>, %arg1: tensor<10x5x4x4xf32>) -> tensor<10x5x4x4xindex> {
   %0 = "stablehlo.triangular_solve"(%arg0, %arg1) {left_side = true, lower = true, transpose_a = #stablehlo<transpose NO_TRANSPOSE>, unit_diagonal = true} : (tensor<10x5x4x4xf32>, tensor<10x5x4x4xf32>) -> tensor<10x5x4x4xf32>
-  // CHECK: {types0 = tensor<10x5x4x4xf32>}
+  // CHECK: types0 = tensor<10x5x4x4xf32>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<10x5x4x4xf32>) -> tensor<10x5x4x4xindex>
   func.return %1 : tensor<10x5x4x4xindex>
 }
@@ -383,7 +383,7 @@ func.func @if(%pred : tensor<i1>, %branch_operand : tensor<2xf32>, %wrong_type :
     }, {
       "stablehlo.return"(%branch_operand) : (tensor<2xf32>) -> ()
     }) : (tensor<i1>) -> tensor<2xf32>
-  // CHECK: {types0 = tensor<2xf32>}
+  // CHECK: types0 = tensor<2xf32>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<2xf32>) -> tensor<2xindex>
   func.return %1 : tensor<2xindex>
 }
@@ -397,7 +397,7 @@ func.func @case(%index : tensor<i32>, %branch_operand : tensor<2xf32>)  -> tenso
   }, {
       "stablehlo.return"(%branch_operand) : (tensor<2xf32>) -> ()
   }) : (tensor<i32>) -> tensor<2xf32>
-  // CHECK: {types0 = tensor<2xf32>}
+  // CHECK: types0 = tensor<2xf32>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<2xf32>) -> tensor<2xindex>
   func.return %1 : tensor<2xindex>
 }
@@ -411,7 +411,7 @@ func.func @sort(%input0: tensor<16x16xf32>, %input1: tensor<16x16xi32>) -> tenso
     %7 = "stablehlo.compare"(%arg0, %arg1) {comparison_direction = #stablehlo<comparison_direction GT>} : (tensor<f32>, tensor<f32>) -> tensor<i1>
     "stablehlo.return"(%7) : (tensor<i1>) -> ()
   }) {dimension = 1 : i64, is_stable = true} : (tensor<16x16xf32>, tensor<16x16xi32>) -> (tensor<16x16xf32>, tensor<16x16xi32>)
-  // CHECK: {types0 = tensor<16x16xf32>, types1 = tensor<16x16xi32>}
+  // CHECK: types0 = tensor<16x16xf32>, types1 = tensor<16x16xi32>
   %1 = "hlo_test_infer.get_return_types"(%0#0) : (tensor<16x16xf32>) -> tensor<16x16xindex>
   func.return %1 : tensor<16x16xindex>
 }
@@ -423,7 +423,7 @@ func.func @outfeed(%arg0: tensor<3x3x3xi32>, %arg1: !stablehlo.token) -> !stable
   %0 = "stablehlo.outfeed"(%arg0, %arg1) {
     outfeed_config = ""
   } : (tensor<3x3x3xi32>, !stablehlo.token) -> !stablehlo.token
-  // CHECK: %1 = "hlo_test_infer.return_types"(%0) {types0 = !stablehlo.token} : (!stablehlo.token) -> !stablehlo.token
+  // CHECK: types0 = !stablehlo.token
   %1 = "hlo_test_infer.get_return_types"(%0) : (!stablehlo.token) -> !stablehlo.token
   func.return %1 : !stablehlo.token
 }
@@ -445,7 +445,7 @@ func.func @while(%arg0: tensor<4xf32>, %arg1: tensor<f32>, %arg2: tensor<f32>, %
     %3 = stablehlo.add %arg9, %cst_0 : tensor<i32>
     "stablehlo.return"(%3, %arg10, %arg11) : (tensor<i32>, tensor<i32>, tensor<i32>) -> ()
   }) : (tensor<i32>, tensor<i32>, tensor<i32>) -> (tensor<i32>, tensor<i32>, tensor<i32>)
-  // CHECK: {types0 = tensor<i32>, types1 = tensor<i32>, types2 = tensor<i32>}
+  // CHECK: types0 = tensor<i32>, types1 = tensor<i32>, types2 = tensor<i32>
   %4 = "hlo_test_infer.get_return_types"(%1#0) : (tensor<i32>) -> tensor<index>
   func.return %4 : tensor<index>
 }
@@ -455,7 +455,7 @@ func.func @while(%arg0: tensor<4xf32>, %arg1: tensor<f32>, %arg2: tensor<f32>, %
 // CHECK-LABEL: @dynamic_update_slice
 func.func @dynamic_update_slice(%arg0: tensor<4x4xi32>, %arg1: tensor<2x2xi32>, %arg2: tensor<i64>, %arg3: tensor<i64>) -> tensor<4x4xindex> {
   %0 = "stablehlo.dynamic_update_slice"(%arg0, %arg1, %arg2, %arg3) : (tensor<4x4xi32>, tensor<2x2xi32>, tensor<i64>, tensor<i64>) -> tensor<4x4xi32>
-  // CHECK: {types0 = tensor<4x4xi32>}
+  // CHECK: types0 = tensor<4x4xi32>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<4x4xi32>) -> tensor<4x4xindex>
   func.return %1 : tensor<4x4xindex>
 }
@@ -464,7 +464,7 @@ func.func @dynamic_update_slice(%arg0: tensor<4x4xi32>, %arg1: tensor<2x2xi32>, 
 
 func.func @dynamic_update_slice(%input: tensor<3x?x?xi64, #stablehlo.type_extensions<bounds = [?, ?, 5]>>, %update: tensor<1x4x3xi64>, %start1: tensor<i64>, %start2: tensor<i64>, %start3 : tensor<i64>) -> tensor<*xindex> {
   %0 = "stablehlo.dynamic_update_slice"(%input, %update, %start1, %start2, %start3) : (tensor<3x?x?xi64, #stablehlo.type_extensions<bounds = [?, ?, 5]>>, tensor<1x4x3xi64>, tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<3x?x?xi64>
-  // CHECK: {types0 = tensor<3x?x?xi64, #stablehlo.type_extensions<bounds = [?, ?, 5]>>}
+  // CHECK: types0 = tensor<3x?x?xi64, #stablehlo.type_extensions<bounds = [?, ?, 5]>>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<3x?x?xi64>) -> tensor<*xindex>
   func.return %1 : tensor<*xindex>
 }
@@ -474,7 +474,7 @@ func.func @dynamic_update_slice(%input: tensor<3x?x?xi64, #stablehlo.type_extens
 // CHECK-LABEL: func @create_token
 func.func @create_token() -> !stablehlo.token {
   %0 = "stablehlo.create_token"() : () -> !stablehlo.token
-  // CHECK: %1 = "hlo_test_infer.return_types"(%0) {types0 = !stablehlo.token} : (!stablehlo.token) -> !stablehlo.token
+  // CHECK: types0 = !stablehlo.token
   %1 = "hlo_test_infer.get_return_types"(%0) : (!stablehlo.token) -> !stablehlo.token
   func.return %1 : !stablehlo.token
 }
@@ -484,7 +484,7 @@ func.func @create_token() -> !stablehlo.token {
 // CHECK-LABEL: func @after_all_empty_arg
 func.func @after_all_empty_arg() -> !stablehlo.token {
   %0 = "stablehlo.after_all"() : () -> !stablehlo.token
-  // CHECK: %1 = "hlo_test_infer.return_types"(%0) {types0 = !stablehlo.token} : (!stablehlo.token) -> !stablehlo.token
+  // CHECK: types0 = !stablehlo.token
   %1 = "hlo_test_infer.get_return_types"(%0) : (!stablehlo.token) -> !stablehlo.token
   func.return %1 : !stablehlo.token
 }
@@ -494,7 +494,7 @@ func.func @after_all_empty_arg() -> !stablehlo.token {
 // CHECK-LABEL: func @after_all
 func.func @after_all(%arg0: !stablehlo.token, %arg1: !stablehlo.token) -> !stablehlo.token {
   %0 = "stablehlo.after_all"(%arg0, %arg1) : (!stablehlo.token, !stablehlo.token) -> !stablehlo.token
-  // CHECK: %1 = "hlo_test_infer.return_types"(%0) {types0 = !stablehlo.token} : (!stablehlo.token) -> !stablehlo.token
+  // CHECK: types0 = !stablehlo.token
   %1 = "hlo_test_infer.get_return_types"(%0) : (!stablehlo.token) -> !stablehlo.token
   func.return %1 : !stablehlo.token
 }
@@ -523,7 +523,7 @@ func.func @select_and_scatter(
     window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>
   } : (tensor<10x24x24x64xf32>, tensor<10x12x12x64xf32>, tensor<f32>) ->
         tensor<10x24x24x64xf32>
-  // CHECK: %2 = "hlo_test_infer.return_types"(%1) {types0 = tensor<10x24x24x64xf32>} : (tensor<10x24x24x64xf32>) -> tensor<10x24x24x64xindex>
+  // CHECK: types0 = tensor<10x24x24x64xf32>
   %3 = "hlo_test_infer.get_return_types"(%1) : (tensor<10x24x24x64xf32>) -> tensor<10x24x24x64xindex>
   func.return %3 : tensor<10x24x24x64xindex>
 }
@@ -549,7 +549,7 @@ func.func @scatter(%input_tensor: tensor<200x100x300xf32>,
     unique_indices = true
   } : (tensor<200x100x300xf32>, tensor<10x2xi32>, tensor<10x300xf32>) ->
       tensor<200x100x300xf32>
-  // CHECK: %1 = "hlo_test_infer.return_types"(%0) {types0 = tensor<200x100x300xf32>} : (tensor<200x100x300xf32>) -> tensor<200x100x300xindex>
+  // CHECK: types0 = tensor<200x100x300xf32>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<200x100x300xf32>) -> tensor<200x100x300xindex>
   func.return %1 : tensor<200x100x300xindex>
 }
@@ -585,7 +585,7 @@ func.func @scatter_bounds(%input_tensor: tensor<200x?x?xf32, #stablehlo.type_ext
 // CHECK-LABEL: func @get_dimension_size
 func.func @get_dimension_size(%arg0: tensor<4x2xf32>) -> tensor<index> {
   %0 = "stablehlo.get_dimension_size"(%arg0) {dimension = 1 : i64} : (tensor<4x2xf32>) -> tensor<i32>
-  // CHECK: %1 = "hlo_test_infer.return_types"(%0) {types0 = tensor<i32>} : (tensor<i32>) -> tensor<index>
+  // CHECK: types0 = tensor<i32>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<i32>) -> tensor<index>
   func.return %1 : tensor<index>
 }
@@ -603,7 +603,7 @@ func.func @get_dimension_size(%arg0: tensor<4x2xf32>) -> tensor<index> {
 // CHECK-LABEL: @tanh_sparsity
 func.func @tanh_sparsity(%arg0: tensor<10x10xf32, #CSR>) -> tensor<10x10xindex> {
   %0 = "stablehlo.tanh"(%arg0) : (tensor<10x10xf32, #CSR>) -> tensor<10x10xf32>
-  // CHECK: %1 = "hlo_test_infer.return_types"(%0) {types0 = tensor<10x10xf32, {{.*}}>} : (tensor<10x10xf32>) -> tensor<10x10xindex>
+  // CHECK: types0 = tensor<10x10xf32, {{.*}}>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<10x10xf32>) -> tensor<10x10xindex>
   func.return %1 : tensor<10x10xindex>
 }
@@ -617,7 +617,7 @@ func.func @tanh_sparsity(%arg0: tensor<10x10xf32, #CSR>) -> tensor<10x10xindex> 
 // CHECK-LABEL: @abs_sparsity
 func.func @abs_sparsity(%arg0: tensor<10x10xf32, #CSR>) -> tensor<10x10xindex> {
   %0 = "stablehlo.abs"(%arg0) : (tensor<10x10xf32, #CSR>) -> tensor<10x10xf32>
-  // CHECK: %1 = "hlo_test_infer.return_types"(%0) {types0 = tensor<10x10xf32, {{.*}}>} : (tensor<10x10xf32>) -> tensor<10x10xindex>
+  // CHECK: types0 = tensor<10x10xf32, {{.*}}>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<10x10xf32>) -> tensor<10x10xindex>
   func.return %1 : tensor<10x10xindex>
 }
@@ -631,7 +631,7 @@ func.func @abs_sparsity(%arg0: tensor<10x10xf32, #CSR>) -> tensor<10x10xindex> {
 // CHECK-LABEL: @real_sparsity
 func.func @real_sparsity(%arg0: tensor<10x10xcomplex<f32>, #CSR>) -> tensor<10x10xindex> {
   %0 = "stablehlo.real"(%arg0) : (tensor<10x10xcomplex<f32>, #CSR>) -> tensor<10x10xf32>
-  // CHECK: %1 = "hlo_test_infer.return_types"(%0) {types0 = tensor<10x10xf32, {{.*}}>} : (tensor<10x10xf32>) -> tensor<10x10xindex>
+  // CHECK: types0 = tensor<10x10xf32, {{.*}}>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<10x10xf32>) -> tensor<10x10xindex>
   func.return %1 : tensor<10x10xindex>
 }
@@ -645,7 +645,7 @@ func.func @real_sparsity(%arg0: tensor<10x10xcomplex<f32>, #CSR>) -> tensor<10x1
 // CHECK-LABEL: @imag_sparsity
 func.func @imag_sparsity(%arg0: tensor<10x10xcomplex<f32>, #CSR>) -> tensor<10x10xindex> {
   %0 = "stablehlo.imag"(%arg0) : (tensor<10x10xcomplex<f32>, #CSR>) -> tensor<10x10xf32>
-  // CHECK: %1 = "hlo_test_infer.return_types"(%0) {types0 = tensor<10x10xf32, {{.*}}>} : (tensor<10x10xf32>) -> tensor<10x10xindex>
+  // CHECK: types0 = tensor<10x10xf32, {{.*}}>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<10x10xf32>) -> tensor<10x10xindex>
   func.return %1 : tensor<10x10xindex>
 }
@@ -659,7 +659,7 @@ func.func @imag_sparsity(%arg0: tensor<10x10xcomplex<f32>, #CSR>) -> tensor<10x1
 // CHECK-LABEL: @complex_sparsity
 func.func @complex_sparsity(%arg0: tensor<10x10xf32, #CSR>, %arg1: tensor<10x10xf32, #CSR>) -> tensor<10x10xindex> {
   %0 = "stablehlo.complex"(%arg0, %arg1) : (tensor<10x10xf32, #CSR>, tensor<10x10xf32, #CSR>) -> tensor<10x10xcomplex<f32>>
-  // CHECK: %1 = "hlo_test_infer.return_types"(%0) {types0 = tensor<10x10xcomplex<f32>, {{.*}}>} : (tensor<10x10xcomplex<f32>>) -> tensor<10x10xindex>
+  // CHECK: types0 = tensor<10x10xcomplex<f32>, {{.*}}>}
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<10x10xcomplex<f32>>) -> tensor<10x10xindex>
   func.return %1 : tensor<10x10xindex>
 }
@@ -677,7 +677,7 @@ func.func @reduce(%arg0: tensor<7x5xf32>, %arg1 : tensor<5xf32>)
 
   }) {dimensions = dense<[0]> : tensor<1xi64>} : (tensor<7x5xf32>, tensor<5xf32>) -> tensor<5xf32>
 
-  // CHECK: {types0 = tensor<5xf32>}
+  // CHECK: types0 = tensor<5xf32>
   %2 = "hlo_test_infer.get_return_types"(%0)
       : (tensor<5xf32>) -> tensor<5xindex>
 
@@ -740,7 +740,7 @@ func.func @unranked_reduce(%arg0: tensor<*xf32>, %arg1 : tensor<f32>)
 
   }) {dimensions = dense<[0]> : tensor<1xi64>} : (tensor<*xf32>, tensor<f32>) -> tensor<*xf32>
 
-  // CHECK: {types0 = tensor<*xf32>}
+  // CHECK: types0 = tensor<*xf32>
   %2 = "hlo_test_infer.get_return_types"(%0)
       : (tensor<*xf32>) -> tensor<*xindex>
 
@@ -766,7 +766,7 @@ func.func @reduce_window(%arg0: tensor<4x2xf32>, %arg1: tensor<4x2xi32>,
          : (tensor<4x2xf32>, tensor<4x2xi32>, tensor<f32>, tensor<i32>) ->
               (tensor<2x2xf32>, tensor<2x2xi32>)
 
-  // CHECK: {types0 = tensor<2x2xf32>, types1 = tensor<2x2xi32>}
+  // CHECK: types0 = tensor<2x2xf32>, types1 = tensor<2x2xi32>
   %1 = "hlo_test_infer.get_return_types"(%0#0) : (tensor<2x2xf32>) -> tensor<2x2xindex>
   func.return %1 : tensor<2x2xindex>
 }

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -19,9 +19,8 @@ func.func @select(%pred : tensor<i1>, %a : tensor<?x2x3xf32>, %b : tensor<1x?x3x
     -> tensor<1x2x3xindex> {
   %0 = "stablehlo.select"(%pred, %a, %b)
       : (tensor<i1>, tensor<?x2x3xf32>, tensor<1x?x3xf32>) -> tensor<*xf32>
-  %1 = "hlo_test_infer.get_return_types"(%0)
-      : (tensor<*xf32>) -> tensor<1x2x3xindex>
   // CHECK: {types0 = tensor<1x2x3xf32>}
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xf32>) -> tensor<1x2x3xindex>
   func.return %1 : tensor<1x2x3xindex>
 }
 
@@ -31,9 +30,8 @@ func.func @select(%pred : tensor<i1>, %a : tensor<?x2x3xf32>, %b : tensor<1x?x3x
 func.func @compare(%a : tensor<2x2xf32>, %b : tensor<2x2xf32>) -> tensor<2x2xindex> {
   %0 = "stablehlo.compare"(%a, %b) {comparison_direction = #stablehlo<comparison_direction NE>}
       : (tensor<2x2xf32>, tensor<2x2xf32>) -> tensor<2x2xi1>
-  %1 = "hlo_test_infer.get_return_types"(%0)
-      : (tensor<2x2xi1>) -> tensor<2x2xindex>
   // CHECK: {types0 = tensor<2x2xi1>}
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<2x2xi1>) -> tensor<2x2xindex>
   func.return %1 : tensor<2x2xindex>
 }
 
@@ -43,9 +41,8 @@ func.func @compare(%a : tensor<2x2xf32>, %b : tensor<2x2xf32>) -> tensor<2x2xind
 func.func @broadcast(%a : tensor<3xi32>) -> tensor<1x2x3xindex> {
   %0 = "stablehlo.broadcast"(%a) {broadcast_sizes = dense<[1, 2]> : tensor<2xi64>}
       : (tensor<3xi32>) -> tensor<1x2x3xi32>
-  %1 = "hlo_test_infer.get_return_types"(%0)
-      : (tensor<1x2x3xi32>) -> tensor<1x2x3xindex>
   // CHECK: {types0 = tensor<1x2x3xi32>}
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<1x2x3xi32>) -> tensor<1x2x3xindex>
   func.return %1 : tensor<1x2x3xindex>
 }
 
@@ -63,9 +60,8 @@ func.func @broadcast(%a : tensor<3xi32>) -> tensor<1x2x3xi32> {
 // CHECK-LABEL: @dynamic_slice
 func.func @dynamic_slice(%arg0: tensor<3x4xi32>, %arg1: tensor<i64>, %arg2: tensor<i64>) -> tensor<1x4xindex> {
   %0 = "stablehlo.dynamic_slice"(%arg0, %arg1, %arg2) {slice_sizes = dense<[1, 4]> : tensor<2xi64>} : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xi32>
-  %1 = "hlo_test_infer.get_return_types"(%0)
-      : (tensor<1x4xi32>) -> tensor<1x4xindex>
   // CHECK: {types0 = tensor<1x4xi32>}
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<1x4xi32>) -> tensor<1x4xindex>
   func.return %1 : tensor<1x4xindex>
 }
 
@@ -78,8 +74,8 @@ func.func @pad(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x4x7xind
     edge_padding_low = dense<[0, 1, 2]> : tensor<3xi64>,
     interior_padding = dense<[0, 0, 1]> : tensor<3xi64>
   } : (tensor<1x2x3xf16>, tensor<f16>) -> tensor<2x4x7xf16>
-  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<2x4x7xf16>) -> tensor<2x4x7xindex>
   // CHECK: %1 = "hlo_test_infer.return_types"(%0) {types0 = tensor<2x4x7xf16>} : (tensor<2x4x7xf16>) -> tensor<2x4x7xindex>
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<2x4x7xf16>) -> tensor<2x4x7xindex>
   func.return %1 : tensor<2x4x7xindex>
 }
 
@@ -88,8 +84,8 @@ func.func @pad(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x4x7xind
 // CHECK-LABEL: @cholesky
 func.func @cholesky(%arg0: tensor<1x2x2xf32>) -> tensor<1x2x2xindex> {
   %0 = "stablehlo.cholesky"(%arg0) { lower = true } : (tensor<1x2x2xf32>) -> tensor<1x2x2xf32>
-  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<1x2x2xf32>) -> tensor<1x2x2xindex>
   // CHECK: {types0 = tensor<1x2x2xf32>}
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<1x2x2xf32>) -> tensor<1x2x2xindex>
   func.return %1: tensor<1x2x2xindex>
 }
 
@@ -103,9 +99,8 @@ func.func @alltoall(%data: tensor<4x16xf32>) -> tensor<16x4xindex> {
     split_count = 4 : i64,
     replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>
   } : (tensor<4x16xf32>) -> tensor<16x4xf32>
-  %1 = "hlo_test_infer.get_return_types"(%0)
-      : (tensor<16x4xf32>) -> tensor<16x4xindex>
   // CHECK: {types0 = tensor<16x4xf32>}
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<16x4xf32>) -> tensor<16x4xindex>
   func.return %1 : tensor<16x4xindex>
 }
 
@@ -129,9 +124,8 @@ func.func @alltoall_bounds(%data: tensor<16x?xf32, #stablehlo.type_extensions<bo
 // CHECK-LABEL: func @abs
 func.func @abs(%arg0: tensor<1x2xf32>) -> tensor<1x2xindex> {
   %0 = "stablehlo.abs"(%arg0) {} : (tensor<1x2xf32>) -> tensor<1x2xf32>
-  %1 = "hlo_test_infer.get_return_types"(%0)
-      : (tensor<1x2xf32>) -> tensor<1x2xindex>
   // CHECK: {types0 = tensor<1x2xf32>}
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<1x2xf32>) -> tensor<1x2xindex>
   func.return %1: tensor<1x2xindex>
 }
 
@@ -140,9 +134,8 @@ func.func @abs(%arg0: tensor<1x2xf32>) -> tensor<1x2xindex> {
 // CHECK-LABEL: @concat
 func.func @concat(%arg0: tensor<1xi32>, %arg1: tensor<2xi32>)  -> tensor<3xindex> {
   %0 = "stablehlo.concatenate"(%arg0, %arg1) { dimension = 0 : i64 } : (tensor<1xi32>, tensor<2xi32>) -> tensor<3xi32>
-  %1 = "hlo_test_infer.get_return_types"(%0)
-      : (tensor<3xi32>) -> tensor<3xindex>
   // CHECK: {types0 = tensor<3xi32>}
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<3xi32>) -> tensor<3xindex>
   func.return %1 : tensor<3xindex>
 }
 
@@ -160,9 +153,8 @@ func.func @gather(%operand : tensor<2x4x9xi32>, %start_indices : tensor<1x5x2xi3
     indices_are_sorted = false,
     slice_sizes = dense<[1, 1, 8]> : tensor<3xi64>
   } : (tensor<2x4x9xi32>, tensor<1x5x2xi32>) -> tensor<1x5x8xi32>
-  %1 = "hlo_test_infer.get_return_types"(%res)
-      : (tensor<1x5x8xi32>) -> tensor<1x5x8xindex>
   // CHECK: {types0 = tensor<1x5x8xi32>}
+  %1 = "hlo_test_infer.get_return_types"(%res) : (tensor<1x5x8xi32>) -> tensor<1x5x8xindex>
   func.return %1 : tensor<1x5x8xindex>
 }
 
@@ -193,9 +185,8 @@ func.func @gather_bounds(%operand : tensor<?x?x?xi32, #stablehlo.type_extensions
 func.func @rng_normal(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<7xindex> {
   %0 = "stablehlo.constant"() {value = dense<7> : tensor<1xi64>} : () -> tensor<1xi64>
   %1 = "stablehlo.rng"(%arg0, %arg1, %0) {rng_distribution = #stablehlo<rng_distribution NORMAL>} : (tensor<f32>, tensor<f32>, tensor<1xi64>) -> tensor<7xf32>
-  %2 = "hlo_test_infer.get_return_types"(%1)
-      : (tensor<7xf32>) -> tensor<7xindex>
   // CHECK: {types0 = tensor<7xf32>}
+  %2 = "hlo_test_infer.get_return_types"(%1) : (tensor<7xf32>) -> tensor<7xindex>
   func.return %2 : tensor<7xindex>
 }
 
@@ -205,9 +196,8 @@ func.func @rng_normal(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<7xindex>
 func.func @rng_uniform(%a: tensor<f32>, %b: tensor<f32>) -> tensor<2x3x5xindex> {
   %0 = stablehlo.constant dense<[2, 3, 5]> : tensor<3xi64>
   %1 = "stablehlo.rng"(%a, %b, %0) {rng_distribution = #stablehlo<rng_distribution UNIFORM>} : (tensor<f32>, tensor<f32>, tensor<3xi64>) -> tensor<2x3x5xf32>
-  %2 = "hlo_test_infer.get_return_types"(%1)
-      : (tensor<2x3x5xf32>) -> tensor<2x3x5xindex>
   // CHECK: {types0 = tensor<2x3x5xf32>}
+  %2 = "hlo_test_infer.get_return_types"(%1) : (tensor<2x3x5xf32>) -> tensor<2x3x5xindex>
   func.return %2 : tensor<2x3x5xindex>
 }
 
@@ -216,9 +206,8 @@ func.func @rng_uniform(%a: tensor<f32>, %b: tensor<f32>) -> tensor<2x3x5xindex> 
 // CHECK-LABEL: func @slice
 func.func @slice(%arg0: tensor<3x4xi32>) -> tensor<1x2xindex> {
   %0 = "stablehlo.slice"(%arg0) {start_indices = dense<[1, 0]> : tensor<2xi64>, limit_indices = dense<[2, 4]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<3x4xi32>) -> tensor<1x2xi32>
-  %1 = "hlo_test_infer.get_return_types"(%0)
-      : (tensor<1x2xi32>) -> tensor<1x2xindex>
   // CHECK: {types0 = tensor<1x2xi32>}
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<1x2xi32>) -> tensor<1x2xindex>
   func.return %1 : tensor<1x2xindex>
 }
 
@@ -227,9 +216,8 @@ func.func @slice(%arg0: tensor<3x4xi32>) -> tensor<1x2xindex> {
 // CHECK-LABEL: func @clamp
 func.func @clamp(%arg0: tensor<1xi32>) -> tensor<1xindex> {
   %0 = "stablehlo.clamp"(%arg0, %arg0, %arg0) : (tensor<1xi32>, tensor<1xi32>, tensor<1xi32>) -> tensor<1xi32>
-  %1 = "hlo_test_infer.get_return_types"(%0)
-      : (tensor<1xi32>) -> tensor<1xindex>
   // CHECK: {types0 = tensor<1xi32>}
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<1xi32>) -> tensor<1xindex>
   func.return %1 : tensor<1xindex>
 }
 
@@ -238,9 +226,8 @@ func.func @clamp(%arg0: tensor<1xi32>) -> tensor<1xindex> {
 // CHECK: func @uniform_dequantize
 func.func @uniform_dequantize(%arg: tensor<16x16x!quant.uniform<i8:f32, 34.0:16>>) -> tensor<16x16xindex> {
   %0 = stablehlo.uniform_dequantize %arg : (tensor<16x16x!quant.uniform<i8:f32, 34.0:16>>) -> tensor<16x16xf32>
-  %1 = "hlo_test_infer.get_return_types"(%0)
-      : (tensor<16x16xf32>) -> tensor<16x16xindex>
   // CHECK: {types0 = tensor<16x16xf32>}
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<16x16xf32>) -> tensor<16x16xindex>
   func.return %1 : tensor<16x16xindex>
 }
 
@@ -249,9 +236,8 @@ func.func @uniform_dequantize(%arg: tensor<16x16x!quant.uniform<i8:f32, 34.0:16>
 // CHECK-LABEL: func @fft
 func.func @fft(%arg0: tensor<3x9xcomplex<f32>>) -> tensor<3x9xindex> {
   %0 = "stablehlo.fft"(%arg0) { fft_length = dense<9> : tensor<1xi64>, fft_type = #stablehlo<fft_type FFT> } : (tensor<3x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>>
-  %1 = "hlo_test_infer.get_return_types"(%0)
-      : (tensor<3x9xcomplex<f32>>) -> tensor<3x9xindex>
   // CHECK: {types0 = tensor<3x9xcomplex<f32>>}
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<3x9xcomplex<f32>>) -> tensor<3x9xindex>
   func.return %1 : tensor<3x9xindex>
 }
 
@@ -469,8 +455,8 @@ func.func @while(%arg0: tensor<4xf32>, %arg1: tensor<f32>, %arg2: tensor<f32>, %
 // CHECK-LABEL: @dynamic_update_slice
 func.func @dynamic_update_slice(%arg0: tensor<4x4xi32>, %arg1: tensor<2x2xi32>, %arg2: tensor<i64>, %arg3: tensor<i64>) -> tensor<4x4xindex> {
   %0 = "stablehlo.dynamic_update_slice"(%arg0, %arg1, %arg2, %arg3) : (tensor<4x4xi32>, tensor<2x2xi32>, tensor<i64>, tensor<i64>) -> tensor<4x4xi32>
-  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<4x4xi32>) -> tensor<4x4xindex>
   // CHECK: {types0 = tensor<4x4xi32>}
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<4x4xi32>) -> tensor<4x4xindex>
   func.return %1 : tensor<4x4xindex>
 }
 

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -19,9 +19,9 @@ func.func @select(%pred : tensor<i1>, %a : tensor<?x2x3xf32>, %b : tensor<1x?x3x
     -> tensor<1x2x3xindex> {
   %0 = "stablehlo.select"(%pred, %a, %b)
       : (tensor<i1>, tensor<?x2x3xf32>, tensor<1x?x3xf32>) -> tensor<*xf32>
-  %1 = "hlo_test_infer.get_return_type_components"(%0)
+  %1 = "hlo_test_infer.get_return_types"(%0)
       : (tensor<*xf32>) -> tensor<1x2x3xindex>
-  // CHECK: %1 = "hlo_test_infer.return_type_components"(%0) {dims0 = "[1, 2, 3]", element_type0 = f32} : (tensor<*xf32>) -> tensor<1x2x3xindex>
+  // CHECK: {types0 = tensor<1x2x3xf32>}
   func.return %1 : tensor<1x2x3xindex>
 }
 
@@ -31,9 +31,9 @@ func.func @select(%pred : tensor<i1>, %a : tensor<?x2x3xf32>, %b : tensor<1x?x3x
 func.func @compare(%a : tensor<2x2xf32>, %b : tensor<2x2xf32>) -> tensor<2x2xindex> {
   %0 = "stablehlo.compare"(%a, %b) {comparison_direction = #stablehlo<comparison_direction NE>}
       : (tensor<2x2xf32>, tensor<2x2xf32>) -> tensor<2x2xi1>
-  %1 = "hlo_test_infer.get_return_type_components"(%0)
+  %1 = "hlo_test_infer.get_return_types"(%0)
       : (tensor<2x2xi1>) -> tensor<2x2xindex>
-// CHECK: %1 = "hlo_test_infer.return_type_components"(%0) {dims0 = "[2, 2]", element_type0 = i1} : (tensor<2x2xi1>) -> tensor<2x2xindex>
+  // CHECK: {types0 = tensor<2x2xi1>}
   func.return %1 : tensor<2x2xindex>
 }
 
@@ -43,9 +43,9 @@ func.func @compare(%a : tensor<2x2xf32>, %b : tensor<2x2xf32>) -> tensor<2x2xind
 func.func @broadcast(%a : tensor<3xi32>) -> tensor<1x2x3xindex> {
   %0 = "stablehlo.broadcast"(%a) {broadcast_sizes = dense<[1, 2]> : tensor<2xi64>}
       : (tensor<3xi32>) -> tensor<1x2x3xi32>
-  %1 = "hlo_test_infer.get_return_type_components"(%0)
+  %1 = "hlo_test_infer.get_return_types"(%0)
       : (tensor<1x2x3xi32>) -> tensor<1x2x3xindex>
-// CHECK: %1 = "hlo_test_infer.return_type_components"(%0) {dims0 = "[1, 2, 3]", element_type0 = i32} : (tensor<1x2x3xi32>) -> tensor<1x2x3xindex>
+  // CHECK: {types0 = tensor<1x2x3xi32>}
   func.return %1 : tensor<1x2x3xindex>
 }
 
@@ -63,9 +63,9 @@ func.func @broadcast(%a : tensor<3xi32>) -> tensor<1x2x3xi32> {
 // CHECK-LABEL: @dynamic_slice
 func.func @dynamic_slice(%arg0: tensor<3x4xi32>, %arg1: tensor<i64>, %arg2: tensor<i64>) -> tensor<1x4xindex> {
   %0 = "stablehlo.dynamic_slice"(%arg0, %arg1, %arg2) {slice_sizes = dense<[1, 4]> : tensor<2xi64>} : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xi32>
-  %1 = "hlo_test_infer.get_return_type_components"(%0)
+  %1 = "hlo_test_infer.get_return_types"(%0)
       : (tensor<1x4xi32>) -> tensor<1x4xindex>
-// CHECK: %1 = "hlo_test_infer.return_type_components"(%0) {dims0 = "[1, 4]", element_type0 = i32} : (tensor<1x4xi32>) -> tensor<1x4xindex>
+  // CHECK: {types0 = tensor<1x4xi32>}
   func.return %1 : tensor<1x4xindex>
 }
 
@@ -88,8 +88,8 @@ func.func @pad(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x4x7xind
 // CHECK-LABEL: @cholesky
 func.func @cholesky(%arg0: tensor<1x2x2xf32>) -> tensor<1x2x2xindex> {
   %0 = "stablehlo.cholesky"(%arg0) { lower = true } : (tensor<1x2x2xf32>) -> tensor<1x2x2xf32>
-  %1 = "hlo_test_infer.get_return_type_components"(%0) : (tensor<1x2x2xf32>) -> tensor<1x2x2xindex>
-  // CHECK: %1 = "hlo_test_infer.return_type_components"(%0) {dims0 = "[1, 2, 2]", element_type0 = f32} : (tensor<1x2x2xf32>) -> tensor<1x2x2xindex>
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<1x2x2xf32>) -> tensor<1x2x2xindex>
+  // CHECK: {types0 = tensor<1x2x2xf32>}
   func.return %1: tensor<1x2x2xindex>
 }
 
@@ -103,9 +103,9 @@ func.func @alltoall(%data: tensor<4x16xf32>) -> tensor<16x4xindex> {
     split_count = 4 : i64,
     replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>
   } : (tensor<4x16xf32>) -> tensor<16x4xf32>
-  %1 = "hlo_test_infer.get_return_type_components"(%0)
+  %1 = "hlo_test_infer.get_return_types"(%0)
       : (tensor<16x4xf32>) -> tensor<16x4xindex>
-// CHECK: %1 = "hlo_test_infer.return_type_components"(%0) {dims0 = "[16, 4]", element_type0 = f32} : (tensor<16x4xf32>) -> tensor<16x4xindex>
+  // CHECK: {types0 = tensor<16x4xf32>}
   func.return %1 : tensor<16x4xindex>
 }
 
@@ -129,9 +129,9 @@ func.func @alltoall_bounds(%data: tensor<16x?xf32, #stablehlo.type_extensions<bo
 // CHECK-LABEL: func @abs
 func.func @abs(%arg0: tensor<1x2xf32>) -> tensor<1x2xindex> {
   %0 = "stablehlo.abs"(%arg0) {} : (tensor<1x2xf32>) -> tensor<1x2xf32>
-  %1 = "hlo_test_infer.get_return_type_components"(%0)
+  %1 = "hlo_test_infer.get_return_types"(%0)
       : (tensor<1x2xf32>) -> tensor<1x2xindex>
-// CHECK: %1 = "hlo_test_infer.get_return_type_components"(%0) : (tensor<1x2xf32>) -> tensor<1x2xindex>
+  // CHECK: {types0 = tensor<1x2xf32>}
   func.return %1: tensor<1x2xindex>
 }
 
@@ -140,9 +140,9 @@ func.func @abs(%arg0: tensor<1x2xf32>) -> tensor<1x2xindex> {
 // CHECK-LABEL: @concat
 func.func @concat(%arg0: tensor<1xi32>, %arg1: tensor<2xi32>)  -> tensor<3xindex> {
   %0 = "stablehlo.concatenate"(%arg0, %arg1) { dimension = 0 : i64 } : (tensor<1xi32>, tensor<2xi32>) -> tensor<3xi32>
-  %1 = "hlo_test_infer.get_return_type_components"(%0)
+  %1 = "hlo_test_infer.get_return_types"(%0)
       : (tensor<3xi32>) -> tensor<3xindex>
-// CHECK: %1 = "hlo_test_infer.get_return_type_components"(%0) : (tensor<3xi32>) -> tensor<3xindex>
+  // CHECK: {types0 = tensor<3xi32>}
   func.return %1 : tensor<3xindex>
 }
 
@@ -160,9 +160,9 @@ func.func @gather(%operand : tensor<2x4x9xi32>, %start_indices : tensor<1x5x2xi3
     indices_are_sorted = false,
     slice_sizes = dense<[1, 1, 8]> : tensor<3xi64>
   } : (tensor<2x4x9xi32>, tensor<1x5x2xi32>) -> tensor<1x5x8xi32>
-  %1 = "hlo_test_infer.get_return_type_components"(%res)
+  %1 = "hlo_test_infer.get_return_types"(%res)
       : (tensor<1x5x8xi32>) -> tensor<1x5x8xindex>
-// CHECK: %1 = "hlo_test_infer.return_type_components"(%0) {dims0 = "[1, 5, 8]", element_type0 = i32} : (tensor<1x5x8xi32>) -> tensor<1x5x8xindex>
+  // CHECK: {types0 = tensor<1x5x8xi32>}
   func.return %1 : tensor<1x5x8xindex>
 }
 
@@ -193,9 +193,9 @@ func.func @gather_bounds(%operand : tensor<?x?x?xi32, #stablehlo.type_extensions
 func.func @rng_normal(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<7xindex> {
   %0 = "stablehlo.constant"() {value = dense<7> : tensor<1xi64>} : () -> tensor<1xi64>
   %1 = "stablehlo.rng"(%arg0, %arg1, %0) {rng_distribution = #stablehlo<rng_distribution NORMAL>} : (tensor<f32>, tensor<f32>, tensor<1xi64>) -> tensor<7xf32>
-  %2 = "hlo_test_infer.get_return_type_components"(%1)
+  %2 = "hlo_test_infer.get_return_types"(%1)
       : (tensor<7xf32>) -> tensor<7xindex>
-// CHECK: %2 = "hlo_test_infer.return_type_components"(%1) {dims0 = "[7]", element_type0 = f32} : (tensor<7xf32>) -> tensor<7xindex>
+  // CHECK: {types0 = tensor<7xf32>}
   func.return %2 : tensor<7xindex>
 }
 
@@ -205,9 +205,9 @@ func.func @rng_normal(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<7xindex>
 func.func @rng_uniform(%a: tensor<f32>, %b: tensor<f32>) -> tensor<2x3x5xindex> {
   %0 = stablehlo.constant dense<[2, 3, 5]> : tensor<3xi64>
   %1 = "stablehlo.rng"(%a, %b, %0) {rng_distribution = #stablehlo<rng_distribution UNIFORM>} : (tensor<f32>, tensor<f32>, tensor<3xi64>) -> tensor<2x3x5xf32>
-  %2 = "hlo_test_infer.get_return_type_components"(%1)
+  %2 = "hlo_test_infer.get_return_types"(%1)
       : (tensor<2x3x5xf32>) -> tensor<2x3x5xindex>
-// CHECK: %2 = "hlo_test_infer.return_type_components"(%1) {dims0 = "[2, 3, 5]", element_type0 = f32} : (tensor<2x3x5xf32>) -> tensor<2x3x5xindex>
+  // CHECK: {types0 = tensor<2x3x5xf32>}
   func.return %2 : tensor<2x3x5xindex>
 }
 
@@ -216,9 +216,9 @@ func.func @rng_uniform(%a: tensor<f32>, %b: tensor<f32>) -> tensor<2x3x5xindex> 
 // CHECK-LABEL: func @slice
 func.func @slice(%arg0: tensor<3x4xi32>) -> tensor<1x2xindex> {
   %0 = "stablehlo.slice"(%arg0) {start_indices = dense<[1, 0]> : tensor<2xi64>, limit_indices = dense<[2, 4]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<3x4xi32>) -> tensor<1x2xi32>
-  %1 = "hlo_test_infer.get_return_type_components"(%0)
+  %1 = "hlo_test_infer.get_return_types"(%0)
       : (tensor<1x2xi32>) -> tensor<1x2xindex>
-// CHECK: %1 = "hlo_test_infer.get_return_type_components"(%0) : (tensor<1x2xi32>) -> tensor<1x2xindex>
+  // CHECK: {types0 = tensor<1x2xi32>}
   func.return %1 : tensor<1x2xindex>
 }
 
@@ -227,9 +227,9 @@ func.func @slice(%arg0: tensor<3x4xi32>) -> tensor<1x2xindex> {
 // CHECK-LABEL: func @clamp
 func.func @clamp(%arg0: tensor<1xi32>) -> tensor<1xindex> {
   %0 = "stablehlo.clamp"(%arg0, %arg0, %arg0) : (tensor<1xi32>, tensor<1xi32>, tensor<1xi32>) -> tensor<1xi32>
-  %1 = "hlo_test_infer.get_return_type_components"(%0)
+  %1 = "hlo_test_infer.get_return_types"(%0)
       : (tensor<1xi32>) -> tensor<1xindex>
-// CHECK: %1 = "hlo_test_infer.return_type_components"(%0) {dims0 = "[1]", element_type0 = i32} : (tensor<1xi32>) -> tensor<1xindex>
+  // CHECK: {types0 = tensor<1xi32>}
   func.return %1 : tensor<1xindex>
 }
 
@@ -238,9 +238,9 @@ func.func @clamp(%arg0: tensor<1xi32>) -> tensor<1xindex> {
 // CHECK: func @uniform_dequantize
 func.func @uniform_dequantize(%arg: tensor<16x16x!quant.uniform<i8:f32, 34.0:16>>) -> tensor<16x16xindex> {
   %0 = stablehlo.uniform_dequantize %arg : (tensor<16x16x!quant.uniform<i8:f32, 34.0:16>>) -> tensor<16x16xf32>
-  %1 = "hlo_test_infer.get_return_type_components"(%0)
+  %1 = "hlo_test_infer.get_return_types"(%0)
       : (tensor<16x16xf32>) -> tensor<16x16xindex>
-// CHECK: %1 = "hlo_test_infer.return_type_components"(%0) {dims0 = "[16, 16]", element_type0 = f32} : (tensor<16x16xf32>) -> tensor<16x16xindex>
+  // CHECK: {types0 = tensor<16x16xf32>}
   func.return %1 : tensor<16x16xindex>
 }
 
@@ -249,9 +249,9 @@ func.func @uniform_dequantize(%arg: tensor<16x16x!quant.uniform<i8:f32, 34.0:16>
 // CHECK-LABEL: func @fft
 func.func @fft(%arg0: tensor<3x9xcomplex<f32>>) -> tensor<3x9xindex> {
   %0 = "stablehlo.fft"(%arg0) { fft_length = dense<9> : tensor<1xi64>, fft_type = #stablehlo<fft_type FFT> } : (tensor<3x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>>
-  %1 = "hlo_test_infer.get_return_type_components"(%0)
+  %1 = "hlo_test_infer.get_return_types"(%0)
       : (tensor<3x9xcomplex<f32>>) -> tensor<3x9xindex>
-// CHECK: %1 = "hlo_test_infer.return_type_components"(%0) {dims0 = "[3, 9]", element_type0 = complex<f32>} : (tensor<3x9xcomplex<f32>>) -> tensor<3x9xindex>
+  // CHECK: {types0 = tensor<3x9xcomplex<f32>>}
   func.return %1 : tensor<3x9xindex>
 }
 
@@ -373,8 +373,8 @@ func.func @map(%arg0: tensor<4x5xf32>, %arg1: tensor<4x5xf32>) -> tensor<4x5xind
     %1 = stablehlo.constant dense<2.0> : tensor<f32>
     "stablehlo.return"(%1) : (tensor<f32>) -> ()
   }) {dimensions = dense<[0, 1]> : tensor<2xi64>} : (tensor<4x5xf32>, tensor<4x5xf32>) -> tensor<4x5xf32>
-  // CHECK: (tensor<4x5xf32>) -> tensor<4x5xindex>
-  %2 = "hlo_test_infer.get_return_type_components"(%0) : (tensor<4x5xf32>) -> tensor<4x5xindex>
+  // CHECK: {types0 = tensor<4x5xf32>}
+  %2 = "hlo_test_infer.get_return_types"(%0) : (tensor<4x5xf32>) -> tensor<4x5xindex>
   func.return %2 : tensor<4x5xindex>
 }
 
@@ -383,8 +383,8 @@ func.func @map(%arg0: tensor<4x5xf32>, %arg1: tensor<4x5xf32>) -> tensor<4x5xind
 // CHECK-LABEL: func @triangular_solve
 func.func @triangular_solve(%arg0: tensor<10x5x4x4xf32>, %arg1: tensor<10x5x4x4xf32>) -> tensor<10x5x4x4xindex> {
   %0 = "stablehlo.triangular_solve"(%arg0, %arg1) {left_side = true, lower = true, transpose_a = #stablehlo<transpose NO_TRANSPOSE>, unit_diagonal = true} : (tensor<10x5x4x4xf32>, tensor<10x5x4x4xf32>) -> tensor<10x5x4x4xf32>
-  // CHECK: (tensor<10x5x4x4xf32>) -> tensor<10x5x4x4xindex>
-  %1 = "hlo_test_infer.get_return_type_components"(%0) : (tensor<10x5x4x4xf32>) -> tensor<10x5x4x4xindex>
+  // CHECK: {types0 = tensor<10x5x4x4xf32>}
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<10x5x4x4xf32>) -> tensor<10x5x4x4xindex>
   func.return %1 : tensor<10x5x4x4xindex>
 }
 
@@ -397,8 +397,8 @@ func.func @if(%pred : tensor<i1>, %branch_operand : tensor<2xf32>, %wrong_type :
     }, {
       "stablehlo.return"(%branch_operand) : (tensor<2xf32>) -> ()
     }) : (tensor<i1>) -> tensor<2xf32>
-  // CHECK: (tensor<2xf32>) -> tensor<2xindex>
-  %1 = "hlo_test_infer.get_return_type_components"(%0) : (tensor<2xf32>) -> tensor<2xindex>
+  // CHECK: {types0 = tensor<2xf32>}
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<2xf32>) -> tensor<2xindex>
   func.return %1 : tensor<2xindex>
 }
 
@@ -411,25 +411,23 @@ func.func @case(%index : tensor<i32>, %branch_operand : tensor<2xf32>)  -> tenso
   }, {
       "stablehlo.return"(%branch_operand) : (tensor<2xf32>) -> ()
   }) : (tensor<i32>) -> tensor<2xf32>
-  // CHECK: (tensor<2xf32>) -> tensor<2xindex>
-  %1 = "hlo_test_infer.get_return_type_components"(%0) : (tensor<2xf32>) -> tensor<2xindex>
+  // CHECK: {types0 = tensor<2xf32>}
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<2xf32>) -> tensor<2xindex>
   func.return %1 : tensor<2xindex>
 }
 
 // -----
 
 // CHECK-LABEL: func @sort
-func.func @sort(%input0: tensor<16x16xf32>, %input1: tensor<16x16xi32>) -> (tensor<16x16xindex>, tensor<16x16xindex>) {
+func.func @sort(%input0: tensor<16x16xf32>, %input1: tensor<16x16xi32>) -> tensor<16x16xindex> {
   %0:2 = "stablehlo.sort"(%input0, %input1) ({
   ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>, %arg2: tensor<i32>, %arg3: tensor<i32>):
     %7 = "stablehlo.compare"(%arg0, %arg1) {comparison_direction = #stablehlo<comparison_direction GT>} : (tensor<f32>, tensor<f32>) -> tensor<i1>
     "stablehlo.return"(%7) : (tensor<i1>) -> ()
   }) {dimension = 1 : i64, is_stable = true} : (tensor<16x16xf32>, tensor<16x16xi32>) -> (tensor<16x16xf32>, tensor<16x16xi32>)
-  // CHECK: (tensor<16x16xf32>) -> tensor<16x16xindex>
-  %1 = "hlo_test_infer.get_return_type_components"(%0#0) : (tensor<16x16xf32>) -> tensor<16x16xindex>
-  // CHECK: (tensor<16x16xi32>) -> tensor<16x16xindex>
-  %2 = "hlo_test_infer.get_return_type_components"(%0#1) : (tensor<16x16xi32>) -> tensor<16x16xindex>
-  func.return %1, %2 : tensor<16x16xindex>, tensor<16x16xindex>
+  // CHECK: {types0 = tensor<16x16xf32>, types1 = tensor<16x16xi32>}
+  %1 = "hlo_test_infer.get_return_types"(%0#0) : (tensor<16x16xf32>) -> tensor<16x16xindex>
+  func.return %1 : tensor<16x16xindex>
 }
 
 // -----
@@ -461,12 +459,8 @@ func.func @while(%arg0: tensor<4xf32>, %arg1: tensor<f32>, %arg2: tensor<f32>, %
     %3 = stablehlo.add %arg9, %cst_0 : tensor<i32>
     "stablehlo.return"(%3, %arg10, %arg11) : (tensor<i32>, tensor<i32>, tensor<i32>) -> ()
   }) : (tensor<i32>, tensor<i32>, tensor<i32>) -> (tensor<i32>, tensor<i32>, tensor<i32>)
-  // CHECK: (tensor<i32>) -> tensor<index>
-  %4 = "hlo_test_infer.get_return_type_components"(%1#0) : (tensor<i32>) -> tensor<index>
-  // CHECK: (tensor<i32>) -> tensor<index>
-  %5 = "hlo_test_infer.get_return_type_components"(%1#1) : (tensor<i32>) -> tensor<index>
-  // CHECK: (tensor<i32>) -> tensor<index>
-  %6 = "hlo_test_infer.get_return_type_components"(%1#2) : (tensor<i32>) -> tensor<index>
+  // CHECK: {types0 = tensor<i32>, types1 = tensor<i32>, types2 = tensor<i32>}
+  %4 = "hlo_test_infer.get_return_types"(%1#0) : (tensor<i32>) -> tensor<index>
   func.return %4 : tensor<index>
 }
 
@@ -475,8 +469,8 @@ func.func @while(%arg0: tensor<4xf32>, %arg1: tensor<f32>, %arg2: tensor<f32>, %
 // CHECK-LABEL: @dynamic_update_slice
 func.func @dynamic_update_slice(%arg0: tensor<4x4xi32>, %arg1: tensor<2x2xi32>, %arg2: tensor<i64>, %arg3: tensor<i64>) -> tensor<4x4xindex> {
   %0 = "stablehlo.dynamic_update_slice"(%arg0, %arg1, %arg2, %arg3) : (tensor<4x4xi32>, tensor<2x2xi32>, tensor<i64>, tensor<i64>) -> tensor<4x4xi32>
-  %1 = "hlo_test_infer.get_return_type_components"(%0) : (tensor<4x4xi32>) -> tensor<4x4xindex>
-  // CHECK: %1 = "hlo_test_infer.return_type_components"(%0) {dims0 = "[4, 4]", element_type0 = i32}  : (tensor<4x4xi32>) -> tensor<4x4xindex>
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<4x4xi32>) -> tensor<4x4xindex>
+  // CHECK: {types0 = tensor<4x4xi32>}
   func.return %1 : tensor<4x4xindex>
 }
 
@@ -484,8 +478,8 @@ func.func @dynamic_update_slice(%arg0: tensor<4x4xi32>, %arg1: tensor<2x2xi32>, 
 
 func.func @dynamic_update_slice(%input: tensor<3x?x?xi64, #stablehlo.type_extensions<bounds = [?, ?, 5]>>, %update: tensor<1x4x3xi64>, %start1: tensor<i64>, %start2: tensor<i64>, %start3 : tensor<i64>) -> tensor<*xindex> {
   %0 = "stablehlo.dynamic_update_slice"(%input, %update, %start1, %start2, %start3) : (tensor<3x?x?xi64, #stablehlo.type_extensions<bounds = [?, ?, 5]>>, tensor<1x4x3xi64>, tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<3x?x?xi64>
-  // CHECK: bounds0 = #stablehlo.type_extensions<bounds = [?, ?, 5]>, dims0 = "[3, ?, ?]", element_type0 = i64
-  %1 = "hlo_test_infer.get_return_type_components"(%0) : (tensor<3x?x?xi64>) -> tensor<*xindex>
+  // CHECK: {types0 = tensor<3x?x?xi64, #stablehlo.type_extensions<bounds = [?, ?, 5]>>}
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<3x?x?xi64>) -> tensor<*xindex>
   func.return %1 : tensor<*xindex>
 }
 
@@ -703,8 +697,8 @@ func.func @reduce(%arg0: tensor<7x5xf32>, %arg1 : tensor<5xf32>)
 
   }) {dimensions = dense<[0]> : tensor<1xi64>} : (tensor<7x5xf32>, tensor<5xf32>) -> tensor<5xf32>
 
-  // CHECK: {dims0 = "[5]", element_type0 = f32}
-  %2 = "hlo_test_infer.get_return_type_components"(%0)
+  // CHECK: {types0 = tensor<5xf32>}
+  %2 = "hlo_test_infer.get_return_types"(%0)
       : (tensor<5xf32>) -> tensor<5xindex>
 
   func.return %2: tensor<5xindex>
@@ -766,8 +760,8 @@ func.func @unranked_reduce(%arg0: tensor<*xf32>, %arg1 : tensor<f32>)
 
   }) {dimensions = dense<[0]> : tensor<1xi64>} : (tensor<*xf32>, tensor<f32>) -> tensor<*xf32>
 
-  // CHECK: {element_type0 = f32}
-  %2 = "hlo_test_infer.get_return_type_components"(%0)
+  // CHECK: {types0 = tensor<*xf32>}
+  %2 = "hlo_test_infer.get_return_types"(%0)
       : (tensor<*xf32>) -> tensor<*xindex>
 
   func.return %2: tensor<*xindex>
@@ -777,8 +771,8 @@ func.func @unranked_reduce(%arg0: tensor<*xf32>, %arg1 : tensor<f32>)
 
 // CHECK-LABEL: func @reduce_window
 func.func @reduce_window(%arg0: tensor<4x2xf32>, %arg1: tensor<4x2xi32>,
-                    %init0: tensor<f32>, %init1: tensor<i32>) ->
-                      (tensor<2x2xindex>, tensor<2x2xindex>) {
+                         %init0: tensor<f32>, %init1: tensor<i32>) ->
+                         tensor<2x2xindex> {
   %0:2 = "stablehlo.reduce_window"(%arg0, %arg1, %init0, %init1) ({
          ^bb0(%a0: tensor<f32>, %a1: tensor<i32>,
                 %b0: tensor<f32>, %b1: tensor<i32>):
@@ -792,14 +786,9 @@ func.func @reduce_window(%arg0: tensor<4x2xf32>, %arg1: tensor<4x2xi32>,
          : (tensor<4x2xf32>, tensor<4x2xi32>, tensor<f32>, tensor<i32>) ->
               (tensor<2x2xf32>, tensor<2x2xi32>)
 
-  // CHECK: %1 = "hlo_test_infer.return_type_components"(%0#0) {dims0 = "[2, 2]", dims1 = "[2, 2]", element_type0 = f32, element_type1 = i32} : (tensor<2x2xf32>) -> tensor<2x2xindex>
-  %1 = "hlo_test_infer.get_return_type_components"(%0#0)
-      : (tensor<2x2xf32>) -> tensor<2x2xindex>
-  // CHECK: %2 = "hlo_test_infer.return_type_components"(%0#1) {dims0 = "[2, 2]", dims1 = "[2, 2]", element_type0 = f32, element_type1 = i32} : (tensor<2x2xi32>) -> tensor<2x2xindex>
-  %2 = "hlo_test_infer.get_return_type_components"(%0#1)
-      : (tensor<2x2xi32>) -> tensor<2x2xindex>
-
-  func.return %1, %2 : tensor<2x2xindex>, tensor<2x2xindex>
+  // CHECK: {types0 = tensor<2x2xf32>, types1 = tensor<2x2xi32>}
+  %1 = "hlo_test_infer.get_return_types"(%0#0) : (tensor<2x2xf32>) -> tensor<2x2xindex>
+  func.return %1 : tensor<2x2xindex>
 }
 
 // -----


### PR DESCRIPTION
  * Move all usages of get_return_type_componets to get_return_types.
  * Move `CHECK` directives in tests before the corresponding MLIR code.

closes #938 