### PR TITLE
Remove type inference for ReturnOp

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -125,7 +125,7 @@ one of the following tracking labels.
 | remainder                | yes           | yes          | yes            | yes             | no          |
 | replica_id               | yes           | yes          | yes            | yes             | no          |
 | reshape                  | yes           | yes          | infeasible     | yes             | yes         |
-| return                   | no            | revisit      | yes            | yes             | no          |
+| return                   | no            | revisit      | infeasible     | yes             | no          |
 | reverse                  | yes           | yes          | yes            | yes             | no          |
 | rng                      | yes           | yes          | yes            | yes             | no          |
 | rng_bit_generator        | yes           | revisit      | infeasible     | yes             | no          |

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -1802,17 +1802,6 @@ LogicalResult OptimizationBarrierOp::inferReturnTypes(
 }
 
 //===----------------------------------------------------------------------===//
-// ReturnOp
-//===----------------------------------------------------------------------===//
-LogicalResult ReturnOp::inferReturnTypes(
-    MLIRContext*, std::optional<Location> location, ValueRange operands,
-    DictionaryAttr attributes, RegionRange,
-    SmallVectorImpl<Type>& inferredReturnTypes) {
-  ReturnOp::Adaptor adaptor(operands, attributes);
-  return hlo::inferReturnOp(location, inferredReturnTypes);
-}
-
-//===----------------------------------------------------------------------===//
 // ReverseOp
 //===----------------------------------------------------------------------===//
 LogicalResult ReverseOp::verify() {

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2855,9 +2855,7 @@ def StableHLO_ReduceWindowOp: StableHLO_Op<"reduce_window", [
   }];
 }
 
-def StableHLO_ReturnOp : StableHLO_Op<"return",
-      [Pure, Terminator,
-      DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
+def StableHLO_ReturnOp : StableHLO_Op<"return", [Pure, Terminator]> {
   let summary = [{
     The `hlo.return` operation terminates a region and returns values.
 

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2636,10 +2636,6 @@ LogicalResult inferReplicaIdOp(MLIRContext* context, std::optional<Location>,
   return success();
 }
 
-LogicalResult inferReturnOp(std::optional<Location>, SmallVectorImpl<Type>&) {
-  return success();
-}
-
 LogicalResult inferScatterOp(std::optional<Location>, ValueRange inputs,
                              SmallVectorImpl<Type>& inferredReturnTypes) {
   llvm::append_range(inferredReturnTypes, inputs.getTypes());

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -291,9 +291,6 @@ LogicalResult inferReduceWindowOp(
 LogicalResult inferReplicaIdOp(MLIRContext* context, std::optional<Location>,
                                SmallVectorImpl<Type>& inferredReturnTypes);
 
-LogicalResult inferReturnOp(std::optional<Location> location,
-                            SmallVectorImpl<Type>& inferredReturnTypes);
-
 LogicalResult inferScatterOp(std::optional<Location> location,
                              ValueRange inputs,
                              SmallVectorImpl<Type>& inferredReturnTypes);


### PR DESCRIPTION
I added a shape function for ReturnOp when working on an initial version of #622 which was relying on --tf-shape-inference.

TensorFlow's shape inference needs all ops which are not hardcoded in the pass to have shape functions, so I added one for ReturnOp even though it is has unclear utility beyond this specific use case (ReturnOp doesn't have any results, so its shape function returns an empty vector, which isn't super useful).

Now that we're working towards a dedicated shape refinement pass for StableHLO, we no longer need a shape function for ReturnOp, so I'm proposing to remove it in this PR.