### PR TITLE
Revert #958: Verify compare_type for compare_op

### DIFF
--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -2313,14 +2313,8 @@ LogicalResult CompareOp::inferReturnTypeComponents(
     ValueShapeRange operands, DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   CompareOp::Adaptor adaptor(operands, attributes, regions);
-  auto compareType = adaptor.getCompareType();
-  return hlo::inferCompareOp(context, location, compareType.has_value(),
-                             compareType == ComparisonType::NOTYPE,
-                             compareType == ComparisonType::FLOAT,
-                             compareType == ComparisonType::TOTALORDER,
-                             compareType == ComparisonType::UNSIGNED,
-                             compareType == ComparisonType::SIGNED,
-                             adaptor.getLhs(), inferredReturnShapes);
+  return hlo::inferCompareOp(context, location, adaptor.getLhs(),
+                             inferredReturnShapes);
 }
 
 LogicalResult CompareOp::reifyReturnTypeShapes(

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -1581,26 +1581,8 @@ LogicalResult inferClampOp(
 }
 
 LogicalResult inferCompareOp(
-    MLIRContext* context, std::optional<Location> location,
-    bool compareTypeHasValue, bool isCompareTypeNoType, bool isCompareTypeFloat,
-    bool isCompareTypeTotalOrder, bool isCompareTypeUnsigned,
-    bool isCompareTypeSigned, Value lhs,
+    MLIRContext* context, std::optional<Location>, Value lhs,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
-  if (compareTypeHasValue) {
-    if (isCompareTypeNoType)
-      return emitOptionalError(location, "compareType cannot be NOTYPE");
-    auto elementType = lhs.getType().cast<ShapedType>().getElementType();
-    if (elementType.isa<FloatType>() && !isCompareTypeFloat &&
-        !isCompareTypeTotalOrder)
-      return emitOptionalError(location,
-                               "compareType must be FLOAT or TOTALORDER");
-    if (elementType.isa<ComplexType>() && !isCompareTypeFloat)
-      return emitOptionalError(location, "compareType must be FLOAT");
-    if (elementType.isUnsignedInteger() && !isCompareTypeUnsigned)
-      return emitOptionalError(location, "compareType must be UNSIGNED");
-    if (elementType.isSignlessInteger() && !isCompareTypeSigned)
-      return emitOptionalError(location, "compareType must be SIGNED");
-  }
   ShapedTypeComponents& components =
       inferredReturnShapes.emplace_back(IntegerType::get(context, /*width=*/1));
   auto argTy = lhs.getType().cast<TensorType>();

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -147,10 +147,7 @@ LogicalResult inferClampOp(
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferCompareOp(
-    MLIRContext* context, std::optional<Location>, bool compareTypeHasValue,
-    bool isCompareTypeNoType, bool isCompareTypeFloat,
-    bool isCompareTypeTotalOrder, bool isCompareTypeUnsigned,
-    bool isCompareTypeSigned, Value lhs,
+    MLIRContext* context, std::optional<Location>, Value lhs,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferComplexOp(std::optional<Location> location, Value lhs,

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -1193,61 +1193,6 @@ func.func @comp_eq(%arg0: tensor<3xi32>, %arg1: tensor<3xi32>) -> tensor<3xi1> {
 
 // -----
 
-func.func @comp_bad_type(%arg0: tensor<3xi32>, %arg1: tensor<3xi32>) -> tensor<3xi1> {
-  // expected-error@+1 {{compareType cannot be NOTYPE}}
-  %0 = "stablehlo.compare"(%arg0, %arg1) {
-    comparison_direction = #stablehlo<comparison_direction EQ>,
-    compare_type = #stablehlo<comparison_type NOTYPE>
-  } : (tensor<3xi32>, tensor<3xi32>) -> tensor<3xi1>
-  func.return %0 : tensor<3xi1>
-}
-
-// -----
-
-func.func @comp_bad_type(%arg0: tensor<3xf32>, %arg1: tensor<3xf32>) -> tensor<3xi1> {
-  // expected-error@+1 {{compareType must be FLOAT or TOTALORDER}}
-  %0 = "stablehlo.compare"(%arg0, %arg1) {
-    comparison_direction = #stablehlo<comparison_direction EQ>,
-    compare_type = #stablehlo<comparison_type UNSIGNED>
-  } : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xi1>
-  func.return %0 : tensor<3xi1>
-}
-
-// -----
-
-func.func @comp_bad_type(%arg0: tensor<3xcomplex<f32>>, %arg1: tensor<3xcomplex<f32>>) -> tensor<3xi1> {
-  // expected-error@+1 {{compareType must be FLOAT}}
-  %0 = "stablehlo.compare"(%arg0, %arg1) {
-    comparison_direction = #stablehlo<comparison_direction EQ>,
-    compare_type = #stablehlo<comparison_type UNSIGNED>
-  } : (tensor<3xcomplex<f32>>, tensor<3xcomplex<f32>>) -> tensor<3xi1>
-  func.return %0 : tensor<3xi1>
-}
-
-// -----
-
-func.func @comp_bad_type(%arg0: tensor<3xui32>, %arg1: tensor<3xui32>) -> tensor<3xi1> {
-  // expected-error@+1 {{compareType must be UNSIGNED}}
-  %0 = "stablehlo.compare"(%arg0, %arg1) {
-    comparison_direction = #stablehlo<comparison_direction EQ>,
-    compare_type = #stablehlo<comparison_type TOTALORDER>
-  } : (tensor<3xui32>, tensor<3xui32>) -> tensor<3xi1>
-  func.return %0 : tensor<3xi1>
-}
-
-// -----
-
-func.func @comp_bad_type(%arg0: tensor<3xi32>, %arg1: tensor<3xi32>) -> tensor<3xi1> {
-  // expected-error@+1 {{compareType must be SIGNED}}
-  %0 = "stablehlo.compare"(%arg0, %arg1) {
-    comparison_direction = #stablehlo<comparison_direction EQ>,
-    compare_type = #stablehlo<comparison_type TOTALORDER>
-  } : (tensor<3xi32>, tensor<3xi32>) -> tensor<3xi1>
-  func.return %0 : tensor<3xi1>
-}
-
-// -----
-
 func.func @comp_bad_direction(%arg0: tensor<3xi32>, %arg1: tensor<3xi32>) -> tensor<3xi1> {
   // expected-error@+1 {{'comparison_direction' failed to satisfy constraint}}
   %0 = "stablehlo.compare"(%arg0, %arg1) {comparison_direction = "FOOBAR"} : (tensor<3xi32>, tensor<3xi32>) -> tensor<3xi1>

--- a/stablehlo/tests/print_stablehlo.mlir
+++ b/stablehlo/tests/print_stablehlo.mlir
@@ -239,9 +239,9 @@ func.func @pairwise_ops(%arg0 : tensor<4xf32>) -> () {
 // CHECK-LABEL: func @compare_op
 func.func @compare_op(%arg0 : tensor<3xi32>) -> () {
   // CHECK:      %0 = stablehlo.compare LT, %arg0, %arg0 : (tensor<3xi32>, tensor<3xi32>) -> tensor<3xi1>
-  // CHECK-NEXT: %1 = stablehlo.compare LT, %arg0, %arg0, SIGNED : (tensor<3xi32>, tensor<3xi32>) -> tensor<3xi1>
+  // CHECK-NEXT: %1 = stablehlo.compare LT, %arg0, %arg0, TOTALORDER : (tensor<3xi32>, tensor<3xi32>) -> tensor<3xi1>
    %0 = "stablehlo.compare"(%arg0, %arg0) {comparison_direction = #stablehlo<comparison_direction LT>} : (tensor<3xi32>, tensor<3xi32>) -> tensor<3xi1>
-   %1 = "stablehlo.compare"(%arg0, %arg0) {compare_type = #stablehlo<comparison_type SIGNED>, comparison_direction = #stablehlo<comparison_direction LT>} : (tensor<3xi32>, tensor<3xi32>) -> tensor<3xi1>
+   %1 = "stablehlo.compare"(%arg0, %arg0) {compare_type = #stablehlo<comparison_type TOTALORDER>, comparison_direction = #stablehlo<comparison_direction LT>} : (tensor<3xi32>, tensor<3xi32>) -> tensor<3xi1>
   "stablehlo.return"() : () -> ()
 }
 

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.mlir
@@ -59,6 +59,16 @@ func.func @attr_comparison_direction_lt(%arg0: tensor<f32>, %arg1: tensor<f32>) 
 }
 // CHECK-LABEL: "attr_comparison_direction_lt"
 
+func.func @attr_comparison_type_notype(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<i1> {
+  %0 = "stablehlo.compare"(%arg0, %arg1) {
+    comparison_direction = #stablehlo<comparison_direction EQ>,
+    // CHECK: compare_type = #vhlo<comparison_type NOTYPE>,
+    compare_type = #stablehlo<comparison_type NOTYPE>
+  } : (tensor<f32>, tensor<f32>) -> tensor<i1>
+  func.return %0 : tensor<i1>
+}
+// CHECK-LABEL: "attr_comparison_type_notype"
+
 func.func @attr_comparison_type_float(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<i1> {
   %0 = "stablehlo.compare"(%arg0, %arg1) {
     comparison_direction = #stablehlo<comparison_direction EQ>,
@@ -79,22 +89,22 @@ func.func @attr_comparison_type_totalorder(%arg0: tensor<f32>, %arg1: tensor<f32
 }
 // CHECK-LABEL: "attr_comparison_type_totalorder"
 
-func.func @attr_comparison_type_signed(%arg0: tensor<i32>, %arg1: tensor<i32>) -> tensor<i1> {
+func.func @attr_comparison_type_signed(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<i1> {
   %0 = "stablehlo.compare"(%arg0, %arg1) {
     comparison_direction = #stablehlo<comparison_direction EQ>,
     // CHECK: compare_type = #vhlo<comparison_type SIGNED>,
     compare_type = #stablehlo<comparison_type SIGNED>
-  } : (tensor<i32>, tensor<i32>) -> tensor<i1>
+  } : (tensor<f32>, tensor<f32>) -> tensor<i1>
   func.return %0 : tensor<i1>
 }
 // CHECK-LABEL: "attr_comparison_type_signed"
 
-func.func @attr_comparison_type_unsigned(%arg0: tensor<ui32>, %arg1: tensor<ui32>) -> tensor<i1> {
+func.func @attr_comparison_type_unsigned(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<i1> {
   %0 = "stablehlo.compare"(%arg0, %arg1) {
     comparison_direction = #stablehlo<comparison_direction EQ>,
     // CHECK: compare_type = #vhlo<comparison_type UNSIGNED>,
     compare_type = #stablehlo<comparison_type UNSIGNED>
-  } : (tensor<ui32>, tensor<ui32>) -> tensor<i1>
+  } : (tensor<f32>, tensor<f32>) -> tensor<i1>
   func.return %0 : tensor<i1>
 }
 // CHECK-LABEL: "attr_comparison_type_unsigned"


### PR DESCRIPTION
Reverting https://github.com/openxla/stablehlo/pull/958 to unblock downstream integration.

## Details
The tests which are failing downstream falls into two categories:
(1) Verifier failing on compareOps with  wrong combination of element-type and compare_type. 
(2) Verifier  failing on creating `compareOp` with `compare_type == NOTYPE`. Note that creating a compareOp with `NOTYPE` is still allowed. 
(3) Type inference failures: As the implementation of verification and type inference is unified for this op, the above mentioned categories also contributed to type inference failures.