### PR TITLE
Add interpreter for DivideOp

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2174,12 +2174,9 @@ produces a `result` tensor. Depending on the element type, does the following:
 // %rhs: [3.0, 3.0, -3.0, -3.0]
 %result = "stablehlo.divide"(%lhs, %rhs) : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
 // %result: [5.66666651, -5.66666651, -5.66666651, 5.66666651]
-
-// %lhs: [17, -17, 17, -17]
-// %rhs: [3, 3, -3, -3]
-%result = "stablehlo.divide"(%lhs, %rhs) : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi32>
-// %result: [5, -5, -5, 5]
 ```
+
+&nbsp;[More Examples](../stablehlo/tests/interpret_divide.mlir)
 
 ### dot_general
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -75,7 +75,7 @@ one of the following tracking labels.
 | cross-replica-sum        | no            | revisit      | yes\*          | no              | no          |
 | cstr_reshapable          | no            | revisit      | no             | yes             | no          |
 | custom_call              | yes           | yes          | infeasible     | yes             | no          |
-| divide                   | yes           | yes          | yes            | yes             | no          |
+| divide                   | yes           | yes          | yes            | yes             | yes         |
 | dot                      | no            | revisit      | infeasible     | yes             | no          |
 | dot_general              | yes           | revisit      | infeasible     | no              | no          |
 | dynamic_broadcast_in_dim | no            | revisit      | infeasible     | no              | no          |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -739,7 +739,8 @@ def StableHLO_ComplexOp: StableHLO_BinaryElementwiseOp<"complex", [Pure,
 }
 
 def StableHLO_DivOp : StableHLO_BinaryElementwiseOp<"divide", [Pure,
-    HLO_CompatibleOperandsAndResultType /*div_c1*/], HLO_IntFpOrComplexTensor> {
+    HLO_CompatibleOperandsAndResultType /* div_c1 */],
+    HLO_IntFpOrComplexTensor /* div_i1, div_i2 */> {
   let summary = "Divide operation";
   let description = [{
     Performs element-wise division of dividend `lhs` and divisor `rhs` tensors

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -738,8 +738,8 @@ def StableHLO_ComplexOp: StableHLO_BinaryElementwiseOp<"complex", [Pure,
   }];
 }
 
-def StableHLO_DivOp : StableHLO_BinaryElementwiseOp<"divide",
-      [Pure, HLO_CompatibleOperandsAndResultType], HLO_IntFpOrComplexTensor> {
+def StableHLO_DivOp : StableHLO_BinaryElementwiseOp<"divide", [Pure,
+    HLO_CompatibleOperandsAndResultType /*div_c1*/], HLO_IntFpOrComplexTensor> {
   let summary = "Division operation";
   let description = [{
     Performs element-wise division of dividend `lhs` and divisor `rhs` tensors

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -740,7 +740,7 @@ def StableHLO_ComplexOp: StableHLO_BinaryElementwiseOp<"complex", [Pure,
 
 def StableHLO_DivOp : StableHLO_BinaryElementwiseOp<"divide", [Pure,
     HLO_CompatibleOperandsAndResultType /*div_c1*/], HLO_IntFpOrComplexTensor> {
-  let summary = "Division operation";
+  let summary = "Divide operation";
   let description = [{
     Performs element-wise division of dividend `lhs` and divisor `rhs` tensors
     and produces a `result` tensor.

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -740,7 +740,7 @@ def StableHLO_ComplexOp: StableHLO_BinaryElementwiseOp<"complex", [Pure,
 
 def StableHLO_DivOp : StableHLO_BinaryElementwiseOp<"divide",
       [Pure, HLO_CompatibleOperandsAndResultType], HLO_IntFpOrComplexTensor> {
-  let summary = "Division operator";
+  let summary = "Division operation";
   let description = [{
     Performs element-wise division of dividend `lhs` and divisor `rhs` tensors
     and produces a `result` tensor.
@@ -750,7 +750,7 @@ def StableHLO_DivOp : StableHLO_BinaryElementwiseOp<"divide",
 
     Example:
     ```mlir
