### PR TITLE
Update signature of `infer<Op>` function for re-usability

### DIFF
--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -1179,7 +1179,7 @@ LogicalResult ConcatenateOp::inferReturnTypes(
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<Type>& inferredReturnTypes) {
   ConcatenateOp::Adaptor adaptor(operands, attributes, regions);
-  return hlo::inferConcatenateOp(location, adaptor.getInputs(),
+  return hlo::inferConcatenateOp(location, adaptor.getInputs().getTypes(),
                                  adaptor.getDimension(), inferredReturnTypes);
 }
 
@@ -1736,9 +1736,9 @@ LogicalResult ReduceOp::inferReturnTypeComponents(
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   ReduceOp::Adaptor adaptor(operands, attributes, regions);
-  return hlo::inferReduceOp(location, adaptor.getInputs(),
-                            adaptor.getInitValues(), adaptor.getDimensions(),
-                            inferredReturnShapes);
+  return hlo::inferReduceOp(location, adaptor.getInputs().getTypes(),
+                            adaptor.getInitValues().getTypes(),
+                            adaptor.getDimensions(), inferredReturnShapes);
 }
 
 LogicalResult ReduceOp::verify() {
@@ -2156,7 +2156,7 @@ LogicalResult SliceOp::inferReturnTypes(
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<Type>& inferredReturnTypes) {
   SliceOpAdaptor adaptor(operands, attributes);
-  return hlo::inferSliceOp(location, adaptor.getOperand(),
+  return hlo::inferSliceOp(location, adaptor.getOperand().getType(),
                            adaptor.getStartIndices(), adaptor.getLimitIndices(),
                            adaptor.getStrides(), inferredReturnTypes);
 }

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -157,7 +157,7 @@ LogicalResult inferComplexOp(std::optional<Location> location, Value lhs,
                              SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferConcatenateOp(std::optional<Location> location,
-                                 ValueRange inputs, int64_t dimension,
+                                 TypeRange inputTypes, int64_t dimension,
                                  SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferConstantOp(std::optional<Location>, ElementsAttr value,
@@ -193,7 +193,7 @@ LogicalResult inferDotOp(
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferDotGeneralOp(
-    std::optional<Location> location, Value lhs, Value rhs,
+    std::optional<Location> location, Type lhsType, Type rhsType,
     ArrayRef<int64_t> lhsBatchingDimensions,
     ArrayRef<int64_t> rhsBatchingDimensions,
     ArrayRef<int64_t> lhsContractingDimensions,
@@ -275,8 +275,8 @@ LogicalResult inferRealOp(std::optional<Location> location, Value operand,
                           SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferReduceOp(
-    std::optional<Location> location, ValueRange inputs, ValueRange initValues,
-    DenseIntElementsAttr dimensions,
+    std::optional<Location> location, TypeRange inputTypes,
+    TypeRange initValueTypes, DenseIntElementsAttr dimensions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferReduceWindowOp(
@@ -308,7 +308,7 @@ LogicalResult inferSelectAndScatterOp(
 LogicalResult inferSendOp(Dialect* dialect, std::optional<Location> location,
                           SmallVectorImpl<Type>& inferredReturnTypes);
 
-LogicalResult inferSliceOp(std::optional<Location> location, Value operand,
+LogicalResult inferSliceOp(std::optional<Location> location, Type operandType,
                            DenseIntElementsAttr startIndices,
                            DenseIntElementsAttr limitIndices,
                            DenseIntElementsAttr strides,


### PR DESCRIPTION
Based on the proposal discussed @ https://github.com/openxla/stablehlo/issues/1000, this PR implements the second step: "Sharing the shape inference code from TypeInference.cpp"

Some of the salient  features of the PR:
1. Addresses updating the signature of the type-inference-methods of 4 four ops (`concatenate, dot_general, reduce, slice`) which, according to #1000, could be shared for type-inference and reference implementation.

2. The shared code (e.g. `inferDotGeneralOp, inferConcatenateOp, inferSliceOp, inferReduceOp`)  do have code related to verification of input/output constraints. That means, the reference implementation will execute that verification code
whenever it wants to re-use the eval for those ops. Those verification checks are  redundant, as they must have already been executed while parsing the code, and affect the performance of the interpreter. Despite of that I decided to keep the code as is based on following reasons: 
    - Performance is a non-goal for the "readable" reference. After all it affects only 4 ops. 
    - Some part of type inference is tied closely with the verification code (e.g. usage of [newDimensions at inferReduceOp](https://github.com/openxla/stablehlo/blob/211bd058c88a0c1164b1e77c0dd1e067c6a1bb63/stablehlo/dialect/TypeInference.cpp#L2567)). Isolating just type inference counterparts  involve duplication of code affecting the performance of the verification/inference  which is critical. I note that this observation is true only for `inferReuceOp`. For the remaining ops, the split seems possible.

@burmako @zhouxin913 Please let me know your opinion on this. 