### PR TITLE
Update eval signature for re-usability

### DIFF
--- a/stablehlo/reference/Interpreter.cpp
+++ b/stablehlo/reference/Interpreter.cpp
@@ -69,62 +69,64 @@ llvm::Expected<SmallVector<Tensor>> eval(func::FuncOp func,
     if (auto addOp = dyn_cast<AddOp>(op)) {
       Tensor runtimeLhs = fetchOperand(addOp.getLhs());
       Tensor runtimeRhs = fetchOperand(addOp.getRhs());
-      Tensor runtimeResult = eval(addOp, runtimeLhs, runtimeRhs);
+      Tensor runtimeResult = eval_add(addOp.getType(), runtimeLhs, runtimeRhs);
       populateResults({runtimeResult});
     } else if (auto andOp = dyn_cast<AndOp>(op)) {
       Tensor runtimeLhs = fetchOperand(andOp.getLhs());
       Tensor runtimeRhs = fetchOperand(andOp.getRhs());
-      Tensor runtimeResult = eval(andOp, runtimeLhs, runtimeRhs);
+      Tensor runtimeResult = eval_and(andOp.getType(), runtimeLhs, runtimeRhs);
       populateResults({runtimeResult});
     } else if (auto ceilOp = dyn_cast<CeilOp>(op)) {
       Tensor runtimeOperand = fetchOperand(ceilOp.getOperand());
-      Tensor runtimeResult = eval(ceilOp, runtimeOperand);
+      Tensor runtimeResult = eval_ceil(ceilOp.getType(), runtimeOperand);
       populateResults({runtimeResult});
     } else if (auto constantOp = dyn_cast<ConstantOp>(op)) {
-      Tensor runtimeResult = eval(constantOp);
+      Tensor runtimeResult = eval_constant(constantOp.getValue());
       populateResults({runtimeResult});
     } else if (auto cosineOp = dyn_cast<CosineOp>(op)) {
       Tensor runtimeOperand = fetchOperand(cosineOp.getOperand());
-      Tensor runtimeResult = eval(cosineOp, runtimeOperand);
+      Tensor runtimeResult = eval_cosine(cosineOp.getType(), runtimeOperand);
       populateResults({runtimeResult});
     } else if (auto floorOp = dyn_cast<FloorOp>(op)) {
       Tensor runtimeOperand = fetchOperand(floorOp.getOperand());
-      Tensor runtimeResult = eval(floorOp, runtimeOperand);
+      Tensor runtimeResult = eval_floor(floorOp.getType(), runtimeOperand);
       populateResults({runtimeResult});
     } else if (auto iotaOp = dyn_cast<IotaOp>(op)) {
-      Tensor runtimeResult = eval(iotaOp);
+      Tensor runtimeResult =
+          eval_iota(iotaOp.getType(), iotaOp.getIotaDimension());
       populateResults({runtimeResult});
     } else if (auto maxOp = dyn_cast<MaxOp>(op)) {
       Tensor runtimeLhs = fetchOperand(maxOp.getLhs());
       Tensor runtimeRhs = fetchOperand(maxOp.getRhs());
-      Tensor runtimeResult = eval(maxOp, runtimeLhs, runtimeRhs);
+      Tensor runtimeResult = eval_max(maxOp.getType(), runtimeLhs, runtimeRhs);
       populateResults({runtimeResult});
     } else if (auto minOp = dyn_cast<MinOp>(op)) {
       Tensor runtimeLhs = fetchOperand(minOp.getLhs());
       Tensor runtimeRhs = fetchOperand(minOp.getRhs());
-      Tensor runtimeResult = eval(minOp, runtimeLhs, runtimeRhs);
+      Tensor runtimeResult = eval_min(minOp.getType(), runtimeLhs, runtimeRhs);
       populateResults({runtimeResult});
     } else if (auto multiplyOp = dyn_cast<MulOp>(op)) {
       Tensor runtimeLhs = fetchOperand(multiplyOp.getLhs());
       Tensor runtimeRhs = fetchOperand(multiplyOp.getRhs());
-      Tensor runtimeResult = eval(multiplyOp, runtimeLhs, runtimeRhs);
+      Tensor runtimeResult =
+          eval_multiply(multiplyOp.getType(), runtimeLhs, runtimeRhs);
       populateResults({runtimeResult});
     } else if (auto negOp = dyn_cast<NegOp>(op)) {
       Tensor runtimeOperand = fetchOperand(negOp.getOperand());
-      Tensor runtimeResult = eval(negOp, runtimeOperand);
+      Tensor runtimeResult = eval_neg(negOp.getType(), runtimeOperand);
       populateResults({runtimeResult});
     } else if (auto notOp = dyn_cast<NotOp>(op)) {
       Tensor runtimeOperand = fetchOperand(notOp.getOperand());
-      Tensor runtimeResult = eval(notOp, runtimeOperand);
+      Tensor runtimeResult = eval_not(notOp.getType(), runtimeOperand);
       populateResults({runtimeResult});
     } else if (auto orOp = dyn_cast<OrOp>(op)) {
       Tensor runtimeLhs = fetchOperand(orOp.getLhs());
       Tensor runtimeRhs = fetchOperand(orOp.getRhs());
-      Tensor runtimeResult = eval(orOp, runtimeLhs, runtimeRhs);
+      Tensor runtimeResult = eval_or(orOp.getType(), runtimeLhs, runtimeRhs);
       populateResults({runtimeResult});
     } else if (auto reshapeOp = dyn_cast<ReshapeOp>(op)) {
       Tensor runtimeOperand = fetchOperand(reshapeOp.getOperand());
-      Tensor runtimeResult = eval(reshapeOp, runtimeOperand);
+      Tensor runtimeResult = eval_reshape(reshapeOp.getType(), runtimeOperand);
       populateResults({runtimeResult});
     } else if (auto returnOp = dyn_cast<func::ReturnOp>(op)) {
       SmallVector<Tensor> runtimeOperands;
@@ -134,25 +136,27 @@ llvm::Expected<SmallVector<Tensor>> eval(func::FuncOp func,
       return runtimeOperands;
     } else if (auto sineOp = dyn_cast<SineOp>(op)) {
       Tensor runtimeOperand = fetchOperand(sineOp.getOperand());
-      Tensor runtimeResult = eval(sineOp, runtimeOperand);
+      Tensor runtimeResult = eval_sine(sineOp.getType(), runtimeOperand);
       populateResults({runtimeResult});
     } else if (auto subtractOp = dyn_cast<SubtractOp>(op)) {
       Tensor runtimeLhs = fetchOperand(subtractOp.getLhs());
       Tensor runtimeRhs = fetchOperand(subtractOp.getRhs());
-      Tensor runtimeResult = eval(subtractOp, runtimeLhs, runtimeRhs);
+      Tensor runtimeResult =
+          eval_subtract(subtractOp.getType(), runtimeLhs, runtimeRhs);
       populateResults({runtimeResult});
     } else if (auto tanhOp = dyn_cast<TanhOp>(op)) {
       Tensor runtimeOperand = fetchOperand(tanhOp.getOperand());
-      Tensor runtimeResult = eval(tanhOp, runtimeOperand);
+      Tensor runtimeResult = eval_tanh(tanhOp.getType(), runtimeOperand);
       populateResults({runtimeResult});
     } else if (auto transposeOp = dyn_cast<TransposeOp>(op)) {
       Tensor runtimeOperand = fetchOperand(transposeOp.getOperand());
-      Tensor runtimeResult = eval(transposeOp, runtimeOperand);
+      Tensor runtimeResult = eval_transpose(
+          transposeOp.getType(), runtimeOperand, transposeOp.getPermutation());
       populateResults({runtimeResult});
     } else if (auto xorOp = dyn_cast<XorOp>(op)) {
       Tensor runtimeLhs = fetchOperand(xorOp.getLhs());
       Tensor runtimeRhs = fetchOperand(xorOp.getRhs());
-      Tensor runtimeResult = eval(xorOp, runtimeLhs, runtimeRhs);
+      Tensor runtimeResult = eval_xor(xorOp.getType(), runtimeLhs, runtimeRhs);
       populateResults({runtimeResult});
     } else {
       return invalidArgument("Unsupported op: %s", debugString(op).c_str());

--- a/stablehlo/reference/Interpreter.cpp
+++ b/stablehlo/reference/Interpreter.cpp
@@ -69,64 +69,64 @@ llvm::Expected<SmallVector<Tensor>> eval(func::FuncOp func,
     if (auto addOp = dyn_cast<AddOp>(op)) {
       Tensor runtimeLhs = fetchOperand(addOp.getLhs());
       Tensor runtimeRhs = fetchOperand(addOp.getRhs());
-      Tensor runtimeResult = eval_add(addOp.getType(), runtimeLhs, runtimeRhs);
+      Tensor runtimeResult = evalAddOp(runtimeLhs, runtimeRhs, addOp.getType());
       populateResults({runtimeResult});
     } else if (auto andOp = dyn_cast<AndOp>(op)) {
       Tensor runtimeLhs = fetchOperand(andOp.getLhs());
       Tensor runtimeRhs = fetchOperand(andOp.getRhs());
-      Tensor runtimeResult = eval_and(andOp.getType(), runtimeLhs, runtimeRhs);
+      Tensor runtimeResult = evalAndOp(runtimeLhs, runtimeRhs, andOp.getType());
       populateResults({runtimeResult});
     } else if (auto ceilOp = dyn_cast<CeilOp>(op)) {
       Tensor runtimeOperand = fetchOperand(ceilOp.getOperand());
-      Tensor runtimeResult = eval_ceil(ceilOp.getType(), runtimeOperand);
+      Tensor runtimeResult = evalCeilOp(runtimeOperand, ceilOp.getType());
       populateResults({runtimeResult});
     } else if (auto constantOp = dyn_cast<ConstantOp>(op)) {
-      Tensor runtimeResult = eval_constant(constantOp.getValue());
+      Tensor runtimeResult = evalConstantOp(constantOp.getValue());
       populateResults({runtimeResult});
     } else if (auto cosineOp = dyn_cast<CosineOp>(op)) {
       Tensor runtimeOperand = fetchOperand(cosineOp.getOperand());
-      Tensor runtimeResult = eval_cosine(cosineOp.getType(), runtimeOperand);
+      Tensor runtimeResult = evalCosineOp(runtimeOperand, cosineOp.getType());
       populateResults({runtimeResult});
     } else if (auto floorOp = dyn_cast<FloorOp>(op)) {
       Tensor runtimeOperand = fetchOperand(floorOp.getOperand());
-      Tensor runtimeResult = eval_floor(floorOp.getType(), runtimeOperand);
+      Tensor runtimeResult = evalFloorOp(runtimeOperand, floorOp.getType());
       populateResults({runtimeResult});
     } else if (auto iotaOp = dyn_cast<IotaOp>(op)) {
       Tensor runtimeResult =
-          eval_iota(iotaOp.getType(), iotaOp.getIotaDimension());
+          evalIotaOp(iotaOp.getIotaDimension(), iotaOp.getType());
       populateResults({runtimeResult});
     } else if (auto maxOp = dyn_cast<MaxOp>(op)) {
       Tensor runtimeLhs = fetchOperand(maxOp.getLhs());
       Tensor runtimeRhs = fetchOperand(maxOp.getRhs());
-      Tensor runtimeResult = eval_max(maxOp.getType(), runtimeLhs, runtimeRhs);
+      Tensor runtimeResult = evalMaxOp(runtimeLhs, runtimeRhs, maxOp.getType());
       populateResults({runtimeResult});
     } else if (auto minOp = dyn_cast<MinOp>(op)) {
       Tensor runtimeLhs = fetchOperand(minOp.getLhs());
       Tensor runtimeRhs = fetchOperand(minOp.getRhs());
-      Tensor runtimeResult = eval_min(minOp.getType(), runtimeLhs, runtimeRhs);
+      Tensor runtimeResult = evalMinOp(runtimeLhs, runtimeRhs, minOp.getType());
       populateResults({runtimeResult});
     } else if (auto multiplyOp = dyn_cast<MulOp>(op)) {
       Tensor runtimeLhs = fetchOperand(multiplyOp.getLhs());
       Tensor runtimeRhs = fetchOperand(multiplyOp.getRhs());
       Tensor runtimeResult =
-          eval_multiply(multiplyOp.getType(), runtimeLhs, runtimeRhs);
+          evalMultiplyOp(runtimeLhs, runtimeRhs, multiplyOp.getType());
       populateResults({runtimeResult});
     } else if (auto negOp = dyn_cast<NegOp>(op)) {
       Tensor runtimeOperand = fetchOperand(negOp.getOperand());
-      Tensor runtimeResult = eval_neg(negOp.getType(), runtimeOperand);
+      Tensor runtimeResult = evalNegOp(runtimeOperand, negOp.getType());
       populateResults({runtimeResult});
     } else if (auto notOp = dyn_cast<NotOp>(op)) {
       Tensor runtimeOperand = fetchOperand(notOp.getOperand());
-      Tensor runtimeResult = eval_not(notOp.getType(), runtimeOperand);
+      Tensor runtimeResult = evalNotOp(runtimeOperand, notOp.getType());
       populateResults({runtimeResult});
     } else if (auto orOp = dyn_cast<OrOp>(op)) {
       Tensor runtimeLhs = fetchOperand(orOp.getLhs());
       Tensor runtimeRhs = fetchOperand(orOp.getRhs());
-      Tensor runtimeResult = eval_or(orOp.getType(), runtimeLhs, runtimeRhs);
+      Tensor runtimeResult = evalOrOp(runtimeLhs, runtimeRhs, orOp.getType());
       populateResults({runtimeResult});
     } else if (auto reshapeOp = dyn_cast<ReshapeOp>(op)) {
       Tensor runtimeOperand = fetchOperand(reshapeOp.getOperand());
-      Tensor runtimeResult = eval_reshape(reshapeOp.getType(), runtimeOperand);
+      Tensor runtimeResult = evalReshapeOp(runtimeOperand, reshapeOp.getType());
       populateResults({runtimeResult});
     } else if (auto returnOp = dyn_cast<func::ReturnOp>(op)) {
       SmallVector<Tensor> runtimeOperands;
@@ -136,27 +136,27 @@ llvm::Expected<SmallVector<Tensor>> eval(func::FuncOp func,
       return runtimeOperands;
     } else if (auto sineOp = dyn_cast<SineOp>(op)) {
       Tensor runtimeOperand = fetchOperand(sineOp.getOperand());
-      Tensor runtimeResult = eval_sine(sineOp.getType(), runtimeOperand);
+      Tensor runtimeResult = evalSineOp(runtimeOperand, sineOp.getType());
       populateResults({runtimeResult});
     } else if (auto subtractOp = dyn_cast<SubtractOp>(op)) {
       Tensor runtimeLhs = fetchOperand(subtractOp.getLhs());
       Tensor runtimeRhs = fetchOperand(subtractOp.getRhs());
       Tensor runtimeResult =
-          eval_subtract(subtractOp.getType(), runtimeLhs, runtimeRhs);
+          evalSubtractOp(runtimeLhs, runtimeRhs, subtractOp.getType());
       populateResults({runtimeResult});
     } else if (auto tanhOp = dyn_cast<TanhOp>(op)) {
       Tensor runtimeOperand = fetchOperand(tanhOp.getOperand());
-      Tensor runtimeResult = eval_tanh(tanhOp.getType(), runtimeOperand);
+      Tensor runtimeResult = evalTanhOp(runtimeOperand, tanhOp.getType());
       populateResults({runtimeResult});
     } else if (auto transposeOp = dyn_cast<TransposeOp>(op)) {
       Tensor runtimeOperand = fetchOperand(transposeOp.getOperand());
-      Tensor runtimeResult = eval_transpose(
+      Tensor runtimeResult = evalTransposeOp(
           transposeOp.getType(), runtimeOperand, transposeOp.getPermutation());
       populateResults({runtimeResult});
     } else if (auto xorOp = dyn_cast<XorOp>(op)) {
       Tensor runtimeLhs = fetchOperand(xorOp.getLhs());
       Tensor runtimeRhs = fetchOperand(xorOp.getRhs());
-      Tensor runtimeResult = eval_xor(xorOp.getType(), runtimeLhs, runtimeRhs);
+      Tensor runtimeResult = evalXorOp(runtimeLhs, runtimeRhs, xorOp.getType());
       populateResults({runtimeResult});
     } else {
       return invalidArgument("Unsupported op: %s", debugString(op).c_str());

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -40,7 +40,7 @@ std::vector<int64_t> permute(ArrayRef<int64_t> array, ArrayRef<int64_t> perm) {
 
 }  // namespace
 
-Tensor eval_add(Type resultType, const Tensor &lhs, const Tensor &rhs) {
+Tensor evalAddOp(const Tensor &lhs, const Tensor &rhs, Type resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
     result.set(*it, lhs.get(*it) + rhs.get(*it));
@@ -48,7 +48,7 @@ Tensor eval_add(Type resultType, const Tensor &lhs, const Tensor &rhs) {
   return result;
 }
 
-Tensor eval_and(Type resultType, const Tensor &lhs, const Tensor &rhs) {
+Tensor evalAndOp(const Tensor &lhs, const Tensor &rhs, Type resultType) {
   Tensor result(resultType);
   for (auto it = lhs.index_begin(); it != lhs.index_end(); ++it) {
     result.set(*it, lhs.get(*it) & rhs.get(*it));
@@ -56,7 +56,7 @@ Tensor eval_and(Type resultType, const Tensor &lhs, const Tensor &rhs) {
   return result;
 }
 
-Tensor eval_ceil(Type resultType, const Tensor &operand) {
+Tensor evalCeilOp(const Tensor &operand, Type resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
     result.set(*it, ceil(operand.get(*it)));
@@ -64,11 +64,11 @@ Tensor eval_ceil(Type resultType, const Tensor &operand) {
   return result;
 }
 
-Tensor eval_constant(const ElementsAttr &value) {
+Tensor evalConstantOp(ElementsAttr value) {
   return makeTensor(value.cast<DenseElementsAttr>());
 }
 
-Tensor eval_cosine(Type resultType, const Tensor &operand) {
+Tensor evalCosineOp(const Tensor &operand, Type resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
     result.set(*it, cosine(operand.get(*it)));
@@ -76,7 +76,7 @@ Tensor eval_cosine(Type resultType, const Tensor &operand) {
   return result;
 }
 
-Tensor eval_floor(Type resultType, const Tensor &operand) {
+Tensor evalFloorOp(const Tensor &operand, Type resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
     result.set(*it, floor(operand.get(*it)));
@@ -84,7 +84,7 @@ Tensor eval_floor(Type resultType, const Tensor &operand) {
   return result;
 }
 
-Tensor eval_iota(Type resultType, uint64_t iotaDimension) {
+Tensor evalIotaOp(int64_t iotaDimension, Type resultType) {
   Tensor result(resultType);
   Type elType = result.getType().getElementType();
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
@@ -120,7 +120,7 @@ Tensor eval_iota(Type resultType, uint64_t iotaDimension) {
   return result;
 }
 
-Tensor eval_max(Type resultType, const Tensor &lhs, const Tensor &rhs) {
+Tensor evalMaxOp(const Tensor &lhs, const Tensor &rhs, Type resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
     result.set(*it, max(lhs.get(*it), rhs.get(*it)));
@@ -128,7 +128,7 @@ Tensor eval_max(Type resultType, const Tensor &lhs, const Tensor &rhs) {
   return result;
 }
 
-Tensor eval_min(Type resultType, const Tensor &lhs, const Tensor &rhs) {
+Tensor evalMinOp(const Tensor &lhs, const Tensor &rhs, Type resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
     result.set(*it, min(lhs.get(*it), rhs.get(*it)));
@@ -136,7 +136,7 @@ Tensor eval_min(Type resultType, const Tensor &lhs, const Tensor &rhs) {
   return result;
 }
 
-Tensor eval_multiply(Type resultType, const Tensor &lhs, const Tensor &rhs) {
+Tensor evalMultiplyOp(const Tensor &lhs, const Tensor &rhs, Type resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
     result.set(*it, lhs.get(*it) * rhs.get(*it));
@@ -144,7 +144,7 @@ Tensor eval_multiply(Type resultType, const Tensor &lhs, const Tensor &rhs) {
   return result;
 }
 
-Tensor eval_neg(Type resultType, const Tensor &operand) {
+Tensor evalNegOp(const Tensor &operand, Type resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
     result.set(*it, -operand.get(*it));
@@ -152,7 +152,7 @@ Tensor eval_neg(Type resultType, const Tensor &operand) {
   return result;
 }
 
-Tensor eval_not(Type resultType, const Tensor &operand) {
+Tensor evalNotOp(const Tensor &operand, Type resultType) {
   Tensor result(resultType);
   for (auto it = operand.index_begin(); it != operand.index_end(); ++it) {
     result.set(*it, ~operand.get(*it));
@@ -160,7 +160,7 @@ Tensor eval_not(Type resultType, const Tensor &operand) {
   return result;
 }
 
-Tensor eval_or(Type resultType, const Tensor &lhs, const Tensor &rhs) {
+Tensor evalOrOp(const Tensor &lhs, const Tensor &rhs, Type resultType) {
   Tensor result(resultType);
   for (auto it = lhs.index_begin(); it != lhs.index_end(); ++it) {
     result.set(*it, lhs.get(*it) | rhs.get(*it));
@@ -168,7 +168,7 @@ Tensor eval_or(Type resultType, const Tensor &lhs, const Tensor &rhs) {
   return result;
 }
 
-Tensor eval_reshape(Type resultType, const Tensor &operand) {
+Tensor evalReshapeOp(const Tensor &operand, Type resultType) {
   Tensor result(resultType);
   for (auto resultIt = result.index_begin(), operandIt = operand.index_begin();
        resultIt != result.index_end(); ++resultIt, ++operandIt) {
@@ -177,7 +177,7 @@ Tensor eval_reshape(Type resultType, const Tensor &operand) {
   return result;
 }
 
-Tensor eval_sine(Type resultType, const Tensor &operand) {
+Tensor evalSineOp(const Tensor &operand, Type resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
     result.set(*it, sine(operand.get(*it)));
@@ -185,7 +185,7 @@ Tensor eval_sine(Type resultType, const Tensor &operand) {
   return result;
 }
 
-Tensor eval_subtract(Type resultType, const Tensor &lhs, const Tensor &rhs) {
+Tensor evalSubtractOp(const Tensor &lhs, const Tensor &rhs, Type resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
     result.set(*it, lhs.get(*it) - rhs.get(*it));
@@ -193,7 +193,7 @@ Tensor eval_subtract(Type resultType, const Tensor &lhs, const Tensor &rhs) {
   return result;
 }
 
-Tensor eval_tanh(Type resultType, const Tensor &operand) {
+Tensor evalTanhOp(const Tensor &operand, Type resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
     result.set(*it, tanh(operand.get(*it)));
@@ -201,8 +201,8 @@ Tensor eval_tanh(Type resultType, const Tensor &operand) {
   return result;
 }
 
-Tensor eval_transpose(Type resultType, const Tensor &operand,
-                      const DenseElementsAttr &permutation) {
+Tensor evalTransposeOp(Type resultType, const Tensor &operand,
+                       DenseIntElementsAttr permutation) {
   Tensor result(resultType);
   for (auto operandIt = operand.index_begin(); operandIt != operand.index_end();
        ++operandIt) {
@@ -213,7 +213,7 @@ Tensor eval_transpose(Type resultType, const Tensor &operand,
   return result;
 }
 
-Tensor eval_xor(Type resultType, const Tensor &lhs, const Tensor &rhs) {
+Tensor evalXorOp(const Tensor &lhs, const Tensor &rhs, Type resultType) {
   Tensor result(resultType);
   for (auto it = lhs.index_begin(); it != lhs.index_end(); ++it) {
     result.set(*it, lhs.get(*it) ^ rhs.get(*it));

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -40,54 +40,53 @@ std::vector<int64_t> permute(ArrayRef<int64_t> array, ArrayRef<int64_t> perm) {
 
 }  // namespace
 
-Tensor eval(AddOp op, const Tensor &lhs, const Tensor &rhs) {
-  Tensor result(op.getType());
+Tensor eval_add(Type resultType, const Tensor &lhs, const Tensor &rhs) {
+  Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
     result.set(*it, lhs.get(*it) + rhs.get(*it));
   }
   return result;
 }
 
-Tensor eval(AndOp op, const Tensor &lhs, const Tensor &rhs) {
-  Tensor result(op.getType());
+Tensor eval_and(Type resultType, const Tensor &lhs, const Tensor &rhs) {
+  Tensor result(resultType);
   for (auto it = lhs.index_begin(); it != lhs.index_end(); ++it) {
     result.set(*it, lhs.get(*it) & rhs.get(*it));
   }
   return result;
 }
 
-Tensor eval(CeilOp op, const Tensor &operand) {
-  Tensor result(op.getType());
+Tensor eval_ceil(Type resultType, const Tensor &operand) {
+  Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
     result.set(*it, ceil(operand.get(*it)));
   }
   return result;
 }
 
-Tensor eval(ConstantOp op) {
-  return makeTensor(op.getValue().cast<DenseElementsAttr>());
+Tensor eval_constant(const ElementsAttr &value) {
+  return makeTensor(value.cast<DenseElementsAttr>());
 }
 
-Tensor eval(CosineOp op, const Tensor &operand) {
-  Tensor result(op.getType());
+Tensor eval_cosine(Type resultType, const Tensor &operand) {
+  Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
     result.set(*it, cosine(operand.get(*it)));
   }
   return result;
 }
 
-Tensor eval(FloorOp op, const Tensor &operand) {
-  Tensor result(op.getType());
+Tensor eval_floor(Type resultType, const Tensor &operand) {
+  Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
     result.set(*it, floor(operand.get(*it)));
   }
   return result;
 }
 
-Tensor eval(IotaOp op) {
-  Tensor result(op.getType());
+Tensor eval_iota(Type resultType, uint64_t iotaDimension) {
+  Tensor result(resultType);
   Type elType = result.getType().getElementType();
-  uint64_t iotaDimension = op.getIotaDimension();
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
     auto iota = (*it)[iotaDimension];
     if (isSupportedSignedIntegerType(elType)) {
@@ -121,56 +120,56 @@ Tensor eval(IotaOp op) {
   return result;
 }
 
-Tensor eval(MaxOp op, const Tensor &lhs, const Tensor &rhs) {
-  Tensor result(op.getType());
+Tensor eval_max(Type resultType, const Tensor &lhs, const Tensor &rhs) {
+  Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
     result.set(*it, max(lhs.get(*it), rhs.get(*it)));
   }
   return result;
 }
 
-Tensor eval(MinOp op, const Tensor &lhs, const Tensor &rhs) {
-  Tensor result(op.getType());
+Tensor eval_min(Type resultType, const Tensor &lhs, const Tensor &rhs) {
+  Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
     result.set(*it, min(lhs.get(*it), rhs.get(*it)));
   }
   return result;
 }
 
-Tensor eval(MulOp op, const Tensor &lhs, const Tensor &rhs) {
-  Tensor result(op.getType());
+Tensor eval_multiply(Type resultType, const Tensor &lhs, const Tensor &rhs) {
+  Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
     result.set(*it, lhs.get(*it) * rhs.get(*it));
   }
   return result;
 }
 
-Tensor eval(NegOp op, const Tensor &operand) {
-  Tensor result(op.getType());
+Tensor eval_neg(Type resultType, const Tensor &operand) {
+  Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
     result.set(*it, -operand.get(*it));
   }
   return result;
 }
 
-Tensor eval(NotOp op, const Tensor &operand) {
-  Tensor result(op.getType());
+Tensor eval_not(Type resultType, const Tensor &operand) {
+  Tensor result(resultType);
   for (auto it = operand.index_begin(); it != operand.index_end(); ++it) {
     result.set(*it, ~operand.get(*it));
   }
   return result;
 }
 
-Tensor eval(OrOp op, const Tensor &lhs, const Tensor &rhs) {
-  Tensor result(op.getType());
+Tensor eval_or(Type resultType, const Tensor &lhs, const Tensor &rhs) {
+  Tensor result(resultType);
   for (auto it = lhs.index_begin(); it != lhs.index_end(); ++it) {
     result.set(*it, lhs.get(*it) | rhs.get(*it));
   }
   return result;
 }
 
-Tensor eval(ReshapeOp op, const Tensor &operand) {
-  Tensor result(op.getType());
+Tensor eval_reshape(Type resultType, const Tensor &operand) {
+  Tensor result(resultType);
   for (auto resultIt = result.index_begin(), operandIt = operand.index_begin();
        resultIt != result.index_end(); ++resultIt, ++operandIt) {
     result.set(*resultIt, operand.get(*operandIt));
@@ -178,43 +177,44 @@ Tensor eval(ReshapeOp op, const Tensor &operand) {
   return result;
 }
 
-Tensor eval(SineOp op, const Tensor &operand) {
-  Tensor result(op.getType());
+Tensor eval_sine(Type resultType, const Tensor &operand) {
+  Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
     result.set(*it, sine(operand.get(*it)));
   }
   return result;
 }
 
-Tensor eval(SubtractOp op, const Tensor &lhs, const Tensor &rhs) {
-  Tensor result(op.getType());
+Tensor eval_subtract(Type resultType, const Tensor &lhs, const Tensor &rhs) {
+  Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
     result.set(*it, lhs.get(*it) - rhs.get(*it));
   }
   return result;
 }
 
-Tensor eval(TanhOp op, const Tensor &operand) {
-  Tensor result(op.getType());
+Tensor eval_tanh(Type resultType, const Tensor &operand) {
+  Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
     result.set(*it, tanh(operand.get(*it)));
   }
   return result;
 }
 
-Tensor eval(TransposeOp op, const Tensor &operand) {
-  Tensor result(op.getType());
+Tensor eval_transpose(Type resultType, const Tensor &operand,
+                      const DenseElementsAttr &permutation) {
+  Tensor result(resultType);
   for (auto operandIt = operand.index_begin(); operandIt != operand.index_end();
        ++operandIt) {
-    auto resultIndex = permute(
-        *operandIt, llvm::to_vector(op.getPermutation().getValues<int64_t>()));
+    auto resultIndex =
+        permute(*operandIt, llvm::to_vector(permutation.getValues<int64_t>()));
     result.set(resultIndex, operand.get(*operandIt));
   }
   return result;
 }
 
-Tensor eval(XorOp op, const Tensor &lhs, const Tensor &rhs) {
-  Tensor result(op.getType());
+Tensor eval_xor(Type resultType, const Tensor &lhs, const Tensor &rhs) {
+  Tensor result(resultType);
   for (auto it = lhs.index_begin(); it != lhs.index_end(); ++it) {
     result.set(*it, lhs.get(*it) ^ rhs.get(*it));
   }

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -23,26 +23,26 @@ limitations under the License.
 namespace mlir {
 namespace stablehlo {
 
-Tensor eval_add(Type resultType, const Tensor &lhs, const Tensor &rhs);
-Tensor eval_and(Type resultType, const Tensor &lhs, const Tensor &rhs);
-Tensor eval_ceil(Type resultType, const Tensor &operand);
-Tensor eval_constant(const ElementsAttr &value);
-Tensor eval_cosine(Type resultType, const Tensor &operand);
-Tensor eval_floor(Type resultType, const Tensor &operand);
-Tensor eval_iota(Type resultType, uint64_t iotaDimension);
-Tensor eval_max(Type resultType, const Tensor &lhs, const Tensor &rhs);
-Tensor eval_min(Type resultType, const Tensor &lhs, const Tensor &rhs);
-Tensor eval_multiply(Type resultType, const Tensor &lhs, const Tensor &rhs);
-Tensor eval_neg(Type resultType, const Tensor &operand);
-Tensor eval_not(Type resultType, const Tensor &operand);
-Tensor eval_or(Type resultType, const Tensor &lhs, const Tensor &rhs);
-Tensor eval_reshape(Type resultType, const Tensor &operand);
-Tensor eval_sine(Type resultType, const Tensor &operand);
-Tensor eval_subtract(Type resultType, const Tensor &lhs, const Tensor &rhs);
-Tensor eval_tanh(Type resultType, const Tensor &operand);
-Tensor eval_transpose(Type resultType, const Tensor &operand,
-                      const DenseElementsAttr &permutation);
-Tensor eval_xor(Type resultType, const Tensor &lhs, const Tensor &rhs);
+Tensor evalAddOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
+Tensor evalAndOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
+Tensor evalCeilOp(const Tensor &operand, Type resultType);
+Tensor evalConstantOp(ElementsAttr value);
+Tensor evalCosineOp(const Tensor &operand, Type resultType);
+Tensor evalFloorOp(const Tensor &operand, Type resultType);
+Tensor evalIotaOp(int64_t iotaDimension, Type resultType);
+Tensor evalMaxOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
+Tensor evalMinOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
+Tensor evalMultiplyOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
+Tensor evalNegOp(const Tensor &operand, Type resultType);
+Tensor evalNotOp(const Tensor &operand, Type resultType);
+Tensor evalOrOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
+Tensor evalReshapeOp(const Tensor &operand, Type resultType);
+Tensor evalSineOp(const Tensor &operand, Type resultType);
+Tensor evalSubtractOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
+Tensor evalTanhOp(const Tensor &operand, Type resultType);
+Tensor evalTransposeOp(Type resultType, const Tensor &operand,
+                       DenseIntElementsAttr permutation);
+Tensor evalXorOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
 
 }  // namespace stablehlo
 }  // namespace mlir

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -23,25 +23,26 @@ limitations under the License.
 namespace mlir {
 namespace stablehlo {
 
-Tensor eval(AddOp op, const Tensor &lhs, const Tensor &rhs);
-Tensor eval(AndOp op, const Tensor &lhs, const Tensor &rhs);
-Tensor eval(CeilOp op, const Tensor &operand);
-Tensor eval(ConstantOp op);
-Tensor eval(CosineOp op, const Tensor &operand);
-Tensor eval(FloorOp op, const Tensor &operand);
-Tensor eval(IotaOp op);
-Tensor eval(MaxOp op, const Tensor &lhs, const Tensor &rhs);
-Tensor eval(MinOp op, const Tensor &lhs, const Tensor &rhs);
-Tensor eval(MulOp op, const Tensor &lhs, const Tensor &rhs);
-Tensor eval(NegOp op, const Tensor &operand);
-Tensor eval(NotOp op, const Tensor &operand);
-Tensor eval(OrOp op, const Tensor &lhs, const Tensor &rhs);
-Tensor eval(ReshapeOp op, const Tensor &operand);
-Tensor eval(SineOp op, const Tensor &operand);
-Tensor eval(SubtractOp op, const Tensor &lhs, const Tensor &rhs);
-Tensor eval(TanhOp op, const Tensor &operand);
-Tensor eval(TransposeOp op, const Tensor &operand);
-Tensor eval(XorOp op, const Tensor &lhs, const Tensor &rhs);
+Tensor eval_add(Type resultType, const Tensor &lhs, const Tensor &rhs);
+Tensor eval_and(Type resultType, const Tensor &lhs, const Tensor &rhs);
+Tensor eval_ceil(Type resultType, const Tensor &operand);
+Tensor eval_constant(const ElementsAttr &value);
+Tensor eval_cosine(Type resultType, const Tensor &operand);
+Tensor eval_floor(Type resultType, const Tensor &operand);
+Tensor eval_iota(Type resultType, uint64_t iotaDimension);
+Tensor eval_max(Type resultType, const Tensor &lhs, const Tensor &rhs);
+Tensor eval_min(Type resultType, const Tensor &lhs, const Tensor &rhs);
+Tensor eval_multiply(Type resultType, const Tensor &lhs, const Tensor &rhs);
+Tensor eval_neg(Type resultType, const Tensor &operand);
+Tensor eval_not(Type resultType, const Tensor &operand);
+Tensor eval_or(Type resultType, const Tensor &lhs, const Tensor &rhs);
+Tensor eval_reshape(Type resultType, const Tensor &operand);
+Tensor eval_sine(Type resultType, const Tensor &operand);
+Tensor eval_subtract(Type resultType, const Tensor &lhs, const Tensor &rhs);
+Tensor eval_tanh(Type resultType, const Tensor &operand);
+Tensor eval_transpose(Type resultType, const Tensor &operand,
+                      const DenseElementsAttr &permutation);
+Tensor eval_xor(Type resultType, const Tensor &lhs, const Tensor &rhs);
 
 }  // namespace stablehlo
 }  // namespace mlir


### PR DESCRIPTION
Based on the proposal discussed @ https://github.com/openxla/stablehlo/issues/1000, this PR implements the first step:  "to replace `eval(AddOp, ...)` with `eval_add(Type returnType, ...)`.

This changes immediately enables reusing the `eval_op` for an `op` whose type can be trivially inferred (like most of the elementwise ops).