### PR TITLE
Handle bounds in the Select shape function

### DIFF
--- a/stablehlo/dialect/Base.cpp
+++ b/stablehlo/dialect/Base.cpp
@@ -365,7 +365,10 @@ LogicalResult inferMostSpecificTypeComponents(
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   auto inferredTypeOrErr = inferMostSpecificType(location, inputTypes);
   if (failed(inferredTypeOrErr)) return failure();
-  inferredReturnShapes.emplace_back(*inferredTypeOrErr);
+  auto resultType = (*inferredTypeOrErr).cast<RankedTensorType>();
+  inferredReturnShapes.emplace_back(resultType.getShape(),
+                                    resultType.getElementType(),
+                                    resultType.getEncoding());
   return success();
 }
 

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2670,21 +2670,10 @@ LogicalResult inferSelectOp(
                                "requires the same shape for all operands");
 
   // The output shape should be derived from the most specific parts of the
-  // `onTrue` and `onFalse` when the bounds are missing (see documantation for
-  // `inferMostSpecificTypeComponents` or `inferMostSpecificType` for details).
-  auto onTrueRankedTy = onTrue.getType().dyn_cast<RankedTensorType>();
-  auto onFalseRankedTy = onFalse.getType().dyn_cast<RankedTensorType>();
-  if (!onTrueRankedTy || !onFalseRankedTy)
-    return inferMostSpecificTypeComponents(location, {trueType, falseType},
-                                           inferredReturnShapes);
-  auto inferredTypeOrErr =
-      inferMostSpecificType(location, {onTrueRankedTy, onFalseRankedTy});
-  if (failed(inferredTypeOrErr)) return failure();
-  auto resultType = (*inferredTypeOrErr).cast<RankedTensorType>();
-  inferredReturnShapes.emplace_back(resultType.getShape(),
-                                    resultType.getElementType(),
-                                    resultType.getEncoding());
-  return success();
+  // `onTrue` and `onFalse` (see documentation for details).
+  SmallVector<Type> inferredReturnTypes;
+  return inferMostSpecificTypeComponents(location, {trueType, falseType},
+                                         inferredReturnShapes);
 }
 
 LogicalResult inferSelectAndScatterOp(

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2671,20 +2671,14 @@ LogicalResult inferSelectOp(
 
   // The output shape should be derived from the most specific parts of the
   // `onTrue` and `onFalse` when the bounds are missing (see documantation for
-  // `inferMostSpecificTypeComponents` for details).
+  // `inferMostSpecificTypeComponents` or `inferMostSpecificType` for details).
   auto onTrueRankedTy = onTrue.getType().dyn_cast<RankedTensorType>();
   auto onFalseRankedTy = onFalse.getType().dyn_cast<RankedTensorType>();
-  if (!onTrueRankedTy || !onFalseRankedTy ||
-      (encodingToBounds(onTrueRankedTy.getEncoding()).empty() &&
-       encodingToBounds(onFalseRankedTy.getEncoding()).empty()))
+  if (!onTrueRankedTy || !onFalseRankedTy)
     return inferMostSpecificTypeComponents(location, {trueType, falseType},
                                            inferredReturnShapes);
-
-  // The output shape and bounds are derived using the least specifc rules for
-  // `onTrue` and `onFalse` when the bounds are present (see documentation for
-  // `inferLeastSpecificType` for details).
   auto inferredTypeOrErr =
-      inferLeastSpecificType(location, {onTrueRankedTy, onFalseRankedTy});
+      inferMostSpecificType(location, {onTrueRankedTy, onFalseRankedTy});
   if (failed(inferredTypeOrErr)) return failure();
   auto resultType = (*inferredTypeOrErr).cast<RankedTensorType>();
   inferredReturnShapes.emplace_back(resultType.getShape(),

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2670,7 +2670,8 @@ LogicalResult inferSelectOp(
                                "requires the same shape for all operands");
 
   // The output shape should be derived from the most specific parts of the
-  // `onTrue` and `onFalse` (see documentation for details).
+  // `onTrue` and `onFalse` when the bounds are missing (see documantation for
+  // `inferMostSpecificTypeComponents` for details).
   auto onTrueRankedTy = onTrue.getType().dyn_cast<RankedTensorType>();
   auto onFalseRankedTy = onFalse.getType().dyn_cast<RankedTensorType>();
   if (!onTrueRankedTy || !onFalseRankedTy ||
@@ -2680,7 +2681,8 @@ LogicalResult inferSelectOp(
                                            inferredReturnShapes);
 
   // The output shape and bounds are derived using the least specifc rules for
-  // `onTrue` and `onFalse` (see documentation for details).
+  // `onTrue` and `onFalse` when the bounds are present (see documentation for
+  // `inferLeastSpecificType` for details).
   auto inferredTypeOrErr =
       inferLeastSpecificType(location, {onTrueRankedTy, onFalseRankedTy});
   if (failed(inferredTypeOrErr)) return failure();

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -1537,3 +1537,17 @@ func.func @dynamic_gather(%arg0: tensor<?x4xf32>, %arg1: tensor<1xi64>) -> tenso
   %2 = "hlo_test_infer.get_return_types"(%1) : (tensor<*xf32>) -> tensor<*xindex>
   func.return %2 : tensor<*xindex>
 }
+
+// -----
+
+// CHECK-LABEL: @select
+func.func @select(%pred : tensor<i1>,
+    %a : tensor<?x2x3x?xf32, #stablehlo.type_extensions<bounds = [5, ?, ?, 7]>>,
+    %b : tensor<1x?x3x?xf32, #stablehlo.type_extensions<bounds = [?, 6, ?, 8]>>) -> tensor<*xindex> {
+  %0 = "stablehlo.select"(%pred, %a, %b) : (tensor<i1>,
+      tensor<?x2x3x?xf32, #stablehlo.type_extensions<bounds = [5, ?, ?, 7]>>,
+      tensor<1x?x3x?xf32, #stablehlo.type_extensions<bounds = [?, 6, ?, 8]>>) -> tensor<*xf32>
+  // CHECK: types0 = tensor<?x?x3x?xf32, #stablehlo.type_extensions<bounds = [5, 6, ?, 8]>>
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xf32>) -> tensor<*xindex>
+  func.return %1 : tensor<*xindex>
+}

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -1547,7 +1547,7 @@ func.func @select(%pred : tensor<i1>,
   %0 = "stablehlo.select"(%pred, %a, %b) : (tensor<i1>,
       tensor<?x2x3x?xf32, #stablehlo.type_extensions<bounds = [5, ?, ?, 7]>>,
       tensor<1x?x3x?xf32, #stablehlo.type_extensions<bounds = [?, 6, ?, 8]>>) -> tensor<*xf32>
-  // CHECK: types0 = tensor<?x?x3x?xf32, #stablehlo.type_extensions<bounds = [5, 6, ?, 8]>>
+  // CHECK: types0 = tensor<1x2x3x?xf32, #stablehlo.type_extensions<bounds = [?, ?, ?, 7]>>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xf32>) -> tensor<*xindex>
   func.return %1 : tensor<*xindex>
 }


### PR DESCRIPTION
For all dimensions, it infers the most specific of the `onTrue` and `onFalse` bounds, following the same inference rule in `inferMostSpecificTypeComponents`, so there is no change required to the inference rule except that the code for `inferMostSpecificTypeComponents` is updated to also include bounds information.
closes #750