### PR TITLE
Add interpreter for PadOp

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3592,6 +3592,8 @@ and `di = dim(operand, i)`.
 //          ]
 ```
 
+&nbsp;[More Examples](../stablehlo/tests/interpret_pad.mlir)
+
 ### partition_id
 
 #### Semantics

--- a/docs/status.md
+++ b/docs/status.md
@@ -111,7 +111,7 @@ one of the following tracking labels.
 | optimization_barrier     | yes           | yes          | yes            | yes             | no          |
 | or                       | yes           | yes          | yes            | yes             | yes         |
 | outfeed                  | yes           | yes          | yes            | no              | no          |
-| pad                      | yes           | yes          | yes            | yes             | no          |
+| pad                      | yes           | yes          | yes            | yes             | yes         |
 | partition_id             | yes           | yes          | yes            | yes             | no          |
 | popcnt                   | yes           | yes          | yes            | yes             | no          |
 | power                    | yes           | yes          | yes            | yes             | no          |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2670,7 +2670,6 @@ def StableHLO_ReverseOp: StableHLO_Op<"reverse",
 
 def StableHLO_PadOp: StableHLO_ShapedInterfaceOp<"pad",
       [Pure, SameOperandsAndResultElementType /*pad_c1*/,
-      AllTypesMatch<["edge_padding_low", "edge_padding_high", "interior_padding"]> /*pad_c2_i3_i4_i5*/,
       DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
   let summary = "Pad operation";
   let description = [{

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2670,6 +2670,8 @@ def StableHLO_ReverseOp: StableHLO_Op<"reverse",
 
 def StableHLO_PadOp: StableHLO_ShapedInterfaceOp<"pad",
       [Pure, SameOperandsAndResultElementType /*pad_c1*/,
+      AllTypesMatch<["edge_padding_low", "edge_padding_high",
+      "interior_padding"]> /*pad_c2, pad_i3, pad_i4, pad_i5*/,
       DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
   let summary = "Pad operation";
   let description = [{

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2671,7 +2671,7 @@ def StableHLO_ReverseOp: StableHLO_Op<"reverse",
 def StableHLO_PadOp: StableHLO_ShapedInterfaceOp<"pad",
       [Pure, SameOperandsAndResultElementType,
       DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
-  let summary = "Pad operator";
+  let summary = "Pad operation";
   let description = [{
     Expands `operand` by padding around the tensor as well as between the
     elements of the tensor with the given `padding_value`.

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2669,7 +2669,8 @@ def StableHLO_ReverseOp: StableHLO_Op<"reverse",
 }
 
 def StableHLO_PadOp: StableHLO_ShapedInterfaceOp<"pad",
-      [Pure, SameOperandsAndResultElementType,
+      [Pure, SameOperandsAndResultElementType /*pad_c1*/,
+      AllTypesMatch<["edge_padding_low", "edge_padding_high", "interior_padding"]> /*pad_c2_i3_i4_i5*/,
       DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
   let summary = "Pad operation";
   let description = [{

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2686,11 +2686,11 @@ def StableHLO_PadOp: StableHLO_ShapedInterfaceOp<"pad",
     ```
   }];
   let arguments = (ins
-    HLO_Tensor:$operand,
-    HLO_Tensor:$padding_value,
-    I64ElementsAttr:$edge_padding_low,
-    I64ElementsAttr:$edge_padding_high,
-    I64ElementsAttr:$interior_padding
+    HLO_Tensor:$operand /*pad_i1*/,
+    HLO_Tensor:$padding_value /*pad_i2*/,
+    I64ElementsAttr:$edge_padding_low /*pad_i3*/,
+    I64ElementsAttr:$edge_padding_high /*pad_i4*/,
+    I64ElementsAttr:$interior_padding /*pad_i5*/
   );
 
   let results = (outs HLO_Tensor);

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2435,23 +2435,17 @@ LogicalResult inferPadOp(std::optional<Location> location, Value operand,
                              "tensor, is rank ",
                              padType.getRank());
 
-  // PadOp_C2
+  // pad_i3
+  if (edgePaddingLow.getType().getRank() != 1)
+    return emitOptionalError(location, "start_indices has rank ",
+                             edgePaddingLow.getType().getRank(),
+                             " instead of required rank 1");
+
+  // pad_c2
   int64_t rank = inputType.getRank();
   if (edgePaddingLow.getType().getNumElements() != rank)
     return emitOptionalError(location, "edge_padding_low length (",
                              edgePaddingLow.getType().getNumElements(),
-                             ") must match operand rank (", rank, ")");
-
-  // PadOp_C2
-  if (edgePaddingHigh.getType().getNumElements() != rank)
-    return emitOptionalError(location, "edge_padding_high length (",
-                             edgePaddingHigh.getType().getNumElements(),
-                             ") must match operand rank (", rank, ")");
-
-  // PadOp_C2
-  if (interiorPadding.getType().getNumElements() != rank)
-    return emitOptionalError(location, "interior_padding length (",
-                             interiorPadding.getType().getNumElements(),
                              ") must match operand rank (", rank, ")");
 
   auto inputShape = inputType.getShape();
