### PR TITLE
Add .bazelignore

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,1 @@
+llvm-project


### PR DESCRIPTION
This enables Bazel to skip the Bazel build of the llvm-project/ folder that shows up when building the repo using the standard CMake workflow documented in README.md.

Without this, Bazel gets pretty confused and produces rather cryptic error messages.