### PR TITLE
Clean up GitHub workflows

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -1,4 +1,16 @@
 # Copyright 2023 The StableHLO Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # The setup-build action gets everything needed by buildAndTest into the workspace.
 name: "Setup build environment (ninja, ccache, llvm, lld)"

--- a/.github/workflows/buildAndTestCMake.yml
+++ b/.github/workflows/buildAndTestCMake.yml
@@ -1,6 +1,18 @@
 # Copyright 2023 The StableHLO Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-name: Build and Test
+name: CMake Build
 
 on:
   pull_request:
@@ -10,7 +22,7 @@ on:
     branches: [ main ]
     paths-ignore: ['**.md', 'docs/**']
   schedule:
-    # Run buildAndTest workflow once a day
+    # Run once a day
     - cron:  '0 12 * * *'
   workflow_dispatch:
 
@@ -22,10 +34,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# Build using CMake and run tests.
-# Use Cached LLVM to improve build times.
 jobs:
-  build-test:
+  cmake-build:
     env:
       LLVM_PROJECT_DIR: "llvm-project"
       LLVM_BUILD_DIR: "llvm-build"
@@ -39,14 +49,12 @@ jobs:
     - name: Checkout StableHLO
       uses: actions/checkout@v2
 
-    # Read LLVM version from `build_tools/llvm_version.txt`
     - name: Get LLVM Version
       id: llvm-version
       shell: bash
       run: |
         echo "version=$(cat ${{ github.workspace }}/build_tools/llvm_version.txt)" >> $GITHUB_OUTPUT
 
-    # Check out LLVM, and install tools for compilation
     - name: Setup workspace
       uses: ./.github/actions/setup-build
       with:

--- a/.github/workflows/buildBazel.yml
+++ b/.github/workflows/buildBazel.yml
@@ -22,7 +22,7 @@ on:
     branches: [ main ]
     paths-ignore: ['**.md', 'docs/**']
   schedule:
-    # Run buildBazel workflow once a day
+    # Run once a day
     - cron:  '0 12 * * *'
   workflow_dispatch:
 

--- a/.github/workflows/buildBazel.yml
+++ b/.github/workflows/buildBazel.yml
@@ -1,4 +1,16 @@
 # Copyright 2023 The StableHLO Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 name: Bazel Build
 
@@ -45,13 +57,13 @@ jobs:
     - name: Setup Bazelisk
       uses: bazelbuild/setup-bazelisk@v2
 
-    - name: Mount bazel cache
+    - name: Mount Bazel Cache
       uses: actions/cache@v3
       with:
         path: "~/.cache/bazel"
         key: ${{ runner.os }}-stablehlo_build_assets-${{ steps.llvm-version.outputs.version }}-bazelbuild
 
-    - name: Build StableHLO using Bazel
+    - name: Build StableHLO
       shell: bash
       run: |
         ./build_tools/github_actions/ci_build_bazel.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,16 @@
 # Copyright 2023 The StableHLO Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 name: Lint
 

--- a/.github/workflows/markdown_lint.yml
+++ b/.github/workflows/markdown_lint.yml
@@ -1,4 +1,16 @@
 # Copyright 2023 The StableHLO Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 name: Markdown Lint
 


### PR DESCRIPTION
This PR contains a number of assorted cleanups:
  1) Alignment between buildAndTestCMake.yml and buildBazel.yml
     (including workflow and job names as well as commits).
  2) Adding license headers next to copyrights, to be consistent with
     other files in the repository.