### PR TITLE
Add interpreter for SliceOp

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4955,18 +4955,6 @@ dimension `d` in `operand`.
 #### Examples
 
 ```mlir
-// 1-dimensional slice
-
-// %operand: [0, 1, 2, 3, 4]
-%result = "stablehlo.slice"(%operand) {
-  start_indices = dense<2> : tensor<1xi64>,
-  limit_indices = dense<4> : tensor<1xi64>,
-  strides = dense<1> : tensor<1xi64>
-} : (tensor<5xi64>) -> tensor<2xi64>
-// %result: [2, 3]
-
-// 2-dimensional slice
-
 // %operand: [
 //            [0, 0, 0, 0],
 //            [0, 0, 1, 1],
@@ -4982,6 +4970,8 @@ dimension `d` in `operand`.
 //            [1, 1]
 //           ]
 ```
+
+&nbsp;[More Examples](../stablehlo/tests/interpret_slice.mlir)
 
 ### sort
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -142,7 +142,7 @@ one of the following tracking labels.
 | shift_right_logical      | yes           | yes          | yes            | yes             | no          |
 | sign                     | yes           | yes          | yes            | yes             | no          |
 | sine                     | yes           | yes          | yes            | yes             | yes         |
-| slice                    | yes           | yes          | yes            | no              | no          |
+| slice                    | yes           | yes          | yes            | no              | yes         |
 | sort                     | yes           | yes          | yes            | no              | no          |
 | sqrt                     | yes           | yes          | yes            | yes             | no          |
 | subtract                 | yes           | yes          | yes            | yes             | yes         |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1584,8 +1584,8 @@ def StableHLO_CompareOp: StableHLO_Op<"compare", [Pure, SameOperandsElementType,
 
 def StableHLO_SliceOp: StableHLO_Op<
       "slice",
-      [Pure, SameOperandsAndResultElementType,
-       AllTypesMatch<["start_indices", "limit_indices", "strides"]>,
+      [Pure, SameOperandsAndResultElementType /*slice_c1*/,
+       AllTypesMatch<["start_indices", "limit_indices", "strides"]> /*slice_c2*/,
        DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
   let summary = "Slice operation";
   let description = [{

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1587,7 +1587,7 @@ def StableHLO_SliceOp: StableHLO_Op<
       [Pure, SameOperandsAndResultElementType,
        AllTypesMatch<["start_indices", "limit_indices", "strides"]>,
        DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
-  let summary = "Slice operator";
+  let summary = "Slice operation";
   let description = [{
     Extracts a slice from the `operand` using statically-computed starting
     indices and produces a `result` tensor.

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1598,10 +1598,10 @@ def StableHLO_SliceOp: StableHLO_Op<
     Example:
     ```mlir
     %result = "stablehlo.slice" (%operand) {
-      start_indices = dense<2> : tensor<1xi64>,
-      limit_indices = dense<4> : tensor<1xi64>,
-      strides = dense<1> : tensor<1xi64>
-    } : (tensor<5xi64>) -> tensor<2xi64>
+      start_indices = dense<[1, 2]> : tensor<2xi64>,
+      limit_indices = dense<[3, 4]> : tensor<2xi64>,
+      strides = dense<1> : tensor<2xi64>
+    } : (tensor<3x4xi64>) -> tensor<2x2xi64>
     ```
   }];
 

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2689,12 +2689,12 @@ LogicalResult inferSendOp(Dialect* dialect, std::optional<Location> location,
   return success();
 }
 
-LogicalResult inferSliceOp(std::optional<Location> location, Value operand,
+LogicalResult inferSliceOp(std::optional<Location> location, Type operandType,
                            DenseIntElementsAttr startIndices,
                            DenseIntElementsAttr limitIndices,
                            DenseIntElementsAttr strides,
                            SmallVectorImpl<Type>& inferredReturnTypes) {
-  RankedTensorType rankedTy = operandType.dyn_cast<RankedTensorType>();
+  auto rankedTy = operandType.dyn_cast<RankedTensorType>();
   if (!rankedTy) {
     // The operand type is unranked, so the best we can infer for the result
     // type is an unranked tensor with the same element type as the operand
@@ -2703,7 +2703,7 @@ LogicalResult inferSliceOp(std::optional<Location> location, Value operand,
     return success();
   }
 
-  // slice_c2
+  // slice_i2
   ShapedType attrTy = startIndices.getType();
   if (attrTy.getRank() != 1)
     return emitOptionalError(location, "start_indices has rank ",

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2731,7 +2731,6 @@ LogicalResult inferSliceOp(std::optional<Location> location, Value operand,
       return emitOptionalError(location, "negative start index ", start[i],
                                " in dimension ", i);
 
-    // SliceOp_C3
     bool isStaticDim = !isDynamicDimSize(rankedTy.getDimSize(i));
     bool isStaticBound =
         !inputBounds.empty() && !isDynamicDimSize(inputBounds[i]);
@@ -2739,6 +2738,7 @@ LogicalResult inferSliceOp(std::optional<Location> location, Value operand,
       int64_t operandSizeOrBound =
           isStaticDim ? rankedTy.getDimSize(i) : inputBounds[i];
       StringRef sizeOrBound = isStaticDim ? "size" : "bound";
+      // SliceOp_C3
       if (limit[i] > operandSizeOrBound)
         return emitOptionalError(location, "limit index ", limit[i],
                                  " is larger than dimension ", sizeOrBound, " ",

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2703,13 +2703,13 @@ LogicalResult inferSliceOp(std::optional<Location> location, Value operand,
     return success();
   }
 
-  // SliceOp_C2
+  // slice_c2
   ShapedType attrTy = startIndices.getType();
   if (attrTy.getRank() != 1)
     return emitOptionalError(location, "start_indices has rank ",
                              attrTy.getRank(), " instead of required rank 1");
 
-  // SliceOp_C2
+  // slice_c2
   int64_t rank = rankedTy.getRank();
   if (attrTy.getNumElements() != rank)
     return emitOptionalError(
@@ -2726,7 +2726,7 @@ LogicalResult inferSliceOp(std::optional<Location> location, Value operand,
   SmallVector<int64_t> resultBounds(inputBounds.size(), ShapedType::kDynamic);
 
   for (int64_t i = 0, e = rank; i != e; i++) {
-    // SliceOp_C3
+    // slice_c3
     if (start[i] < 0)
       return emitOptionalError(location, "negative start index ", start[i],
                                " in dimension ", i);
@@ -2738,29 +2738,29 @@ LogicalResult inferSliceOp(std::optional<Location> location, Value operand,
       int64_t operandSizeOrBound =
           isStaticDim ? rankedTy.getDimSize(i) : inputBounds[i];
       StringRef sizeOrBound = isStaticDim ? "size" : "bound";
-      // SliceOp_C3
+      // slice_c3
       if (limit[i] > operandSizeOrBound)
         return emitOptionalError(location, "limit index ", limit[i],
                                  " is larger than dimension ", sizeOrBound, " ",
                                  operandSizeOrBound, " in dimension ", i);
     }
 
-    // SliceOp_C3
+    // slice_c3
     if (start[i] > limit[i])
       return emitOptionalError(location, "start index ", start[i],
                                " is larger than limit index ", limit[i],
                                " in dimension ", i);
-    // SliceOp_C4
+    // slice_c4
     if (strideVals[i] <= 0)
       return emitOptionalError(location, "stride must be positive but got ",
                                strideVals[i], " in dimension ", i);
 
-    // SliceOp_C5
+    // slice_c5
     shape[i] = static_cast<int64_t>(
         llvm::divideCeil(limit[i] - start[i], strideVals[i]));
   }
 
-  // SliceOp_C1
+  // slice_c1
   inferredReturnTypes.push_back(RankedTensorType::get(
       shape, rankedTy.getElementType(),
       boundsToEncoding(rankedTy.getEncoding(), resultBounds)));

--- a/stablehlo/reference/Interpreter.cpp
+++ b/stablehlo/reference/Interpreter.cpp
@@ -135,6 +135,12 @@ llvm::Expected<SmallVector<Tensor>> eval(func::FuncOp func,
       Tensor runtimeOperand = fetchOperand(sineOp.getOperand());
       Tensor runtimeResult = evalSineOp(runtimeOperand, sineOp.getType());
       populateResults({runtimeResult});
+    } else if (auto sliceOp = dyn_cast<SliceOp>(op)) {
+      Tensor runtimeOperand = fetchOperand(sliceOp.getOperand());
+      Tensor runtimeResult = evalSliceOp(runtimeOperand,
+          sliceOp.getStartIndices(), sliceOp.getLimitIndices(),
+          sliceOp.getStrides(), sliceOp.getType());
+      populateResults({runtimeResult});
     } else if (auto subtractOp = dyn_cast<SubtractOp>(op)) {
       Tensor runtimeLhs = fetchOperand(subtractOp.getLhs());
       Tensor runtimeRhs = fetchOperand(subtractOp.getRhs());

--- a/stablehlo/reference/Interpreter.cpp
+++ b/stablehlo/reference/Interpreter.cpp
@@ -137,9 +137,9 @@ llvm::Expected<SmallVector<Tensor>> eval(func::FuncOp func,
       populateResults({runtimeResult});
     } else if (auto sliceOp = dyn_cast<SliceOp>(op)) {
       Tensor runtimeOperand = fetchOperand(sliceOp.getOperand());
-      Tensor runtimeResult = evalSliceOp(runtimeOperand,
-          sliceOp.getStartIndices(), sliceOp.getLimitIndices(),
-          sliceOp.getStrides(), sliceOp.getType());
+      Tensor runtimeResult =
+          evalSliceOp(runtimeOperand, sliceOp.getStartIndices(),
+                      sliceOp.getStrides(), sliceOp.getType());
       populateResults({runtimeResult});
     } else if (auto subtractOp = dyn_cast<SubtractOp>(op)) {
       Tensor runtimeLhs = fetchOperand(subtractOp.getLhs());

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -172,9 +172,8 @@ Tensor evalSineOp(const Tensor &operand, Type resultType) {
   return result;
 }
 
-Tensor evalSliceOp(const Tensor &operand,
-                   const SmallVector<int64_t> startIndices,
-                   const SmallVector<int64_t> strides, Type resultType) {
+Tensor evalSliceOp(const Tensor &operand, ArrayRef<int64_t> startIndices,
+                   ArrayRef<int64_t> strides, Type resultType) {
   Tensor result(resultType);
   for (auto resultIt = result.index_begin(); resultIt != result.index_end();
        ++resultIt) {

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -172,11 +172,10 @@ Tensor evalSineOp(const Tensor &operand, Type resultType) {
   return result;
 }
 
-Tensor evalSliceOp(const Tensor &operand, DenseIntElementsAttr startIndicesAttr,
-                   DenseIntElementsAttr stridesAttr, Type resultType) {
+Tensor evalSliceOp(const Tensor &operand,
+                   const SmallVector<int64_t> startIndices,
+                   const SmallVector<int64_t> strides, Type resultType) {
   Tensor result(resultType);
-  auto startIndices = startIndicesAttr.getValues<int64_t>();
-  auto strides = stridesAttr.getValues<int64_t>();
   for (auto resultIt = result.index_begin(); resultIt != result.index_end();
        ++resultIt) {
     SmallVector<int64_t> operandIdx;

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -177,13 +177,12 @@ Tensor evalSliceOp(const Tensor &operand, DenseIntElementsAttr startIndicesAttr,
   Tensor result(resultType);
   auto startIndices = startIndicesAttr.getValues<int64_t>();
   auto strides = stridesAttr.getValues<int64_t>();
-
   for (auto resultIt = result.index_begin(); resultIt != result.index_end();
        ++resultIt) {
-    SmallVector<int64_t> opIdx;
+    SmallVector<int64_t> operandIdx;
     for (auto dim = 0; dim < operand.getType().getRank(); ++dim)
-      opIdx.push_back(startIndices[dim] + (*resultIt)[dim] * strides[dim]);
-    result.set(*resultIt, operand.get(opIdx));
+      operandIdx.push_back(startIndices[dim] + (*resultIt)[dim] * strides[dim]);
+    result.set(*resultIt, operand.get(operandIdx));
   }
   return result;
 }

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -38,8 +38,9 @@ Tensor evalNotOp(const Tensor &operand, Type resultType);
 Tensor evalOrOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
 Tensor evalReshapeOp(const Tensor &operand, Type resultType);
 Tensor evalSineOp(const Tensor &operand, Type resultType);
-Tensor evalSliceOp(const Tensor &operand, DenseIntElementsAttr startIndices,
-                   DenseIntElementsAttr strides, Type resultType);
+Tensor evalSliceOp(const Tensor &operand,
+                   const SmallVector<int64_t> startIndices,
+                   const SmallVector<int64_t> strides, Type resultType);
 Tensor evalSubtractOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
 Tensor evalTanhOp(const Tensor &operand, Type resultType);
 Tensor evalTransposeOp(const Tensor &operand, ArrayRef<int64_t> permutation,

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -38,6 +38,9 @@ Tensor evalNotOp(const Tensor &operand, Type resultType);
 Tensor evalOrOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
 Tensor evalReshapeOp(const Tensor &operand, Type resultType);
 Tensor evalSineOp(const Tensor &operand, Type resultType);
+Tensor evalSliceOp(const Tensor &operand, DenseIntElementsAttr startIndices,
+    DenseIntElementsAttr limitIndices, DenseIntElementsAttr strides,
+    Type resultType);
 Tensor evalSubtractOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
 Tensor evalTanhOp(const Tensor &operand, Type resultType);
 Tensor evalTransposeOp(const Tensor &operand, ArrayRef<int64_t> permutation,

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -39,8 +39,7 @@ Tensor evalOrOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
 Tensor evalReshapeOp(const Tensor &operand, Type resultType);
 Tensor evalSineOp(const Tensor &operand, Type resultType);
 Tensor evalSliceOp(const Tensor &operand, DenseIntElementsAttr startIndices,
-    DenseIntElementsAttr limitIndices, DenseIntElementsAttr strides,
-    Type resultType);
+                   DenseIntElementsAttr strides, Type resultType);
 Tensor evalSubtractOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
 Tensor evalTanhOp(const Tensor &operand, Type resultType);
 Tensor evalTransposeOp(const Tensor &operand, ArrayRef<int64_t> permutation,

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -38,9 +38,8 @@ Tensor evalNotOp(const Tensor &operand, Type resultType);
 Tensor evalOrOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
 Tensor evalReshapeOp(const Tensor &operand, Type resultType);
 Tensor evalSineOp(const Tensor &operand, Type resultType);
-Tensor evalSliceOp(const Tensor &operand,
-                   const SmallVector<int64_t> startIndices,
-                   const SmallVector<int64_t> strides, Type resultType);
+Tensor evalSliceOp(const Tensor &operand, ArrayRef<int64_t> startIndices,
+                   ArrayRef<int64_t> strides, Type resultType);
 Tensor evalSubtractOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
 Tensor evalTanhOp(const Tensor &operand, Type resultType);
 Tensor evalTransposeOp(const Tensor &operand, ArrayRef<int64_t> permutation,

--- a/stablehlo/tests/interpret_slice.mlir
+++ b/stablehlo/tests/interpret_slice.mlir
@@ -2,42 +2,6 @@
 
 // CHECK-LABEL: Evaluated results of function: slice_op
 func.func @slice_op() -> tensor<2x2xi64> {
-  %operand = stablehlo.constant dense<[[0, 0, 0, 0],
-                                       [0, 0, 1, 1],
-                                       [0, 0, 1, 1]]> : tensor<3x4xi64>
-  %result = "stablehlo.slice"(%operand) {
-    start_indices = dense<[1, 2]> : tensor<2xi64>,
-    limit_indices = dense<[3, 4]> : tensor<2xi64>,
-    strides = dense<1> : tensor<2xi64>
-  } : (tensor<3x4xi64>) -> tensor<2x2xi64>
-  func.return %result : tensor<2x2xi64>
-  // CHECK-NEXT: tensor<2x2xi64>
-  // CHECK-NEXT: 1 : i64
-  // CHECK-NEXT: 1 : i64
-  // CHECK-NEXT: 1 : i64
-  // CHECK-NEXT: 1 : i64
-}
-
-// -----
-
-// CHECK-LABEL: Evaluated results of function: slice_op_1d
-func.func @slice_op_1d() -> tensor<2xi64> {
-  %operand = stablehlo.constant dense<[0, 1, 2, 3, 4]> : tensor<5xi64>
-  %result = "stablehlo.slice"(%operand) {
-    start_indices = dense<2> : tensor<1xi64>,
-    limit_indices = dense<4> : tensor<1xi64>,
-    strides = dense<1> : tensor<1xi64>
-  } : (tensor<5xi64>) -> tensor<2xi64>
-  func.return %result : tensor<2xi64>
-  // CHECK-NEXT: tensor<2xi64>
-  // CHECK-NEXT: 2 : i64
-  // CHECK-NEXT: 3 : i64
-}
-
-// -----
-
-// CHECK-LABEL: Evaluated results of function: slice_op_2d
-func.func @slice_op_2d() -> tensor<2x2xi64> {
   %operand = stablehlo.constant dense<[[0, 0, 1, 0, 0, 1],
                                        [0, 0, 0, 0, 0, 0],
                                        [0, 0, 1, 0, 0, 1]]> : tensor<3x6xi64>
@@ -56,8 +20,8 @@ func.func @slice_op_2d() -> tensor<2x2xi64> {
 
 // -----
 
-// CHECK-LABEL: Evaluated results of function: slice_op_empty
-func.func @slice_op_empty() -> tensor<0x0xi64> {
+// CHECK-LABEL: Evaluated results of function: slice_op_empty_slice
+func.func @slice_op_empty_slice() -> tensor<0x0xi64> {
   %operand = stablehlo.constant dense<[[1,  2,  3,  4],
                                        [5,  6,  7,  8],
                                        [9, 10, 11, 12]]> : tensor<3x4xi64>

--- a/stablehlo/tests/interpret_slice.mlir
+++ b/stablehlo/tests/interpret_slice.mlir
@@ -17,19 +17,3 @@ func.func @slice_op() -> tensor<2x2xi64> {
   // CHECK-NEXT: 1 : i64
   // CHECK-NEXT: 1 : i64
 }
-
-// -----
-
-// CHECK-LABEL: Evaluated results of function: slice_op_empty_slice
-func.func @slice_op_empty_slice() -> tensor<0x0xi64> {
-  %operand = stablehlo.constant dense<[[1,  2,  3,  4],
-                                       [5,  6,  7,  8],
-                                       [9, 10, 11, 12]]> : tensor<3x4xi64>
-  %result = "stablehlo.slice"(%operand) {
-    start_indices = dense<[1, 2]> : tensor<2xi64>,
-    limit_indices = dense<[1, 2]> : tensor<2xi64>,
-    strides = dense<1> : tensor<2xi64>
-  } : (tensor<3x4xi64>) -> tensor<0x0xi64>
-  func.return %result : tensor<0x0xi64>
-  // CHECK-NEXT: tensor<0x0xi64>
-}

--- a/stablehlo/tests/interpret_slice.mlir
+++ b/stablehlo/tests/interpret_slice.mlir
@@ -1,0 +1,17 @@
+// RUN: stablehlo-interpreter --interpret -split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: Evaluated results of function: slice_op
+func.func @slice_op() -> tensor<2x2xi64> {
+  %0 = stablehlo.constant dense<[[0, 0, 1, 0, 0, 1], [0, 0, 0, 0, 0, 0], [0, 0, 1, 0, 0, 1]]> : tensor<3x6xi64>
+  %1 = "stablehlo.slice"(%0) {
+    start_indices = dense<[0, 2]> : tensor<2xi64>,
+    limit_indices = dense<[3, 6]> : tensor<2xi64>,
+    strides = dense<[2, 3]> : tensor<2xi64>
+  } : (tensor<3x6xi64>) -> tensor<2x2xi64>
+  func.return %1 : tensor<2x2xi64>
+  // CHECK-NEXT: tensor<2x2xi64>
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+}

--- a/stablehlo/tests/interpret_slice.mlir
+++ b/stablehlo/tests/interpret_slice.mlir
@@ -2,16 +2,64 @@
 
 // CHECK-LABEL: Evaluated results of function: slice_op
 func.func @slice_op() -> tensor<2x2xi64> {
-  %0 = stablehlo.constant dense<[[0, 0, 1, 0, 0, 1], [0, 0, 0, 0, 0, 0], [0, 0, 1, 0, 0, 1]]> : tensor<3x6xi64>
-  %1 = "stablehlo.slice"(%0) {
-    start_indices = dense<[0, 2]> : tensor<2xi64>,
-    limit_indices = dense<[3, 6]> : tensor<2xi64>,
-    strides = dense<[2, 3]> : tensor<2xi64>
-  } : (tensor<3x6xi64>) -> tensor<2x2xi64>
-  func.return %1 : tensor<2x2xi64>
+  %operand = stablehlo.constant dense<[[0, 0, 0, 0], [0, 0, 1, 1], [0, 0, 1, 1]]> : tensor<3x4xi64>
+  %result = "stablehlo.slice"(%operand) {
+    start_indices = dense<[1, 2]> : tensor<2xi64>,
+    limit_indices = dense<[3, 4]> : tensor<2xi64>,
+    strides = dense<1> : tensor<2xi64>
+  } : (tensor<3x4xi64>) -> tensor<2x2xi64>
+  func.return %result : tensor<2x2xi64>
   // CHECK-NEXT: tensor<2x2xi64>
   // CHECK-NEXT: 1 : i64
   // CHECK-NEXT: 1 : i64
   // CHECK-NEXT: 1 : i64
   // CHECK-NEXT: 1 : i64
+}
+
+// -----
+
+// CHECK-LABEL: Evaluated results of function: slice_op_1d
+func.func @slice_op_1d() -> tensor<2xi64> {
+  %operand = stablehlo.constant dense<[0, 1, 2, 3, 4]> : tensor<5xi64>
+  %result = "stablehlo.slice"(%operand) {
+    start_indices = dense<2> : tensor<1xi64>,
+    limit_indices = dense<4> : tensor<1xi64>,
+    strides = dense<1> : tensor<1xi64>
+  } : (tensor<5xi64>) -> tensor<2xi64>
+  func.return %result : tensor<2xi64>
+  // CHECK-NEXT: tensor<2xi64>
+  // CHECK-NEXT: 2 : i64
+  // CHECK-NEXT: 3 : i64
+}
+
+// -----
+
+// CHECK-LABEL: Evaluated results of function: slice_op_2d
+func.func @slice_op_2d() -> tensor<2x2xi64> {
+  %operand = stablehlo.constant dense<[[0, 0, 1, 0, 0, 1], [0, 0, 0, 0, 0, 0], [0, 0, 1, 0, 0, 1]]> : tensor<3x6xi64>
+  %result = "stablehlo.slice"(%operand) {
+    start_indices = dense<[0, 2]> : tensor<2xi64>,
+    limit_indices = dense<[3, 6]> : tensor<2xi64>,
+    strides = dense<[2, 3]> : tensor<2xi64>
+  } : (tensor<3x6xi64>) -> tensor<2x2xi64>
+  func.return %result : tensor<2x2xi64>
+  // CHECK-NEXT: tensor<2x2xi64>
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+}
+
+// -----
+
+// CHECK-LABEL: Evaluated results of function: slice_op_empty
+func.func @slice_op_empty() -> tensor<0xi64> {
+  %operand = stablehlo.constant dense<[]> : tensor<0xi64>
+  %result = "stablehlo.slice"(%operand) {
+    start_indices = dense<0> : tensor<1xi64>,
+    limit_indices = dense<0> : tensor<1xi64>,
+    strides = dense<1> : tensor<1xi64>
+  } : (tensor<0xi64>) -> tensor<0xi64>
+  func.return %result : tensor<0xi64>
+  // CHECK-NEXT: tensor<0xi64>
 }

--- a/stablehlo/tests/interpret_slice.mlir
+++ b/stablehlo/tests/interpret_slice.mlir
@@ -2,7 +2,9 @@
 
 // CHECK-LABEL: Evaluated results of function: slice_op
 func.func @slice_op() -> tensor<2x2xi64> {
-  %operand = stablehlo.constant dense<[[0, 0, 0, 0], [0, 0, 1, 1], [0, 0, 1, 1]]> : tensor<3x4xi64>
+  %operand = stablehlo.constant dense<[[0, 0, 0, 0],
+                                       [0, 0, 1, 1],
+                                       [0, 0, 1, 1]]> : tensor<3x4xi64>
   %result = "stablehlo.slice"(%operand) {
     start_indices = dense<[1, 2]> : tensor<2xi64>,
     limit_indices = dense<[3, 4]> : tensor<2xi64>,
@@ -36,7 +38,9 @@ func.func @slice_op_1d() -> tensor<2xi64> {
 
 // CHECK-LABEL: Evaluated results of function: slice_op_2d
 func.func @slice_op_2d() -> tensor<2x2xi64> {
-  %operand = stablehlo.constant dense<[[0, 0, 1, 0, 0, 1], [0, 0, 0, 0, 0, 0], [0, 0, 1, 0, 0, 1]]> : tensor<3x6xi64>
+  %operand = stablehlo.constant dense<[[0, 0, 1, 0, 0, 1],
+                                       [0, 0, 0, 0, 0, 0],
+                                       [0, 0, 1, 0, 0, 1]]> : tensor<3x6xi64>
   %result = "stablehlo.slice"(%operand) {
     start_indices = dense<[0, 2]> : tensor<2xi64>,
     limit_indices = dense<[3, 6]> : tensor<2xi64>,
@@ -53,13 +57,15 @@ func.func @slice_op_2d() -> tensor<2x2xi64> {
 // -----
 
 // CHECK-LABEL: Evaluated results of function: slice_op_empty
-func.func @slice_op_empty() -> tensor<0xi64> {
-  %operand = stablehlo.constant dense<[]> : tensor<0xi64>
+func.func @slice_op_empty() -> tensor<0x0xi64> {
+  %operand = stablehlo.constant dense<[[1,  2,  3,  4],
+                                       [5,  6,  7,  8],
+                                       [9, 10, 11, 12]]> : tensor<3x4xi64>
   %result = "stablehlo.slice"(%operand) {
-    start_indices = dense<0> : tensor<1xi64>,
-    limit_indices = dense<0> : tensor<1xi64>,
-    strides = dense<1> : tensor<1xi64>
-  } : (tensor<0xi64>) -> tensor<0xi64>
-  func.return %result : tensor<0xi64>
-  // CHECK-NEXT: tensor<0xi64>
+    start_indices = dense<[1, 2]> : tensor<2xi64>,
+    limit_indices = dense<[1, 2]> : tensor<2xi64>,
+    strides = dense<1> : tensor<2xi64>
+  } : (tensor<3x4xi64>) -> tensor<0x0xi64>
+  func.return %result : tensor<0x0xi64>
+  // CHECK-NEXT: tensor<0x0xi64>
 }

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -2250,14 +2250,6 @@ func.func @slice(%arg0: tensor<3x4xi32>) -> tensor<1x2xi32> {
 
 // -----
 
-func.func @slice_c1(%arg0: tensor<3x4xi32>) -> tensor<1x4xf32> {
-  // expected-error@+1 {{requires the same element type for all operands and results}}
-  %0 = "stablehlo.slice"(%arg0) {start_indices = dense<[1, 0]> : tensor<2xi64>, limit_indices = dense<[2, 4]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<3x4xi32>) -> tensor<1x4xf32>
-  func.return %0 : tensor<1x4xf32>
-}
-
-// -----
-
 func.func @slice_c2(%arg0: tensor<3x4xi32>) -> tensor<1x2xi32> {
   // expected-error@+1 {{start_indices has rank 2 instead of required rank 1}}
   %0 = "stablehlo.slice"(%arg0) {
@@ -2290,18 +2282,6 @@ func.func @slice_c3(%arg0: tensor<3x4xi32>) -> tensor<1x2xi32> {
     strides = dense<[1, 2]> : tensor<2xi64>
   } : (tensor<3x4xi32>) -> tensor<1x2xi32>
   func.return %0 : tensor<1x2xi32>
-}
-
-// -----
-
-func.func @slice_c3(%arg0: tensor<3x?xi32>) -> tensor<1x?xi32> {
-  // expected-error@+1 {{negative start index -1 in dimension 1}}
-  %0 = "stablehlo.slice"(%arg0) {
-    start_indices = dense<[1, -1]> : tensor<2xi64>,
-    limit_indices = dense<[2, 2]> : tensor<2xi64>,
-    strides = dense<[1, 1]> : tensor<2xi64>
-  } : (tensor<3x?xi32>) -> tensor<1x?xi32>
-  func.return %0 : tensor<1x?xi32>
 }
 
 // -----
@@ -2350,14 +2330,6 @@ func.func @slice_dynamic_dim(%arg0: tensor<3x?xi32>) -> tensor<1x?xi32> {
     strides = dense<[1, 1]> : tensor<2xi64>
   } : (tensor<3x?xi32>) -> tensor<1x?xi32>
   func.return %0 : tensor<1x?xi32>
-}
-
-// -----
-
-func.func @slice_indices_mismatch(%arg0: tensor<3x4xi32>) -> tensor<1x4xi32> {
-  // expected-error@+1 {{failed to verify that all of {start_indices, limit_indices, strides} have same type}}
-  %0 = "stablehlo.slice"(%arg0) {start_indices = dense<[1, 2]> : tensor<2xi64>, limit_indices = dense<[2, 4, 1]> : tensor<3xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<3x4xi32>) -> tensor<1x4xi32>
-  func.return %0 : tensor<1x4xi32>
 }
 
 // -----

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -2250,14 +2250,6 @@ func.func @slice(%arg0: tensor<3x4xi32>) -> tensor<1x2xi32> {
 
 // -----
 
-// CHECK-LABEL: func @slice_unranked
-func.func @slice_unranked(%arg0: tensor<*xi32>) -> tensor<*xi32> {
-  %0 = "stablehlo.slice"(%arg0) {start_indices = dense<[1, 0]> : tensor<2xi64>, limit_indices = dense<[2, 4]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<*xi32>) -> tensor<*xi32>
-  func.return %0 : tensor<*xi32>
-}
-
-// -----
-
 // CHECK-LABEL: func @slice_dynamic_dim
 func.func @slice_dynamic_dim(%arg0: tensor<3x?xi32>) -> tensor<1x?xi32> {
   %0 = "stablehlo.slice"(%arg0) {
@@ -2274,6 +2266,14 @@ func.func @slice_indices_mismatch(%arg0: tensor<3x4xi32>) -> tensor<1x4xi32> {
   // expected-error@+1 {{failed to verify that all of {start_indices, limit_indices, strides} have same type}}
   %0 = "stablehlo.slice"(%arg0) {start_indices = dense<[1, 2]> : tensor<2xi64>, limit_indices = dense<[2, 4, 1]> : tensor<3xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<3x4xi32>) -> tensor<1x4xi32>
   func.return %0 : tensor<1x4xi32>
+}
+
+// -----
+
+// CHECK-LABEL: func @slice_unranked
+func.func @slice_unranked(%arg0: tensor<*xi32>) -> tensor<*xi32> {
+  %0 = "stablehlo.slice"(%arg0) {start_indices = dense<[1, 0]> : tensor<2xi64>, limit_indices = dense<[2, 4]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<*xi32>) -> tensor<*xi32>
+  func.return %0 : tensor<*xi32>
 }
 
 // -----

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -2250,7 +2250,7 @@ func.func @slice(%arg0: tensor<3x4xi32>) -> tensor<1x2xi32> {
 
 // -----
 
-func.func @slice_C1(%arg0: tensor<3x4xi32>) -> tensor<1x4xf32> {
+func.func @slice_c1(%arg0: tensor<3x4xi32>) -> tensor<1x4xf32> {
   // expected-error@+1 {{requires the same element type for all operands and results}}
   %0 = "stablehlo.slice"(%arg0) {start_indices = dense<[1, 0]> : tensor<2xi64>, limit_indices = dense<[2, 4]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<3x4xi32>) -> tensor<1x4xf32>
   func.return %0 : tensor<1x4xf32>
@@ -2258,7 +2258,7 @@ func.func @slice_C1(%arg0: tensor<3x4xi32>) -> tensor<1x4xf32> {
 
 // -----
 
-func.func @slice_C2(%arg0: tensor<3x4xi32>) -> tensor<1x2xi32> {
+func.func @slice_c2(%arg0: tensor<3x4xi32>) -> tensor<1x2xi32> {
   // expected-error@+1 {{start_indices has rank 2 instead of required rank 1}}
   %0 = "stablehlo.slice"(%arg0) {
     start_indices = dense<[[1, 0]]> : tensor<1x2xi64>,
@@ -2270,7 +2270,7 @@ func.func @slice_C2(%arg0: tensor<3x4xi32>) -> tensor<1x2xi32> {
 
 // -----
 
-func.func @slice_C2(%arg0: tensor<3x4xi32>) -> tensor<1x2xi32> {
+func.func @slice_c2(%arg0: tensor<3x4xi32>) -> tensor<1x2xi32> {
   // expected-error@+1 {{the number of elements in start_indices (3) does not match the rank of the operand (2)}}
   %0 = "stablehlo.slice"(%arg0) {
     start_indices = dense<[1, 0, 0]> : tensor<3xi64>,
@@ -2282,7 +2282,7 @@ func.func @slice_C2(%arg0: tensor<3x4xi32>) -> tensor<1x2xi32> {
 
 // -----
 
-func.func @slice_C3(%arg0: tensor<3x4xi32>) -> tensor<1x2xi32> {
+func.func @slice_c3(%arg0: tensor<3x4xi32>) -> tensor<1x2xi32> {
   // expected-error@+1 {{negative start index -1 in dimension 0}}
   %0 = "stablehlo.slice"(%arg0) {
     start_indices = dense<[-1, 0]> : tensor<2xi64>,
@@ -2294,7 +2294,7 @@ func.func @slice_C3(%arg0: tensor<3x4xi32>) -> tensor<1x2xi32> {
 
 // -----
 
-func.func @slice_C3(%arg0: tensor<3x?xi32>) -> tensor<1x?xi32> {
+func.func @slice_c3(%arg0: tensor<3x?xi32>) -> tensor<1x?xi32> {
   // expected-error@+1 {{negative start index -1 in dimension 1}}
   %0 = "stablehlo.slice"(%arg0) {
     start_indices = dense<[1, -1]> : tensor<2xi64>,
@@ -2306,7 +2306,7 @@ func.func @slice_C3(%arg0: tensor<3x?xi32>) -> tensor<1x?xi32> {
 
 // -----
 
-func.func @slice_C3(%arg0: tensor<3x4xi32>) -> tensor<1x2xi32> {
+func.func @slice_c3(%arg0: tensor<3x4xi32>) -> tensor<1x2xi32> {
   // expected-error@+1 {{limit index 5 is larger than dimension size 4 in dimension 1}}
   %0 = "stablehlo.slice"(%arg0) {
     start_indices = dense<[1, 0]> : tensor<2xi64>,
@@ -2318,7 +2318,7 @@ func.func @slice_C3(%arg0: tensor<3x4xi32>) -> tensor<1x2xi32> {
 
 // -----
 
-func.func @slice_C3(%arg0: tensor<3x4xi32>) -> tensor<1x2xi32> {
+func.func @slice_c3(%arg0: tensor<3x4xi32>) -> tensor<1x2xi32> {
   // expected-error@+1 {{start index 3 is larger than limit index 2 in dimension 1}}
   %0 = "stablehlo.slice"(%arg0) {
     start_indices = dense<[1, 3]> : tensor<2xi64>,
@@ -2330,7 +2330,7 @@ func.func @slice_C3(%arg0: tensor<3x4xi32>) -> tensor<1x2xi32> {
 
 // -----
 
-func.func @slice_C4(%arg0: tensor<3x4xi32>) -> tensor<1x2xi32> {
+func.func @slice_c4(%arg0: tensor<3x4xi32>) -> tensor<1x2xi32> {
   // expected-error@+1 {{stride must be positive but got 0 in dimension 0}}
   %0 = "stablehlo.slice"(%arg0) {
     start_indices = dense<[1, 0]> : tensor<2xi64>,

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -2250,34 +2250,6 @@ func.func @slice(%arg0: tensor<3x4xi32>) -> tensor<1x2xi32> {
 
 // -----
 
-// CHECK-LABEL: func @slice_dynamic_dim
-func.func @slice_dynamic_dim(%arg0: tensor<3x?xi32>) -> tensor<1x?xi32> {
-  %0 = "stablehlo.slice"(%arg0) {
-    start_indices = dense<[1, 1]> : tensor<2xi64>,
-    limit_indices = dense<[2, 2]> : tensor<2xi64>,
-    strides = dense<[1, 1]> : tensor<2xi64>
-  } : (tensor<3x?xi32>) -> tensor<1x?xi32>
-  func.return %0 : tensor<1x?xi32>
-}
-
-// -----
-
-func.func @slice_indices_mismatch(%arg0: tensor<3x4xi32>) -> tensor<1x4xi32> {
-  // expected-error@+1 {{failed to verify that all of {start_indices, limit_indices, strides} have same type}}
-  %0 = "stablehlo.slice"(%arg0) {start_indices = dense<[1, 2]> : tensor<2xi64>, limit_indices = dense<[2, 4, 1]> : tensor<3xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<3x4xi32>) -> tensor<1x4xi32>
-  func.return %0 : tensor<1x4xi32>
-}
-
-// -----
-
-// CHECK-LABEL: func @slice_unranked
-func.func @slice_unranked(%arg0: tensor<*xi32>) -> tensor<*xi32> {
-  %0 = "stablehlo.slice"(%arg0) {start_indices = dense<[1, 0]> : tensor<2xi64>, limit_indices = dense<[2, 4]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<*xi32>) -> tensor<*xi32>
-  func.return %0 : tensor<*xi32>
-}
-
-// -----
-
 func.func @slice_C1(%arg0: tensor<3x4xi32>) -> tensor<1x4xf32> {
   // expected-error@+1 {{requires the same element type for all operands and results}}
   %0 = "stablehlo.slice"(%arg0) {start_indices = dense<[1, 0]> : tensor<2xi64>, limit_indices = dense<[2, 4]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<3x4xi32>) -> tensor<1x4xf32>
@@ -2366,6 +2338,34 @@ func.func @slice_C4(%arg0: tensor<3x4xi32>) -> tensor<1x2xi32> {
     strides = dense<[0, 2]> : tensor<2xi64>
   } : (tensor<3x4xi32>) -> tensor<1x2xi32>
   func.return %0 : tensor<1x2xi32>
+}
+
+// -----
+
+// CHECK-LABEL: func @slice_dynamic_dim
+func.func @slice_dynamic_dim(%arg0: tensor<3x?xi32>) -> tensor<1x?xi32> {
+  %0 = "stablehlo.slice"(%arg0) {
+    start_indices = dense<[1, 1]> : tensor<2xi64>,
+    limit_indices = dense<[2, 2]> : tensor<2xi64>,
+    strides = dense<[1, 1]> : tensor<2xi64>
+  } : (tensor<3x?xi32>) -> tensor<1x?xi32>
+  func.return %0 : tensor<1x?xi32>
+}
+
+// -----
+
+func.func @slice_indices_mismatch(%arg0: tensor<3x4xi32>) -> tensor<1x4xi32> {
+  // expected-error@+1 {{failed to verify that all of {start_indices, limit_indices, strides} have same type}}
+  %0 = "stablehlo.slice"(%arg0) {start_indices = dense<[1, 2]> : tensor<2xi64>, limit_indices = dense<[2, 4, 1]> : tensor<3xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<3x4xi32>) -> tensor<1x4xi32>
+  func.return %0 : tensor<1x4xi32>
+}
+
+// -----
+
+// CHECK-LABEL: func @slice_unranked
+func.func @slice_unranked(%arg0: tensor<*xi32>) -> tensor<*xi32> {
+  %0 = "stablehlo.slice"(%arg0) {start_indices = dense<[1, 0]> : tensor<2xi64>, limit_indices = dense<[2, 4]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<*xi32>) -> tensor<*xi32>
+  func.return %0 : tensor<*xi32>
 }
 
 // -----

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -2251,18 +2251,6 @@ func.func @slice(%arg0: tensor<3x4xi32>) -> tensor<1x2xi32> {
 // -----
 
 func.func @slice_c2(%arg0: tensor<3x4xi32>) -> tensor<1x2xi32> {
-  // expected-error@+1 {{start_indices has rank 2 instead of required rank 1}}
-  %0 = "stablehlo.slice"(%arg0) {
-    start_indices = dense<[[1, 0]]> : tensor<1x2xi64>,
-    limit_indices = dense<[[2, 4]]> : tensor<1x2xi64>,
-    strides = dense<[[1, 2]]> : tensor<1x2xi64>
-  } : (tensor<3x4xi32>) -> tensor<1x2xi32>
-  func.return %0 : tensor<1x2xi32>
-}
-
-// -----
-
-func.func @slice_c2(%arg0: tensor<3x4xi32>) -> tensor<1x2xi32> {
   // expected-error@+1 {{the number of elements in start_indices (3) does not match the rank of the operand (2)}}
   %0 = "stablehlo.slice"(%arg0) {
     start_indices = dense<[1, 0, 0]> : tensor<3xi64>,
@@ -2330,6 +2318,18 @@ func.func @slice_dynamic_dim(%arg0: tensor<3x?xi32>) -> tensor<1x?xi32> {
     strides = dense<[1, 1]> : tensor<2xi64>
   } : (tensor<3x?xi32>) -> tensor<1x?xi32>
   func.return %0 : tensor<1x?xi32>
+}
+
+// -----
+
+func.func @slice_i2(%arg0: tensor<3x4xi32>) -> tensor<1x2xi32> {
+  // expected-error@+1 {{start_indices has rank 2 instead of required rank 1}}
+  %0 = "stablehlo.slice"(%arg0) {
+    start_indices = dense<[[1, 0]]> : tensor<1x2xi64>,
+    limit_indices = dense<[[2, 4]]> : tensor<1x2xi64>,
+    strides = dense<[[1, 2]]> : tensor<1x2xi64>
+  } : (tensor<3x4xi32>) -> tensor<1x2xi32>
+  func.return %0 : tensor<1x2xi32>
 }
 
 // -----


### PR DESCRIPTION
We have the following constraints in the spec:

```
// Ix constraints come from the Inputs table
(I1) operand tensor
(I2) start_indices 1-dimensional tensor constant of type si64
(I3) limit_indices 1-dimensional tensor constant of type si64
(I4) strides 1-dimensional tensor constant of type si64
(C1) operand and result have the same element type.
(C2) size(start_indices) = size(limit_indices) = size(strides) = rank(operand).
(C3) 0 <= start_indices[d] <= limit_indices[d] <= dim(operand, d) for all dimension d.
(C4) 0 < strides[d] for all dimension d.
(C5) dim(result, d) = ... for all dimension d in operand.
```

These constraints will be comprehensively covered by the following tests:

```
I1: a) operand is not a tensor. (Covered by ODS).
I2: a) start_indices is not a tensor. (Covered by ODS).
    b) rank(start_indices) != 1.
    c) element_type(start_indices) != si64. (Covered by ODS).
I3: a) limit_indices is not a tensor. (Covered by ODS).
    b) rank(limit_indices) != 1. (Covered by ODS).
    c) element_type(limit_indices) != si64. (Covered by ODS).
I4: a) strides is not a tensor. (Covered by ODS).
    b) rank(strides) != 1. (Covered by ODS).
    c) element_type(strides) != si64. (Covered by ODS).
C1: element_type(operand) != element_type(result). (Covered by ODS).
C2: a) size(start_indices) != rank(operand).
    b) size(limit_indices) != rank(operand). (Covered by ODS).
    c) size(strides) != rank(operand). (Covered by ODS).
C3: a) start_indices < 0.
    b) start_indices > limit_indices.
    c) limit_indices > shape(operand).
C4: a) strides <= 0.
C5: no negative test needed since it's just inferring the shape
```

If we drop the "Covered by ODS" pieces, this will leave us with the following test cases:

```
I2b: rank(start_indices) != 1.
C2a: size(start_indices) != rank(operand).
C3a: start_indices < 0.
C3b: start_indices > limit_indices.
C3c: limit_indices > shape(operand).
C4a: strides <= 0.
```
closes #990 