### PR TITLE
Add interpreter for DynamicUpdateSliceOp

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2418,6 +2418,8 @@ More formally, `result[i0, ..., iR-1]` is defined as:
 //          ]
 ```
 
+&nbsp;[More Examples](../stablehlo/tests/interpret_dynamic_update_slice.mlir)
+
 ### exponential
 
 #### Semantics

--- a/docs/status.md
+++ b/docs/status.md
@@ -85,7 +85,7 @@ one of the following tracking labels.
 | dynamic_pad              | no            | revisit      | no             | yes             | no          |
 | dynamic_reshape          | no            | revisit      | infeasible     | yes             | no          |
 | dynamic_slice            | yes           | yes          | yes            | yes             | no          |
-| dynamic_update_slice     | yes           | yes          | yes            | yes             | no          |
+| dynamic_update_slice     | yes           | yes          | yes            | yes             | yes         |
 | einsum                   | no            | revisit      | no             | yes             | no          |
 | exponential              | yes           | yes          | yes            | yes             | no          |
 | exponential_minus_one    | yes           | yes          | yes            | yes             | no          |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1666,8 +1666,8 @@ def StableHLO_DynamicUpdateSliceOp: StableHLO_Op<"dynamic_update_slice",
     ```
   }];
   let arguments = (ins
-    HLO_Tensor:$operand,
-    HLO_Tensor:$update,
+    HLO_Tensor:$operand /*dynamic_update_slice_i1*/,
+    HLO_Tensor:$update /*dynamic_update_slice_i2*/,
     Variadic<HLO_ScalarIntTensor>:$start_indices /*dynamic_update_slice_i3*/
   );
   let results = (outs HLO_Tensor:$result);

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1648,7 +1648,7 @@ def StableHLO_DynamicSliceOp: StableHLO_Op<"dynamic_slice",
 }
 
 def StableHLO_DynamicUpdateSliceOp: StableHLO_Op<"dynamic_update_slice",
