### PR TITLE
Change return type for shape function of bounds

### DIFF
--- a/stablehlo/dialect/Base.cpp
+++ b/stablehlo/dialect/Base.cpp
@@ -368,7 +368,9 @@ LogicalResult inferMostSpecificTypeComponents(
 
   auto rankedResultType = (*inferredTypeOrErr).dyn_cast<RankedTensorType>();
   if (!rankedResultType) {
-    inferredReturnShapes.emplace_back((*inferredTypeOrErr).cast<ShapedType>());
+    auto inferredShapeType = (*inferredTypeOrErr).dyn_cast<ShapedType>();
+    if(!inferedShapeType) return failure();
+    inferredReturnShapes.emplace_back(inferredShapeType);
   } else {
     inferredReturnShapes.emplace_back(rankedResultType.getShape(),
                                       rankedResultType.getElementType(),

--- a/stablehlo/dialect/Base.cpp
+++ b/stablehlo/dialect/Base.cpp
@@ -337,25 +337,25 @@ FailureOr<TensorType> inferTypeWithCustomFn(
           anyInputHaveBounds ? inferredBounds : ArrayRef<int64_t>({})));
 }
 
-FailureOr<ShapedType> inferLeastSpecificType(Optional<Location> location,
-                                             TypeRange inputTypes) {
+FailureOr<Type> inferLeastSpecificType(Optional<Location> location,
+                                       TypeRange inputTypes) {
   SmallVector<RankedTensorType> rankedTypes;
   for (auto inputType : inputTypes)
     if (auto rankedType = inputType.dyn_cast<RankedTensorType>())
       rankedTypes.push_back(rankedType);
     else
-      return inputType.cast<ShapedType>();
+      return inputType;
   return inferTypeWithCustomFn(location, rankedTypes,
                                inferLeastSpecificDimAndBound);
 }
 
-FailureOr<ShapedType> inferMostSpecificType(Optional<Location> location,
-                                            TypeRange inputTypes) {
+FailureOr<Type> inferMostSpecificType(Optional<Location> location,
+                                      TypeRange inputTypes) {
   SmallVector<RankedTensorType> rankedTypes;
   for (auto inputType : inputTypes)
     if (auto rankedType = inputType.dyn_cast<RankedTensorType>())
       rankedTypes.push_back(rankedType);
-  if (rankedTypes.empty()) return inputTypes[0].cast<ShapedType>();
+  if (rankedTypes.empty()) return inputTypes[0];
   return inferTypeWithCustomFn(location, rankedTypes,
                                inferMostSpecificDimAndBound);
 }
@@ -368,7 +368,7 @@ LogicalResult inferMostSpecificTypeComponents(
 
   auto rankedResultType = (*inferredTypeOrErr).dyn_cast<RankedTensorType>();
   if (!rankedResultType) {
-    inferredReturnShapes.emplace_back(*inferredTypeOrErr);
+    inferredReturnShapes.emplace_back((*inferredTypeOrErr).cast<ShapedType>());
   } else {
     inferredReturnShapes.emplace_back(rankedResultType.getShape(),
                                       rankedResultType.getElementType(),

--- a/stablehlo/dialect/Base.cpp
+++ b/stablehlo/dialect/Base.cpp
@@ -369,7 +369,7 @@ LogicalResult inferMostSpecificTypeComponents(
   auto rankedResultType = (*inferredTypeOrErr).dyn_cast<RankedTensorType>();
   if (!rankedResultType) {
     auto inferredShapeType = (*inferredTypeOrErr).dyn_cast<ShapedType>();
-    if(!inferedShapeType) return failure();
+    if (!inferredShapeType) return failure();
     inferredReturnShapes.emplace_back(inferredShapeType);
   } else {
     inferredReturnShapes.emplace_back(rankedResultType.getShape(),

--- a/stablehlo/dialect/Base.h
+++ b/stablehlo/dialect/Base.h
@@ -86,15 +86,15 @@ FailureOr<std::pair<int64_t, int64_t>> inferLeastSpecificDimAndBound(
 // bounds. (Size, bound) of each dimension of the return type will be merged
 // from corresponding dimensions of every inputType by extracting the least
 // specific one. Return unranked tensor if any input is unranked.
-FailureOr<ShapedType> inferLeastSpecificType(Optional<Location> location,
-                                             TypeRange inputTypes);
+FailureOr<Type> inferLeastSpecificType(Optional<Location> location,
+                                       TypeRange inputTypes);
 
 // Infer single most specific return type from inputTypes with support for
 // bounds. (Size, bound) of each dimension of the return type will be merged
 // from corresponding dimensions of every inputType by extracting the most
 // specific one. Return unranked tensor if all inputs are unranked.
-FailureOr<ShapedType> inferMostSpecificType(Optional<Location> location,
-                                            TypeRange inputTypes);
+FailureOr<Type> inferMostSpecificType(Optional<Location> location,
+                                      TypeRange inputTypes);
 
 LogicalResult inferMostSpecificTypeComponents(
     std::optional<Location> location, TypeRange inputTypes,


### PR DESCRIPTION
This is a quick fix revert back the return type of inferMost/LeastType methods from ShapeType to Type, to accommodate the tuple type in MHLO tests. 