-    %result = stablehlo.divide %lhs, %rhs : tensor<2xi32>
+    %result = stablehlo.divide %lhs, %rhs : tensor<4xf32>
     ```
   }];
 }

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -317,6 +317,19 @@ Element Element::operator+(const Element &other) const {
       });
 }
 
+Element Element::operator/(const Element &other) const {
+  return mapWithUpcastToDouble(
+      *this, other, [&](APInt lhs, APInt rhs) { return lhs.sdiv(rhs); },
+      [&](APInt lhs, APInt rhs) { return lhs.udiv(rhs); },
+      [](bool lhs, bool rhs) -> bool {
+        llvm::report_fatal_error("-bool is unsupported");
+      },
+      [](double lhs, double rhs) { return lhs / rhs; },
+      [](std::complex<double> lhs, std::complex<double> rhs) {
+        return lhs / rhs;
+      });
+}
+
 Element Element::operator*(const Element &other) const {
   return map(
       *this, other, [](APInt lhs, APInt rhs) { return lhs * rhs; },

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -403,7 +403,9 @@ Element cosine(const Element &el) {
       [&](APInt e) -> APInt {
         llvm::report_fatal_error("cosine(int) is unsupported");
       },
-      [](bool e) -> bool { llvm::report_fatal_error("cosine(bool) is unsupported"); },
+      [](bool e) -> bool {
+        llvm::report_fatal_error("cosine(bool) is unsupported");
+      },
       [](double e) { return std::cos(e); },
       [](std::complex<double> e) { return std::cos(e); });
 }
@@ -456,7 +458,9 @@ Element sine(const Element &el) {
       [&](APInt e) -> APInt {
         llvm::report_fatal_error("sine(int) is unsupported");
       },
-      [](bool e) -> bool { llvm::report_fatal_error("sine(bool) is unsupported"); },
+      [](bool e) -> bool {
+        llvm::report_fatal_error("sine(bool) is unsupported");
+      },
       [](double e) { return std::sin(e); },
       [](std::complex<double> e) { return std::sin(e); });
 }
@@ -473,7 +477,9 @@ Element tanh(const Element &el) {
       [&](APInt e) -> APInt {
         llvm::report_fatal_error("tanh(int) is unsupported");
       },
-      [](bool e) -> bool { llvm::report_fatal_error("tanh(bool) is unsupported"); },
+      [](bool e) -> bool {
+        llvm::report_fatal_error("tanh(bool) is unsupported");
+      },
       [](double e) { return std::tanh(e); },
       [](std::complex<double> e) { return std::tanh(e); });
 }

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -265,7 +265,7 @@ Element Element::operator/(const Element &other) const {
                                                              : lhs.udiv(rhs);
       },
       [](bool lhs, bool rhs) -> bool {
-        llvm::report_fatal_error("-bool is unsupported");
+        llvm::report_fatal_error("bool / bool is unsupported");
       },
       [](double lhs, double rhs) { return lhs / rhs; },
       [](std::complex<double> lhs, std::complex<double> rhs) {
@@ -401,9 +401,9 @@ Element cosine(const Element &el) {
   return mapWithUpcastToDouble(
       el,
       [&](APInt e) -> APInt {
-        llvm::report_fatal_error("~int is unsupported");
+        llvm::report_fatal_error("cosine(int) is unsupported");
       },
-      [](bool e) -> bool { llvm::report_fatal_error("~bool is unsupported"); },
+      [](bool e) -> bool { llvm::report_fatal_error("cosine(bool) is unsupported"); },
       [](double e) { return std::cos(e); },
       [](std::complex<double> e) { return std::cos(e); });
 }
@@ -454,9 +454,9 @@ Element sine(const Element &el) {
   return mapWithUpcastToDouble(
       el,
       [&](APInt e) -> APInt {
-        llvm::report_fatal_error("~int is unsupported");
+        llvm::report_fatal_error("sine(int) is unsupported");
       },
-      [](bool e) -> bool { llvm::report_fatal_error("~bool is unsupported"); },
+      [](bool e) -> bool { llvm::report_fatal_error("sine(bool) is unsupported"); },
       [](double e) { return std::sin(e); },
       [](std::complex<double> e) { return std::sin(e); });
 }
@@ -471,9 +471,9 @@ Element tanh(const Element &el) {
   return mapWithUpcastToDouble(
       el,
       [&](APInt e) -> APInt {
-        llvm::report_fatal_error("~int is unsupported");
+        llvm::report_fatal_error("tanh(int) is unsupported");
       },
-      [](bool e) -> bool { llvm::report_fatal_error("~bool is unsupported"); },
+      [](bool e) -> bool { llvm::report_fatal_error("tanh(bool) is unsupported"); },
       [](double e) { return std::tanh(e); },
       [](std::complex<double> e) { return std::tanh(e); });
 }

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -30,15 +30,21 @@ namespace stablehlo {
 
 namespace {
 
-template <typename IntegerFn, typename BooleanFn, typename FloatFn,
-          typename ComplexFn>
-Element map(const Element &el, IntegerFn integerFn, BooleanFn boolFn,
+template <typename SignedIntegerFn, typename UnignedIntegerFn,
+          typename BooleanFn, typename FloatFn, typename ComplexFn>
+Element map(const Element &el, SignedIntegerFn signedIntegerFn,
+            UnignedIntegerFn unignedIntegerFn, BooleanFn boolFn,
             FloatFn floatFn, ComplexFn complexFn) {
   Type type = el.getType();
 
-  if (isSupportedIntegerType(type)) {
+  if (isSupportedSignedIntegerType(type)) {
     auto intEl = el.getIntegerValue();
-    return Element(type, integerFn(intEl));
+    return Element(type, signedIntegerFn(intEl));
+  }
+
+  if (isSupportedUnsignedIntegerType(type)) {
+    auto intEl = el.getIntegerValue();
+    return Element(type, unignedIntegerFn(intEl));
   }
 
   if (isSupportedBooleanType(type)) {
@@ -63,7 +69,15 @@ Element map(const Element &el, IntegerFn integerFn, BooleanFn boolFn,
 
 template <typename IntegerFn, typename BooleanFn, typename FloatFn,
           typename ComplexFn>
-Element map(const Element &lhs, const Element &rhs, IntegerFn integerFn,
+Element map(const Element &el, IntegerFn integerFn, BooleanFn boolFn,
+            FloatFn floatFn, ComplexFn complexFn) {
+  return map(el, integerFn, integerFn, boolFn, floatFn, complexFn);
+}
+
+template <typename SignedIntegerFn, typename UnignedIntegerFn,
+          typename BooleanFn, typename FloatFn, typename ComplexFn>
+Element map(const Element &lhs, const Element &rhs,
+            SignedIntegerFn signedIntegerFn, UnignedIntegerFn unignedIntegerFn,
             BooleanFn boolFn, FloatFn floatFn, ComplexFn complexFn) {
   Type type = lhs.getType();
   if (lhs.getType() != rhs.getType())
@@ -71,10 +85,16 @@ Element map(const Element &lhs, const Element &rhs, IntegerFn integerFn,
                                        debugString(lhs.getType()).c_str(),
                                        debugString(rhs.getType()).c_str()));
 
-  if (isSupportedIntegerType(type)) {
+  if (isSupportedSignedIntegerType(type)) {
     auto intLhs = lhs.getIntegerValue();
     auto intRhs = rhs.getIntegerValue();
-    return Element(type, integerFn(intLhs, intRhs));
+    return Element(type, signedIntegerFn(intLhs, intRhs));
+  }
+
+  if (isSupportedUnsignedIntegerType(type)) {
+    auto intLhs = lhs.getIntegerValue();
+    auto intRhs = rhs.getIntegerValue();
+    return Element(type, unignedIntegerFn(intLhs, intRhs));
   }
 
   if (isSupportedBooleanType(type)) {
@@ -100,10 +120,36 @@ Element map(const Element &lhs, const Element &rhs, IntegerFn integerFn,
                                      debugString(type).c_str()));
 }
 
-template <typename FloatFn, typename ComplexFn>
-Element mapWithUpcastToDouble(const Element &el, FloatFn floatFn,
+template <typename IntegerFn, typename BooleanFn, typename FloatFn,
+          typename ComplexFn>
+Element map(const Element &lhs, const Element &rhs, IntegerFn integerFn,
+            BooleanFn boolFn, FloatFn floatFn, ComplexFn complexFn) {
+  return map(lhs, rhs, integerFn, integerFn, boolFn, floatFn, complexFn);
+}
+
+template <typename SignedIntegerFn, typename UnignedIntegerFn,
+          typename BooleanFn, typename FloatFn, typename ComplexFn>
+Element mapWithUpcastToDouble(const Element &el,
+                              SignedIntegerFn signedIntegerFn,
+                              UnignedIntegerFn unignedIntegerFn,
+                              BooleanFn boolFn, FloatFn floatFn,
                               ComplexFn complexFn) {
   Type type = el.getType();
+
+  if (isSupportedSignedIntegerType(type)) {
+    auto intEl = el.getIntegerValue();
+    return Element(type, signedIntegerFn(intEl));
+  }
+
+  if (isSupportedUnsignedIntegerType(type)) {
+    auto intEl = el.getIntegerValue();
+    return Element(type, unignedIntegerFn(intEl));
+  }
+
+  if (isSupportedBooleanType(type)) {
+    auto boolEl = el.getBooleanValue();
+    return Element(type, boolFn(boolEl));
+  }
 
   if (isSupportedFloatType(type)) {
     APFloat elVal = el.getFloatValue();
@@ -129,6 +175,87 @@ Element mapWithUpcastToDouble(const Element &el, FloatFn floatFn,
 
   report_fatal_error(invalidArgument("Unsupported element type: %s",
                                      debugString(type).c_str()));
+}
+
+template <typename IntegerFn, typename BooleanFn, typename FloatFn,
+          typename ComplexFn>
+Element mapWithUpcastToDouble(const Element &el, IntegerFn integerFn,
+                              BooleanFn boolFn, FloatFn floatFn,
+                              ComplexFn complexFn) {
+  return mapWithUpcastToDouble(el, integerFn, integerFn, boolFn, floatFn,
+                               complexFn);
+}
+
+template <typename SignedIntegerFn, typename UnignedIntegerFn,
+          typename BooleanFn, typename FloatFn, typename ComplexFn>
+Element mapWithUpcastToDouble(const Element &lhs, const Element &rhs,
+                              SignedIntegerFn signedIntegerFn,
+                              UnignedIntegerFn unignedIntegerFn,
+                              BooleanFn boolFn, FloatFn floatFn,
+                              ComplexFn complexFn) {
+  Type type = lhs.getType();
+  if (lhs.getType() != rhs.getType())
+    report_fatal_error(invalidArgument("Element types don't match: %s vs %s",
+                                       debugString(lhs.getType()).c_str(),
+                                       debugString(rhs.getType()).c_str()));
+
+  if (isSupportedSignedIntegerType(type)) {
+    auto intLhs = lhs.getIntegerValue();
+    auto intRhs = rhs.getIntegerValue();
+    return Element(type, signedIntegerFn(intLhs, intRhs));
+  }
+
+  if (isSupportedUnsignedIntegerType(type)) {
+    auto intLhs = lhs.getIntegerValue();
+    auto intRhs = rhs.getIntegerValue();
+    return Element(type, unignedIntegerFn(intLhs, intRhs));
+  }
+
+  if (isSupportedBooleanType(type)) {
+    auto boolLhs = lhs.getBooleanValue();
+    auto boolRhs = rhs.getBooleanValue();
+    return Element(type, boolFn(boolLhs, boolRhs));
+  }
+
+  if (isSupportedFloatType(type)) {
+    APFloat lhsVal = lhs.getFloatValue();
+    APFloat rhsVal = rhs.getFloatValue();
+    const llvm::fltSemantics &elSemantics = lhsVal.getSemantics();
+    APFloat resultVal(
+        floatFn(lhsVal.convertToDouble(), rhsVal.convertToDouble()));
+    bool roundingErr;
+    resultVal.convert(elSemantics, APFloat::rmNearestTiesToEven, &roundingErr);
+    return Element(type, resultVal);
+  }
+
+  if (isSupportedComplexType(type)) {
+    auto lhsVal = lhs.getComplexValue();
+    auto rhsVal = rhs.getComplexValue();
+    const llvm::fltSemantics &elSemantics = lhsVal.real().getSemantics();
+    auto resultVal =
+        complexFn(std::complex<double>(lhsVal.real().convertToDouble(),
+                                       lhsVal.imag().convertToDouble()),
+                  std::complex<double>(rhsVal.real().convertToDouble(),
+                                       rhsVal.imag().convertToDouble()));
+    bool roundingErr;
+    APFloat resultReal(resultVal.real());
+    resultReal.convert(elSemantics, APFloat::rmNearestTiesToEven, &roundingErr);
+    APFloat resultImag(resultVal.imag());
+    resultImag.convert(elSemantics, APFloat::rmNearestTiesToEven, &roundingErr);
+    return Element(type, std::complex<APFloat>(resultReal, resultImag));
+  }
+
+  report_fatal_error(invalidArgument("Unsupported element type: %s",
+                                     debugString(type).c_str()));
+}
+
+template <typename IntegerFn, typename BooleanFn, typename FloatFn,
+          typename ComplexFn>
+Element mapWithUpcastToDouble(const Element &lhs, const Element &rhs,
+                              IntegerFn integerFn, BooleanFn boolFn,
+                              FloatFn floatFn, ComplexFn complexFn) {
+  return mapWithUpcastToDouble(lhs, rhs, integerFn, integerFn, boolFn, floatFn,
+                               complexFn);
 }
 
 }  // namespace
@@ -316,7 +443,12 @@ Element floor(const Element &el) {
 
 Element cosine(const Element &el) {
   return mapWithUpcastToDouble(
-      el, [](double e) { return std::cos(e); },
+      el,
+      [&](APInt e) -> APInt {
+        llvm::report_fatal_error("~int is unsupported");
+      },
+      [](bool e) -> bool { llvm::report_fatal_error("~bool is unsupported"); },
+      [](double e) { return std::cos(e); },
       [](std::complex<double> e) { return std::cos(e); });
 }
 
@@ -329,11 +461,8 @@ Element log(const Element &el) {
 Element max(const Element &e1, const Element &e2) {
   return map(
       e1, e2,
-      [&](APInt lhs, APInt rhs) {
-        return isSupportedSignedIntegerType(e1.getType())
-                   ? llvm::APIntOps::smax(lhs, rhs)
-                   : llvm::APIntOps::umax(lhs, rhs);
-      },
+      [&](APInt lhs, APInt rhs) { return llvm::APIntOps::smax(lhs, rhs); },
+      [&](APInt lhs, APInt rhs) { return llvm::APIntOps::umax(lhs, rhs); },
       [](bool lhs, bool rhs) -> bool { return lhs | rhs; },
       [](APFloat lhs, APFloat rhs) { return llvm::maximum(lhs, rhs); },
       [](std::complex<APFloat> lhs, std::complex<APFloat> rhs) {
@@ -347,11 +476,8 @@ Element max(const Element &e1, const Element &e2) {
 Element min(const Element &e1, const Element &e2) {
   return map(
       e1, e2,
-      [&](APInt lhs, APInt rhs) {
-        return isSupportedSignedIntegerType(e1.getType())
-                   ? llvm::APIntOps::smin(lhs, rhs)
-                   : llvm::APIntOps::umin(lhs, rhs);
-      },
+      [&](APInt lhs, APInt rhs) { return llvm::APIntOps::smin(lhs, rhs); },
+      [&](APInt lhs, APInt rhs) { return llvm::APIntOps::umin(lhs, rhs); },
       [](bool lhs, bool rhs) -> bool { return lhs & rhs; },
       [](APFloat lhs, APFloat rhs) { return llvm::minimum(lhs, rhs); },
       [](std::complex<APFloat> lhs, std::complex<APFloat> rhs) {
@@ -364,7 +490,12 @@ Element min(const Element &e1, const Element &e2) {
 
 Element sine(const Element &el) {
   return mapWithUpcastToDouble(
-      el, [](double e) { return std::sin(e); },
+      el,
+      [&](APInt e) -> APInt {
+        llvm::report_fatal_error("~int is unsupported");
+      },
+      [](bool e) -> bool { llvm::report_fatal_error("~bool is unsupported"); },
+      [](double e) { return std::sin(e); },
       [](std::complex<double> e) { return std::sin(e); });
 }
 
@@ -376,7 +507,12 @@ Element sqrt(const Element &el) {
 
 Element tanh(const Element &el) {
   return mapWithUpcastToDouble(
-      el, [](double e) { return std::tanh(e); },
+      el,
+      [&](APInt e) -> APInt {
+        llvm::report_fatal_error("~int is unsupported");
+      },
+      [](bool e) -> bool { llvm::report_fatal_error("~bool is unsupported"); },
+      [](double e) { return std::tanh(e); },
       [](std::complex<double> e) { return std::tanh(e); });
 }
 

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -30,21 +30,15 @@ namespace stablehlo {
 
 namespace {
 
-template <typename SignedIntegerFn, typename UnignedIntegerFn,
-          typename BooleanFn, typename FloatFn, typename ComplexFn>
-Element map(const Element &el, SignedIntegerFn signedIntegerFn,
-            UnignedIntegerFn unignedIntegerFn, BooleanFn boolFn,
+template <typename IntegerFn, typename BooleanFn, typename FloatFn,
+          typename ComplexFn>
+Element map(const Element &el, IntegerFn integerFn, BooleanFn boolFn,
             FloatFn floatFn, ComplexFn complexFn) {
   Type type = el.getType();
 
-  if (isSupportedSignedIntegerType(type)) {
+  if (isSupportedIntegerType(type)) {
     auto intEl = el.getIntegerValue();
-    return Element(type, signedIntegerFn(intEl));
-  }
-
-  if (isSupportedUnsignedIntegerType(type)) {
-    auto intEl = el.getIntegerValue();
-    return Element(type, unignedIntegerFn(intEl));
+    return Element(type, integerFn(intEl));
   }
 
   if (isSupportedBooleanType(type)) {
@@ -69,15 +63,7 @@ Element map(const Element &el, SignedIntegerFn signedIntegerFn,
 
 template <typename IntegerFn, typename BooleanFn, typename FloatFn,
           typename ComplexFn>
-Element map(const Element &el, IntegerFn integerFn, BooleanFn boolFn,
-            FloatFn floatFn, ComplexFn complexFn) {
-  return map(el, integerFn, integerFn, boolFn, floatFn, complexFn);
-}
-
-template <typename SignedIntegerFn, typename UnignedIntegerFn,
-          typename BooleanFn, typename FloatFn, typename ComplexFn>
-Element map(const Element &lhs, const Element &rhs,
-            SignedIntegerFn signedIntegerFn, UnignedIntegerFn unignedIntegerFn,
+Element map(const Element &lhs, const Element &rhs, IntegerFn integerFn,
             BooleanFn boolFn, FloatFn floatFn, ComplexFn complexFn) {
   Type type = lhs.getType();
   if (lhs.getType() != rhs.getType())
@@ -85,16 +71,10 @@ Element map(const Element &lhs, const Element &rhs,
                                        debugString(lhs.getType()).c_str(),
                                        debugString(rhs.getType()).c_str()));
 
-  if (isSupportedSignedIntegerType(type)) {
+  if (isSupportedIntegerType(type)) {
     auto intLhs = lhs.getIntegerValue();
     auto intRhs = rhs.getIntegerValue();
-    return Element(type, signedIntegerFn(intLhs, intRhs));
-  }
-
-  if (isSupportedUnsignedIntegerType(type)) {
-    auto intLhs = lhs.getIntegerValue();
-    auto intRhs = rhs.getIntegerValue();
-    return Element(type, unignedIntegerFn(intLhs, intRhs));
+    return Element(type, integerFn(intLhs, intRhs));
   }
 
   if (isSupportedBooleanType(type)) {
@@ -122,28 +102,14 @@ Element map(const Element &lhs, const Element &rhs,
 
 template <typename IntegerFn, typename BooleanFn, typename FloatFn,
           typename ComplexFn>
-Element map(const Element &lhs, const Element &rhs, IntegerFn integerFn,
-            BooleanFn boolFn, FloatFn floatFn, ComplexFn complexFn) {
-  return map(lhs, rhs, integerFn, integerFn, boolFn, floatFn, complexFn);
-}
-
-template <typename SignedIntegerFn, typename UnignedIntegerFn,
-          typename BooleanFn, typename FloatFn, typename ComplexFn>
-Element mapWithUpcastToDouble(const Element &el,
-                              SignedIntegerFn signedIntegerFn,
-                              UnignedIntegerFn unignedIntegerFn,
+Element mapWithUpcastToDouble(const Element &el, IntegerFn integerFn,
                               BooleanFn boolFn, FloatFn floatFn,
                               ComplexFn complexFn) {
   Type type = el.getType();
 
-  if (isSupportedSignedIntegerType(type)) {
+  if (isSupportedIntegerType(type)) {
     auto intEl = el.getIntegerValue();
-    return Element(type, signedIntegerFn(intEl));
-  }
-
-  if (isSupportedUnsignedIntegerType(type)) {
-    auto intEl = el.getIntegerValue();
-    return Element(type, unignedIntegerFn(intEl));
+    return Element(type, integerFn(intEl));
   }
 
   if (isSupportedBooleanType(type)) {
@@ -179,36 +145,19 @@ Element mapWithUpcastToDouble(const Element &el,
 
 template <typename IntegerFn, typename BooleanFn, typename FloatFn,
           typename ComplexFn>
-Element mapWithUpcastToDouble(const Element &el, IntegerFn integerFn,
-                              BooleanFn boolFn, FloatFn floatFn,
-                              ComplexFn complexFn) {
-  return mapWithUpcastToDouble(el, integerFn, integerFn, boolFn, floatFn,
-                               complexFn);
-}
-
-template <typename SignedIntegerFn, typename UnignedIntegerFn,
-          typename BooleanFn, typename FloatFn, typename ComplexFn>
 Element mapWithUpcastToDouble(const Element &lhs, const Element &rhs,
-                              SignedIntegerFn signedIntegerFn,
-                              UnignedIntegerFn unignedIntegerFn,
-                              BooleanFn boolFn, FloatFn floatFn,
-                              ComplexFn complexFn) {
+                              IntegerFn integerFn, BooleanFn boolFn,
+                              FloatFn floatFn, ComplexFn complexFn) {
   Type type = lhs.getType();
   if (lhs.getType() != rhs.getType())
     report_fatal_error(invalidArgument("Element types don't match: %s vs %s",
                                        debugString(lhs.getType()).c_str(),
                                        debugString(rhs.getType()).c_str()));
 
-  if (isSupportedSignedIntegerType(type)) {
+  if (isSupportedIntegerType(type)) {
     auto intLhs = lhs.getIntegerValue();
     auto intRhs = rhs.getIntegerValue();
-    return Element(type, signedIntegerFn(intLhs, intRhs));
-  }
-
-  if (isSupportedUnsignedIntegerType(type)) {
-    auto intLhs = lhs.getIntegerValue();
-    auto intRhs = rhs.getIntegerValue();
-    return Element(type, unignedIntegerFn(intLhs, intRhs));
+    return Element(type, integerFn(intLhs, intRhs));
   }
 
   if (isSupportedBooleanType(type)) {
@@ -247,15 +196,6 @@ Element mapWithUpcastToDouble(const Element &lhs, const Element &rhs,
 
   report_fatal_error(invalidArgument("Unsupported element type: %s",
                                      debugString(type).c_str()));
-}
-
-template <typename IntegerFn, typename BooleanFn, typename FloatFn,
-          typename ComplexFn>
-Element mapWithUpcastToDouble(const Element &lhs, const Element &rhs,
-                              IntegerFn integerFn, BooleanFn boolFn,
-                              FloatFn floatFn, ComplexFn complexFn) {
-  return mapWithUpcastToDouble(lhs, rhs, integerFn, integerFn, boolFn, floatFn,
-                               complexFn);
 }
 
 }  // namespace
@@ -319,8 +259,11 @@ Element Element::operator+(const Element &other) const {
 
 Element Element::operator/(const Element &other) const {
   return mapWithUpcastToDouble(
-      *this, other, [&](APInt lhs, APInt rhs) { return lhs.sdiv(rhs); },
-      [&](APInt lhs, APInt rhs) { return lhs.udiv(rhs); },
+      *this, other,
+      [&](APInt lhs, APInt rhs) {
+        return isSupportedSignedIntegerType(other.getType()) ? lhs.sdiv(rhs)
+                                                             : lhs.udiv(rhs);
+      },
       [](bool lhs, bool rhs) -> bool {
         llvm::report_fatal_error("-bool is unsupported");
       },
@@ -474,8 +417,11 @@ Element log(const Element &el) {
 Element max(const Element &e1, const Element &e2) {
   return map(
       e1, e2,
-      [&](APInt lhs, APInt rhs) { return llvm::APIntOps::smax(lhs, rhs); },
-      [&](APInt lhs, APInt rhs) { return llvm::APIntOps::umax(lhs, rhs); },
+      [&](APInt lhs, APInt rhs) {
+        return isSupportedSignedIntegerType(e1.getType())
+                   ? llvm::APIntOps::smax(lhs, rhs)
+                   : llvm::APIntOps::umax(lhs, rhs);
+      },
       [](bool lhs, bool rhs) -> bool { return lhs | rhs; },
       [](APFloat lhs, APFloat rhs) { return llvm::maximum(lhs, rhs); },
       [](std::complex<APFloat> lhs, std::complex<APFloat> rhs) {
@@ -489,8 +435,11 @@ Element max(const Element &e1, const Element &e2) {
 Element min(const Element &e1, const Element &e2) {
   return map(
       e1, e2,
-      [&](APInt lhs, APInt rhs) { return llvm::APIntOps::smin(lhs, rhs); },
-      [&](APInt lhs, APInt rhs) { return llvm::APIntOps::umin(lhs, rhs); },
+      [&](APInt lhs, APInt rhs) {
+        return isSupportedSignedIntegerType(e1.getType())
+                   ? llvm::APIntOps::smin(lhs, rhs)
+                   : llvm::APIntOps::umin(lhs, rhs);
+      },
       [](bool lhs, bool rhs) -> bool { return lhs & rhs; },
       [](APFloat lhs, APFloat rhs) { return llvm::minimum(lhs, rhs); },
       [](std::complex<APFloat> lhs, std::complex<APFloat> rhs) {

--- a/stablehlo/reference/Element.h
+++ b/stablehlo/reference/Element.h
@@ -71,6 +71,9 @@ class Element {
   /// Overloaded add operator.
   Element operator+(const Element &other) const;
 
+  /// Overloaded divide operator.
+  Element operator/(const Element &other) const;
+
   /// Overloaded multiply operator.
   Element operator*(const Element &other) const;
 

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -437,6 +437,12 @@ SmallVector<Tensor> eval(Region &region, ArrayRef<Tensor> args, Scope *parent) {
       Tensor runtimeOperand = scope.find(cosineOp.getOperand());
       Tensor runtimeResult = evalCosineOp(runtimeOperand, cosineOp.getType());
       scope.add(op.getResults(), {runtimeResult});
+    } else if (auto divideOp = dyn_cast<DivOp>(op)) {
+      Tensor runtimeLhs = scope.find(divideOp.getLhs());
+      Tensor runtimeRhs = scope.find(divideOp.getRhs());
+      Tensor runtimeResult =
+          evalDivideOp(runtimeLhs, runtimeRhs, divideOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
     } else if (auto dynamicSliceOp = dyn_cast<DynamicSliceOp>(op)) {
       Tensor runtimeOperand = scope.find(dynamicSliceOp.getOperand());
       SmallVector<Tensor> runtimeStartIndices =

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -116,6 +116,14 @@ Tensor evalCosineOp(const Tensor &operand, TensorType resultType) {
   return result;
 }
 
+Tensor evalDivideOp(const Tensor &lhs, const Tensor &rhs,
+                    TensorType resultType) {
+  Tensor result(resultType);
+  for (auto it = result.index_begin(); it != result.index_end(); ++it)
+    result.set(*it, lhs.get(*it) / rhs.get(*it));
+  return result;
+}
+
 Tensor evalDynamicSliceOp(const Tensor &operand, ArrayRef<Tensor> startIndices,
                           Sizes sliceSizes, TensorType resultType) {
   Tensor result(resultType);

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -38,6 +38,8 @@ Tensor evalClampOp(const Tensor &min, const Tensor &operand, const Tensor &max,
 Tensor evalConstantOp(ElementsAttr value);
 Tensor evalConvertOp(const Tensor &operand, TensorType resultType);
 Tensor evalCosineOp(const Tensor &operand, TensorType resultType);
+Tensor evalDivideOp(const Tensor &lhs, const Tensor &rhs,
+                    TensorType resultType);
 Tensor evalDynamicSliceOp(const Tensor &operand, ArrayRef<Tensor> startIndices,
                           Sizes sliceSizes, TensorType resultType);
 Tensor evalDynamicUpdateSliceOp(const Tensor &operand, const Tensor &update,

--- a/stablehlo/tests/interpret_divide.mlir
+++ b/stablehlo/tests/interpret_divide.mlir
@@ -1,0 +1,57 @@
+// RUN: stablehlo-interpreter --interpret -split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: Evaluated results of function: div_op_test_ui64
+func.func @div_op_test_ui64() -> tensor<4xui64> {
+  %0 = stablehlo.constant dense<[17, 18, 19, 20]> : tensor<4xui64>
+  %1 = stablehlo.constant dense<[3, 4, 5, 7]> : tensor<4xui64>
+  %2 = stablehlo.divide %0, %1 : tensor<4xui64>
+  func.return %2 : tensor<4xui64>
+  // CHECK-NEXT: tensor<4xui64>
+  // CHECK-NEXT: 5 : ui64
+  // CHECK-NEXT: 4 : ui64
+  // CHECK-NEXT: 3 : ui64
+  // CHECK-NEXT: 2 : ui64
+}
+
+// -----
+
+// CHECK-LABEL: Evaluated results of function: div_op_test_si64
+func.func @div_op_test_si64() -> tensor<4xi64> {
+  %0 = stablehlo.constant dense<[17, -17, 17, -17]> : tensor<4xi64>
+  %1 = stablehlo.constant dense<[3, 3, -3, -3]> : tensor<4xi64>
+  %2 = stablehlo.divide %0, %1 : tensor<4xi64>
+  func.return %2 : tensor<4xi64>
+  // CHECK-NEXT: tensor<4xi64>
+  // CHECK-NEXT: 5 : i64
+  // CHECK-NEXT: -5 : i64
+  // CHECK-NEXT: -5 : i64
+  // CHECK-NEXT: 5 : i64
+}
+
+// -----
+
+// CHECK-LABEL: Evaluated results of function: div_op_test_f64
+func.func @div_op_test_f64() -> tensor<4xf64> {
+  %0 = stablehlo.constant dense<[17.1, -17.1, 17.1, -17.1]> : tensor<4xf64>
+  %1 = stablehlo.constant dense<[3.0, 3.0, -3.0, -3.0]> : tensor<4xf64>
+  %2 = stablehlo.divide %0, %1 : tensor<4xf64>
+  func.return %2 : tensor<4xf64>
+  // CHECK-NEXT: tensor<4xf64>
+  // CHECK-NEXT: 5.700000e+00 : f64
+  // CHECK-NEXT: -5.700000e+00 : f64
+  // CHECK-NEXT: -5.700000e+00 : f64
+  // CHECK-NEXT: 5.700000e+00 : f64
+}
+
+// -----
+
+// CHECK-LABEL: Evaluated results of function: div_op_test_c64
+func.func @div_op_test_c64() -> tensor<2xcomplex<f64>> {
+  %0 = stablehlo.constant dense<[(1.5, 2.5), (7.5, 5.5)]> : tensor<2xcomplex<f64>>
+  %1 = stablehlo.constant dense<[(2.5, 1.5), (5.5, 7.5)]> : tensor<2xcomplex<f64>>
+  %2 = stablehlo.divide %0, %1 : tensor<2xcomplex<f64>>
+  func.return %2 : tensor<2xcomplex<f64>>
+  // CHECK-NEXT: tensor<2xcomplex<f64>>
+  // CHECK-NEXT: [0.88235294117647056 : f64, 0.4705882352941177 : f64]
+  // CHECK-NEXT: [0.95375722543352603 : f64, -0.30057803468208094 : f64]
+}

--- a/stablehlo/tests/interpret_divide.mlir
+++ b/stablehlo/tests/interpret_divide.mlir
@@ -1,26 +1,11 @@
 // RUN: stablehlo-interpreter --interpret -split-input-file %s | FileCheck %s
 
-// CHECK-LABEL: Evaluated results of function: div_op_test_ui64
-func.func @div_op_test_ui64() -> tensor<4xui64> {
-  %0 = stablehlo.constant dense<[17, 18, 19, 20]> : tensor<4xui64>
-  %1 = stablehlo.constant dense<[3, 4, 5, 7]> : tensor<4xui64>
-  %2 = stablehlo.divide %0, %1 : tensor<4xui64>
-  func.return %2 : tensor<4xui64>
-  // CHECK-NEXT: tensor<4xui64>
-  // CHECK-NEXT: 5 : ui64
-  // CHECK-NEXT: 4 : ui64
-  // CHECK-NEXT: 3 : ui64
-  // CHECK-NEXT: 2 : ui64
-}
-
-// -----
-
-// CHECK-LABEL: Evaluated results of function: div_op_test_si64
-func.func @div_op_test_si64() -> tensor<4xi64> {
-  %0 = stablehlo.constant dense<[17, -17, 17, -17]> : tensor<4xi64>
-  %1 = stablehlo.constant dense<[3, 3, -3, -3]> : tensor<4xi64>
-  %2 = stablehlo.divide %0, %1 : tensor<4xi64>
-  func.return %2 : tensor<4xi64>
+// CHECK-LABEL: Evaluated results of function: divide_op_test_si64
+func.func @divide_op_test_si64() -> tensor<4xi64> {
+  %lhs = stablehlo.constant dense<[17, -17, 17, -17]> : tensor<4xi64>
+  %rhs = stablehlo.constant dense<[3, 3, -3, -3]> : tensor<4xi64>
+  %result = stablehlo.divide %lhs, %rhs : tensor<4xi64>
+  func.return %result : tensor<4xi64>
   // CHECK-NEXT: tensor<4xi64>
   // CHECK-NEXT: 5 : i64
   // CHECK-NEXT: -5 : i64
@@ -30,12 +15,27 @@ func.func @div_op_test_si64() -> tensor<4xi64> {
 
 // -----
 
-// CHECK-LABEL: Evaluated results of function: div_op_test_f64
-func.func @div_op_test_f64() -> tensor<4xf64> {
-  %0 = stablehlo.constant dense<[17.1, -17.1, 17.1, -17.1]> : tensor<4xf64>
-  %1 = stablehlo.constant dense<[3.0, 3.0, -3.0, -3.0]> : tensor<4xf64>
-  %2 = stablehlo.divide %0, %1 : tensor<4xf64>
-  func.return %2 : tensor<4xf64>
+// CHECK-LABEL: Evaluated results of function: divide_op_test_ui64
+func.func @divide_op_test_ui64() -> tensor<4xui64> {
+  %lhs = stablehlo.constant dense<[17, 18, 19, 20]> : tensor<4xui64>
+  %rhs = stablehlo.constant dense<[3, 4, 5, 7]> : tensor<4xui64>
+  %result = stablehlo.divide %lhs, %rhs : tensor<4xui64>
+  func.return %result : tensor<4xui64>
+  // CHECK-NEXT: tensor<4xui64>
+  // CHECK-NEXT: 5 : ui64
+  // CHECK-NEXT: 4 : ui64
+  // CHECK-NEXT: 3 : ui64
+  // CHECK-NEXT: 2 : ui64
+}
+
+// -----
+
+// CHECK-LABEL: Evaluated results of function: divide_op_test_f64
+func.func @divide_op_test_f64() -> tensor<4xf64> {
+  %lhs = stablehlo.constant dense<[17.1, -17.1, 17.1, -17.1]> : tensor<4xf64>
+  %rhs = stablehlo.constant dense<[3.0, 3.0, -3.0, -3.0]> : tensor<4xf64>
+  %result = stablehlo.divide %lhs, %rhs : tensor<4xf64>
+  func.return %result : tensor<4xf64>
   // CHECK-NEXT: tensor<4xf64>
   // CHECK-NEXT: 5.700000e+00 : f64
   // CHECK-NEXT: -5.700000e+00 : f64
@@ -45,12 +45,12 @@ func.func @div_op_test_f64() -> tensor<4xf64> {
 
 // -----
 
-// CHECK-LABEL: Evaluated results of function: div_op_test_c64
-func.func @div_op_test_c64() -> tensor<2xcomplex<f64>> {
-  %0 = stablehlo.constant dense<[(1.5, 2.5), (7.5, 5.5)]> : tensor<2xcomplex<f64>>
-  %1 = stablehlo.constant dense<[(2.5, 1.5), (5.5, 7.5)]> : tensor<2xcomplex<f64>>
-  %2 = stablehlo.divide %0, %1 : tensor<2xcomplex<f64>>
-  func.return %2 : tensor<2xcomplex<f64>>
+// CHECK-LABEL: Evaluated results of function: divide_op_test_c128
+func.func @divide_op_test_c128() -> tensor<2xcomplex<f64>> {
+  %lhs = stablehlo.constant dense<[(1.5, 2.5), (7.5, 5.5)]> : tensor<2xcomplex<f64>>
+  %rhs = stablehlo.constant dense<[(2.5, 1.5), (5.5, 7.5)]> : tensor<2xcomplex<f64>>
+  %result = stablehlo.divide %lhs, %rhs : tensor<2xcomplex<f64>>
+  func.return %result : tensor<2xcomplex<f64>>
   // CHECK-NEXT: tensor<2xcomplex<f64>>
   // CHECK-NEXT: [0.88235294117647056 : f64, 0.4705882352941177 : f64]
   // CHECK-NEXT: [0.95375722543352603 : f64, -0.30057803468208094 : f64]


### PR DESCRIPTION
closes #971 

We have the following constraints in the spec:

```
(I1) lhs is a tensor of integer, floating-point, or complex type.
(I2) rhs is a tensor of integer, floating-point, or complex type.
(C1) lhs, rhs, and result have the same type.
```

These constraints are covered by the following tests

```
(I1) lhs is not a tensor of integer, floating-point, or complex type. (covered by ODS)
(I2) rhs is not a tensor of integer, floating-point, or complex type. (covered by ODS)
(C1) lhs, rhs, and result do not have the same type. (covered by ODS)
```

Add a binary op version of mapWithUpcastToDouble