@@ -2465,7 +2459,7 @@ LogicalResult inferPadOp(std::optional<Location> location, Value operand,
         edgePaddingHigh.getValues<APInt>()[i].getSExtValue();
     int64_t paddingInteriorVal =
         interiorPadding.getValues<APInt>()[i].getSExtValue();
-    // PadOp_C3
+    // pad_c3
     if (paddingInteriorVal < 0)
       return emitOptionalError(
           location,
@@ -2480,7 +2474,7 @@ LogicalResult inferPadOp(std::optional<Location> location, Value operand,
           operandSizeOrBound + paddingLowVal + paddingHighVal +
           std::max<int64_t>(operandSizeOrBound - 1, 0LL) * paddingInteriorVal;
 
-      // PadOp_C4
+      // pad_c4
       if (resultSizeOrBound < 0) {
         auto sizeOrBound = isStaticDim ? "size" : "bound";
         return emitOptionalError(location, "Padding result in negative ",
@@ -2490,7 +2484,7 @@ LogicalResult inferPadOp(std::optional<Location> location, Value operand,
     }
   }
 
-  // PadOp_C1
+  // pad_c1
   inferredReturnTypes.push_back(RankedTensorType::get(
       resultShape, inputType.getElementType(),
       boundsToEncoding(inputType.getEncoding(), resultBounds)));

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2435,17 +2435,20 @@ LogicalResult inferPadOp(std::optional<Location> location, Value operand,
                              "tensor, is rank ",
                              padType.getRank());
 
+  // PadOp_C2
   int64_t rank = inputType.getRank();
   if (edgePaddingLow.getType().getNumElements() != rank)
     return emitOptionalError(location, "edge_padding_low length (",
                              edgePaddingLow.getType().getNumElements(),
                              ") must match operand rank (", rank, ")");
 
+  // PadOp_C2
   if (edgePaddingHigh.getType().getNumElements() != rank)
     return emitOptionalError(location, "edge_padding_high length (",
                              edgePaddingHigh.getType().getNumElements(),
                              ") must match operand rank (", rank, ")");
 
+  // PadOp_C2
   if (interiorPadding.getType().getNumElements() != rank)
     return emitOptionalError(location, "interior_padding length (",
                              interiorPadding.getType().getNumElements(),
@@ -2462,6 +2465,7 @@ LogicalResult inferPadOp(std::optional<Location> location, Value operand,
         edgePaddingHigh.getValues<APInt>()[i].getSExtValue();
     int64_t paddingInteriorVal =
         interiorPadding.getValues<APInt>()[i].getSExtValue();
+    // PadOp_C3
     if (paddingInteriorVal < 0)
       return emitOptionalError(
           location,
@@ -2476,6 +2480,7 @@ LogicalResult inferPadOp(std::optional<Location> location, Value operand,
           operandSizeOrBound + paddingLowVal + paddingHighVal +
           std::max<int64_t>(operandSizeOrBound - 1, 0LL) * paddingInteriorVal;
 
+      // PadOp_C4
       if (resultSizeOrBound < 0) {
         auto sizeOrBound = isStaticDim ? "size" : "bound";
         return emitOptionalError(location, "Padding result in negative ",
@@ -2484,6 +2489,8 @@ LogicalResult inferPadOp(std::optional<Location> location, Value operand,
       (isStaticDim ? resultShape : resultBounds)[i] = resultSizeOrBound;
     }
   }
+
+  // PadOp_C1
   inferredReturnTypes.push_back(RankedTensorType::get(
       resultShape, inputType.getElementType(),
       boundsToEncoding(inputType.getEncoding(), resultBounds)));

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2429,20 +2429,30 @@ LogicalResult inferPadOp(std::optional<Location> location, Value operand,
   auto inputType = operand.getType().cast<RankedTensorType>();
   auto padType = paddingValue.getType().cast<RankedTensorType>();
 
+  // pad_i2
   if (padType.getRank() != 0)
     return emitOptionalError(location,
                              "padding value type should be a rank-0 "
                              "tensor, is rank ",
                              padType.getRank());
 
+  // pad_c2, pad_i3, pad_i4, pad_i5
+  if (edgePaddingLow.getType() != edgePaddingHigh.getType() ||
+      edgePaddingLow.getType() != interiorPadding.getType())
+    return emitOptionalError(
+        location, "edge_padding_low, edge_padding_high, ",
+        "and interior_padding must have the same type but got: ",
+        edgePaddingLow.getType(), ", ", edgePaddingHigh.getType(), ", and ",
+        interiorPadding.getType());
+
   // pad_i3
   if (edgePaddingLow.getType().getRank() != 1)
-    return emitOptionalError(location, "start_indices has rank ",
+    return emitOptionalError(location, "edge_padding_low has rank ",
                              edgePaddingLow.getType().getRank(),
                              " instead of required rank 1");
 
-  // pad_c2
   int64_t rank = inputType.getRank();
+  // pad_c2
   if (edgePaddingLow.getType().getNumElements() != rank)
     return emitOptionalError(location, "edge_padding_low length (",
                              edgePaddingLow.getType().getNumElements(),

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2436,15 +2436,6 @@ LogicalResult inferPadOp(std::optional<Location> location, Value operand,
                              "tensor, is rank ",
                              padType.getRank());
 
-  // pad_c2, pad_i3, pad_i4, pad_i5
-  if (edgePaddingLow.getType() != edgePaddingHigh.getType() ||
-      edgePaddingLow.getType() != interiorPadding.getType())
-    return emitOptionalError(
-        location, "edge_padding_low, edge_padding_high, ",
-        "and interior_padding must have the same type but got: ",
-        edgePaddingLow.getType(), ", ", edgePaddingHigh.getType(), ", and ",
-        interiorPadding.getType());
-
   // pad_i3
   if (edgePaddingLow.getType().getRank() != 1)
     return emitOptionalError(location, "edge_padding_low has rank ",

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -173,17 +173,17 @@ Tensor evalPadOp(const Tensor &operand, const Tensor &paddingValue,
                  ArrayRef<int64_t> edgePaddingLow,
                  ArrayRef<int64_t> interiorPadding, Type resultType) {
   Tensor result(resultType);
-  for (auto resultItr = result.index_begin(); resultItr != result.index_end();
-       ++resultItr)
-    result.set(*resultItr, paddingValue.get({}));
-  for (auto operandItr = operand.index_begin();
-       operandItr != operand.index_end(); ++operandItr) {
+  for (auto resultIt = result.index_begin(); resultIt != result.index_end();
+       ++resultIt)
+    result.set(*resultIt, paddingValue.get({}));
+  for (auto operandIt = operand.index_begin(); operandIt != operand.index_end();
+       ++operandIt) {
     SmallVector<int64_t> resultIdx(result.getType().getRank());
     for (auto i = 0; i < operand.getType().getRank(); ++i)
       resultIdx[i] =
-          edgePaddingLow[i] + (*operandItr)[i] * (interiorPadding[i] + 1);
+          edgePaddingLow[i] + (*operandIt)[i] * (interiorPadding[i] + 1);
     if (succeeded(verifyIndex(result.getType().getShape(), resultIdx)))
-      result.set(resultIdx, operand.get(*operandItr));
+      result.set(resultIdx, operand.get(*operandIt));
   }
   return result;
 }

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -173,17 +173,17 @@ Tensor evalPadOp(const Tensor &operand, const Tensor &paddingValue,
                  ArrayRef<int64_t> edgePaddingLow,
                  ArrayRef<int64_t> interiorPadding, Type resultType) {
   Tensor result(resultType);
-  for (auto resItr = result.index_begin(); resItr != result.index_end();
-       ++resItr)
-    result.set(*resItr, paddingValue.get({}));
-  for (auto opItr = operand.index_begin(); opItr != operand.index_end();
-       ++opItr) {
-    SmallVector<int64_t> adjustedIdx(result.getType().getRank());
-    for (int64_t i = 0; i < operand.getType().getRank(); ++i)
-      adjustedIdx[i] =
-          edgePaddingLow[i] + (*opItr)[i] * (interiorPadding[i] + 1);
-    if (failed(verifyIndex(result.getType().getShape(), adjustedIdx))) continue;
-    result.set(adjustedIdx, operand.get(*opItr));
+  for (auto resultItr = result.index_begin(); resultItr != result.index_end();
+       ++resultItr)
+    result.set(*resultItr, paddingValue.get({}));
+  for (auto operandItr = operand.index_begin();
+       operandItr != operand.index_end(); ++operandItr) {
+    SmallVector<int64_t> resultIdx(result.getType().getRank());
+    for (auto i = 0; i < operand.getType().getRank(); ++i)
+      resultIdx[i] =
+          edgePaddingLow[i] + (*operandItr)[i] * (interiorPadding[i] + 1);
+    if (succeeded(verifyIndex(result.getType().getShape(), resultIdx)))
+      result.set(resultIdx, operand.get(*operandItr));
   }
   return result;
 }

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -39,6 +39,9 @@ Tensor evalMultiplyOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
 Tensor evalNegOp(const Tensor &operand, Type resultType);
 Tensor evalNotOp(const Tensor &operand, Type resultType);
 Tensor evalOrOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
+Tensor evalPadOp(const Tensor &operand, const Tensor &paddingValue,
+                 ArrayRef<int64_t> edgePaddingLow,
+                 ArrayRef<int64_t> interiorPadding, Type resultType);
 Tensor evalReshapeOp(const Tensor &operand, Type resultType);
 Tensor evalReverseOp(const Tensor &operand, ArrayRef<int64_t> dimensions,
                      Type resultType);

--- a/stablehlo/tests/interpret_pad.mlir
+++ b/stablehlo/tests/interpret_pad.mlir
@@ -4,106 +4,62 @@
 func.func @pad() -> tensor<5x9xi64> {
   %operand = stablehlo.constant dense<[[1, 2, 3],
                                        [4, 5, 6]]> : tensor<2x3xi64>
-  %padding_value = stablehlo.constant dense<0> : tensor<i64>
+  %padding_value = stablehlo.constant dense<-1> : tensor<i64>
   %result = stablehlo.pad %operand, %padding_value, low = [0, 1], high = [2, 1], interior = [1, 2]
     : (tensor<2x3xi64>, tensor<i64>) -> tensor<5x9xi64>
   func.return %result : tensor<5x9xi64>
   // CHECK-NEXT: tensor<5x9xi64>
-  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: -1 : i64
   // CHECK-NEXT: 1 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
   // CHECK-NEXT: 2 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
   // CHECK-NEXT: 3 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
   // CHECK-NEXT: 4 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
   // CHECK-NEXT: 5 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
   // CHECK-NEXT: 6 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
 }
 
 // -----
 
 // CHECK-LABEL: Evaluated results of function: pad_negative_padding
-func.func @pad_negative_padding() -> tensor<2x3xi64> {
-  %operand = stablehlo.constant dense<[[0, 1, 2, 3, 0],
-                                       [0, 4, 5, 6, 0],
-                                       [0, 0, 0, 0, 0],
-                                       [0, 0, 0, 0, 0]]> : tensor<4x5xi64>
-  %padding_value = stablehlo.constant dense<0> : tensor<i64>
-  %result = stablehlo.pad %operand, %padding_value, low = [0, -1], high = [-2, -1], interior = [0, 0]
-    : (tensor<4x5xi64>, tensor<i64>) -> tensor<2x3xi64>
-  func.return %result : tensor<2x3xi64>
-  // CHECK-NEXT: tensor<2x3xi64>
-  // CHECK-NEXT: 1 : i64
-  // CHECK-NEXT: 2 : i64
-  // CHECK-NEXT: 3 : i64
-  // CHECK-NEXT: 4 : i64
-  // CHECK-NEXT: 5 : i64
-  // CHECK-NEXT: 6 : i64
-}
-
-// -----
-
-// CHECK-LABEL: Evaluated results of function: pad_negative_padding_with_interior_dim_0
-func.func @pad_negative_padding_with_interior_dim_0() -> tensor<3x3xi64> {
-  %operand = stablehlo.constant dense<[[0, 1, 2, 3, 0],
-                                       [0, 4, 5, 6, 0],
-                                       [0, 0, 0, 0, 0]]> : tensor<3x5xi64>
-  %padding_value = stablehlo.constant dense<0> : tensor<i64>
-  %result = stablehlo.pad %operand, %padding_value, low = [0, -1], high = [-2, -1], interior = [1, 0]
-    : (tensor<3x5xi64>, tensor<i64>) -> tensor<3x3xi64>
-  func.return %result : tensor<3x3xi64>
-  // CHECK-NEXT: tensor<3x3xi64>
-  // CHECK-NEXT: 1 : i64
-  // CHECK-NEXT: 2 : i64
-  // CHECK-NEXT: 3 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 4 : i64
-  // CHECK-NEXT: 5 : i64
-  // CHECK-NEXT: 6 : i64
-}
-
-// -----
-
-// CHECK-LABEL: Evaluated results of function: pad_negative_padding_with_interior_dim_1
-func.func @pad_negative_padding_with_interior_dim_1() -> tensor<2x7xi64> {
+func.func @pad_negative_padding() -> tensor<2x7xi64> {
   %operand = stablehlo.constant dense<[[0, 1, 2, 3, 0],
                                        [0, 4, 5, 6, 0],
                                        [0, 0, 0, 0, 0],
@@ -125,34 +81,6 @@ func.func @pad_negative_padding_with_interior_dim_1() -> tensor<2x7xi64> {
   // CHECK-NEXT: 0 : i64
   // CHECK-NEXT: 5 : i64
   // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 6 : i64
-  // CHECK-NEXT: 0 : i64
-}
-
-// CHECK-LABEL: Evaluated results of function: pad_negative_padding_value
-func.func @pad_negative_padding_value() -> tensor<3x5xi64> {
-  %operand = stablehlo.constant dense<[[0, 1, 2, 3, 0],
-                                       [0, 4, 5, 6, 0],
-                                       [0, 0, 0, 0, 0],
-                                       [0, 0, 0, 0, 0]]> : tensor<4x5xi64>
-  %padding_value = stablehlo.constant dense<-1> : tensor<i64>
-  %result = stablehlo.pad %operand, %padding_value, low = [1, 0], high = [-2, 0], interior = [0, 0]
-    : (tensor<4x5xi64>, tensor<i64>) -> tensor<3x5xi64>
-  func.return %result : tensor<3x5xi64>
-  // CHECK-NEXT: tensor<3x5xi64>
-  // CHECK-NEXT: -1 : i64
-  // CHECK-NEXT: -1 : i64
-  // CHECK-NEXT: -1 : i64
-  // CHECK-NEXT: -1 : i64
-  // CHECK-NEXT: -1 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 1 : i64
-  // CHECK-NEXT: 2 : i64
-  // CHECK-NEXT: 3 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 4 : i64
-  // CHECK-NEXT: 5 : i64
   // CHECK-NEXT: 6 : i64
   // CHECK-NEXT: 0 : i64
 }

--- a/stablehlo/tests/interpret_pad.mlir
+++ b/stablehlo/tests/interpret_pad.mlir
@@ -1,86 +1,50 @@
 // RUN: stablehlo-interpreter --interpret -split-input-file %s | FileCheck %s
 
 // CHECK-LABEL: Evaluated results of function: pad
-func.func @pad() -> tensor<5x9xi64> {
-  %operand = stablehlo.constant dense<[[1, 2, 3],
-                                       [4, 5, 6]]> : tensor<2x3xi64>
+func.func @pad() -> tensor<7x5xi64> {
+  %operand = stablehlo.constant dense<[[0, 0, 0, 0],
+                                       [0, 1, 2, 0],
+                                       [0, 3, 4, 0],
+                                       [0, 5, 6, 0],
+                                       [0, 0, 0, 0]]> : tensor<5x4xi64>
   %padding_value = stablehlo.constant dense<-1> : tensor<i64>
-  %result = stablehlo.pad %operand, %padding_value, low = [0, 1], high = [2, 1], interior = [1, 2]
-    : (tensor<2x3xi64>, tensor<i64>) -> tensor<5x9xi64>
-  func.return %result : tensor<5x9xi64>
-  // CHECK-NEXT: tensor<5x9xi64>
+  %result = stablehlo.pad %operand, %padding_value, low = [1, -1], high = [1, -1], interior = [0, 1]
+    : (tensor<5x4xi64>, tensor<i64>) -> tensor<7x5xi64>
+  func.return %result : tensor<7x5xi64>
+  // CHECK-NEXT: tensor<7x5xi64>
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: -1 : i64
   // CHECK-NEXT: -1 : i64
   // CHECK-NEXT: 1 : i64
-  // CHECK-NEXT: -1 : i64
   // CHECK-NEXT: -1 : i64
   // CHECK-NEXT: 2 : i64
   // CHECK-NEXT: -1 : i64
   // CHECK-NEXT: -1 : i64
   // CHECK-NEXT: 3 : i64
   // CHECK-NEXT: -1 : i64
-  // CHECK-NEXT: -1 : i64
-  // CHECK-NEXT: -1 : i64
-  // CHECK-NEXT: -1 : i64
-  // CHECK-NEXT: -1 : i64
-  // CHECK-NEXT: -1 : i64
-  // CHECK-NEXT: -1 : i64
-  // CHECK-NEXT: -1 : i64
-  // CHECK-NEXT: -1 : i64
-  // CHECK-NEXT: -1 : i64
-  // CHECK-NEXT: -1 : i64
   // CHECK-NEXT: 4 : i64
   // CHECK-NEXT: -1 : i64
   // CHECK-NEXT: -1 : i64
   // CHECK-NEXT: 5 : i64
   // CHECK-NEXT: -1 : i64
-  // CHECK-NEXT: -1 : i64
   // CHECK-NEXT: 6 : i64
   // CHECK-NEXT: -1 : i64
   // CHECK-NEXT: -1 : i64
-  // CHECK-NEXT: -1 : i64
-  // CHECK-NEXT: -1 : i64
-  // CHECK-NEXT: -1 : i64
-  // CHECK-NEXT: -1 : i64
-  // CHECK-NEXT: -1 : i64
-  // CHECK-NEXT: -1 : i64
-  // CHECK-NEXT: -1 : i64
-  // CHECK-NEXT: -1 : i64
-  // CHECK-NEXT: -1 : i64
-  // CHECK-NEXT: -1 : i64
-  // CHECK-NEXT: -1 : i64
-  // CHECK-NEXT: -1 : i64
-  // CHECK-NEXT: -1 : i64
-  // CHECK-NEXT: -1 : i64
-  // CHECK-NEXT: -1 : i64
-  // CHECK-NEXT: -1 : i64
-  // CHECK-NEXT: -1 : i64
-}
-
-// -----
-
-// CHECK-LABEL: Evaluated results of function: pad_negative_padding
-func.func @pad_negative_padding() -> tensor<2x7xi64> {
-  %operand = stablehlo.constant dense<[[0, 1, 2, 3, 0],
-                                       [0, 4, 5, 6, 0],
-                                       [0, 0, 0, 0, 0],
-                                       [0, 0, 0, 0, 0]]> : tensor<4x5xi64>
-  %padding_value = stablehlo.constant dense<0> : tensor<i64>
-  %result = stablehlo.pad %operand, %padding_value, low = [0, -1], high = [-2, -1], interior = [0, 1]
-    : (tensor<4x5xi64>, tensor<i64>) -> tensor<2x7xi64>
-  func.return %result : tensor<2x7xi64>
-  // CHECK-NEXT: tensor<2x7xi64>
   // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: -1 : i64
   // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 2 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 3 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 4 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 5 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 6 : i64
-  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
 }

--- a/stablehlo/tests/interpret_pad.mlir
+++ b/stablehlo/tests/interpret_pad.mlir
@@ -128,3 +128,31 @@ func.func @pad_negative_padding_with_interior_dim_1() -> tensor<2x7xi64> {
   // CHECK-NEXT: 6 : i64
   // CHECK-NEXT: 0 : i64
 }
+
+// CHECK-LABEL: Evaluated results of function: pad_negative_padding_value
+func.func @pad_negative_padding_value() -> tensor<3x5xi64> {
+  %operand = stablehlo.constant dense<[[0, 1, 2, 3, 0],
+                                       [0, 4, 5, 6, 0],
+                                       [0, 0, 0, 0, 0],
+                                       [0, 0, 0, 0, 0]]> : tensor<4x5xi64>
+  %padding_value = stablehlo.constant dense<-1> : tensor<i64>
+  %result = stablehlo.pad %operand, %padding_value, low = [1, 0], high = [-2, 0], interior = [0, 0]
+    : (tensor<4x5xi64>, tensor<i64>) -> tensor<3x5xi64>
+  func.return %result : tensor<3x5xi64>
+  // CHECK-NEXT: tensor<3x5xi64>
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 2 : i64
+  // CHECK-NEXT: 3 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 4 : i64
+  // CHECK-NEXT: 5 : i64
+  // CHECK-NEXT: 6 : i64
+  // CHECK-NEXT: 0 : i64
+}

--- a/stablehlo/tests/interpret_pad.mlir
+++ b/stablehlo/tests/interpret_pad.mlir
@@ -1,0 +1,130 @@
+// RUN: stablehlo-interpreter --interpret -split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: Evaluated results of function: pad
+func.func @pad() -> tensor<5x9xi64> {
+  %operand = stablehlo.constant dense<[[1, 2, 3],
+                                       [4, 5, 6]]> : tensor<2x3xi64>
+  %padding_value = stablehlo.constant dense<0> : tensor<i64>
+  %result = stablehlo.pad %operand, %padding_value, low = [0, 1], high = [2, 1], interior = [1, 2]
+    : (tensor<2x3xi64>, tensor<i64>) -> tensor<5x9xi64>
+  func.return %result : tensor<5x9xi64>
+  // CHECK-NEXT: tensor<5x9xi64>
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 2 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 3 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 4 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 5 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 6 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 0 : i64
+}
+
+// -----
+
+// CHECK-LABEL: Evaluated results of function: pad_negative_padding
+func.func @pad_negative_padding() -> tensor<2x3xi64> {
+  %operand = stablehlo.constant dense<[[0, 1, 2, 3, 0],
+                                       [0, 4, 5, 6, 0],
+                                       [0, 0, 0, 0, 0],
+                                       [0, 0, 0, 0, 0]]> : tensor<4x5xi64>
+  %padding_value = stablehlo.constant dense<0> : tensor<i64>
+  %result = stablehlo.pad %operand, %padding_value, low = [0, -1], high = [-2, -1], interior = [0, 0]
+    : (tensor<4x5xi64>, tensor<i64>) -> tensor<2x3xi64>
+  func.return %result : tensor<2x3xi64>
+  // CHECK-NEXT: tensor<2x3xi64>
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 2 : i64
+  // CHECK-NEXT: 3 : i64
+  // CHECK-NEXT: 4 : i64
+  // CHECK-NEXT: 5 : i64
+  // CHECK-NEXT: 6 : i64
+}
+
+// -----
+
+// CHECK-LABEL: Evaluated results of function: pad_negative_padding_with_interior_dim_0
+func.func @pad_negative_padding_with_interior_dim_0() -> tensor<3x3xi64> {
+  %operand = stablehlo.constant dense<[[0, 1, 2, 3, 0],
+                                       [0, 4, 5, 6, 0],
+                                       [0, 0, 0, 0, 0]]> : tensor<3x5xi64>
+  %padding_value = stablehlo.constant dense<0> : tensor<i64>
+  %result = stablehlo.pad %operand, %padding_value, low = [0, -1], high = [-2, -1], interior = [1, 0]
+    : (tensor<3x5xi64>, tensor<i64>) -> tensor<3x3xi64>
+  func.return %result : tensor<3x3xi64>
+  // CHECK-NEXT: tensor<3x3xi64>
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 2 : i64
+  // CHECK-NEXT: 3 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 4 : i64
+  // CHECK-NEXT: 5 : i64
+  // CHECK-NEXT: 6 : i64
+}
+
+// -----
+
+// CHECK-LABEL: Evaluated results of function: pad_negative_padding_with_interior_dim_1
+func.func @pad_negative_padding_with_interior_dim_1() -> tensor<2x7xi64> {
+  %operand = stablehlo.constant dense<[[0, 1, 2, 3, 0],
+                                       [0, 4, 5, 6, 0],
+                                       [0, 0, 0, 0, 0],
+                                       [0, 0, 0, 0, 0]]> : tensor<4x5xi64>
+  %padding_value = stablehlo.constant dense<0> : tensor<i64>
+  %result = stablehlo.pad %operand, %padding_value, low = [0, -1], high = [-2, -1], interior = [0, 1]
+    : (tensor<4x5xi64>, tensor<i64>) -> tensor<2x7xi64>
+  func.return %result : tensor<2x7xi64>
+  // CHECK-NEXT: tensor<2x7xi64>
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 2 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 3 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 4 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 5 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 6 : i64
+  // CHECK-NEXT: 0 : i64
+}

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -5342,8 +5342,8 @@ func.func @conv_i4(%arg0: tensor<64x8x8x8xi4>, %arg1: tensor<4x4x8x32xi4>) -> te
 // CHECK-LABEL: func @pad
 func.func @pad(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x4x7xf16> {
   %0 = "stablehlo.pad"(%arg0, %arg1) {
-    edge_padding_high = dense<[1, 1, 0]> : tensor<3xi64>,
     edge_padding_low = dense<[0, 1, 2]> : tensor<3xi64>,
+    edge_padding_high = dense<[1, 1, 0]> : tensor<3xi64>,
     interior_padding = dense<[0, 0, 1]> : tensor<3xi64>
   } : (tensor<1x2x3xf16>, tensor<f16>) -> tensor<2x4x7xf16>
   func.return %0 : tensor<2x4x7xf16>
@@ -5355,8 +5355,8 @@ func.func @pad(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x4x7xf16
 func.func @pad_c2(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x4x7xf16> {
   // expected-error@+1 {{edge_padding_low length (2) must match operand rank (3)}}
   %0 = "stablehlo.pad"(%arg0, %arg1) {
-    edge_padding_high = dense<[1, 1]> : tensor<2xi64>,
     edge_padding_low = dense<[0, 1]> : tensor<2xi64>,
+    edge_padding_high = dense<[1, 1]> : tensor<2xi64>,
     interior_padding = dense<[0, 0]> : tensor<2xi64>
   } : (tensor<1x2x3xf16>, tensor<f16>) -> tensor<2x4x7xf16>
   func.return %0 : tensor<2x4x7xf16>
@@ -5367,8 +5367,8 @@ func.func @pad_c2(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x4x7x
 func.func @pad_c3(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x4x3xf16> {
   // expected-error@+1 {{Interior padding cannot be negative: -1}}
   %0 = "stablehlo.pad"(%arg0, %arg1) {
-    edge_padding_high = dense<[1, 1, 0]> : tensor<3xi64>,
     edge_padding_low = dense<[0, 1, 2]> : tensor<3xi64>,
+    edge_padding_high = dense<[1, 1, 0]> : tensor<3xi64>,
     interior_padding = dense<[0, 0, -1]> : tensor<3xi64>
   } : (tensor<1x2x3xf16>, tensor<f16>) -> tensor<2x4x3xf16>
   func.return %0 : tensor<2x4x3xf16>
@@ -5379,8 +5379,8 @@ func.func @pad_c3(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x4x3x
 func.func @pad_c4(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x4x7xf16> {
   // expected-error@+1 {{Padding result in negative size for dimension 2}}
   %0 = "stablehlo.pad"(%arg0, %arg1) {
-    edge_padding_high = dense<[1, 1, 0]> : tensor<3xi64>,
     edge_padding_low = dense<[0, 1, -4]> : tensor<3xi64>,
+    edge_padding_high = dense<[1, 1, 0]> : tensor<3xi64>,
     interior_padding = dense<[0, 0, 0]> : tensor<3xi64>
   } : (tensor<1x2x3xf16>, tensor<f16>) -> tensor<2x4x7xf16>
   func.return %0 : tensor<2x4x7xf16>
@@ -5390,8 +5390,8 @@ func.func @pad_c4(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x4x7x
 func.func @pad_c4(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<8x8x8xf16> {
   // expected-error@+1 {{'stablehlo.pad' op inferred type(s) 'tensor<2x4x7xf16>' are incompatible with return type(s) of operation 'tensor<8x8x8xf16>'}}
   %0 = "stablehlo.pad"(%arg0, %arg1) {
-    edge_padding_high = dense<[1, 1, 0]> : tensor<3xi64>,
     edge_padding_low = dense<[0, 1, 2]> : tensor<3xi64>,
+    edge_padding_high = dense<[1, 1, 0]> : tensor<3xi64>,
     interior_padding = dense<[0, 0, 1]> : tensor<3xi64>
   } : (tensor<1x2x3xf16>, tensor<f16>) -> tensor<8x8x8xf16>
   func.return %0 : tensor<8x8x8xf16>
@@ -5403,8 +5403,8 @@ func.func @pad_c4(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<8x8x8x
 func.func @pad_dynamic(%arg0: tensor<?x48x48x32xf32>) -> tensor<?x48x48x48xf32> {
   %0 = "stablehlo.constant"() {value = dense<0.000000e+00> : tensor<f32>} : () -> tensor<f32>
   %1 = "stablehlo.pad"(%arg0, %0) {
-    edge_padding_high = dense<[0, 0, 0, 16]> : tensor<4xi64>,
     edge_padding_low = dense<0> : tensor<4xi64>,
+    edge_padding_high = dense<[0, 0, 0, 16]> : tensor<4xi64>,
     interior_padding = dense<0> : tensor<4xi64>
   } : (tensor<?x48x48x32xf32>, tensor<f32>) -> tensor<?x48x48x48xf32>
   func.return %1 : tensor<?x48x48x48xf32>
@@ -5412,15 +5412,64 @@ func.func @pad_dynamic(%arg0: tensor<?x48x48x32xf32>) -> tensor<?x48x48x48xf32> 
 
 // -----
 
-func.func @pad_i1(%arg0: tensor<1x2x3xf16>, %arg1: tensor<2xf16>) -> tensor<2x4x7xf16> {
+func.func @pad_i2(%arg0: tensor<1x2x3xf16>, %arg1: tensor<2xf16>) -> tensor<2x4x7xf16> {
   // expected-error@+1 {{padding value type should be a rank-0 tensor, is rank 1}}
   %0 = "stablehlo.pad"(%arg0, %arg1) {
-    edge_padding_high = dense<[1, 1, 0]> : tensor<3xi64>,
     edge_padding_low = dense<[0, 1, 2]> : tensor<3xi64>,
+    edge_padding_high = dense<[1, 1, 0]> : tensor<3xi64>,
     interior_padding = dense<[0, 0, 1]> : tensor<3xi64>
   } : (tensor<1x2x3xf16>, tensor<2xf16>) -> tensor<2x4x7xf16>
   func.return %0 : tensor<2x4x7xf16>
 }
+
+// -----
+
+func.func @pad_i3(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x4x7xf16> {
+  // expected-error@+1 {{edge_padding_low has rank 0 instead of required rank 1}}
+  %0 = "stablehlo.pad"(%arg0, %arg1) {
+    edge_padding_low = dense<1> : tensor<i64>,
+    edge_padding_high = dense<1> : tensor<i64>,
+    interior_padding = dense<1> : tensor<i64>
+  } : (tensor<1x2x3xf16>, tensor<f16>) -> tensor<2x4x7xf16>
+  func.return %0 : tensor<2x4x7xf16>
+}
+
+// -----
+
+func.func @pad_i3_i4(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x4x7xf16> {
+  // expected-error@+1 {{edge_padding_low, edge_padding_high, and interior_padding must have the same type but got: 'tensor<1xi64>', 'tensor<2xi64>', and 'tensor<1xi64>'}}
+  %0 = "stablehlo.pad"(%arg0, %arg1) {
+    edge_padding_low = dense<1> : tensor<1xi64>,
+    edge_padding_high = dense<1> : tensor<2xi64>,
+    interior_padding = dense<1> : tensor<1xi64>
+  } : (tensor<1x2x3xf16>, tensor<f16>) -> tensor<2x4x7xf16>
+  func.return %0 : tensor<2x4x7xf16>
+}
+
+// -----
+
+func.func @pad_i3_i5(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x4x7xf16> {
+  // expected-error@+1 {{edge_padding_low, edge_padding_high, and interior_padding must have the same type but got: 'tensor<1xi64>', 'tensor<1xi64>', and 'tensor<2xi64>'}}
+  %0 = "stablehlo.pad"(%arg0, %arg1) {
+    edge_padding_low = dense<1> : tensor<1xi64>,
+    edge_padding_high = dense<1> : tensor<1xi64>,
+    interior_padding = dense<1> : tensor<2xi64>
+  } : (tensor<1x2x3xf16>, tensor<f16>) -> tensor<2x4x7xf16>
+  func.return %0 : tensor<2x4x7xf16>
+}
+
+// -----
+
+func.func @pad_i4(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x4x7xf16> {
+  // expected-error@+1 {{edge_padding_low has rank 0 instead of required rank 1}}
+  %0 = "stablehlo.pad"(%arg0, %arg1) {
+    edge_padding_low = dense<1> : tensor<i64>,
+    edge_padding_high = dense<1> : tensor<i64>,
+    interior_padding = dense<1> : tensor<i64>
+  } : (tensor<1x2x3xf16>, tensor<f16>) -> tensor<2x4x7xf16>
+  func.return %0 : tensor<2x4x7xf16>
+}
+
 
 // -----
 

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -5339,8 +5339,8 @@ func.func @conv_i4(%arg0: tensor<64x8x8x8xi4>, %arg1: tensor<4x4x8x32xi4>) -> te
 
 // -----
 
-// CHECK-LABEL: func @static_pad
-func.func @static_pad(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x4x7xf16> {
+// CHECK-LABEL: func @pad
+func.func @pad(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x4x7xf16> {
   %0 = "stablehlo.pad"(%arg0, %arg1) {
     edge_padding_high = dense<[1, 1, 0]> : tensor<3xi64>,
     edge_padding_low = dense<[0, 1, 2]> : tensor<3xi64>,
@@ -5351,8 +5351,8 @@ func.func @static_pad(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x
 
 // -----
 
-// CHECK-LABEL: func @dynamic_pad
-func.func @dynamic_pad(%arg0: tensor<?x48x48x32xf32>) -> tensor<?x48x48x48xf32> {
+// CHECK-LABEL: func @pad_dynamic
+func.func @pad_dynamic(%arg0: tensor<?x48x48x32xf32>) -> tensor<?x48x48x48xf32> {
   %0 = "stablehlo.constant"() {value = dense<0.000000e+00> : tensor<f32>} : () -> tensor<f32>
   %1 = "stablehlo.pad"(%arg0, %0) {
     edge_padding_high = dense<[0, 0, 0, 16]> : tensor<4xi64>,
@@ -5360,66 +5360,6 @@ func.func @dynamic_pad(%arg0: tensor<?x48x48x32xf32>) -> tensor<?x48x48x48xf32> 
     interior_padding = dense<0> : tensor<4xi64>
   } : (tensor<?x48x48x32xf32>, tensor<f32>) -> tensor<?x48x48x48xf32>
   func.return %1 : tensor<?x48x48x48xf32>
-}
-
-// -----
-
-func.func @pad(%arg0: tensor<1x2x3xf16>, %arg1: tensor<i64>) -> tensor<2x4x7xf16> {
-  // expected-error@+1 {{'stablehlo.pad' op requires the same element type for all operands and results}}
-  %0 = "stablehlo.pad"(%arg0, %arg1) {
-    edge_padding_high = dense<[1, 1, 0]> : tensor<3xi64>,
-    edge_padding_low = dense<[0, 1, 2]> : tensor<3xi64>,
-    interior_padding = dense<[0, 0, 1]> : tensor<3xi64>
-  } : (tensor<1x2x3xf16>, tensor<i64>) -> tensor<2x4x7xf16>
-  func.return %0 : tensor<2x4x7xf16>
-}
-
-// -----
-
-func.func @pad(%arg0: tensor<1x2x3xf16>, %arg1: tensor<2xf16>) -> tensor<2x4x7xf16> {
-  // expected-error@+1 {{padding value type should be a rank-0 tensor, is rank 1}}
-  %0 = "stablehlo.pad"(%arg0, %arg1) {
-    edge_padding_high = dense<[1, 1, 0]> : tensor<3xi64>,
-    edge_padding_low = dense<[0, 1, 2]> : tensor<3xi64>,
-    interior_padding = dense<[0, 0, 1]> : tensor<3xi64>
-  } : (tensor<1x2x3xf16>, tensor<2xf16>) -> tensor<2x4x7xf16>
-  func.return %0 : tensor<2x4x7xf16>
-}
-
-// -----
-
-func.func @pad(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x4x7xf16> {
-  // expected-error@+1 {{edge_padding_low length (2) must match operand rank (3)}}
-  %0 = "stablehlo.pad"(%arg0, %arg1) {
-    edge_padding_high = dense<[1, 1, 0]> : tensor<3xi64>,
-    edge_padding_low = dense<[0, 1]> : tensor<2xi64>,
-    interior_padding = dense<[0, 0, 1]> : tensor<3xi64>
-  } : (tensor<1x2x3xf16>, tensor<f16>) -> tensor<2x4x7xf16>
-  func.return %0 : tensor<2x4x7xf16>
-}
-
-// -----
-
-func.func @pad(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x4x7xf16> {
-  // expected-error@+1 {{edge_padding_high length (2) must match operand rank (3)}}
-  %0 = "stablehlo.pad"(%arg0, %arg1) {
-    edge_padding_high = dense<[1, 1]> : tensor<2xi64>,
-    edge_padding_low = dense<[0, 1, 2]> : tensor<3xi64>,
-    interior_padding = dense<[0, 0, 1]> : tensor<3xi64>
-  } : (tensor<1x2x3xf16>, tensor<f16>) -> tensor<2x4x7xf16>
-  func.return %0 : tensor<2x4x7xf16>
-}
-
-// -----
-
-func.func @pad(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x4x7xf16> {
-  // expected-error@+1 {{interior_padding length (2) must match operand rank (3)}}
-  %0 = "stablehlo.pad"(%arg0, %arg1) {
-    edge_padding_high = dense<[1, 1, 0]> : tensor<3xi64>,
-    edge_padding_low = dense<[0, 1, 2]> : tensor<3xi64>,
-    interior_padding = dense<[0, 0]> : tensor<2xi64>
-  } : (tensor<1x2x3xf16>, tensor<f16>) -> tensor<2x4x7xf16>
-  func.return %0 : tensor<2x4x7xf16>
 }
 
 // -----
@@ -5436,7 +5376,67 @@ func.func @pad(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<8x8x8xf16
 
 // -----
 
-func.func @pad(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x4x3xf16> {
+func.func @pad(%arg0: tensor<1x2x3xf16>, %arg1: tensor<2xf16>) -> tensor<2x4x7xf16> {
+  // expected-error@+1 {{padding value type should be a rank-0 tensor, is rank 1}}
+  %0 = "stablehlo.pad"(%arg0, %arg1) {
+    edge_padding_high = dense<[1, 1, 0]> : tensor<3xi64>,
+    edge_padding_low = dense<[0, 1, 2]> : tensor<3xi64>,
+    interior_padding = dense<[0, 0, 1]> : tensor<3xi64>
+  } : (tensor<1x2x3xf16>, tensor<2xf16>) -> tensor<2x4x7xf16>
+  func.return %0 : tensor<2x4x7xf16>
+}
+
+// -----
+
+func.func @pad_C1(%arg0: tensor<1x2x3xf16>, %arg1: tensor<i64>) -> tensor<2x4x7xf16> {
+  // expected-error@+1 {{'stablehlo.pad' op requires the same element type for all operands and results}}
+  %0 = "stablehlo.pad"(%arg0, %arg1) {
+    edge_padding_high = dense<[1, 1, 0]> : tensor<3xi64>,
+    edge_padding_low = dense<[0, 1, 2]> : tensor<3xi64>,
+    interior_padding = dense<[0, 0, 1]> : tensor<3xi64>
+  } : (tensor<1x2x3xf16>, tensor<i64>) -> tensor<2x4x7xf16>
+  func.return %0 : tensor<2x4x7xf16>
+}
+
+// -----
+
+func.func @pad_C2(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x4x7xf16> {
+  // expected-error@+1 {{edge_padding_low length (2) must match operand rank (3)}}
+  %0 = "stablehlo.pad"(%arg0, %arg1) {
+    edge_padding_high = dense<[1, 1, 0]> : tensor<3xi64>,
+    edge_padding_low = dense<[0, 1]> : tensor<2xi64>,
+    interior_padding = dense<[0, 0, 1]> : tensor<3xi64>
+  } : (tensor<1x2x3xf16>, tensor<f16>) -> tensor<2x4x7xf16>
+  func.return %0 : tensor<2x4x7xf16>
+}
+
+// -----
+
+func.func @pad_C2(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x4x7xf16> {
+  // expected-error@+1 {{edge_padding_high length (2) must match operand rank (3)}}
+  %0 = "stablehlo.pad"(%arg0, %arg1) {
+    edge_padding_high = dense<[1, 1]> : tensor<2xi64>,
+    edge_padding_low = dense<[0, 1, 2]> : tensor<3xi64>,
+    interior_padding = dense<[0, 0, 1]> : tensor<3xi64>
+  } : (tensor<1x2x3xf16>, tensor<f16>) -> tensor<2x4x7xf16>
+  func.return %0 : tensor<2x4x7xf16>
+}
+
+// -----
+
+func.func @pad_C2(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x4x7xf16> {
+  // expected-error@+1 {{interior_padding length (2) must match operand rank (3)}}
+  %0 = "stablehlo.pad"(%arg0, %arg1) {
+    edge_padding_high = dense<[1, 1, 0]> : tensor<3xi64>,
+    edge_padding_low = dense<[0, 1, 2]> : tensor<3xi64>,
+    interior_padding = dense<[0, 0]> : tensor<2xi64>
+  } : (tensor<1x2x3xf16>, tensor<f16>) -> tensor<2x4x7xf16>
+  func.return %0 : tensor<2x4x7xf16>
+}
+
+// -----
+
+func.func @pad_C3(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x4x3xf16> {
   // expected-error@+1 {{Interior padding cannot be negative: -1}}
   %0 = "stablehlo.pad"(%arg0, %arg1) {
     edge_padding_high = dense<[1, 1, 0]> : tensor<3xi64>,
@@ -5448,7 +5448,7 @@ func.func @pad(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x4x3xf16
 
 // -----
 
-func.func @pad(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x4x7xf16> {
+func.func @pad_C4(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x4x7xf16> {
   // expected-error@+1 {{Padding result in negative size for dimension 2}}
   %0 = "stablehlo.pad"(%arg0, %arg1) {
     edge_padding_high = dense<[1, 1, 0]> : tensor<3xi64>,

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -5385,6 +5385,7 @@ func.func @pad_c4(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x4x7x
   } : (tensor<1x2x3xf16>, tensor<f16>) -> tensor<2x4x7xf16>
   func.return %0 : tensor<2x4x7xf16>
 }
+
 // -----
 
 func.func @pad_c4(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<8x8x8xf16> {
@@ -5433,43 +5434,6 @@ func.func @pad_i3(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x4x7x
   } : (tensor<1x2x3xf16>, tensor<f16>) -> tensor<2x4x7xf16>
   func.return %0 : tensor<2x4x7xf16>
 }
-
-// -----
-
-func.func @pad_i3_i4(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x4x7xf16> {
-  // expected-error@+1 {{edge_padding_low, edge_padding_high, and interior_padding must have the same type but got: 'tensor<1xi64>', 'tensor<2xi64>', and 'tensor<1xi64>'}}
-  %0 = "stablehlo.pad"(%arg0, %arg1) {
-    edge_padding_low = dense<1> : tensor<1xi64>,
-    edge_padding_high = dense<1> : tensor<2xi64>,
-    interior_padding = dense<1> : tensor<1xi64>
-  } : (tensor<1x2x3xf16>, tensor<f16>) -> tensor<2x4x7xf16>
-  func.return %0 : tensor<2x4x7xf16>
-}
-
-// -----
-
-func.func @pad_i3_i5(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x4x7xf16> {
-  // expected-error@+1 {{edge_padding_low, edge_padding_high, and interior_padding must have the same type but got: 'tensor<1xi64>', 'tensor<1xi64>', and 'tensor<2xi64>'}}
-  %0 = "stablehlo.pad"(%arg0, %arg1) {
-    edge_padding_low = dense<1> : tensor<1xi64>,
-    edge_padding_high = dense<1> : tensor<1xi64>,
-    interior_padding = dense<1> : tensor<2xi64>
-  } : (tensor<1x2x3xf16>, tensor<f16>) -> tensor<2x4x7xf16>
-  func.return %0 : tensor<2x4x7xf16>
-}
-
-// -----
-
-func.func @pad_i4(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x4x7xf16> {
-  // expected-error@+1 {{edge_padding_low has rank 0 instead of required rank 1}}
-  %0 = "stablehlo.pad"(%arg0, %arg1) {
-    edge_padding_low = dense<1> : tensor<i64>,
-    edge_padding_high = dense<1> : tensor<i64>,
-    interior_padding = dense<1> : tensor<i64>
-  } : (tensor<1x2x3xf16>, tensor<f16>) -> tensor<2x4x7xf16>
-  func.return %0 : tensor<2x4x7xf16>
-}
-
 
 // -----
 


### PR DESCRIPTION
We have the following constraints in the spec:

```
(I1) operand tensor
(I2) padding_value 0-dimensional tensor
(I3) edge_padding_low 1-dimensional tensor constant of type si64
(I4) edge_padding_high 1-dimensional tensor constant of type si64
(I5) interior_padding 1-dimensional tensor constant of type si64
(C1) `operand`, `padding_value`, `result` have the same element type.
(C2) `edge_padding_low`, `edge_padding_high`, `interior_padding` have the
size equal to `operand`'s rank.
(C3) 0 $\le$ `interior_padding[i]` for all `i` values in `interior_padding`.
(C4) 0 $\le$ `dim(result, i)` for all `i`th dimension of `operand`, where
`dim(result, i) = di + max(di - 1, 0) * interior_padding[i] + edge_padding_low[i] + edge_padding_high[i]`
and `di = dim(operand, i)`.
```

These constraints will be comprehensively covered by the following tests:

```
I1: a) operand is not a tensor. (Covered by ODS).
I2: a) padding_value is not a 0-dimensional tensor.
I3: a) edge_padding_low is not a 1-dimensional tensor.
    b) element_type(edge_padding_low) != si64. (Covered by ODS).
I4: a) edge_padding_high is not a 1-dimensional tensor.
    b) element_type(edge_padding_high) != si64. (Covered by ODS).
I5: a) interior_padding is not a 1-dimensional tensor.
    b) element_type(interior_padding) != si64. (Covered by ODS).
C1: a) element_type(operand) != element_type(padding_value) != element_type(result). (Covered by ODS).
C2: a) size(edge_padding_low) != rank(operand).
    b) size(edge_padding_high) != rank(operand).
    c) size(interior_padding) != rank(operand).
C3: a) interior_padding < 0.
C4: no negative test added since it's just inferring the shape.
```

If we drop the "Covered by ODS" pieces, this will leave us with the following test cases:

```
I2a: padding_value is not a 0-dimensional tensor.
I3a: edge_padding_low is not a 1-dimensional tensor.
I4a: edge_padding_high is not a 1-dimensional tensor.
I5a: interior_padding is not a 1-dimensional tensor.
C2a: size(edge_padding_low) != rank(operand).
C2b: size(edge_padding_high) != rank(operand).
C2c: size(interior_padding) != rank(operand).
C3a: interior_padding < 0.
```

Note that for `I3a`, `I4a`, and `I5a`, they are partially covered by the `AllTypesMatch` trait, so only one test (`I2a`) is needed to test all three. Similarly with `C2a`, `C2b`, and `C2c` (`C2a` test is added to cover all three).

closes #980 