### PR TITLE
Update llvm lint tool with flag to disable SHA256 check

### DIFF
--- a/build_tools/github_actions/lint_llvm_commit.sh
+++ b/build_tools/github_actions/lint_llvm_commit.sh
@@ -14,12 +14,15 @@
 print_usage() {
   echo "Usage: $0 [-f] <path/to/stablehlo/root>"
   echo "    -f           Auto-fix LLVM commit mismatch."
+  echo "    -s           Skip sha256 hash validation."
 }
 
 FORMAT_MODE='validate'
-while getopts 'f' flag; do
+VALIDATE_SHA256='true'
+while getopts 'fs' flag; do
   case "${flag}" in
     f) FORMAT_MODE="fix" ;;
+    s) VALIDATE_SHA256="false" ;;
     *) print_usage
        exit 1 ;;
   esac
@@ -35,59 +38,77 @@ PATH_TO_STABLEHLO_ROOT="$1"
 PATH_TO_LLVM_VERSION_TXT="$PATH_TO_STABLEHLO_ROOT/build_tools/llvm_version.txt"
 PATH_TO_WORKSPACE="$PATH_TO_STABLEHLO_ROOT/WORKSPACE.bazel"
 
-retrieve_llvm_commit() {
-  echo "Retrieving LLVM Commit..."
-  export LLVM_COMMIT="$(<$PATH_TO_LLVM_VERSION_TXT)"
-  echo "LLVM_COMMIT: $LLVM_COMMIT"
+## Helper functions
+
+# Commit validation functions
+llvm_commit_from_version_txt() {
+  cat $PATH_TO_LLVM_VERSION_TXT
+}
+llvm_commit_from_workspace() {
+  sed -n '/LLVM_COMMIT = /p' $PATH_TO_WORKSPACE | sed 's/LLVM_COMMIT = //; s/\"//g'
+}
+llvm_commit_diff() {
+  diff <(llvm_commit_from_version_txt) <(llvm_commit_from_workspace)
 }
 
-calculate_llvm_commit_sha256() {
-  echo "Calculating SHA256..."
+# SHA256 validation functions
+llvm_sha256_from_workspace() {
+  sed -n '/LLVM_SHA256 = /p' $PATH_TO_WORKSPACE  | sed 's/LLVM_SHA256 = //; s/\"//g'
+}
+llvm_sha256_from_archive() {
+  LLVM_COMMIT=$(llvm_commit_from_workspace)
   HTTP_CODE=$(curl -sIL https://github.com/llvm/llvm-project/archive/$LLVM_COMMIT.tar.gz -o /dev/null -w "%{http_code}")
-  echo "HTTP Code: $HTTP_CODE"
   if [[ "$HTTP_CODE" == "404" ]]; then
-    echo "LLVM_COMMIT: $LLVM_COMMIT in $PATH_TO_LLVM_VERSION_TXT not found."
+    echo "Error 404 downloading LLVM at commit '$LLVM_COMMIT'."
     exit 1
   fi
-  export LLVM_SHA256="$(curl -sL https://github.com/llvm/llvm-project/archive/$LLVM_COMMIT.tar.gz | shasum -a 256 | sed 's/ //g; s/-//g')"
-  echo "LLVM_SHA256: $LLVM_SHA256"
+  LLVM_SHA256="$(curl -sL https://github.com/llvm/llvm-project/archive/$LLVM_COMMIT.tar.gz | shasum -a 256 | sed 's/ //g; s/-//g')"
+  echo "$LLVM_SHA256"
+}
+llvm_sha256_diff() {
+  diff <(llvm_sha256_from_workspace) <(llvm_sha256_from_archive)
 }
 
-calculate_diff() {
-  export LLVM_DIFF=$(sed -n '/LLVM_COMMIT = /p' $PATH_TO_WORKSPACE | sed 's/LLVM_COMMIT = //; s/\"//g' | diff $PATH_TO_LLVM_VERSION_TXT -)
-  export LLVM_SHA256_DIFF=$(sed -n '/LLVM_SHA256 = /p' $PATH_TO_WORKSPACE  | sed 's/LLVM_SHA256 = //; s/\"//g' | diff <(echo $LLVM_SHA256) -)
+# Fix functions
+print_autofix() {
+  echo "Auto-fix using:"
+  echo "  $ lint_llvm_commit.sh -f <path/to/stablehlo/root>"
 }
 
 update_llvm_commit_and_sha256() {
+  LLVM_COMMIT=$(llvm_commit_from_version_txt)
+  LLVM_SHA256=$(llvm_sha256_from_archive)
   sed -i '/^LLVM_COMMIT/s/"[^"]*"/"'$LLVM_COMMIT'"/g' $PATH_TO_WORKSPACE
   sed -i '/^LLVM_SHA256/s/"[^"]*"/"'$LLVM_SHA256'"/g' $PATH_TO_WORKSPACE
 }
 
-retrieve_llvm_commit
-calculate_llvm_commit_sha256
-calculate_diff
-
+## Script body
 if [[ $FORMAT_MODE == 'fix' ]]; then
-  echo "Updating LLVM Commit & SHA256..."
+  echo "Updating LLVM Commit & SHA256"
   update_llvm_commit_and_sha256
-  echo "Done."
-else
-  if [ ! -z "$LLVM_DIFF" ]; then
-    echo "LLVM commit out of sync:"
-    echo $LLVM_DIFF
+  exit 0
+fi
+
+echo "Validating LLVM commit hash..."
+LLVM_COMMIT_DIFF=$(llvm_commit_diff)
+if [[ ! -z "$LLVM_COMMIT_DIFF" ]]; then
+  echo "Commit mismatch:"
+  echo "$LLVM_COMMIT_DIFF"
+  echo
+  print_autofix
+  exit 1
+fi
+echo "Commit hashes match."
+
+if [[ "$VALIDATE_SHA256" == 'true' ]]; then
+  echo "Validating LLVM SHA256 hash..."
+  LLVM_SHA256_DIFF=$(llvm_sha256_diff)
+  if [[ ! -z "$LLVM_SHA256_DIFF" ]]; then
+    echo "...SHA256 mismatch:"
+    echo "$LLVM_SHA256_DIFF"
     echo
-    echo "Auto-fix using:"
-    echo "  $ lint_llvm_commit.sh -f <path/to/stablehlo/root>"
+    print_autofix
     exit 1
   fi
-  echo "No llvm commit mismatches found."
-  if [ ! -z "$LLVM_SHA256_DIFF" ]; then
-    echo "LLVM SHA256 out of sync:"
-    echo $LLVM_SHA256_DIFF
-    echo $(sed -n '/LLVM_SHA256 = /p' $PATH_TO_WORKSPACE | sed 's/LLVM_SHA256 = //; s/\"//g')
-    echo "Auto-fix using:"
-    echo "  $ lint_llvm_commit.sh -f <path/to/stablehlo/root>"
-    exit 1
-  fi
-  echo "No sha256 mismatches found."
+  echo "SHA256 hashes match."
 fi


### PR DESCRIPTION
The SHA256 check takes awhile, and really only impacts llvm revision bump changelists. Given that I run all lint scripts on pre-commit, I'd prefer a way to only verify commit, if commit changes, then I can worry about sha256 validation. In CI we will always check both.

Also I refactored the script a bit, there was so much global state that it was difficult to make modifications, modified to have minimal global state and functions that echo their results. We lose some logging with this, but the error messages we see are still pretty good.

Mismatch error messages:

```bash
# ... commit mismatch

$ ./build_tools/github_actions/lint_llvm_commit.sh -s .
Validating LLVM commit hash...
Commit mismatch:
1c1
< f58de2125caf75ec0d40bc3e094a93c0b314a66a
---
> 858de2125caf75ec0d40bc3e094a93c0b314a66a

Auto-fix using:
  $ lint_llvm_commit.sh -f <path/to/stablehlo/root>

# ... SHA256 mismatch

$ ./build_tools/github_actions/lint_llvm_commit.sh .
Validating LLVM commit hash...
Commit hashes match.
Validating LLVM SHA256 hash...
...SHA256 mismatch:
1c1
< 896047c57addc2a349defab0c7fb84979aeac039ed9ada2901cd2e0ca88fffb6
---
> a96047c57addc2a349defab0c7fb84979aeac039ed9ada2901cd2e0ca88fffb6

Auto-fix using:
  $ lint_llvm_commit.sh -f <path/to/stablehlo/root>

# ...  404

$ ./build_tools/github_actions/lint_llvm_commit.sh .
Validating LLVM commit hash...
Commit hashes match.
Validating LLVM SHA256 hash...
...SHA256 mismatch:
1c1
< a96047c57addc2a349defab0c7fb84979aeac039ed9ada2901cd2e0ca88fffb6
---
> Error 404 downloading LLVM at commit '858de2125caf75ec0d40bc3e094a93c0b314a66a'.

Auto-fix using:
  $ lint_llvm_commit.sh -f <path/to/stablehlo/root>
```