### PR TITLE
Update lint_llvm_commit.sh to also verify SHA256

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -28,7 +28,7 @@ http_archive(
 
 LLVM_COMMIT = "f58de2125caf75ec0d40bc3e094a93c0b314a66a"
 
-LLVM_SHA256 = "826633a410a58ad204afe01b054d2a5cd92943013327e6b6d99d84ac0f3b44e8"
+LLVM_SHA256 = "a96047c57addc2a349defab0c7fb84979aeac039ed9ada2901cd2e0ca88fffb6"
 
 http_archive(
     name = "llvm-raw",

--- a/build_tools/github_actions/lint_llvm_commit.sh
+++ b/build_tools/github_actions/lint_llvm_commit.sh
@@ -43,8 +43,9 @@ retrieve_llvm_commit() {
 
 calculate_llvm_commit_sha256() {
   echo "Calculating SHA256..."
-  HTTP_CODE=$(curl -sIL https://github.com/llvm/llvm-project/archive/$LLVM_COMMIT.tar.gz | grep HTTP | grep -oe "404")
-  if [[ ! -z $HTTP_CODE ]]; then
+  HTTP_CODE=$(curl -sIL https://github.com/llvm/llvm-project/archive/$LLVM_COMMIT.tar.gz -o /dev/null -w "%{http_code}")
+  echo "HTTP Code: $HTTP_CODE"
+  if [[ "$HTTP_CODE" == "404" ]]; then
     echo "LLVM_COMMIT: $LLVM_COMMIT in $PATH_TO_LLVM_VERSION_TXT not found."
     exit 1
   fi


### PR DESCRIPTION
In our previous LLVM Integrate, the SHA256 was calculated incorrectly. This PR addresses this by also verifying that the SHA256 value is also correct even if the llvm commit matches.