### PR TITLE
Add interpreter for BroadcastInDimOp

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1305,6 +1305,8 @@ dimensions `k` in `operand`.
 //          ]
 ```
 
+&nbsp;[More Examples](../stablehlo/tests/interpret_broadcast_in_dim.mlir)
+
 ### case
 
 #### Semantics

--- a/docs/status.md
+++ b/docs/status.md
@@ -55,7 +55,7 @@ one of the following tracking labels.
 | batch_norm_training      | yes           | revisit      | yes            | no              | no          |
 | bitcast_convert          | yes           | yes          | infeasible     | yes             | no          |
 | broadcast                | no            | yes\*        | yes\*          | yes             | no          |
-| broadcast_in_dim         | yes           | yes          | infeasible     | yes             | no          |
+| broadcast_in_dim         | yes           | yes          | infeasible     | yes             | yes         |
 | case                     | yes           | revisit      | yes            | no              | no          |
 | cbrt                     | yes           | yes          | yes            | yes             | no          |
 | ceil                     | yes           | yes          | yes            | yes             | yes         |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1844,8 +1844,8 @@ def StableHLO_BroadcastOp : StableHLO_ShapedInterfaceOp<"broadcast",
 }
 
 def StableHLO_BroadcastInDimOp : StableHLO_Op<"broadcast_in_dim",
-      [Pure, SameOperandsAndResultElementType]> {
-  let summary = "Broadcast a tensor into the given shape by adding dimensions.";
+      [Pure, SameOperandsAndResultElementType /*broadcast_in_dim_c1*/]> {
+  let summary = "BroadcastInDim operation";
   let description = [{
     Expands the dimensions and/or rank of an input tensor by duplicating the
     data in the `operand` tensor and produces a `result` tensor.

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1860,8 +1860,8 @@ def StableHLO_BroadcastInDimOp : StableHLO_Op<"broadcast_in_dim",
     ```
   }];
   let arguments = (ins
-    HLO_Tensor:$operand,
-    BroadcastDimAttr:$broadcast_dimensions
+    HLO_Tensor:$operand /*broadcast_in_dim_i1*/,
+    BroadcastDimAttr:$broadcast_dimensions /*broadcast_in_dim_i2*/
   );
 
   let results = (outs HLO_StaticShapeTensor);

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -3082,6 +3082,7 @@ LogicalResult verifyBroadcastInDimOp(std::optional<Location> location,
 
   auto operandRank = operandType.getRank();
   if (!broadcastDimensions) {
+    // broadcast_in_dim_c2
     if (operandRank == 0) return success();
     return emitOptionalError(location,
                              "broadcast_dimensions is absent, but required "
@@ -3091,10 +3092,11 @@ LogicalResult verifyBroadcastInDimOp(std::optional<Location> location,
 
   auto dimensionsType = broadcastDimensions.getType();
   auto dimensionsRank = dimensionsType.getRank();
+  // broadcast_in_dim_i2
   if (dimensionsRank != 1)
     return emitOptionalError(location, "broadcast_dimensions has rank ",
                              dimensionsRank, " instead of rank 1");
-
+  // broadcast_in_dim_c2
   auto dimensionsSize = dimensionsType.getNumElements();
   if (dimensionsSize != operandRank)
     return emitOptionalError(location, "broadcast_dimensions size (",
@@ -3102,6 +3104,7 @@ LogicalResult verifyBroadcastInDimOp(std::optional<Location> location,
                              operandRank, ")");
 
   auto dimensions = llvm::to_vector(broadcastDimensions.getValues<int64_t>());
+  // broadcast_in_dim_c4
   if (hasDuplicates(dimensions))
     return emitOptionalError(location,
                              "broadcast_dimensions should not have duplicates");
@@ -3110,7 +3113,8 @@ LogicalResult verifyBroadcastInDimOp(std::optional<Location> location,
   auto resultRank = resultType.getRank();
   for (int i = 0; i != dimensionsSize; ++i) {
     auto dimIndex = dimensions[i];
-    if (dimIndex >= resultRank)
+    // broadcast_in_dim_c3
+    if (dimIndex < 0 || dimIndex >= resultRank)
       return emitOptionalError(location,
                                "broadcast_dimensions contains invalid value ",
                                dimIndex, " for result with rank ", resultRank);
@@ -3118,6 +3122,7 @@ LogicalResult verifyBroadcastInDimOp(std::optional<Location> location,
     if (!operandType.isDynamicDim(i)) {
       auto dimSize = operandType.getDimSize(i);
       auto resultDimSize = resultType.getDimSize(dimIndex);
+      // broadcast_in_dim_c5
       if (dimSize != 1 && dimSize != resultDimSize)
         return emitOptionalError(
             location, "size of operand dimension ", i, " (", dimSize,

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -3080,16 +3080,6 @@ LogicalResult verifyBroadcastInDimOp(std::optional<Location> location,
     return success();
   }
 
-  auto operandRank = operandType.getRank();
-  if (!broadcastDimensions) {
-    // broadcast_in_dim_c2
-    if (operandRank == 0) return success();
-    return emitOptionalError(location,
-                             "broadcast_dimensions is absent, but required "
-                             "because operand has non-zero rank (",
-                             operandRank, ")");
-  }
-
   auto dimensionsType = broadcastDimensions.getType();
   auto dimensionsRank = dimensionsType.getRank();
   // broadcast_in_dim_i2
@@ -3098,6 +3088,7 @@ LogicalResult verifyBroadcastInDimOp(std::optional<Location> location,
                              dimensionsRank, " instead of rank 1");
   // broadcast_in_dim_c2
   auto dimensionsSize = dimensionsType.getNumElements();
+  auto operandRank = operandType.getRank();
   if (dimensionsSize != operandRank)
     return emitOptionalError(location, "broadcast_dimensions size (",
                              dimensionsSize, ") does not match operand rank (",

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -27,6 +27,9 @@ namespace stablehlo {
 // Evaluators for StableHLO ops.
 Tensor evalAddOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
 Tensor evalAndOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
+Tensor evalBroadcastInDimOp(const Tensor &operand,
+                            ArrayRef<int64_t> broadcastDimensions,
+                            Type resultType);
 Tensor evalCeilOp(const Tensor &operand, Type resultType);
 Tensor evalConstantOp(ElementsAttr value);
 Tensor evalConvertOp(const Tensor &operand, Type resultType);

--- a/stablehlo/tests/interpret_broadcast_in_dim.mlir
+++ b/stablehlo/tests/interpret_broadcast_in_dim.mlir
@@ -1,0 +1,23 @@
+// RUN: stablehlo-interpreter --interpret -split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: Evaluated results of function: broadcast_in_dim
+func.func @broadcast_in_dim() -> tensor<3x2x2xi64> {
+  %operand = stablehlo.constant dense<[[1], [2], [3]]> : tensor<3x1xi64>
+  %result = "stablehlo.broadcast_in_dim"(%operand) {
+    broadcast_dimensions = dense<[0, 2]>: tensor<2xi64>
+  } : (tensor<3x1xi64>) -> tensor<3x2x2xi64>
+  func.return %result : tensor<3x2x2xi64>
+  // CHECK-NEXT: tensor<3x2x2xi64>
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 2 : i64
+  // CHECK-NEXT: 2 : i64
+  // CHECK-NEXT: 2 : i64
+  // CHECK-NEXT: 2 : i64
+  // CHECK-NEXT: 3 : i64
+  // CHECK-NEXT: 3 : i64
+  // CHECK-NEXT: 3 : i64
+  // CHECK-NEXT: 3 : i64
+}

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -825,22 +825,6 @@ func.func @broadcast_bad_second_part_result_shape(%arg0: tensor<3xi32>) -> tenso
 
 // -----
 
-// CHECK-LABEL: func @broadcast_in_dim
-func.func @broadcast_in_dim(%arg0: tensor<1x2xi32>) -> tensor<1x2x2xi32> {
-  %0 = "stablehlo.broadcast_in_dim"(%arg0) {broadcast_dimensions = dense<[1, 2]> : tensor<2xi64>} : (tensor<1x2xi32>) -> tensor<1x2x2xi32>
-  func.return %0 : tensor<1x2x2xi32>
-}
-
-// -----
-
-// CHECK-LABEL: func @broadcast_in_dim_zero_rank
-func.func @broadcast_in_dim_zero_rank(%arg0: tensor<i32>) -> tensor<1x2x3xi32> {
-  %0 = "stablehlo.broadcast_in_dim"(%arg0) {broadcast_dimensions = dense<[]> : tensor<0xi64>} : (tensor<i32>) -> tensor<1x2x3xi32>
-  func.return %0 : tensor<1x2x3xi32>
-}
-
-// -----
-
 // CHECK-LABEL: func @dynamic_broadcast_in_dim
 func.func @dynamic_broadcast_in_dim(%arg0: tensor<?x?xi32>, %shape: tensor<3xi64>) -> tensor<?x?x?xi32> {
   %0 = "stablehlo.dynamic_broadcast_in_dim"(%arg0, %shape) {broadcast_dimensions = dense<[1, 2]> : tensor<2xi64>} : (tensor<?x?xi32>, tensor<3xi64>) -> tensor<?x?x?xi32>
@@ -873,15 +857,15 @@ func.func @dynamic_broadcast_in_dim_shape_mismatch(%arg0: tensor<32xf32>, %shape
 
 // -----
 
-func.func @broadcast_in_dim_bad_dimension_rank(%arg0: tensor<1x2xi32>) -> tensor<1x2x3xi32> {
-  // expected-error@+1 {{broadcast_dimensions has rank 2 instead of rank 1}}
-  %0 = "stablehlo.broadcast_in_dim"(%arg0) {broadcast_dimensions = dense<[[1,1],[1,1]]> : tensor<2x2xi64>} : (tensor<1x2xi32>) -> tensor<1x2x3xi32>
-  func.return %0 : tensor<1x2x3xi32>
+// CHECK-LABEL: func @broadcast_in_dim
+func.func @broadcast_in_dim(%arg0: tensor<1x2xi32>) -> tensor<1x2x2xi32> {
+  %0 = "stablehlo.broadcast_in_dim"(%arg0) {broadcast_dimensions = dense<[1, 2]> : tensor<2xi64>} : (tensor<1x2xi32>) -> tensor<1x2x2xi32>
+  func.return %0 : tensor<1x2x2xi32>
 }
 
 // -----
 
-func.func @broadcast_in_dim_bad_dimension_size(%arg0: tensor<1x2xi32>) -> tensor<1x2x3xi32> {
+func.func @broadcast_in_dim_c2(%arg0: tensor<1x2xi32>) -> tensor<1x2x3xi32> {
   // expected-error@+1 {{broadcast_dimensions size (1) does not match operand rank (2)}}
   %0 = "stablehlo.broadcast_in_dim"(%arg0) {broadcast_dimensions = dense<[1]> : tensor<1xi64>} : (tensor<1x2xi32>) -> tensor<1x2x3xi32>
   func.return %0 : tensor<1x2x3xi32>
@@ -889,7 +873,15 @@ func.func @broadcast_in_dim_bad_dimension_size(%arg0: tensor<1x2xi32>) -> tensor
 
 // -----
 
-func.func @broadcast_in_dim_bad_rank_decrease(%arg0: tensor<1x2x3xi32>) -> tensor<3xi32> {
+func.func @broadcast_in_dim_c3(%arg0: tensor<1x2xi32>) -> tensor<1x2x2xi32> {
+  // expected-error@+1 {{broadcast_dimensions contains invalid value -1 for result with rank 3}}
+  %0 = "stablehlo.broadcast_in_dim"(%arg0) {broadcast_dimensions = dense<[-1, 2]> : tensor<2xi64>} : (tensor<1x2xi32>) -> tensor<1x2x2xi32>
+  func.return %0 : tensor<1x2x2xi32>
+}
+
+// -----
+
+func.func @broadcast_in_dim_c3(%arg0: tensor<1x2x3xi32>) -> tensor<3xi32> {
   // expected-error@+1 {{broadcast_dimensions contains invalid value 1 for result with rank 1}}
   %0 = "stablehlo.broadcast_in_dim"(%arg0) {broadcast_dimensions = dense<[0,1,2]> : tensor<3xi64>} : (tensor<1x2x3xi32>) -> tensor<3xi32>
   func.return %0 : tensor<3xi32>
@@ -897,15 +889,7 @@ func.func @broadcast_in_dim_bad_rank_decrease(%arg0: tensor<1x2x3xi32>) -> tenso
 
 // -----
 
-func.func @broadcast_in_dim_duplicate_bcast_dimensions(%arg0: tensor<1x1x3xi32>) -> tensor<1x2x3xi32> {
-  // expected-error@+1 {{broadcast_dimensions should not have duplicates}}
-  %0 = "stablehlo.broadcast_in_dim"(%arg0) {broadcast_dimensions = dense<[0,0,2]> : tensor<3xi64>} : (tensor<1x1x3xi32>) -> tensor<1x2x3xi32>
-  func.return %0 : tensor<1x2x3xi32>
-}
-
-// -----
-
-func.func @broadcast_in_dim_dimension_values_too_large(%arg0: tensor<1x2xi32>) -> tensor<1x2x3xi32> {
+func.func @broadcast_in_dim_c3(%arg0: tensor<1x2xi32>) -> tensor<1x2x3xi32> {
   // expected-error@+1 {{broadcast_dimensions contains invalid value 9 for result with rank 3}}
   %0 = "stablehlo.broadcast_in_dim"(%arg0) {broadcast_dimensions = dense<[9, 2]> : tensor<2xi64>} : (tensor<1x2xi32>) -> tensor<1x2x3xi32>
   func.return %0 : tensor<1x2x3xi32>
@@ -913,9 +897,25 @@ func.func @broadcast_in_dim_dimension_values_too_large(%arg0: tensor<1x2xi32>) -
 
 // -----
 
-func.func @broadcast_in_dim_bad_shape_mismatch(%arg0: tensor<3xi32>) -> tensor<1x2x3xi32> {
+func.func @broadcast_in_dim_c4(%arg0: tensor<1x1x3xi32>) -> tensor<1x2x3xi32> {
+  // expected-error@+1 {{broadcast_dimensions should not have duplicates}}
+  %0 = "stablehlo.broadcast_in_dim"(%arg0) {broadcast_dimensions = dense<[0,0,2]> : tensor<3xi64>} : (tensor<1x1x3xi32>) -> tensor<1x2x3xi32>
+  func.return %0 : tensor<1x2x3xi32>
+}
+
+// -----
+
+func.func @broadcast_in_dim_c5(%arg0: tensor<3xi32>) -> tensor<1x2x3xi32> {
   // expected-error@+1 {{size of operand dimension 0 (3) is not equal to 1 or size of result dimension 1 (2)}}
   %0 = "stablehlo.broadcast_in_dim"(%arg0) {broadcast_dimensions = dense<[1]> : tensor<1xi64>} : (tensor<3xi32>) -> tensor<1x2x3xi32>
+  func.return %0 : tensor<1x2x3xi32>
+}
+
+// -----
+
+func.func @broadcast_in_dim_i2(%arg0: tensor<1x2xi32>) -> tensor<1x2x3xi32> {
+  // expected-error@+1 {{broadcast_dimensions has rank 2 instead of rank 1}}
+  %0 = "stablehlo.broadcast_in_dim"(%arg0) {broadcast_dimensions = dense<[[1,1],[1,1]]> : tensor<2x2xi64>} : (tensor<1x2xi32>) -> tensor<1x2x3xi32>
   func.return %0 : tensor<1x2x3xi32>
 }
 
@@ -941,6 +941,14 @@ func.func @broadcast_in_dim_unranked_operand(%arg0 : tensor<*xf32>) -> tensor<2x
     broadcast_dimensions = dense<0> : tensor<1xi64>
   } : (tensor<*xf32>) -> tensor<2xf32>
   func.return %0 : tensor<2xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func @broadcast_in_dim_zero_rank
+func.func @broadcast_in_dim_zero_rank(%arg0: tensor<i32>) -> tensor<1x2x3xi32> {
+  %0 = "stablehlo.broadcast_in_dim"(%arg0) {broadcast_dimensions = dense<[]> : tensor<0xi64>} : (tensor<i32>) -> tensor<1x2x3xi32>
+  func.return %0 : tensor<1x2x3xi32>
 }
 
 // -----

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -889,14 +889,6 @@ func.func @broadcast_in_dim_c3(%arg0: tensor<1x2x3xi32>) -> tensor<3xi32> {
 
 // -----
 
-func.func @broadcast_in_dim_c3(%arg0: tensor<1x2xi32>) -> tensor<1x2x3xi32> {
-  // expected-error@+1 {{broadcast_dimensions contains invalid value 9 for result with rank 3}}
-  %0 = "stablehlo.broadcast_in_dim"(%arg0) {broadcast_dimensions = dense<[9, 2]> : tensor<2xi64>} : (tensor<1x2xi32>) -> tensor<1x2x3xi32>
-  func.return %0 : tensor<1x2x3xi32>
-}
-
-// -----
-
 func.func @broadcast_in_dim_c4(%arg0: tensor<1x1x3xi32>) -> tensor<1x2x3xi32> {
   // expected-error@+1 {{broadcast_dimensions should not have duplicates}}
   %0 = "stablehlo.broadcast_in_dim"(%arg0) {broadcast_dimensions = dense<[0,0,2]> : tensor<3xi64>} : (tensor<1x1x3xi32>) -> tensor<1x2x3xi32>
@@ -941,14 +933,6 @@ func.func @broadcast_in_dim_unranked_operand(%arg0 : tensor<*xf32>) -> tensor<2x
     broadcast_dimensions = dense<0> : tensor<1xi64>
   } : (tensor<*xf32>) -> tensor<2xf32>
   func.return %0 : tensor<2xf32>
-}
-
-// -----
-
-// CHECK-LABEL: func @broadcast_in_dim_zero_rank
-func.func @broadcast_in_dim_zero_rank(%arg0: tensor<i32>) -> tensor<1x2x3xi32> {
-  %0 = "stablehlo.broadcast_in_dim"(%arg0) {broadcast_dimensions = dense<[]> : tensor<0xi64>} : (tensor<i32>) -> tensor<1x2x3xi32>
-  func.return %0 : tensor<1x2x3xi32>
 }
 
 // -----


### PR DESCRIPTION
We have the following constraints in the spec:

```
(I1) operand tensor.
(I2) broadcast_dimensions 1-dimensional tensor constant of type `si64`.
(C1) `operand` and `result` have the same element type.
(C2) size(`broadcast_dimensions`) $=$ rank(`operand`).
(C3) $0 \le$ `broadcast_dimensions[i]` $\lt$ rank(`result`) for all
     dimensions i in `operand`.
(C4) All dimensions in `broadcast_dimensions` are unique.
(C5) For all dimensions `j` in `operand`:
     * `dim(operand, j) = 1` or
     * `dim(operand, j) = dim(result, i)` where `i = broadcast_dimensions[j]`.
```

These constraints will be comprehensively covered by the following tests:

```
I1: a) operand is not a tensor. (Covered by ODS).
I2: a) broadcast_dimensions is not a 1-dimensional tensor.
    b) broadcast_dimensions does not have `si64` type. (Covered by ODS).
C1: a) element_type(operand) != element_type(result). (Covered by ODS).
C2: a) size(broadcast_dimensions) != rank(operand).
C3: a) broadcast_dimensions[i] < 0 for any i.
    b) broadcast_dimensions[i] >= rank(result) for any i.
C4: a) `broadcast_dimensions` values are not unique.
C5: a) dim(operand, j) != 1 and dim(operand, j) != dim(result, i) where `i = broadcast_dimensions[j]` for all dimensions `j` in `operand`.
```

If we drop the "Covered by ODS" pieces, this will leave us with the following test cases:

```
I2a: broadcast_dimensions is not a 1-dimensional tensor.
C2a: size(broadcast_dimensions) != rank(operand).
C3a: broadcast_dimensions[i] < 0 for any i.
C3b: broadcast_dimensions[i] >= rank(result) for any i.
C4a: `broadcast_dimensions` values are not unique.
C5a: dim(operand, j) != 1 and dim(operand, j) != dim(result, i) where `i = broadcast_dimensions[j]` for all dimensions `j` in `operand`.
```


closes #964