### PR TITLE
Migrate away from using MLIR Attributes in `evalTransposeOp`

### DIFF
--- a/stablehlo/reference/Interpreter.cpp
+++ b/stablehlo/reference/Interpreter.cpp
@@ -29,6 +29,16 @@ limitations under the License.
 namespace mlir {
 namespace stablehlo {
 
+namespace {
+
+SmallVector<int64_t> getSExtValues(DenseIntElementsAttr attr) {
+  SmallVector<int64_t> values;
+  for (auto i : attr) values.push_back(i.getSExtValue());
+  return values;
+}
+
+}  // namespace
+
 llvm::Expected<SmallVector<Tensor>> eval(func::FuncOp func,
                                          ArrayRef<Tensor> args) {
   if (func->getNumRegions() != 1) {
@@ -150,8 +160,9 @@ llvm::Expected<SmallVector<Tensor>> eval(func::FuncOp func,
       populateResults({runtimeResult});
     } else if (auto transposeOp = dyn_cast<TransposeOp>(op)) {
       Tensor runtimeOperand = fetchOperand(transposeOp.getOperand());
-      Tensor runtimeResult = evalTransposeOp(
-          transposeOp.getType(), runtimeOperand, transposeOp.getPermutation());
+      auto permutation = getSExtValues(transposeOp.getPermutation());
+      Tensor runtimeResult =
+          evalTransposeOp(runtimeOperand, permutation, transposeOp.getType());
       populateResults({runtimeResult});
     } else if (auto xorOp = dyn_cast<XorOp>(op)) {
       Tensor runtimeLhs = fetchOperand(xorOp.getLhs());

--- a/stablehlo/reference/Interpreter.cpp
+++ b/stablehlo/reference/Interpreter.cpp
@@ -29,16 +29,6 @@ limitations under the License.
 namespace mlir {
 namespace stablehlo {
 
-namespace {
-
-SmallVector<int64_t> getSExtValues(DenseIntElementsAttr attr) {
-  SmallVector<int64_t> values;
-  for (auto i : attr) values.push_back(i.getSExtValue());
-  return values;
-}
-
-}  // namespace
-
 llvm::Expected<SmallVector<Tensor>> eval(func::FuncOp func,
                                          ArrayRef<Tensor> args) {
   if (func->getNumRegions() != 1) {
@@ -160,7 +150,8 @@ llvm::Expected<SmallVector<Tensor>> eval(func::FuncOp func,
       populateResults({runtimeResult});
     } else if (auto transposeOp = dyn_cast<TransposeOp>(op)) {
       Tensor runtimeOperand = fetchOperand(transposeOp.getOperand());
-      auto permutation = getSExtValues(transposeOp.getPermutation());
+      auto permutation =
+          llvm::to_vector(transposeOp.getPermutation().getValues<int64_t>());
       Tensor runtimeResult =
           evalTransposeOp(runtimeOperand, permutation, transposeOp.getType());
       populateResults({runtimeResult});

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -32,8 +32,8 @@ namespace {
 
 // Appies the permutation `perm` to an array `array` where perm[i] indicates the
 // location where the current array[i] goes.
-std::vector<int64_t> permute(ArrayRef<int64_t> array, ArrayRef<int64_t> perm) {
-  std::vector<int64_t> result(array.size());
+SmallVector<int64_t> permute(ArrayRef<int64_t> array, ArrayRef<int64_t> perm) {
+  SmallVector<int64_t> result(array.size());
   for (size_t i = 0; i < array.size(); i++) result[i] = array[perm[i]];
   return result;
 }
@@ -201,13 +201,12 @@ Tensor evalTanhOp(const Tensor &operand, Type resultType) {
   return result;
 }
 
-Tensor evalTransposeOp(Type resultType, const Tensor &operand,
-                       DenseIntElementsAttr permutation) {
+Tensor evalTransposeOp(const Tensor &operand, ArrayRef<int64_t> permutation,
+                       Type resultType) {
   Tensor result(resultType);
   for (auto operandIt = operand.index_begin(); operandIt != operand.index_end();
        ++operandIt) {
-    auto resultIndex =
-        permute(*operandIt, llvm::to_vector(permutation.getValues<int64_t>()));
+    auto resultIndex = permute(*operandIt, permutation);
     result.set(resultIndex, operand.get(*operandIt));
   }
   return result;

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -29,7 +29,7 @@ Tensor evalCeilOp(const Tensor &operand, Type resultType);
 Tensor evalConstantOp(ElementsAttr value);
 Tensor evalCosineOp(const Tensor &operand, Type resultType);
 Tensor evalFloorOp(const Tensor &operand, Type resultType);
-Tensor evalIotaOp(int64_t iotaDimension, Type resultType);
+Tensor evalIotaOp(const int64_t iotaDimension, Type resultType);
 Tensor evalMaxOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
 Tensor evalMinOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
 Tensor evalMultiplyOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
@@ -40,8 +40,8 @@ Tensor evalReshapeOp(const Tensor &operand, Type resultType);
 Tensor evalSineOp(const Tensor &operand, Type resultType);
 Tensor evalSubtractOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
 Tensor evalTanhOp(const Tensor &operand, Type resultType);
-Tensor evalTransposeOp(Type resultType, const Tensor &operand,
-                       DenseIntElementsAttr permutation);
+Tensor evalTransposeOp(const Tensor &operand, ArrayRef<int64_t> permutation,
+                       Type resultType);
 Tensor evalXorOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
 
 }  // namespace stablehlo

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -29,7 +29,7 @@ Tensor evalCeilOp(const Tensor &operand, Type resultType);
 Tensor evalConstantOp(ElementsAttr value);
 Tensor evalCosineOp(const Tensor &operand, Type resultType);
 Tensor evalFloorOp(const Tensor &operand, Type resultType);
-Tensor evalIotaOp(const int64_t iotaDimension, Type resultType);
+Tensor evalIotaOp(int64_t iotaDimension, Type resultType);
 Tensor evalMaxOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
 Tensor evalMinOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
 Tensor evalMultiplyOp(const Tensor &lhs, const Tensor &rhs, Type resultType);


### PR DESCRIPTION
This PR migrates away from using `DenseIntElementsAttr` in favor of `SmallVector<int64_t>`. The rationale is that it is harder to construct MLIR wrapper classes, and we want to avoid having a mix of custom classes (Tensor) and MLIR classes (DenseIntElementsAttr, with ConstantOp being an exception for now) so that we can use the `evalFoo` functions when a more complex op can benefit from reusing them.

closes #1031