### PR TITLE
Add interpreter for ClampOp

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1518,6 +1518,8 @@ for this operation ([#560](https://github.com/openxla/stablehlo/issues/560)).
 // %result: [5, 13, 20]
 ```
 
+&nbsp;[More Examples](../stablehlo/tests/interpret_clamp.mlir)
+
 ### collective_permute
 
 #### Semantics

--- a/docs/status.md
+++ b/docs/status.md
@@ -60,7 +60,7 @@ one of the following tracking labels.
 | cbrt                     | yes           | yes          | yes            | yes             | no          |
 | ceil                     | yes           | yes          | yes            | yes             | yes         |
 | cholesky                 | yes           | yes          | yes            | yes             | no          |
-| clamp                    | yes           | revisit      | yes            | yes             | no          |
+| clamp                    | yes           | revisit      | yes            | yes             | yes         |
 | collective_permute       | yes           | revisit      | yes            | no              | no          |
 | compare                  | yes           | yes          | yes            | yes             | no          |
 | complex                  | yes           | yes          | yes            | yes             | no          |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1958,9 +1958,9 @@ def StableHLO_ClampOp : StableHLO_ShapedInterfaceOp<"clamp", [Pure,
   }];
 
   let arguments = (ins
-    HLO_Tensor:$min, /* clamp_i1 */
-    HLO_Tensor:$operand, /* clamp_c3,  clamp_i2 */
-    HLO_Tensor:$max /* clamp_i3 */
+    HLO_Tensor:$min, /*clamp_i1*/
+    HLO_Tensor:$operand, /*clamp_c3, clamp_i2*/
+    HLO_Tensor:$max /*clamp_i3*/
   );
   let results = (outs HLO_Tensor:$result);
 

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1943,7 +1943,7 @@ def StableHLO_CholeskyOp : StableHLO_Op<"cholesky",
 def StableHLO_ClampOp : StableHLO_ShapedInterfaceOp<"clamp", [Pure,
   SameOperandsAndResultElementType, HLO_BroadcastingElementwise,
   InferTensorType]> {
-  let summary = "Clamp operator";
+  let summary = "Clamp operation";
   let description = [{
     Clamps every element of the `operand` tensor between a minimum and maximum
     value and produces a `result` tensor.

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1958,9 +1958,9 @@ def StableHLO_ClampOp : StableHLO_ShapedInterfaceOp<"clamp", [Pure,
   }];
 
   let arguments = (ins
-    HLO_Tensor:$min,
-    HLO_Tensor:$operand,
-    HLO_Tensor:$max
+    HLO_Tensor:$min, /* clamp_i1 */
+    HLO_Tensor:$operand, /* clamp_c3,  clamp_i2 */
+    HLO_Tensor:$max /* clamp_i3 */
   );
   let results = (outs HLO_Tensor:$result);
 

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1941,7 +1941,7 @@ def StableHLO_CholeskyOp : StableHLO_Op<"cholesky",
 }
 
 def StableHLO_ClampOp : StableHLO_ShapedInterfaceOp<"clamp", [Pure,
-  SameOperandsAndResultElementType, HLO_BroadcastingElementwise, /* Clamp_C3 */
+  SameOperandsAndResultElementType /* Clamp_C3 */, HLO_BroadcastingElementwise,
   InferTensorType]> {
   let summary = "Clamp operation";
   let description = [{

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1941,7 +1941,7 @@ def StableHLO_CholeskyOp : StableHLO_Op<"cholesky",
 }
 
 def StableHLO_ClampOp : StableHLO_ShapedInterfaceOp<"clamp", [Pure,
-  SameOperandsAndResultElementType /* Clamp_C3 */, HLO_BroadcastingElementwise,
+  SameOperandsAndResultElementType /* clamp_c3 */, HLO_BroadcastingElementwise,
   InferTensorType]> {
   let summary = "Clamp operation";
   let description = [{

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1941,7 +1941,7 @@ def StableHLO_CholeskyOp : StableHLO_Op<"cholesky",
 }
 
 def StableHLO_ClampOp : StableHLO_ShapedInterfaceOp<"clamp", [Pure,
-  SameOperandsAndResultElementType, HLO_BroadcastingElementwise,
+  SameOperandsAndResultElementType, HLO_BroadcastingElementwise, /* Clamp_C3 */
   InferTensorType]> {
   let summary = "Clamp operation";
   let description = [{

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -1565,7 +1565,7 @@ LogicalResult inferClampOp(
         "] is not scalar and is not compatible to operand shape [",
         llvm::make_range(operandShape.begin(), operandShape.end()), "]");
 
-  // clampOp_c2
+  // clamp_c2
   auto maxType = max.getType().cast<RankedTensorType>();
   auto maxShape = maxType.getShape();
   if (failed(verifyCompatibleShape(maxType, operandType)) &&
@@ -1576,6 +1576,7 @@ LogicalResult inferClampOp(
         "] is not scalar and is not compatible to operand shape [",
         llvm::make_range(operandShape.begin(), operandShape.end()), "]");
 
+  // clamp_c4
   inferredReturnShapes.emplace_back(operandType.cast<ShapedType>());
   return success();
 }

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -1555,7 +1555,7 @@ LogicalResult inferClampOp(
   auto operandShape = operandType.getShape();
   auto minType = min.getType().cast<RankedTensorType>();
 
-  // ClampOp_C1
+  // clamp_c1
   auto minShape = minType.getShape();
   if (failed(verifyCompatibleShape(minType, operandType)) &&
       minType.getRank() != 0)
@@ -1565,7 +1565,7 @@ LogicalResult inferClampOp(
         "] is not scalar and is not compatible to operand shape [",
         llvm::make_range(operandShape.begin(), operandShape.end()), "]");
 
-  // ClampOp_C2
+  // clampOp_c2
   auto maxType = max.getType().cast<RankedTensorType>();
   auto maxShape = maxType.getShape();
   if (failed(verifyCompatibleShape(maxType, operandType)) &&

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -1554,6 +1554,8 @@ LogicalResult inferClampOp(
   auto operandType = operand.getType().cast<RankedTensorType>();
   auto operandShape = operandType.getShape();
   auto minType = min.getType().cast<RankedTensorType>();
+
+  // ClampOp.C1
   auto minShape = minType.getShape();
   if (failed(verifyCompatibleShape(minType, operandType)) &&
       minType.getRank() != 0)
@@ -1563,6 +1565,7 @@ LogicalResult inferClampOp(
         "] is not scalar and is not compatible to operand shape [",
         llvm::make_range(operandShape.begin(), operandShape.end()), "]");
 
+  // ClampOp.C2
   auto maxType = max.getType().cast<RankedTensorType>();
   auto maxShape = maxType.getShape();
   if (failed(verifyCompatibleShape(maxType, operandType)) &&

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -1555,7 +1555,7 @@ LogicalResult inferClampOp(
   auto operandShape = operandType.getShape();
   auto minType = min.getType().cast<RankedTensorType>();
 
-  // ClampOp.C1
+  // ClampOp_C1
   auto minShape = minType.getShape();
   if (failed(verifyCompatibleShape(minType, operandType)) &&
       minType.getRank() != 0)
@@ -1565,7 +1565,7 @@ LogicalResult inferClampOp(
         "] is not scalar and is not compatible to operand shape [",
         llvm::make_range(operandShape.begin(), operandShape.end()), "]");
 
-  // ClampOp.C2
+  // ClampOp_C2
   auto maxType = max.getType().cast<RankedTensorType>();
   auto maxShape = maxType.getShape();
   if (failed(verifyCompatibleShape(maxType, operandType)) &&

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -96,12 +96,10 @@ Tensor evalClampOp(const Tensor &min, const Tensor &operand, const Tensor &max,
                    Type resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
-    Element minElement = min.getType().getRank() != 0
-                             ? min.get(*it)
-                             : min.get(*(min.index_begin()));
-    Element maxElement = min.getType().getRank() != 0
-                             ? max.get(*it)
-                             : max.get(*(max.index_begin()));
+    Element minElement =
+        min.getType().getRank() != 0 ? min.get(*it) : min.get({});
+    Element maxElement =
+        max.getType().getRank() != 0 ? max.get(*it) : max.get({});
     result.set(*it, stablehlo::min(stablehlo::max(operand.get(*it), minElement),
                                    maxElement));
   }

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -92,7 +92,7 @@ Tensor evalCeilOp(const Tensor &operand, Type resultType) {
   return result;
 }
 
-Tensor evalClampOp(const Tensor &min, const Tensor &operand, const Tensor &max, 
+Tensor evalClampOp(const Tensor &min, const Tensor &operand, const Tensor &max,
                    Type resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -403,6 +403,13 @@ SmallVector<Tensor> eval(Region &region, ArrayRef<Tensor> args, Scope *parent) {
       Tensor runtimeOperand = scope.find(ceilOp.getOperand());
       Tensor runtimeResult = evalCeilOp(runtimeOperand, ceilOp.getType());
       scope.add(op.getResults(), {runtimeResult});
+    } else if (auto clampOp = dyn_cast<ClampOp>(op)) {
+      Tensor runtimeMin = scope.find(clampOp.getMin());
+      Tensor runtimeOperand = scope.find(clampOp.getOperand());
+      Tensor runtimeMax = scope.find(clampOp.getMax());
+      Tensor runtimeResult = evalClampOp(runtimeMin, runtimeOperand, runtimeMax,
+                                         clampOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
     } else if (auto constantOp = dyn_cast<ConstantOp>(op)) {
       Tensor runtimeResult = evalConstantOp(constantOp.getValue());
       scope.add(op.getResults(), {runtimeResult});

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -92,6 +92,21 @@ Tensor evalCeilOp(const Tensor &operand, Type resultType) {
   return result;
 }
 
+Tensor evalClampOp(const Tensor &min, const Tensor &operand, const Tensor &max, 
+                   Type resultType) {
+  Tensor result(resultType);
+  for (auto it = result.index_begin(); it != result.index_end(); ++it) {
+    Element min_element =
+        min.getNumElements() > 1 ? min.get(*it) : min.get(*(min.index_begin()));
+    Element max_element =
+        max.getNumElements() > 1 ? max.get(*it) : max.get(*(max.index_begin()));
+    result.set(*it,
+               stablehlo::min(stablehlo::max(operand.get(*it), min_element),
+                              max_element));
+  }
+  return result;
+}
+
 Tensor evalConstantOp(ElementsAttr value) {
   return makeTensor(value.cast<DenseElementsAttr>());
 }

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -96,10 +96,12 @@ Tensor evalClampOp(const Tensor &min, const Tensor &operand, const Tensor &max,
                    Type resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
-    Element minElement =
-        min.getNumElements() > 1 ? min.get(*it) : min.get(*(min.index_begin()));
-    Element maxElement =
-        max.getNumElements() > 1 ? max.get(*it) : max.get(*(max.index_begin()));
+    Element minElement = min.getType().getRank() != 0
+                             ? min.get(*it)
+                             : min.get(*(min.index_begin()));
+    Element maxElement = min.getType().getRank() != 0
+                             ? max.get(*it)
+                             : max.get(*(max.index_begin()));
     result.set(*it, stablehlo::min(stablehlo::max(operand.get(*it), minElement),
                                    maxElement));
   }

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -96,13 +96,12 @@ Tensor evalClampOp(const Tensor &min, const Tensor &operand, const Tensor &max,
                    Type resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
-    Element min_element =
+    Element minElement =
         min.getNumElements() > 1 ? min.get(*it) : min.get(*(min.index_begin()));
-    Element max_element =
+    Element maxElement =
         max.getNumElements() > 1 ? max.get(*it) : max.get(*(max.index_begin()));
-    result.set(*it,
-               stablehlo::min(stablehlo::max(operand.get(*it), min_element),
-                              max_element));
+    result.set(*it, stablehlo::min(stablehlo::max(operand.get(*it), minElement),
+                                   maxElement));
   }
   return result;
 }

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -32,7 +32,7 @@ Tensor evalBroadcastInDimOp(const Tensor &operand,
                             ArrayRef<int64_t> broadcastDimensions,
                             Type resultType);
 Tensor evalCeilOp(const Tensor &operand, Type resultType);
-Tensor evalClampOp(const Tensor &min, const Tensor &operand, const Tensor &max, 
+Tensor evalClampOp(const Tensor &min, const Tensor &operand, const Tensor &max,
                    Type resultType);
 Tensor evalConstantOp(ElementsAttr value);
 Tensor evalConvertOp(const Tensor &operand, Type resultType);

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -32,6 +32,8 @@ Tensor evalBroadcastInDimOp(const Tensor &operand,
                             ArrayRef<int64_t> broadcastDimensions,
                             Type resultType);
 Tensor evalCeilOp(const Tensor &operand, Type resultType);
+Tensor evalClampOp(const Tensor &min, const Tensor &operand, const Tensor &max, 
+                   Type resultType);
 Tensor evalConstantOp(ElementsAttr value);
 Tensor evalConvertOp(const Tensor &operand, Type resultType);
 Tensor evalCosineOp(const Tensor &operand, Type resultType);

--- a/stablehlo/tests/interpret_clamp.mlir
+++ b/stablehlo/tests/interpret_clamp.mlir
@@ -1,20 +1,5 @@
 // RUN: stablehlo-interpreter --interpret -split-input-file %s | FileCheck %s
 
-// CHECK-LABEL: Evaluated results of function: clamp_op_test_i1
-func.func @clamp_op_test_i1() -> tensor<3xi1> {
-  %min = stablehlo.constant dense<[false, false, true]> : tensor<3xi1>
-  %operand = stablehlo.constant dense<[false, true, false]> : tensor<3xi1>
-  %max = stablehlo.constant dense<[true, true, true]> : tensor<3xi1>
-  %result = stablehlo.clamp %min, %operand, %max : (tensor<3xi1>, tensor<3xi1>, tensor<3xi1>) -> tensor<3xi1>
-  func.return %result : tensor<3xi1>
-  // CHECK-NEXT: tensor<3xi1>
-  // CHECK-NEXT: false
-  // CHECK-NEXT: true
-  // CHECK-NEXT: true
-}
-
-// -----
-
 // CHECK-LABEL: Evaluated results of function: clamp_op_test_si64
 func.func @clamp_op_test_si64() -> tensor<3xi64> {
   %min = stablehlo.constant dense<[1, 5, -5]> : tensor<3xi64>
@@ -41,34 +26,4 @@ func.func @clamp_op_test_si64_scalar() -> tensor<3xi64> {
   // CHECK-NEXT: 1 : i64
   // CHECK-NEXT: 1 : i64
   // CHECK-NEXT: 0 : i64
-}
-
-// -----
-
-// CHECK-LABEL: Evaluated results of function: clamp_op_test_f64
-func.func @clamp_op_test_f64() -> tensor<3xf64> {
-  %min = stablehlo.constant dense<[0.0, 0.7, 0xFFF0000000000001]> : tensor<3xf64>
-  %operand = stablehlo.constant dense<[0.0, 0.3, 0xFFF0000000000003]> : tensor<3xf64>
-  %max = stablehlo.constant dense<[-0.0, 1.0, 0xFFF0000000000002]> : tensor<3xf64>
-  %result = stablehlo.clamp %min, %operand, %max : (tensor<3xf64>, tensor<3xf64>, tensor<3xf64>) -> tensor<3xf64>
-  func.return %result : tensor<3xf64>
-  // CHECK-NEXT: tensor<3xf64>
-  // CHECK-NEXT: -0.000000e+00 : f64
-  // CHECK-NEXT: 0.69999999999999996 : f64
-  // CHECK-NEXT: 0xFFF0000000000003 : f64
-}
-
-// -----
-
-// CHECK-LABEL: Evaluated results of function: clamp_op_test_c128
-func.func @clamp_op_test_c128() -> tensor<3xcomplex<f64>> {
-  %min = stablehlo.constant dense<[(1.5, 2.5), (7.5, 5.5), (10.0, 10.0)]> : tensor<3xcomplex<f64>>
-  %operand = stablehlo.constant dense<[(2.0, 0.0), (7.5, -5.5), (20.0, 100.0)]> : tensor<3xcomplex<f64>>
-  %max = stablehlo.constant dense<[(2.5, 3.5), (7.5, 6.6), (20.0, 20.0)]> : tensor<3xcomplex<f64>>
-  %result = stablehlo.clamp %min, %operand, %max : (tensor<3xcomplex<f64>>, tensor<3xcomplex<f64>>, tensor<3xcomplex<f64>>) -> tensor<3xcomplex<f64>>
-  func.return %result : tensor<3xcomplex<f64>>
-  // CHECK-NEXT: tensor<3xcomplex<f64>>
-  // CHECK-NEXT: [2.000000e+00 : f64, 0.000000e+00 : f64]
-  // CHECK-NEXT: [7.500000e+00 : f64, 5.500000e+00 : f64]
-  // CHECK-NEXT: [2.000000e+01 : f64, 2.000000e+01 : f64]
 }

--- a/stablehlo/tests/interpret_clamp.mlir
+++ b/stablehlo/tests/interpret_clamp.mlir
@@ -1,0 +1,74 @@
+// RUN: stablehlo-interpreter --interpret -split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: Evaluated results of function: clamp_op_test_si4
+func.func @clamp_op_test_si4() -> tensor<3xi4> {
+  %0 = stablehlo.constant dense<[1, 5, -5]> : tensor<3xi4>
+  %1 = stablehlo.constant dense<[2, 3, -1]> : tensor<3xi4>
+  %2 = stablehlo.constant dense<[3, 7, -3]> : tensor<3xi4>
+  %3 = stablehlo.clamp %0, %1, %2 : (tensor<3xi4>, tensor<3xi4>, tensor<3xi4>) -> tensor<3xi4>
+  func.return %3 : tensor<3xi4>
+  // CHECK-NEXT: tensor<3xi4>
+  // CHECK-NEXT: 2 : i4
+  // CHECK-NEXT: 5 : i4
+  // CHECK-NEXT: -3 : i4
+}
+
+// -----
+
+// CHECK-LABEL: Evaluated results of function: clamp_op_test_si4_scalar
+func.func @clamp_op_test_si4_scalar() -> tensor<3xi4> {
+  %0 = stablehlo.constant dense<0> : tensor<i4>
+  %1 = stablehlo.constant dense<[2, 3, -1]> : tensor<3xi4>
+  %2 = stablehlo.constant dense<1> : tensor<i4>
+  %3 = stablehlo.clamp %0, %1, %2 : (tensor<i4>, tensor<3xi4>, tensor<i4>) -> tensor<3xi4>
+  func.return %3 : tensor<3xi4>
+  // CHECK-NEXT: tensor<3xi4>
+  // CHECK-NEXT: 1 : i4
+  // CHECK-NEXT: 1 : i4
+  // CHECK-NEXT: 0 : i4
+}
+
+// -----
+
+// CHECK-LABEL: Evaluated results of function: clamp_op_test_i1
+func.func @clamp_op_test_i1() -> tensor<3xi1> {
+  %0 = stablehlo.constant dense<[false, false, true]> : tensor<3xi1>
+  %1 = stablehlo.constant dense<[false, true, false]> : tensor<3xi1>
+  %2 = stablehlo.constant dense<[true, true, true]> : tensor<3xi1>
+  %3 = stablehlo.clamp %0, %1, %2 : (tensor<3xi1>, tensor<3xi1>, tensor<3xi1>) -> tensor<3xi1>
+  func.return %3 : tensor<3xi1>
+  // CHECK-NEXT: tensor<3xi1>
+  // CHECK-NEXT: false
+  // CHECK-NEXT: true
+  // CHECK-NEXT: true
+}
+
+// -----
+
+// CHECK-LABEL: Evaluated results of function: clamp_op_test_f16
+func.func @clamp_op_test_f16() -> tensor<3xf16> {
+  %0 = stablehlo.constant dense<[0.0, 0.7, 0x7C80]> : tensor<3xf16>
+  %1 = stablehlo.constant dense<[0.0, 0.3, 0x9C80]> : tensor<3xf16>
+  %2 = stablehlo.constant dense<[-0.0, 1.0, 0x8C80]> : tensor<3xf16>
+  %3 = stablehlo.clamp %0, %1, %2 : (tensor<3xf16>, tensor<3xf16>, tensor<3xf16>) -> tensor<3xf16>
+  func.return %3 : tensor<3xf16>
+  // CHECK-NEXT: tensor<3xf16>
+  // CHECK-NEXT: -0.000000e+00 : f16
+  // CHECK-NEXT: 7.001950e-01 : f16
+  // CHECK-NEXT: 0x7C80 : f16
+}
+
+// -----
+
+// CHECK-LABEL: Evaluated results of function: clamp_op_test_c64
+func.func @clamp_op_test_c64() -> tensor<3xcomplex<f32>> {
+  %0 = stablehlo.constant dense<[(1.5, 2.5), (7.5, 5.5), (10.0, 10.0)]> : tensor<3xcomplex<f32>>
+  %1 = stablehlo.constant dense<[(2.0, 0.0), (7.5, -5.5), (20.0, 100.0)]> : tensor<3xcomplex<f32>>
+  %2 = stablehlo.constant dense<[(2.5, 3.5), (7.5, 6.6), (20.0, 20.0)]> : tensor<3xcomplex<f32>>
+  %3 = stablehlo.clamp %0, %1, %2 : (tensor<3xcomplex<f32>>, tensor<3xcomplex<f32>>, tensor<3xcomplex<f32>>) -> tensor<3xcomplex<f32>>
+  func.return %3 : tensor<3xcomplex<f32>>
+  // CHECK-NEXT: tensor<3xcomplex<f32>>
+  // CHECK-NEXT: [2.000000e+00 : f32, 0.000000e+00 : f32]
+  // CHECK-NEXT: [7.500000e+00 : f32, 5.500000e+00 : f32]
+  // CHECK-NEXT: [2.000000e+01 : f32, 2.000000e+01 : f32]
+}

--- a/stablehlo/tests/interpret_clamp.mlir
+++ b/stablehlo/tests/interpret_clamp.mlir
@@ -1,5 +1,20 @@
 // RUN: stablehlo-interpreter --interpret -split-input-file %s | FileCheck %s
 
+// CHECK-LABEL: Evaluated results of function: clamp_op_test_i1
+func.func @clamp_op_test_i1() -> tensor<3xi1> {
+  %min = stablehlo.constant dense<[false, false, true]> : tensor<3xi1>
+  %operand = stablehlo.constant dense<[false, true, false]> : tensor<3xi1>
+  %max = stablehlo.constant dense<[true, true, true]> : tensor<3xi1>
+  %result = stablehlo.clamp %min, %operand, %max : (tensor<3xi1>, tensor<3xi1>, tensor<3xi1>) -> tensor<3xi1>
+  func.return %result : tensor<3xi1>
+  // CHECK-NEXT: tensor<3xi1>
+  // CHECK-NEXT: false
+  // CHECK-NEXT: true
+  // CHECK-NEXT: true
+}
+
+// -----
+
 // CHECK-LABEL: Evaluated results of function: clamp_op_test_si64
 func.func @clamp_op_test_si64() -> tensor<3xi64> {
   %min = stablehlo.constant dense<[1, 5, -5]> : tensor<3xi64>
@@ -26,21 +41,6 @@ func.func @clamp_op_test_si64_scalar() -> tensor<3xi64> {
   // CHECK-NEXT: 1 : i64
   // CHECK-NEXT: 1 : i64
   // CHECK-NEXT: 0 : i64
-}
-
-// -----
-
-// CHECK-LABEL: Evaluated results of function: clamp_op_test_i1
-func.func @clamp_op_test_i1() -> tensor<3xi1> {
-  %min = stablehlo.constant dense<[false, false, true]> : tensor<3xi1>
-  %operand = stablehlo.constant dense<[false, true, false]> : tensor<3xi1>
-  %max = stablehlo.constant dense<[true, true, true]> : tensor<3xi1>
-  %result = stablehlo.clamp %min, %operand, %max : (tensor<3xi1>, tensor<3xi1>, tensor<3xi1>) -> tensor<3xi1>
-  func.return %result : tensor<3xi1>
-  // CHECK-NEXT: tensor<3xi1>
-  // CHECK-NEXT: false
-  // CHECK-NEXT: true
-  // CHECK-NEXT: true
 }
 
 // -----

--- a/stablehlo/tests/interpret_clamp.mlir
+++ b/stablehlo/tests/interpret_clamp.mlir
@@ -1,31 +1,31 @@
 // RUN: stablehlo-interpreter --interpret -split-input-file %s | FileCheck %s
 
-// CHECK-LABEL: Evaluated results of function: clamp_op_test_si4
-func.func @clamp_op_test_si4() -> tensor<3xi4> {
-  %0 = stablehlo.constant dense<[1, 5, -5]> : tensor<3xi4>
-  %1 = stablehlo.constant dense<[2, 3, -1]> : tensor<3xi4>
-  %2 = stablehlo.constant dense<[3, 7, -3]> : tensor<3xi4>
-  %3 = stablehlo.clamp %0, %1, %2 : (tensor<3xi4>, tensor<3xi4>, tensor<3xi4>) -> tensor<3xi4>
-  func.return %3 : tensor<3xi4>
-  // CHECK-NEXT: tensor<3xi4>
-  // CHECK-NEXT: 2 : i4
-  // CHECK-NEXT: 5 : i4
-  // CHECK-NEXT: -3 : i4
+// CHECK-LABEL: Evaluated results of function: clamp_op_test_si64
+func.func @clamp_op_test_si64() -> tensor<3xi64> {
+  %0 = stablehlo.constant dense<[1, 5, -5]> : tensor<3xi64>
+  %1 = stablehlo.constant dense<[2, 3, -1]> : tensor<3xi64>
+  %2 = stablehlo.constant dense<[3, 7, -3]> : tensor<3xi64>
+  %3 = stablehlo.clamp %0, %1, %2 : (tensor<3xi64>, tensor<3xi64>, tensor<3xi64>) -> tensor<3xi64>
+  func.return %3 : tensor<3xi64>
+  // CHECK-NEXT: tensor<3xi64>
+  // CHECK-NEXT: 2 : i64
+  // CHECK-NEXT: 5 : i64
+  // CHECK-NEXT: -3 : i64
 }
 
 // -----
 
-// CHECK-LABEL: Evaluated results of function: clamp_op_test_si4_scalar
-func.func @clamp_op_test_si4_scalar() -> tensor<3xi4> {
-  %0 = stablehlo.constant dense<0> : tensor<i4>
-  %1 = stablehlo.constant dense<[2, 3, -1]> : tensor<3xi4>
-  %2 = stablehlo.constant dense<1> : tensor<i4>
-  %3 = stablehlo.clamp %0, %1, %2 : (tensor<i4>, tensor<3xi4>, tensor<i4>) -> tensor<3xi4>
-  func.return %3 : tensor<3xi4>
-  // CHECK-NEXT: tensor<3xi4>
-  // CHECK-NEXT: 1 : i4
-  // CHECK-NEXT: 1 : i4
-  // CHECK-NEXT: 0 : i4
+// CHECK-LABEL: Evaluated results of function: clamp_op_test_si64_scalar
+func.func @clamp_op_test_si64_scalar() -> tensor<3xi64> {
+  %0 = stablehlo.constant dense<0> : tensor<i64>
+  %1 = stablehlo.constant dense<[2, 3, -1]> : tensor<3xi64>
+  %2 = stablehlo.constant dense<1> : tensor<i64>
+  %3 = stablehlo.clamp %0, %1, %2 : (tensor<i64>, tensor<3xi64>, tensor<i64>) -> tensor<3xi64>
+  func.return %3 : tensor<3xi64>
+  // CHECK-NEXT: tensor<3xi64>
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 0 : i64
 }
 
 // -----
@@ -45,30 +45,30 @@ func.func @clamp_op_test_i1() -> tensor<3xi1> {
 
 // -----
 
-// CHECK-LABEL: Evaluated results of function: clamp_op_test_f16
-func.func @clamp_op_test_f16() -> tensor<3xf16> {
-  %0 = stablehlo.constant dense<[0.0, 0.7, 0x7C80]> : tensor<3xf16>
-  %1 = stablehlo.constant dense<[0.0, 0.3, 0x9C80]> : tensor<3xf16>
-  %2 = stablehlo.constant dense<[-0.0, 1.0, 0x8C80]> : tensor<3xf16>
-  %3 = stablehlo.clamp %0, %1, %2 : (tensor<3xf16>, tensor<3xf16>, tensor<3xf16>) -> tensor<3xf16>
-  func.return %3 : tensor<3xf16>
-  // CHECK-NEXT: tensor<3xf16>
-  // CHECK-NEXT: -0.000000e+00 : f16
-  // CHECK-NEXT: 7.001950e-01 : f16
-  // CHECK-NEXT: 0x7C80 : f16
+// CHECK-LABEL: Evaluated results of function: clamp_op_test_f64
+func.func @clamp_op_test_f64() -> tensor<3xf64> {
+  %0 = stablehlo.constant dense<[0.0, 0.7, 0xFFF0000000000001]> : tensor<3xf64>
+  %1 = stablehlo.constant dense<[0.0, 0.3, 0xFFF0000000000003]> : tensor<3xf64>
+  %2 = stablehlo.constant dense<[-0.0, 1.0, 0xFFF0000000000002]> : tensor<3xf64>
+  %3 = stablehlo.clamp %0, %1, %2 : (tensor<3xf64>, tensor<3xf64>, tensor<3xf64>) -> tensor<3xf64>
+  func.return %3 : tensor<3xf64>
+  // CHECK-NEXT: tensor<3xf64>
+  // CHECK-NEXT: -0.000000e+00 : f64
+  // CHECK-NEXT: 0.69999999999999996 : f64
+  // CHECK-NEXT: 0xFFF0000000000003 : f64
 }
 
 // -----
 
-// CHECK-LABEL: Evaluated results of function: clamp_op_test_c64
-func.func @clamp_op_test_c64() -> tensor<3xcomplex<f32>> {
-  %0 = stablehlo.constant dense<[(1.5, 2.5), (7.5, 5.5), (10.0, 10.0)]> : tensor<3xcomplex<f32>>
-  %1 = stablehlo.constant dense<[(2.0, 0.0), (7.5, -5.5), (20.0, 100.0)]> : tensor<3xcomplex<f32>>
-  %2 = stablehlo.constant dense<[(2.5, 3.5), (7.5, 6.6), (20.0, 20.0)]> : tensor<3xcomplex<f32>>
-  %3 = stablehlo.clamp %0, %1, %2 : (tensor<3xcomplex<f32>>, tensor<3xcomplex<f32>>, tensor<3xcomplex<f32>>) -> tensor<3xcomplex<f32>>
-  func.return %3 : tensor<3xcomplex<f32>>
-  // CHECK-NEXT: tensor<3xcomplex<f32>>
-  // CHECK-NEXT: [2.000000e+00 : f32, 0.000000e+00 : f32]
-  // CHECK-NEXT: [7.500000e+00 : f32, 5.500000e+00 : f32]
-  // CHECK-NEXT: [2.000000e+01 : f32, 2.000000e+01 : f32]
+// CHECK-LABEL: Evaluated results of function: clamp_op_test_c128
+func.func @clamp_op_test_c128() -> tensor<3xcomplex<f64>> {
+  %0 = stablehlo.constant dense<[(1.5, 2.5), (7.5, 5.5), (10.0, 10.0)]> : tensor<3xcomplex<f64>>
+  %1 = stablehlo.constant dense<[(2.0, 0.0), (7.5, -5.5), (20.0, 100.0)]> : tensor<3xcomplex<f64>>
+  %2 = stablehlo.constant dense<[(2.5, 3.5), (7.5, 6.6), (20.0, 20.0)]> : tensor<3xcomplex<f64>>
+  %3 = stablehlo.clamp %0, %1, %2 : (tensor<3xcomplex<f64>>, tensor<3xcomplex<f64>>, tensor<3xcomplex<f64>>) -> tensor<3xcomplex<f64>>
+  func.return %3 : tensor<3xcomplex<f64>>
+  // CHECK-NEXT: tensor<3xcomplex<f64>>
+  // CHECK-NEXT: [2.000000e+00 : f64, 0.000000e+00 : f64]
+  // CHECK-NEXT: [7.500000e+00 : f64, 5.500000e+00 : f64]
+  // CHECK-NEXT: [2.000000e+01 : f64, 2.000000e+01 : f64]
 }

--- a/stablehlo/tests/interpret_clamp.mlir
+++ b/stablehlo/tests/interpret_clamp.mlir
@@ -15,8 +15,38 @@ func.func @clamp_op_test_si64() -> tensor<3xi64> {
 
 // -----
 
-// CHECK-LABEL: Evaluated results of function: clamp_op_test_si64_scalar
-func.func @clamp_op_test_si64_scalar() -> tensor<3xi64> {
+// CHECK-LABEL: Evaluated results of function: clamp_op_test_si64_min_scalar
+func.func @clamp_op_test_si64_min_scalar() -> tensor<3xi64> {
+  %min = stablehlo.constant dense<[0, 0, -2]> : tensor<3xi64>
+  %operand = stablehlo.constant dense<[2, 3, -1]> : tensor<3xi64>
+  %max = stablehlo.constant dense<1> : tensor<i64>
+  %result = stablehlo.clamp %min, %operand, %max : (tensor<3xi64>, tensor<3xi64>, tensor<i64>) -> tensor<3xi64>
+  func.return %result : tensor<3xi64>
+  // CHECK-NEXT: tensor<3xi64>
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: -1 : i64
+}
+
+// -----
+
+// CHECK-LABEL: Evaluated results of function: clamp_op_test_si64_max_scalar
+func.func @clamp_op_test_si64_max_scalar() -> tensor<3xi64> {
+  %min = stablehlo.constant dense<0> : tensor<i64>
+  %operand = stablehlo.constant dense<[2, 3, -1]> : tensor<3xi64>
+  %max = stablehlo.constant dense<[1, 1, 4]> : tensor<3xi64>
+  %result = stablehlo.clamp %min, %operand, %max : (tensor<i64>, tensor<3xi64>, tensor<3xi64>) -> tensor<3xi64>
+  func.return %result : tensor<3xi64>
+  // CHECK-NEXT: tensor<3xi64>
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 0 : i64
+}
+
+// -----
+
+// CHECK-LABEL: Evaluated results of function: clamp_op_test_si64_min_max_both_scalar
+func.func @clamp_op_test_si64_min_max_both_scalar() -> tensor<3xi64> {
   %min = stablehlo.constant dense<0> : tensor<i64>
   %operand = stablehlo.constant dense<[2, 3, -1]> : tensor<3xi64>
   %max = stablehlo.constant dense<1> : tensor<i64>

--- a/stablehlo/tests/interpret_clamp.mlir
+++ b/stablehlo/tests/interpret_clamp.mlir
@@ -2,11 +2,11 @@
 
 // CHECK-LABEL: Evaluated results of function: clamp_op_test_si64
 func.func @clamp_op_test_si64() -> tensor<3xi64> {
-  %0 = stablehlo.constant dense<[1, 5, -5]> : tensor<3xi64>
-  %1 = stablehlo.constant dense<[2, 3, -1]> : tensor<3xi64>
-  %2 = stablehlo.constant dense<[3, 7, -3]> : tensor<3xi64>
-  %3 = stablehlo.clamp %0, %1, %2 : (tensor<3xi64>, tensor<3xi64>, tensor<3xi64>) -> tensor<3xi64>
-  func.return %3 : tensor<3xi64>
+  %min = stablehlo.constant dense<[1, 5, -5]> : tensor<3xi64>
+  %operand = stablehlo.constant dense<[2, 3, -1]> : tensor<3xi64>
+  %max = stablehlo.constant dense<[3, 7, -3]> : tensor<3xi64>
+  %result = stablehlo.clamp %min, %operand, %max : (tensor<3xi64>, tensor<3xi64>, tensor<3xi64>) -> tensor<3xi64>
+  func.return %result : tensor<3xi64>
   // CHECK-NEXT: tensor<3xi64>
   // CHECK-NEXT: 2 : i64
   // CHECK-NEXT: 5 : i64
@@ -17,11 +17,11 @@ func.func @clamp_op_test_si64() -> tensor<3xi64> {
 
 // CHECK-LABEL: Evaluated results of function: clamp_op_test_si64_scalar
 func.func @clamp_op_test_si64_scalar() -> tensor<3xi64> {
-  %0 = stablehlo.constant dense<0> : tensor<i64>
-  %1 = stablehlo.constant dense<[2, 3, -1]> : tensor<3xi64>
-  %2 = stablehlo.constant dense<1> : tensor<i64>
-  %3 = stablehlo.clamp %0, %1, %2 : (tensor<i64>, tensor<3xi64>, tensor<i64>) -> tensor<3xi64>
-  func.return %3 : tensor<3xi64>
+  %min = stablehlo.constant dense<0> : tensor<i64>
+  %operand = stablehlo.constant dense<[2, 3, -1]> : tensor<3xi64>
+  %max = stablehlo.constant dense<1> : tensor<i64>
+  %result = stablehlo.clamp %min, %operand, %max : (tensor<i64>, tensor<3xi64>, tensor<i64>) -> tensor<3xi64>
+  func.return %result : tensor<3xi64>
   // CHECK-NEXT: tensor<3xi64>
   // CHECK-NEXT: 1 : i64
   // CHECK-NEXT: 1 : i64
@@ -32,11 +32,11 @@ func.func @clamp_op_test_si64_scalar() -> tensor<3xi64> {
 
 // CHECK-LABEL: Evaluated results of function: clamp_op_test_i1
 func.func @clamp_op_test_i1() -> tensor<3xi1> {
-  %0 = stablehlo.constant dense<[false, false, true]> : tensor<3xi1>
-  %1 = stablehlo.constant dense<[false, true, false]> : tensor<3xi1>
-  %2 = stablehlo.constant dense<[true, true, true]> : tensor<3xi1>
-  %3 = stablehlo.clamp %0, %1, %2 : (tensor<3xi1>, tensor<3xi1>, tensor<3xi1>) -> tensor<3xi1>
-  func.return %3 : tensor<3xi1>
+  %min = stablehlo.constant dense<[false, false, true]> : tensor<3xi1>
+  %operand = stablehlo.constant dense<[false, true, false]> : tensor<3xi1>
+  %max = stablehlo.constant dense<[true, true, true]> : tensor<3xi1>
+  %result = stablehlo.clamp %min, %operand, %max : (tensor<3xi1>, tensor<3xi1>, tensor<3xi1>) -> tensor<3xi1>
+  func.return %result : tensor<3xi1>
   // CHECK-NEXT: tensor<3xi1>
   // CHECK-NEXT: false
   // CHECK-NEXT: true
@@ -47,11 +47,11 @@ func.func @clamp_op_test_i1() -> tensor<3xi1> {
 
 // CHECK-LABEL: Evaluated results of function: clamp_op_test_f64
 func.func @clamp_op_test_f64() -> tensor<3xf64> {
-  %0 = stablehlo.constant dense<[0.0, 0.7, 0xFFF0000000000001]> : tensor<3xf64>
-  %1 = stablehlo.constant dense<[0.0, 0.3, 0xFFF0000000000003]> : tensor<3xf64>
-  %2 = stablehlo.constant dense<[-0.0, 1.0, 0xFFF0000000000002]> : tensor<3xf64>
-  %3 = stablehlo.clamp %0, %1, %2 : (tensor<3xf64>, tensor<3xf64>, tensor<3xf64>) -> tensor<3xf64>
-  func.return %3 : tensor<3xf64>
+  %min = stablehlo.constant dense<[0.0, 0.7, 0xFFF0000000000001]> : tensor<3xf64>
+  %operand = stablehlo.constant dense<[0.0, 0.3, 0xFFF0000000000003]> : tensor<3xf64>
+  %max = stablehlo.constant dense<[-0.0, 1.0, 0xFFF0000000000002]> : tensor<3xf64>
+  %result = stablehlo.clamp %min, %operand, %max : (tensor<3xf64>, tensor<3xf64>, tensor<3xf64>) -> tensor<3xf64>
+  func.return %result : tensor<3xf64>
   // CHECK-NEXT: tensor<3xf64>
   // CHECK-NEXT: -0.000000e+00 : f64
   // CHECK-NEXT: 0.69999999999999996 : f64
@@ -62,11 +62,11 @@ func.func @clamp_op_test_f64() -> tensor<3xf64> {
 
 // CHECK-LABEL: Evaluated results of function: clamp_op_test_c128
 func.func @clamp_op_test_c128() -> tensor<3xcomplex<f64>> {
-  %0 = stablehlo.constant dense<[(1.5, 2.5), (7.5, 5.5), (10.0, 10.0)]> : tensor<3xcomplex<f64>>
-  %1 = stablehlo.constant dense<[(2.0, 0.0), (7.5, -5.5), (20.0, 100.0)]> : tensor<3xcomplex<f64>>
-  %2 = stablehlo.constant dense<[(2.5, 3.5), (7.5, 6.6), (20.0, 20.0)]> : tensor<3xcomplex<f64>>
-  %3 = stablehlo.clamp %0, %1, %2 : (tensor<3xcomplex<f64>>, tensor<3xcomplex<f64>>, tensor<3xcomplex<f64>>) -> tensor<3xcomplex<f64>>
-  func.return %3 : tensor<3xcomplex<f64>>
+  %min = stablehlo.constant dense<[(1.5, 2.5), (7.5, 5.5), (10.0, 10.0)]> : tensor<3xcomplex<f64>>
+  %operand = stablehlo.constant dense<[(2.0, 0.0), (7.5, -5.5), (20.0, 100.0)]> : tensor<3xcomplex<f64>>
+  %max = stablehlo.constant dense<[(2.5, 3.5), (7.5, 6.6), (20.0, 20.0)]> : tensor<3xcomplex<f64>>
+  %result = stablehlo.clamp %min, %operand, %max : (tensor<3xcomplex<f64>>, tensor<3xcomplex<f64>>, tensor<3xcomplex<f64>>) -> tensor<3xcomplex<f64>>
+  func.return %result : tensor<3xcomplex<f64>>
   // CHECK-NEXT: tensor<3xcomplex<f64>>
   // CHECK-NEXT: [2.000000e+00 : f64, 0.000000e+00 : f64]
   // CHECK-NEXT: [7.500000e+00 : f64, 5.500000e+00 : f64]

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -1376,12 +1376,6 @@ func.func @clamp(%arg0: tensor<1xi32>) -> tensor<1xi32> {
 
 // -----
 
-// CHECK-LABEL: func @clamp_scalar
-func.func @clamp_scalar(%arg0: tensor<1xi32>, %arg1: tensor<i32>) -> tensor<1xi32> {
-  %0 = "stablehlo.clamp"(%arg1, %arg0, %arg1) : (tensor<i32>, tensor<1xi32>, tensor<i32>) -> tensor<1xi32>
-  func.return %0: tensor<1xi32>
-}
-
 // CHECK-LABEL: func @clamp_compatible_dynamic
 func.func @clamp_compatible_dynamic(%arg0: tensor<?xi32>, %arg1: tensor<i32>, %arg2: tensor<3xi32>) -> tensor<?xi32> {
   %0 = "stablehlo.clamp"(%arg1, %arg0, %arg2) : (tensor<i32>, tensor<?xi32>, tensor<3xi32>) -> tensor<?xi32>
@@ -1392,14 +1386,6 @@ func.func @clamp_compatible_dynamic(%arg0: tensor<?xi32>, %arg1: tensor<i32>, %a
 func.func @clamp_compatible_dynamic_match_static(%arg0: tensor<?xi32>, %arg1: tensor<i32>, %arg2: tensor<3xi32>) -> tensor<3xi32> {
   %0 = "stablehlo.clamp"(%arg1, %arg0, %arg2) : (tensor<i32>, tensor<?xi32>, tensor<3xi32>) -> tensor<3xi32>
   func.return %0: tensor<3xi32>
-}
-
-// -----
-
-func.func @clamp_c3(%arg0: tensor<1xi32>, %arg1: tensor<1xf32>) -> tensor<1xi32> {
-  // expected-error@+1 {{'stablehlo.clamp' op requires the same element type for all operands and results}}
-  %0 = "stablehlo.clamp"(%arg1, %arg0, %arg0) : (tensor<1xf32>, tensor<1xi32>, tensor<1xi32>) -> tensor<1xi32>
-  func.return %0: tensor<1xi32>
 }
 
 // -----
@@ -1420,10 +1406,26 @@ func.func @clamp_c2(%arg0: tensor<1xi32>, %arg1: tensor<2xi32>) -> tensor<1xi32>
 
 // -----
 
+func.func @clamp_c3(%arg0: tensor<1xi32>, %arg1: tensor<1xf32>) -> tensor<1xi32> {
+  // expected-error@+1 {{'stablehlo.clamp' op requires the same element type for all operands and results}}
+  %0 = "stablehlo.clamp"(%arg1, %arg0, %arg0) : (tensor<1xf32>, tensor<1xi32>, tensor<1xi32>) -> tensor<1xi32>
+  func.return %0: tensor<1xi32>
+}
+
+// -----
+
 func.func @clamp_c4(%arg0: tensor<1xi32>) -> tensor<1x2xi32> {
   // // expected-error@+1{{inferred type(s) 'tensor<1xi32>' are incompatible with return type(s) of operation 'tensor<1x2xi32>'}}
   %0 = "stablehlo.clamp"(%arg0, %arg0, %arg0) : (tensor<1xi32>, tensor<1xi32>, tensor<1xi32>) -> tensor<1x2xi32>
   func.return %0: tensor<1x2xi32>
+}
+
+// -----
+
+// CHECK-LABEL: func @clamp_scalar
+func.func @clamp_scalar(%arg0: tensor<1xi32>, %arg1: tensor<i32>) -> tensor<1xi32> {
+  %0 = "stablehlo.clamp"(%arg1, %arg0, %arg1) : (tensor<i32>, tensor<1xi32>, tensor<i32>) -> tensor<1xi32>
+  func.return %0: tensor<1xi32>
 }
 
 // -----

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -1404,7 +1404,7 @@ func.func @clamp_invalid_clamp_element_type(%arg0: tensor<1xi32>, %arg1: tensor<
 
 // -----
 
-func.func @clamp_invalid_clamp_min_shape(%arg0: tensor<1xi32>, %arg1: tensor<2xi32>) -> tensor<1xi32> {
+func.func @clamp_invalid_clamp_min_shape_C1(%arg0: tensor<1xi32>, %arg1: tensor<2xi32>) -> tensor<1xi32> {
   // expected-error@+1 {{min shape [2] is not scalar and is not compatible to operand shape [1]}}
   %0 = "stablehlo.clamp"(%arg1, %arg0, %arg0) : (tensor<2xi32>, tensor<1xi32>, tensor<1xi32>) -> tensor<1xi32>
   func.return %0: tensor<1xi32>
@@ -1412,7 +1412,7 @@ func.func @clamp_invalid_clamp_min_shape(%arg0: tensor<1xi32>, %arg1: tensor<2xi
 
 // -----
 
-func.func @clamp_invalid_clamp_max_shape(%arg0: tensor<1xi32>, %arg1: tensor<2xi32>) -> tensor<1xi32> {
+func.func @clamp_invalid_clamp_max_shape_C2(%arg0: tensor<1xi32>, %arg1: tensor<2xi32>) -> tensor<1xi32> {
   // expected-error@+1 {{max shape [2] is not scalar and is not compatible to operand shape [1]}}
   %0 = "stablehlo.clamp"(%arg0, %arg0, %arg1) : (tensor<1xi32>, tensor<1xi32>, tensor<2xi32>) -> tensor<1xi32>
   func.return %0: tensor<1xi32>

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -1406,14 +1406,6 @@ func.func @clamp_c2(%arg0: tensor<1xi32>, %arg1: tensor<2xi32>) -> tensor<1xi32>
 
 // -----
 
-func.func @clamp_c3(%arg0: tensor<1xi32>, %arg1: tensor<1xf32>) -> tensor<1xi32> {
-  // expected-error@+1 {{'stablehlo.clamp' op requires the same element type for all operands and results}}
-  %0 = "stablehlo.clamp"(%arg1, %arg0, %arg0) : (tensor<1xf32>, tensor<1xi32>, tensor<1xi32>) -> tensor<1xi32>
-  func.return %0: tensor<1xi32>
-}
-
-// -----
-
 func.func @clamp_c4(%arg0: tensor<1xi32>) -> tensor<1x2xi32> {
   // // expected-error@+1{{inferred type(s) 'tensor<1xi32>' are incompatible with return type(s) of operation 'tensor<1x2xi32>'}}
   %0 = "stablehlo.clamp"(%arg0, %arg0, %arg0) : (tensor<1xi32>, tensor<1xi32>, tensor<1xi32>) -> tensor<1x2xi32>

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -1396,7 +1396,7 @@ func.func @clamp_compatible_dynamic_match_static(%arg0: tensor<?xi32>, %arg1: te
 
 // -----
 
-func.func @clamp_invalid_clamp_element_type(%arg0: tensor<1xi32>, %arg1: tensor<1xf32>) -> tensor<1xi32> {
+func.func @clamp_c3(%arg0: tensor<1xi32>, %arg1: tensor<1xf32>) -> tensor<1xi32> {
   // expected-error@+1 {{'stablehlo.clamp' op requires the same element type for all operands and results}}
   %0 = "stablehlo.clamp"(%arg1, %arg0, %arg0) : (tensor<1xf32>, tensor<1xi32>, tensor<1xi32>) -> tensor<1xi32>
   func.return %0: tensor<1xi32>
@@ -1404,7 +1404,7 @@ func.func @clamp_invalid_clamp_element_type(%arg0: tensor<1xi32>, %arg1: tensor<
 
 // -----
 
-func.func @clamp_invalid_clamp_min_shape_C1(%arg0: tensor<1xi32>, %arg1: tensor<2xi32>) -> tensor<1xi32> {
+func.func @clamp_c1(%arg0: tensor<1xi32>, %arg1: tensor<2xi32>) -> tensor<1xi32> {
   // expected-error@+1 {{min shape [2] is not scalar and is not compatible to operand shape [1]}}
   %0 = "stablehlo.clamp"(%arg1, %arg0, %arg0) : (tensor<2xi32>, tensor<1xi32>, tensor<1xi32>) -> tensor<1xi32>
   func.return %0: tensor<1xi32>
@@ -1412,7 +1412,7 @@ func.func @clamp_invalid_clamp_min_shape_C1(%arg0: tensor<1xi32>, %arg1: tensor<
 
 // -----
 
-func.func @clamp_invalid_clamp_max_shape_C2(%arg0: tensor<1xi32>, %arg1: tensor<2xi32>) -> tensor<1xi32> {
+func.func @clamp_c2(%arg0: tensor<1xi32>, %arg1: tensor<2xi32>) -> tensor<1xi32> {
   // expected-error@+1 {{max shape [2] is not scalar and is not compatible to operand shape [1]}}
   %0 = "stablehlo.clamp"(%arg0, %arg0, %arg1) : (tensor<1xi32>, tensor<1xi32>, tensor<2xi32>) -> tensor<1xi32>
   func.return %0: tensor<1xi32>
@@ -1420,7 +1420,7 @@ func.func @clamp_invalid_clamp_max_shape_C2(%arg0: tensor<1xi32>, %arg1: tensor<
 
 // -----
 
-func.func @clamp(%arg0: tensor<1xi32>) -> tensor<1x2xi32> {
+func.func @clamp_c4(%arg0: tensor<1xi32>) -> tensor<1x2xi32> {
   // // expected-error@+1{{inferred type(s) 'tensor<1xi32>' are incompatible with return type(s) of operation 'tensor<1x2xi32>'}}
   %0 = "stablehlo.clamp"(%arg0, %arg0, %arg0) : (tensor<1xi32>, tensor<1xi32>, tensor<1xi32>) -> tensor<1x2xi32>
   func.return %0: tensor<1x2xi32>


### PR DESCRIPTION
ClampOp has Inputs and constrains:
(I1) min is tensor. (By ODS)
(I2) operand is tensor. (By ODS)
(I3) max is tensor. (By ODS)

(C1) Either rank(min)=0 or shape(min)=shape(operand).
(C2) Either rank(max)=0 or shape(max)=shape(operand).
(C3) min, operand, and max have the same element type. (By ODS)
(C4) operand and result have the same type.

I1, I2, I3, and C3 is done by ODS.
C1, C2, C4 are verified by `inferClampOp()` in `TypeInference.cpp`