-      [Pure, AllElementTypesMatch<["operand", "update", "result"]>,
+      [Pure, AllElementTypesMatch<["operand", "update", "result"]> /*dynamic_update_slice_c1, dynamic_update_slice_c2*/,
        InferTensorType]> {
   let summary = "DynamicUpdateSlice operation";
   let description = [{

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1650,7 +1650,7 @@ def StableHLO_DynamicSliceOp: StableHLO_Op<"dynamic_slice",
 def StableHLO_DynamicUpdateSliceOp: StableHLO_Op<"dynamic_update_slice",
       [Pure, AllElementTypesMatch<["operand", "update", "result"]>,
        InferTensorType]> {
-  let summary = "Dynamic Update Slice operator";
+  let summary = "DynamicUpdateSlice operation";
   let description = [{
     Produces a `result` tensor which is equal to the `operand` tensor except
     that the slice starting at `start_indices` is updated with the values in

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1668,7 +1668,7 @@ def StableHLO_DynamicUpdateSliceOp: StableHLO_Op<"dynamic_update_slice",
   let arguments = (ins
     HLO_Tensor:$operand,
     HLO_Tensor:$update,
-    Variadic<HLO_ScalarIntTensor>:$start_indices
+    Variadic<HLO_ScalarIntTensor>:$start_indices /*dynamic_update_slice_i3*/
   );
   let results = (outs HLO_Tensor:$result);
 

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2065,7 +2065,7 @@ LogicalResult inferDynamicUpdateSliceOp(
   auto operandType = operand.getType().cast<ShapedType>();
   auto updateType = update.getType().cast<ShapedType>();
 
-  // (C3)
+  // DynamicUpdateSliceOp_C3
   if (updateType.hasRank() && operandType.hasRank() &&
       updateType.getRank() != operandType.getRank())
     return emitOptionalError(
@@ -2073,20 +2073,20 @@ LogicalResult inferDynamicUpdateSliceOp(
         "update rank does not match operand rank: ", updateType.getRank(),
         " vs ", operandType.getRank(), ".");
 
-  // (C4)
+  // DynamicUpdateSliceOp_C4
   if (operandType.hasRank() &&
       (int64_t)startIndices.size() != operandType.getRank())
     return emitOptionalError(
         location, "expects number of start_indices to match operand rank: ",
         startIndices.size(), " vs ", operandType.getRank(), ".");
 
-  // (C5)
+  // DynamicUpdateSliceOp_C5
   if (!tensorsHaveSameElType(startIndices.getTypes()))
     return emitOptionalError(location,
                              "start indices must have same element type");
 
-  // (C6)
-  if (operandType.hasRank() && updateType.hasRank()) {
+  // DynamicUpdateSliceOp_C6
+  if (operandType.hasRank() && updateType.hasRank())
     for (auto [index, dims] : llvm::enumerate(
              llvm::zip(operandType.getShape(), updateType.getShape()))) {
       auto [operandDim, updateDim] = dims;
@@ -2103,8 +2103,8 @@ LogicalResult inferDynamicUpdateSliceOp(
               " of update to be non-negative. Got: ", updateDim, ".");
       }
     }
-  }
-  // (C1)
+
+  // DynamicUpdateSliceOp_C1
   if (operandType.hasRank())
     inferredReturnShapes.emplace_back(
         operandType.getShape(), operandType.getElementType(),

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2065,7 +2065,7 @@ LogicalResult inferDynamicUpdateSliceOp(
   auto operandType = operand.getType().cast<ShapedType>();
   auto updateType = update.getType().cast<ShapedType>();
 
-  // DynamicUpdateSliceOp_C3
+  // dynamic_update_slice_c3
   if (updateType.hasRank() && operandType.hasRank() &&
       updateType.getRank() != operandType.getRank())
     return emitOptionalError(
@@ -2073,19 +2073,19 @@ LogicalResult inferDynamicUpdateSliceOp(
         "update rank does not match operand rank: ", updateType.getRank(),
         " vs ", operandType.getRank(), ".");
 
-  // DynamicUpdateSliceOp_C4
+  // dynamic_update_slice_c4
   if (operandType.hasRank() &&
       (int64_t)startIndices.size() != operandType.getRank())
     return emitOptionalError(
         location, "expects number of start_indices to match operand rank: ",
         startIndices.size(), " vs ", operandType.getRank(), ".");
 
-  // DynamicUpdateSliceOp_C5
+  // dynamic_update_slice_c5
   if (!tensorsHaveSameElType(startIndices.getTypes()))
     return emitOptionalError(location,
                              "start indices must have same element type");
 
-  // DynamicUpdateSliceOp_C6
+  // dynamic_update_slice_c6
   if (operandType.hasRank() && updateType.hasRank())
     for (auto [index, dims] : llvm::enumerate(
              llvm::zip(operandType.getShape(), updateType.getShape()))) {
@@ -2104,7 +2104,7 @@ LogicalResult inferDynamicUpdateSliceOp(
       }
     }
 
-  // DynamicUpdateSliceOp_C1
+  // dynamic_update_slice_c1
   if (operandType.hasRank())
     inferredReturnShapes.emplace_back(
         operandType.getShape(), operandType.getElementType(),

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -102,14 +102,13 @@ Tensor evalDynamicUpdateSliceOp(const Tensor &operand, const Tensor &update,
     adjustedStartIndices.push_back(std::min(
         std::max(startIndices[i].get({}).getIntegerValue().getSExtValue(), 0l),
         operandShape[i] - updateShape[i]));
-  for (auto resItr = result.index_begin(), updItr = update.index_begin();
-       resItr != result.index_end(); ++resItr) {
-    if (updItr != update.index_end() &&
-        llvm::equal(*resItr, addIndices(*updItr, adjustedStartIndices)))
-      result.set(*resItr, update.get(*updItr++));
-    else
-      result.set(*resItr, operand.get(*resItr));
-  }
+  for (auto resultIt = result.index_begin(); resultIt != result.index_end();
+       ++resultIt)
+    result.set(*resultIt, operand.get(*resultIt));
+  for (auto updateIt = update.index_begin(); updateIt != update.index_end();
+       ++updateIt)
+    result.set(addIndices(*updateIt, adjustedStartIndices),
+               update.get(*updateIt));
   return result;
 }
 

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -92,7 +92,7 @@ Tensor evalCosineOp(const Tensor &operand, Type resultType) {
 }
 
 Tensor evalDynamicUpdateSliceOp(const Tensor &operand, const Tensor &update,
-                                const ArrayRef<Tensor> &startIndices,
+                                ArrayRef<Tensor> startIndices,
                                 Type resultType) {
   Tensor result(resultType);
   auto operandShape = operand.getType().getShape();

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -17,7 +17,6 @@ limitations under the License.
 
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/APInt.h"
-#include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Errc.h"
 #include "llvm/Support/Error.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -25,7 +24,6 @@ limitations under the License.
 #include "mlir/Support/DebugStringHelper.h"
 #include "stablehlo/reference/Element.h"
 #include "stablehlo/reference/Errors.h"
-#include "stablehlo/reference/Tensor.h"
 #include "stablehlo/reference/Types.h"
 
 namespace mlir {

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -32,8 +32,7 @@ Tensor evalConstantOp(ElementsAttr value);
 Tensor evalConvertOp(const Tensor &operand, Type resultType);
 Tensor evalCosineOp(const Tensor &operand, Type resultType);
 Tensor evalDynamicUpdateSliceOp(const Tensor &operand, const Tensor &update,
-                                const ArrayRef<Tensor> &startIndices,
-                                Type resultType);
+                                ArrayRef<Tensor> startIndices, Type resultType);
 Tensor evalFloorOp(const Tensor &operand, Type resultType);
 Tensor evalIotaOp(int64_t iotaDimension, Type resultType);
 Tensor evalMaxOp(const Tensor &lhs, const Tensor &rhs, Type resultType);

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -31,6 +31,9 @@ Tensor evalCeilOp(const Tensor &operand, Type resultType);
 Tensor evalConstantOp(ElementsAttr value);
 Tensor evalConvertOp(const Tensor &operand, Type resultType);
 Tensor evalCosineOp(const Tensor &operand, Type resultType);
+Tensor evalDynamicUpdateSliceOp(const Tensor &operand, const Tensor &update,
+                                const ArrayRef<Tensor> &startIndices,
+                                Type resultType);
 Tensor evalFloorOp(const Tensor &operand, Type resultType);
 Tensor evalIotaOp(int64_t iotaDimension, Type resultType);
 Tensor evalMaxOp(const Tensor &lhs, const Tensor &rhs, Type resultType);

--- a/stablehlo/tests/interpret_dynamic_update_slice.mlir
+++ b/stablehlo/tests/interpret_dynamic_update_slice.mlir
@@ -31,3 +31,56 @@ func.func @dynamic_update_slice() -> tensor<4x4xi64> {
   // CHECK-NEXT: 1 : i64
   // CHECK-NEXT: 1 : i64
 }
+
+// -----
+
+// CHECK-LABEL: Evaluated results of function: dynamic_update_slice_adjusted_start_indices
+func.func @dynamic_update_slice_adjusted_start_indices() -> tensor<4x4xi64> {
+  %operand = stablehlo.constant dense<[[1, 1, 1, 1],
+                                       [1, 1, 1, 1],
+                                       [1, 2, 2, 2],
+                                       [1, 2, 2, 2]]> : tensor<4x4xi64>
+  %update = stablehlo.constant dense<[[1, 1, 1],
+                                      [1, 1, 1]]> : tensor<2x3xi64>
+  %start_indices0 = stablehlo.constant dense<4> : tensor<i64>
+  %start_indices1 = stablehlo.constant dense<4> : tensor<i64>
+  %result = stablehlo.dynamic_update_slice %operand, %update, %start_indices0, %start_indices1 :
+      (tensor<4x4xi64>, tensor<2x3xi64>, tensor<i64>, tensor<i64>) -> tensor<4x4xi64>
+  func.return %result : tensor<4x4xi64>
+  // CHECK-NEXT: tensor<4x4xi64>
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+}
+
+// -----
+
+// CHECK-LABEL: Evaluated results of function: dynamic_update_slice_empty
+func.func @dynamic_update_slice_empty() -> tensor<2x2xi64> {
+  %operand = stablehlo.constant dense<[[1, 2],
+                                       [3, 4]]> : tensor<2x2xi64>
+  %update = stablehlo.constant dense<> : tensor<0x0xi64>
+  %start_indices0 = stablehlo.constant dense<0> : tensor<i64>
+  %start_indices1 = stablehlo.constant dense<0> : tensor<i64>
+  %result = stablehlo.dynamic_update_slice %operand, %update, %start_indices0, %start_indices1 :
+      (tensor<2x2xi64>, tensor<0x0xi64>, tensor<i64>, tensor<i64>) -> tensor<2x2xi64>
+  func.return %result : tensor<2x2xi64>
+  // CHECK-NEXT: tensor<2x2xi64>
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 2 : i64
+  // CHECK-NEXT: 3 : i64
+  // CHECK-NEXT: 4 : i64
+}

--- a/stablehlo/tests/interpret_dynamic_update_slice.mlir
+++ b/stablehlo/tests/interpret_dynamic_update_slice.mlir
@@ -2,40 +2,6 @@
 
 // CHECK-LABEL: Evaluated results of function: dynamic_update_slice
 func.func @dynamic_update_slice() -> tensor<4x4xi64> {
-  %operand = stablehlo.constant dense<[[1, 1, 0, 0],
-                                       [1, 1, 0, 0],
-                                       [1, 1, 1, 1],
-                                       [1, 1, 1, 1]]> : tensor<4x4xi64>
-  %update = stablehlo.constant dense<[[1, 1],
-                                      [1, 1]]> : tensor<2x2xi64>
-  %start_indices0 = stablehlo.constant dense<-1> : tensor<i64>
-  %start_indices1 = stablehlo.constant dense<3> : tensor<i64>
-  %result = stablehlo.dynamic_update_slice %operand, %update, %start_indices0, %start_indices1 :
-      (tensor<4x4xi64>, tensor<2x2xi64>, tensor<i64>, tensor<i64>) -> tensor<4x4xi64>
-  func.return %result : tensor<4x4xi64>
-  // CHECK-NEXT: tensor<4x4xi64>
-  // CHECK-NEXT: 1 : i64
-  // CHECK-NEXT: 1 : i64
-  // CHECK-NEXT: 1 : i64
-  // CHECK-NEXT: 1 : i64
-  // CHECK-NEXT: 1 : i64
-  // CHECK-NEXT: 1 : i64
-  // CHECK-NEXT: 1 : i64
-  // CHECK-NEXT: 1 : i64
-  // CHECK-NEXT: 1 : i64
-  // CHECK-NEXT: 1 : i64
-  // CHECK-NEXT: 1 : i64
-  // CHECK-NEXT: 1 : i64
-  // CHECK-NEXT: 1 : i64
-  // CHECK-NEXT: 1 : i64
-  // CHECK-NEXT: 1 : i64
-  // CHECK-NEXT: 1 : i64
-}
-
-// -----
-
-// CHECK-LABEL: Evaluated results of function: dynamic_update_slice_adjusted_start_indices
-func.func @dynamic_update_slice_adjusted_start_indices() -> tensor<4x4xi64> {
   %operand = stablehlo.constant dense<[[1, 1, 1, 1],
                                        [1, 1, 1, 1],
                                        [1, 2, 2, 2],
@@ -64,23 +30,4 @@ func.func @dynamic_update_slice_adjusted_start_indices() -> tensor<4x4xi64> {
   // CHECK-NEXT: 1 : i64
   // CHECK-NEXT: 1 : i64
   // CHECK-NEXT: 1 : i64
-}
-
-// -----
-
-// CHECK-LABEL: Evaluated results of function: dynamic_update_slice_empty
-func.func @dynamic_update_slice_empty() -> tensor<2x2xi64> {
-  %operand = stablehlo.constant dense<[[1, 2],
-                                       [3, 4]]> : tensor<2x2xi64>
-  %update = stablehlo.constant dense<> : tensor<0x0xi64>
-  %start_indices0 = stablehlo.constant dense<0> : tensor<i64>
-  %start_indices1 = stablehlo.constant dense<0> : tensor<i64>
-  %result = stablehlo.dynamic_update_slice %operand, %update, %start_indices0, %start_indices1 :
-      (tensor<2x2xi64>, tensor<0x0xi64>, tensor<i64>, tensor<i64>) -> tensor<2x2xi64>
-  func.return %result : tensor<2x2xi64>
-  // CHECK-NEXT: tensor<2x2xi64>
-  // CHECK-NEXT: 1 : i64
-  // CHECK-NEXT: 2 : i64
-  // CHECK-NEXT: 3 : i64
-  // CHECK-NEXT: 4 : i64
 }

--- a/stablehlo/tests/interpret_dynamic_update_slice.mlir
+++ b/stablehlo/tests/interpret_dynamic_update_slice.mlir
@@ -1,0 +1,33 @@
+// RUN: stablehlo-interpreter --interpret -split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: Evaluated results of function: dynamic_update_slice
+func.func @dynamic_update_slice() -> tensor<4x4xi64> {
+  %operand = stablehlo.constant dense<[[1, 1, 0, 0],
+                                       [1, 1, 0, 0],
+                                       [1, 1, 1, 1],
+                                       [1, 1, 1, 1]]> : tensor<4x4xi64>
+  %update = stablehlo.constant dense<[[1, 1],
+                                      [1, 1]]> : tensor<2x2xi64>
+  %start_indices0 = stablehlo.constant dense<-1> : tensor<i64>
+  %start_indices1 = stablehlo.constant dense<3> : tensor<i64>
+  %result = stablehlo.dynamic_update_slice %operand, %update, %start_indices0, %start_indices1 :
+      (tensor<4x4xi64>, tensor<2x2xi64>, tensor<i64>, tensor<i64>) -> tensor<4x4xi64>
+  func.return %result : tensor<4x4xi64>
+  // CHECK-NEXT: tensor<4x4xi64>
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+}

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -2376,80 +2376,80 @@ func.func @dynamic_slice_slice_size_too_large(%arg0: tensor<3x4xi32>, %arg1: ten
 // -----
 
 // CHECK-LABEL: @dynamic_update_slice
-func.func @dynamic_update_slice(%operand: tensor<3x4xi64>, %update: tensor<1x4xi64>, %start1: tensor<i64>, %start2: tensor<i64>) -> tensor<3x4xi64> {
-  %0 = "stablehlo.dynamic_update_slice"(%operand, %update, %start1, %start2) : (tensor<3x4xi64>, tensor<1x4xi64>, tensor<i64>, tensor<i64>) -> tensor<3x4xi64>
+func.func @dynamic_update_slice(%operand: tensor<3x4xi64>, %update: tensor<1x4xi64>, %start_indices0: tensor<i64>, %start_indices1: tensor<i64>) -> tensor<3x4xi64> {
+  %0 = "stablehlo.dynamic_update_slice"(%operand, %update, %start_indices0, %start_indices1) : (tensor<3x4xi64>, tensor<1x4xi64>, tensor<i64>, tensor<i64>) -> tensor<3x4xi64>
   func.return %0 : tensor<3x4xi64>
 }
 
 // -----
 
-func.func @dynamic_update_slice_c1(%operand: tensor<3x4xi64>, %update: tensor<1x4xi64>, %start1: tensor<i64>, %start2: tensor<i64>) -> tensor<3x5xi64> {
+func.func @dynamic_update_slice_c1(%operand: tensor<3x4xi64>, %update: tensor<1x4xi64>, %start_indices0: tensor<i64>, %start_indices1: tensor<i64>) -> tensor<3x5xi64> {
   // expected-error@+1 {{op inferred type(s) 'tensor<3x4xi64>' are incompatible with return type(s) of operation 'tensor<3x5xi64>'}}
-  %0 = "stablehlo.dynamic_update_slice"(%operand, %update, %start1, %start2) : (tensor<3x4xi64>, tensor<1x4xi64>, tensor<i64>, tensor<i64>) -> tensor<3x5xi64>
+  %0 = "stablehlo.dynamic_update_slice"(%operand, %update, %start_indices0, %start_indices1) : (tensor<3x4xi64>, tensor<1x4xi64>, tensor<i64>, tensor<i64>) -> tensor<3x5xi64>
   func.return %0 : tensor<3x5xi64>
 }
 
 // -----
 
-func.func @dynamic_update_slice_c3(%operand: tensor<3x4xi64>, %update: tensor<2xi64>, %start1: tensor<i64>, %start2: tensor<i64>) -> tensor<3x4xi64> {
+func.func @dynamic_update_slice_c3(%operand: tensor<3x4xi64>, %update: tensor<2xi64>, %start_indices0: tensor<i64>, %start_indices1: tensor<i64>) -> tensor<3x4xi64> {
   // expected-error@+1 {{update rank does not match operand rank: 1 vs 2.}}
-  %0 = "stablehlo.dynamic_update_slice"(%operand, %update, %start1, %start2) : (tensor<3x4xi64>, tensor<2xi64>, tensor<i64>, tensor<i64>) -> tensor<3x4xi64>
+  %0 = "stablehlo.dynamic_update_slice"(%operand, %update, %start_indices0, %start_indices1) : (tensor<3x4xi64>, tensor<2xi64>, tensor<i64>, tensor<i64>) -> tensor<3x4xi64>
   func.return %0 : tensor<3x4xi64>
 }
 
 // -----
 
-func.func @dynamic_update_slice_c4(%operand: tensor<3x4xi64>, %update: tensor<1x2xi64>, %start: tensor<i64>) -> tensor<3x4xi64> {
+func.func @dynamic_update_slice_c4(%operand: tensor<3x4xi64>, %update: tensor<1x2xi64>, %start_indices0: tensor<i64>) -> tensor<3x4xi64> {
   // expected-error@+1 {{expects number of start_indices to match operand rank: 1 vs 2.}}
-  %0 = "stablehlo.dynamic_update_slice"(%operand, %update, %start) : (tensor<3x4xi64>, tensor<1x2xi64>, tensor<i64>) -> tensor<3x4xi64>
+  %0 = "stablehlo.dynamic_update_slice"(%operand, %update, %start_indices0) : (tensor<3x4xi64>, tensor<1x2xi64>, tensor<i64>) -> tensor<3x4xi64>
   func.return %0 : tensor<3x4xi64>
 }
 
 // -----
 
-func.func @dynamic_update_slice_c5(%operand: tensor<11x3x4xi32>, %update: tensor<1x3x4xi32>, %start1: tensor<i32>, %start2: tensor<i64>, %start3: tensor<i64>) -> tensor<11x3x4xi32> {
+func.func @dynamic_update_slice_c5(%operand: tensor<11x3x4xi32>, %update: tensor<1x3x4xi32>, %start_indices0: tensor<i32>, %start_indices1: tensor<i64>, %start_indices2: tensor<i64>) -> tensor<11x3x4xi32> {
   // expected-error@+1 {{start indices must have same element type}}
-  %0 = "stablehlo.dynamic_update_slice"(%operand, %update, %start1, %start2, %start3) : (tensor<11x3x4xi32>, tensor<1x3x4xi32>, tensor<i32>, tensor<i64>, tensor<i64>) -> tensor<11x3x4xi32>
+  %0 = "stablehlo.dynamic_update_slice"(%operand, %update, %start_indices0, %start_indices1, %start_indices2) : (tensor<11x3x4xi32>, tensor<1x3x4xi32>, tensor<i32>, tensor<i64>, tensor<i64>) -> tensor<11x3x4xi32>
   func.return %0 : tensor<11x3x4xi32>
 }
 
 // -----
 
-func.func @dynamic_update_slice_c6(%operand: tensor<3x4xi64>, %update: tensor<1x5xi64>, %start1: tensor<i64>, %start2: tensor<i64>) -> tensor<3x4xi64> {
+func.func @dynamic_update_slice_c6(%operand: tensor<3x4xi64>, %update: tensor<1x5xi64>, %start_indices0: tensor<i64>, %start_indices1: tensor<i64>) -> tensor<3x4xi64> {
   // expected-error@+1 {{expects size at dimension 1 of update to be in range [0, 4]. Got: 5.}}
-  %0 = "stablehlo.dynamic_update_slice"(%operand, %update, %start1, %start2) : (tensor<3x4xi64>, tensor<1x5xi64>, tensor<i64>, tensor<i64>) -> tensor<3x4xi64>
+  %0 = "stablehlo.dynamic_update_slice"(%operand, %update, %start_indices0, %start_indices1) : (tensor<3x4xi64>, tensor<1x5xi64>, tensor<i64>, tensor<i64>) -> tensor<3x4xi64>
   func.return %0 : tensor<3x4xi64>
 }
 
 // -----
 
 // CHECK-LABEL: @dynamic_update_slice_dynamic_dim
-func.func @dynamic_update_slice_dynamic_dim(%operand: tensor<?x4xi64>, %update: tensor<1x4xi64>, %start1: tensor<i64>, %start2: tensor<i64>) -> tensor<3x4xi64> {
-  %0 = "stablehlo.dynamic_update_slice"(%operand, %update, %start1, %start2) : (tensor<?x4xi64>, tensor<1x4xi64>, tensor<i64>, tensor<i64>) -> tensor<3x4xi64>
+func.func @dynamic_update_slice_dynamic_dim(%operand: tensor<?x4xi64>, %update: tensor<1x4xi64>, %start_indices0: tensor<i64>, %start_indices1: tensor<i64>) -> tensor<3x4xi64> {
+  %0 = "stablehlo.dynamic_update_slice"(%operand, %update, %start_indices0, %start_indices1) : (tensor<?x4xi64>, tensor<1x4xi64>, tensor<i64>, tensor<i64>) -> tensor<3x4xi64>
   func.return %0 : tensor<3x4xi64>
 }
 
 // -----
 
 // CHECK-LABEL: func @dynamic_update_slice_dynamic_rank_operand
-func.func @dynamic_update_slice_dynamic_rank_operand(%operand: tensor<*xi64>, %update: tensor<1x4xi64>, %start1: tensor<i64>, %start2: tensor<i64>) -> tensor<*xi64> {
-  %0 = "stablehlo.dynamic_update_slice"(%operand, %update, %start1, %start2) : (tensor<*xi64>, tensor<1x4xi64>, tensor<i64>, tensor<i64>) -> tensor<*xi64>
+func.func @dynamic_update_slice_dynamic_rank_operand(%operand: tensor<*xi64>, %update: tensor<1x4xi64>, %start_indices0: tensor<i64>, %start_indices1: tensor<i64>) -> tensor<*xi64> {
+  %0 = "stablehlo.dynamic_update_slice"(%operand, %update, %start_indices0, %start_indices1) : (tensor<*xi64>, tensor<1x4xi64>, tensor<i64>, tensor<i64>) -> tensor<*xi64>
   func.return %0 : tensor<*xi64>
 }
 
 // -----
 
 // CHECK-LABEL: func @dynamic_update_slice_dynamic_rank_update
-func.func @dynamic_update_slice_dynamic_rank_update(%operand: tensor<3x4xi64>, %update: tensor<*xi64>, %start1: tensor<i64>, %start2: tensor<i64>) -> tensor<3x4xi64> {
-  %0 = "stablehlo.dynamic_update_slice"(%operand, %update, %start1, %start2) : (tensor<3x4xi64>, tensor<*xi64>, tensor<i64>, tensor<i64>) -> tensor<3x4xi64>
+func.func @dynamic_update_slice_dynamic_rank_update(%operand: tensor<3x4xi64>, %update: tensor<*xi64>, %start_indices0: tensor<i64>, %start_indices1: tensor<i64>) -> tensor<3x4xi64> {
+  %0 = "stablehlo.dynamic_update_slice"(%operand, %update, %start_indices0, %start_indices1) : (tensor<3x4xi64>, tensor<*xi64>, tensor<i64>, tensor<i64>) -> tensor<3x4xi64>
   func.return %0 : tensor<3x4xi64>
 }
 
 // -----
 
 // CHECK-LABEL: func @dynamic_update_slice_dynamic_sizes
-func.func @dynamic_update_slice_dynamic_sizes(%operand: tensor<?x4xi64>, %update: tensor<1x?xi64>, %start1: tensor<i64>, %start2: tensor<i64>) -> tensor<?x4xi64> {
-  %0 = "stablehlo.dynamic_update_slice"(%operand, %update, %start1, %start2) : (tensor<?x4xi64>, tensor<1x?xi64>, tensor<i64>, tensor<i64>) -> tensor<?x4xi64>
+func.func @dynamic_update_slice_dynamic_sizes(%operand: tensor<?x4xi64>, %update: tensor<1x?xi64>, %start_indices0: tensor<i64>, %start_indices1: tensor<i64>) -> tensor<?x4xi64> {
+  %0 = "stablehlo.dynamic_update_slice"(%operand, %update, %start_indices0, %start_indices1) : (tensor<?x4xi64>, tensor<1x?xi64>, tensor<i64>, tensor<i64>) -> tensor<?x4xi64>
   func.return %0 : tensor<?x4xi64>
 }
 

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -2376,80 +2376,88 @@ func.func @dynamic_slice_slice_size_too_large(%arg0: tensor<3x4xi32>, %arg1: ten
 // -----
 
 // CHECK-LABEL: @dynamic_update_slice
-func.func @dynamic_update_slice(%input: tensor<3x4xi64>, %update: tensor<1x4xi64>, %start1: tensor<i64>, %start2: tensor<i64>) -> tensor<3x4xi64> {
-  %0 = "stablehlo.dynamic_update_slice"(%input, %update, %start1, %start2) : (tensor<3x4xi64>, tensor<1x4xi64>, tensor<i64>, tensor<i64>) -> tensor<3x4xi64>
+func.func @dynamic_update_slice(%operand: tensor<3x4xi64>, %update: tensor<1x4xi64>, %start1: tensor<i64>, %start2: tensor<i64>) -> tensor<3x4xi64> {
+  %0 = "stablehlo.dynamic_update_slice"(%operand, %update, %start1, %start2) : (tensor<3x4xi64>, tensor<1x4xi64>, tensor<i64>, tensor<i64>) -> tensor<3x4xi64>
   func.return %0 : tensor<3x4xi64>
 }
 
 // -----
 
-func.func @dynamic_update_slice_C3(%input: tensor<3x4xi64>, %update: tensor<2xi64>, %start1: tensor<i64>, %start2: tensor<i64>) -> tensor<3x4xi64> {
+func.func @dynamic_update_slice_c1(%operand: tensor<3x4xi64>, %update: tensor<1x4xi64>, %start1: tensor<i64>, %start2: tensor<i64>) -> tensor<3x5xi64> {
+  // expected-error@+1 {{op inferred type(s) 'tensor<3x4xi64>' are incompatible with return type(s) of operation 'tensor<3x5xi64>'}}
+  %0 = "stablehlo.dynamic_update_slice"(%operand, %update, %start1, %start2) : (tensor<3x4xi64>, tensor<1x4xi64>, tensor<i64>, tensor<i64>) -> tensor<3x5xi64>
+  func.return %0 : tensor<3x5xi64>
+}
+
+// -----
+
+func.func @dynamic_update_slice_c3(%operand: tensor<3x4xi64>, %update: tensor<2xi64>, %start1: tensor<i64>, %start2: tensor<i64>) -> tensor<3x4xi64> {
   // expected-error@+1 {{update rank does not match operand rank: 1 vs 2.}}
-  %0 = "stablehlo.dynamic_update_slice"(%input, %update, %start1, %start2) : (tensor<3x4xi64>, tensor<2xi64>, tensor<i64>, tensor<i64>) -> tensor<3x4xi64>
+  %0 = "stablehlo.dynamic_update_slice"(%operand, %update, %start1, %start2) : (tensor<3x4xi64>, tensor<2xi64>, tensor<i64>, tensor<i64>) -> tensor<3x4xi64>
   func.return %0 : tensor<3x4xi64>
 }
 
 // -----
 
-func.func @dynamic_update_slice_C4(%input: tensor<3x4xi64>, %update: tensor<1x2xi64>, %start: tensor<i64>) -> tensor<3x4xi64> {
+func.func @dynamic_update_slice_c4(%operand: tensor<3x4xi64>, %update: tensor<1x2xi64>, %start: tensor<i64>) -> tensor<3x4xi64> {
   // expected-error@+1 {{expects number of start_indices to match operand rank: 1 vs 2.}}
-  %0 = "stablehlo.dynamic_update_slice"(%input, %update, %start) : (tensor<3x4xi64>, tensor<1x2xi64>, tensor<i64>) -> tensor<3x4xi64>
+  %0 = "stablehlo.dynamic_update_slice"(%operand, %update, %start) : (tensor<3x4xi64>, tensor<1x2xi64>, tensor<i64>) -> tensor<3x4xi64>
   func.return %0 : tensor<3x4xi64>
 }
 
 // -----
 
-func.func @dynamic_update_slice_C5(%input: tensor<11x3x4xi32>, %update: tensor<1x3x4xi32>, %start1: tensor<i32>, %start2: tensor<i64>, %start3: tensor<i64>) -> tensor<11x3x4xi32> {
+func.func @dynamic_update_slice_c5(%operand: tensor<11x3x4xi32>, %update: tensor<1x3x4xi32>, %start1: tensor<i32>, %start2: tensor<i64>, %start3: tensor<i64>) -> tensor<11x3x4xi32> {
   // expected-error@+1 {{start indices must have same element type}}
-  %0 = "stablehlo.dynamic_update_slice"(%input, %update, %start1, %start2, %start3) : (tensor<11x3x4xi32>, tensor<1x3x4xi32>, tensor<i32>, tensor<i64>, tensor<i64>) -> tensor<11x3x4xi32>
+  %0 = "stablehlo.dynamic_update_slice"(%operand, %update, %start1, %start2, %start3) : (tensor<11x3x4xi32>, tensor<1x3x4xi32>, tensor<i32>, tensor<i64>, tensor<i64>) -> tensor<11x3x4xi32>
   func.return %0 : tensor<11x3x4xi32>
 }
 
 // -----
 
-func.func @dynamic_update_slice_C6(%input: tensor<3x4xi64>, %update: tensor<1x5xi64>, %start1: tensor<i64>, %start2: tensor<i64>) -> tensor<3x4xi64> {
+func.func @dynamic_update_slice_c6(%operand: tensor<3x4xi64>, %update: tensor<1x5xi64>, %start1: tensor<i64>, %start2: tensor<i64>) -> tensor<3x4xi64> {
   // expected-error@+1 {{expects size at dimension 1 of update to be in range [0, 4]. Got: 5.}}
-  %0 = "stablehlo.dynamic_update_slice"(%input, %update, %start1, %start2) : (tensor<3x4xi64>, tensor<1x5xi64>, tensor<i64>, tensor<i64>) -> tensor<3x4xi64>
+  %0 = "stablehlo.dynamic_update_slice"(%operand, %update, %start1, %start2) : (tensor<3x4xi64>, tensor<1x5xi64>, tensor<i64>, tensor<i64>) -> tensor<3x4xi64>
   func.return %0 : tensor<3x4xi64>
 }
 
 // -----
 
 // CHECK-LABEL: @dynamic_update_slice_dynamic_dim
-func.func @dynamic_update_slice_dynamic_dim(%input: tensor<?x4xi64>, %update: tensor<1x4xi64>, %start1: tensor<i64>, %start2: tensor<i64>) -> tensor<3x4xi64> {
-  %0 = "stablehlo.dynamic_update_slice"(%input, %update, %start1, %start2) : (tensor<?x4xi64>, tensor<1x4xi64>, tensor<i64>, tensor<i64>) -> tensor<3x4xi64>
+func.func @dynamic_update_slice_dynamic_dim(%operand: tensor<?x4xi64>, %update: tensor<1x4xi64>, %start1: tensor<i64>, %start2: tensor<i64>) -> tensor<3x4xi64> {
+  %0 = "stablehlo.dynamic_update_slice"(%operand, %update, %start1, %start2) : (tensor<?x4xi64>, tensor<1x4xi64>, tensor<i64>, tensor<i64>) -> tensor<3x4xi64>
   func.return %0 : tensor<3x4xi64>
 }
 
 // -----
 
-// CHECK-LABEL: func @dynamic_update_slice_dynamic_rank_input
-func.func @dynamic_update_slice_dynamic_rank_input(%input: tensor<*xi64>, %update: tensor<1x4xi64>, %start1: tensor<i64>, %start2: tensor<i64>) -> tensor<*xi64> {
-  %0 = "stablehlo.dynamic_update_slice"(%input, %update, %start1, %start2) : (tensor<*xi64>, tensor<1x4xi64>, tensor<i64>, tensor<i64>) -> tensor<*xi64>
+// CHECK-LABEL: func @dynamic_update_slice_dynamic_rank_operand
+func.func @dynamic_update_slice_dynamic_rank_operand(%operand: tensor<*xi64>, %update: tensor<1x4xi64>, %start1: tensor<i64>, %start2: tensor<i64>) -> tensor<*xi64> {
+  %0 = "stablehlo.dynamic_update_slice"(%operand, %update, %start1, %start2) : (tensor<*xi64>, tensor<1x4xi64>, tensor<i64>, tensor<i64>) -> tensor<*xi64>
   func.return %0 : tensor<*xi64>
 }
 
 // -----
 
 // CHECK-LABEL: func @dynamic_update_slice_dynamic_rank_update
-func.func @dynamic_update_slice_dynamic_rank_update(%input: tensor<3x4xi64>, %update: tensor<*xi64>, %start1: tensor<i64>, %start2: tensor<i64>) -> tensor<3x4xi64> {
-  %0 = "stablehlo.dynamic_update_slice"(%input, %update, %start1, %start2) : (tensor<3x4xi64>, tensor<*xi64>, tensor<i64>, tensor<i64>) -> tensor<3x4xi64>
+func.func @dynamic_update_slice_dynamic_rank_update(%operand: tensor<3x4xi64>, %update: tensor<*xi64>, %start1: tensor<i64>, %start2: tensor<i64>) -> tensor<3x4xi64> {
+  %0 = "stablehlo.dynamic_update_slice"(%operand, %update, %start1, %start2) : (tensor<3x4xi64>, tensor<*xi64>, tensor<i64>, tensor<i64>) -> tensor<3x4xi64>
   func.return %0 : tensor<3x4xi64>
 }
 
 // -----
 
 // CHECK-LABEL: func @dynamic_update_slice_dynamic_sizes
-func.func @dynamic_update_slice_dynamic_sizes(%input: tensor<?x4xi64>, %update: tensor<1x?xi64>, %start1: tensor<i64>, %start2: tensor<i64>) -> tensor<?x4xi64> {
-  %0 = "stablehlo.dynamic_update_slice"(%input, %update, %start1, %start2) : (tensor<?x4xi64>, tensor<1x?xi64>, tensor<i64>, tensor<i64>) -> tensor<?x4xi64>
+func.func @dynamic_update_slice_dynamic_sizes(%operand: tensor<?x4xi64>, %update: tensor<1x?xi64>, %start1: tensor<i64>, %start2: tensor<i64>) -> tensor<?x4xi64> {
+  %0 = "stablehlo.dynamic_update_slice"(%operand, %update, %start1, %start2) : (tensor<?x4xi64>, tensor<1x?xi64>, tensor<i64>, tensor<i64>) -> tensor<?x4xi64>
   func.return %0 : tensor<?x4xi64>
 }
 
 // -----
 
-func.func @dynamic_update_slice_invalid_start(%input: tensor<3x4xi64>, %update: tensor<1x2xi64>, %start: tensor<2xi64>) -> tensor<3x4xi64> {
+func.func @dynamic_update_slice_invalid_start(%operand: tensor<3x4xi64>, %update: tensor<1x2xi64>, %start: tensor<2xi64>) -> tensor<3x4xi64> {
   // expected-error@+1 {{operand #2 must be 0D tensor of 4/8/16/32/64-bit signless integer or 4/8/16/32/64-bit unsigned integer values, but got 'tensor<2xi64>'}}
-  %0 = "stablehlo.dynamic_update_slice"(%input, %update, %start) : (tensor<3x4xi64>, tensor<1x2xi64>, tensor<2xi64>) -> tensor<3x4xi64>
+  %0 = "stablehlo.dynamic_update_slice"(%operand, %update, %start) : (tensor<3x4xi64>, tensor<1x2xi64>, tensor<2xi64>) -> tensor<3x4xi64>
   func.return %0 : tensor<3x4xi64>
 }
 

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -2455,14 +2455,6 @@ func.func @dynamic_update_slice_dynamic_sizes(%operand: tensor<?x4xi64>, %update
 
 // -----
 
-func.func @dynamic_update_slice_invalid_start(%operand: tensor<3x4xi64>, %update: tensor<1x2xi64>, %start: tensor<2xi64>) -> tensor<3x4xi64> {
-  // expected-error@+1 {{operand #2 must be 0D tensor of 4/8/16/32/64-bit signless integer or 4/8/16/32/64-bit unsigned integer values, but got 'tensor<2xi64>'}}
-  %0 = "stablehlo.dynamic_update_slice"(%operand, %update, %start) : (tensor<3x4xi64>, tensor<1x2xi64>, tensor<2xi64>) -> tensor<3x4xi64>
-  func.return %0 : tensor<3x4xi64>
-}
-
-// -----
-
 // CHECK-LABEL: func @transpose
 func.func @transpose(%arg0: tensor<1x2x3x4xi32>) -> tensor<2x1x4x3xi32> {
   %0 = "stablehlo.transpose"(%arg0) {permutation = dense<[1, 0, 3, 2]> : tensor<4xi64>} : (tensor<1x2x3x4xi32>) -> tensor<2x1x4x3xi32>

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -2383,23 +2383,7 @@ func.func @dynamic_update_slice(%input: tensor<3x4xi64>, %update: tensor<1x4xi64
 
 // -----
 
-// CHECK-LABEL: @dynamic_update_slice_dynamic_dim
-func.func @dynamic_update_slice_dynamic_dim(%input: tensor<?x4xi64>, %update: tensor<1x4xi64>, %start1: tensor<i64>, %start2: tensor<i64>) -> tensor<3x4xi64> {
-  %0 = "stablehlo.dynamic_update_slice"(%input, %update, %start1, %start2) : (tensor<?x4xi64>, tensor<1x4xi64>, tensor<i64>, tensor<i64>) -> tensor<3x4xi64>
-  func.return %0 : tensor<3x4xi64>
-}
-
-// -----
-
-func.func @dynamic_update_slice_invalid_start(%input: tensor<3x4xi64>, %update: tensor<1x2xi64>, %start: tensor<2xi64>) -> tensor<3x4xi64> {
-  // expected-error@+1 {{operand #2 must be 0D tensor of 4/8/16/32/64-bit signless integer or 4/8/16/32/64-bit unsigned integer values, but got 'tensor<2xi64>'}}
-  %0 = "stablehlo.dynamic_update_slice"(%input, %update, %start) : (tensor<3x4xi64>, tensor<1x2xi64>, tensor<2xi64>) -> tensor<3x4xi64>
-  func.return %0 : tensor<3x4xi64>
-}
-
-// -----
-
-func.func @dynamic_update_slice_invalid_update(%input: tensor<3x4xi64>, %update: tensor<2xi64>, %start1: tensor<i64>, %start2: tensor<i64>) -> tensor<3x4xi64> {
+func.func @dynamic_update_slice_C3(%input: tensor<3x4xi64>, %update: tensor<2xi64>, %start1: tensor<i64>, %start2: tensor<i64>) -> tensor<3x4xi64> {
   // expected-error@+1 {{update rank does not match operand rank: 1 vs 2.}}
   %0 = "stablehlo.dynamic_update_slice"(%input, %update, %start1, %start2) : (tensor<3x4xi64>, tensor<2xi64>, tensor<i64>, tensor<i64>) -> tensor<3x4xi64>
   func.return %0 : tensor<3x4xi64>
@@ -2407,7 +2391,7 @@ func.func @dynamic_update_slice_invalid_update(%input: tensor<3x4xi64>, %update:
 
 // -----
 
-func.func @dynamic_update_slice_invalid_start_size(%input: tensor<3x4xi64>, %update: tensor<1x2xi64>, %start: tensor<i64>) -> tensor<3x4xi64> {
+func.func @dynamic_update_slice_C4(%input: tensor<3x4xi64>, %update: tensor<1x2xi64>, %start: tensor<i64>) -> tensor<3x4xi64> {
   // expected-error@+1 {{expects number of start_indices to match operand rank: 1 vs 2.}}
   %0 = "stablehlo.dynamic_update_slice"(%input, %update, %start) : (tensor<3x4xi64>, tensor<1x2xi64>, tensor<i64>) -> tensor<3x4xi64>
   func.return %0 : tensor<3x4xi64>
@@ -2415,7 +2399,7 @@ func.func @dynamic_update_slice_invalid_start_size(%input: tensor<3x4xi64>, %upd
 
 // -----
 
-func.func @dynamic_update_slice_mismatched_start(%input: tensor<11x3x4xi32>, %update: tensor<1x3x4xi32>, %start1: tensor<i32>, %start2: tensor<i64>, %start3: tensor<i64>) -> tensor<11x3x4xi32> {
+func.func @dynamic_update_slice_C5(%input: tensor<11x3x4xi32>, %update: tensor<1x3x4xi32>, %start1: tensor<i32>, %start2: tensor<i64>, %start3: tensor<i64>) -> tensor<11x3x4xi32> {
   // expected-error@+1 {{start indices must have same element type}}
   %0 = "stablehlo.dynamic_update_slice"(%input, %update, %start1, %start2, %start3) : (tensor<11x3x4xi32>, tensor<1x3x4xi32>, tensor<i32>, tensor<i64>, tensor<i64>) -> tensor<11x3x4xi32>
   func.return %0 : tensor<11x3x4xi32>
@@ -2423,9 +2407,17 @@ func.func @dynamic_update_slice_mismatched_start(%input: tensor<11x3x4xi32>, %up
 
 // -----
 
-func.func @dynamic_update_slice_invalid_update_size(%input: tensor<3x4xi64>, %update: tensor<1x5xi64>, %start1: tensor<i64>, %start2: tensor<i64>) -> tensor<3x4xi64> {
+func.func @dynamic_update_slice_C6(%input: tensor<3x4xi64>, %update: tensor<1x5xi64>, %start1: tensor<i64>, %start2: tensor<i64>) -> tensor<3x4xi64> {
   // expected-error@+1 {{expects size at dimension 1 of update to be in range [0, 4]. Got: 5.}}
   %0 = "stablehlo.dynamic_update_slice"(%input, %update, %start1, %start2) : (tensor<3x4xi64>, tensor<1x5xi64>, tensor<i64>, tensor<i64>) -> tensor<3x4xi64>
+  func.return %0 : tensor<3x4xi64>
+}
+
+// -----
+
+// CHECK-LABEL: @dynamic_update_slice_dynamic_dim
+func.func @dynamic_update_slice_dynamic_dim(%input: tensor<?x4xi64>, %update: tensor<1x4xi64>, %start1: tensor<i64>, %start2: tensor<i64>) -> tensor<3x4xi64> {
+  %0 = "stablehlo.dynamic_update_slice"(%input, %update, %start1, %start2) : (tensor<?x4xi64>, tensor<1x4xi64>, tensor<i64>, tensor<i64>) -> tensor<3x4xi64>
   func.return %0 : tensor<3x4xi64>
 }
 
@@ -2451,6 +2443,14 @@ func.func @dynamic_update_slice_dynamic_rank_update(%input: tensor<3x4xi64>, %up
 func.func @dynamic_update_slice_dynamic_sizes(%input: tensor<?x4xi64>, %update: tensor<1x?xi64>, %start1: tensor<i64>, %start2: tensor<i64>) -> tensor<?x4xi64> {
   %0 = "stablehlo.dynamic_update_slice"(%input, %update, %start1, %start2) : (tensor<?x4xi64>, tensor<1x?xi64>, tensor<i64>, tensor<i64>) -> tensor<?x4xi64>
   func.return %0 : tensor<?x4xi64>
+}
+
+// -----
+
+func.func @dynamic_update_slice_invalid_start(%input: tensor<3x4xi64>, %update: tensor<1x2xi64>, %start: tensor<2xi64>) -> tensor<3x4xi64> {
+  // expected-error@+1 {{operand #2 must be 0D tensor of 4/8/16/32/64-bit signless integer or 4/8/16/32/64-bit unsigned integer values, but got 'tensor<2xi64>'}}
+  %0 = "stablehlo.dynamic_update_slice"(%input, %update, %start) : (tensor<3x4xi64>, tensor<1x2xi64>, tensor<2xi64>) -> tensor<3x4xi64>
+  func.return %0 : tensor<3x4xi64>
 }
 
 // -----


### PR DESCRIPTION
Unlike the spec, the interpreter uses its own implementation of clamp to calculate `adjustedStartIndices` since the start indices are given as variadic tensors, and formulating as one tensor to use the ClampOp is more loc.

We have the following constraints in the spec:

```
(I1) operand tensor.
(I2) update tensor.
(I3) start_indices variadic number of 0-dimensional tensors of integer type.
(C1) `operand` and `result` have the same type.
(C2) element_type(`update`) $=$ element_type(`operand`).
(C3) rank(`update`) $=$ rank(`operand`).
(C4) size(`start_indices`) $=$ rank(`operand`).
(C5) All `start_indices` have the same type.
(C6) dim(`update`, `k`) $\in$ [0, dim(`operand`, `k`)] for all `k` $\in$ [0, rank(`operand`)).
```

These constraints will be comprehensively covered by the following tests:

```
I1: a) operand is not a tensor. (Covered by ODS).
I2: a) update is not a tensor. (Covered by ODS).
I3: a) start_indices does not have 0-dimensional tensors. (Covered by ODS).
    b) start_indices does not have integer type. (Covered by ODS).
C1: a) element_type(operand) != element_type(result). (Covered by ODS).
    b) shape(operand) != shape(result).
C2: a) element_type(update) != element_type(operand). (Covered by ODS).
C3: a) rank(update) != rank(operand).
C4: a) size(start_indices) != rank(operand).
C5: a) all start_indices does not have the same type.
C6: a) dim(update, k) < 0 for any k.
    b) dim(update, k) > dim(operand, k) for any k.
```

If we drop the "Covered by ODS" pieces, this will leave us with the following test cases:

```
C1b: no negative test needed since result shape is inferred from operand shape
C3a: rank(update) != rank(operand).
C4a: size(start_indices) != rank(operand).
C5a: all start_indices does not have the same type.
C6a: dim(update, k) < 0 for any k.
C6b: dim(update, k) > dim(operand, k) for any k. 
```

closes #974