### PR TITLE
Improve type inference for DynamicGatherOp

### DIFF
--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -1521,3 +1521,20 @@ func.func @irfft_with_bound(%arg0: tensor<3x?x?xcomplex<f32>, #stablehlo.type_ex
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xf32>) -> tensor<*xindex>
   func.return %1 : tensor<*xindex>
 }
+
+// -----
+
+// CHECK-LABEL: func @dynamic_gather
+func.func @dynamic_gather(%arg0: tensor<?x4xf32>, %arg1: tensor<1xi64>) -> tensor<*xindex> {
+  %0 = stablehlo.constant dense<[1, 2]> : tensor<2xi32>
+  %1 = "stablehlo.dynamic_gather"(%arg0, %arg1, %0) {
+    dimension_numbers = #stablehlo.gather<
+      offset_dims = [0, 1],
+      start_index_map = [1]
+    >,
+    indices_are_sorted = true
+  } : (tensor<?x4xf32>, tensor<1xi64>, tensor<2xi32>) -> tensor<*xf32>
+  // CHECK: types0 = tensor<1x2xf32>
+  %2 = "hlo_test_infer.get_return_types"(%1) : (tensor<*xf32>) -> tensor<*xindex>
+  func.return %2 : tensor<*xindex>
+}


### PR DESCRIPTION
If slice_sizes are constant, then we can infer static dimension sizes for the offset dims parts of the result shape.