### PR TITLE
Add interpreter for DynamicSliceOp

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2333,7 +2333,7 @@ More formally, `result[i0, ..., iR-1] = operand[j0, ..., jR-1]` where:
 * (C1) `operand` and `result` have the same element type.
 * (C2) size(`start_indices`) $=$ size(`slice_sizes`) $=$ rank(`operand`).
 * (C3) All `start_indices` have the same type.
-* (C4) `slice_sizes[k]` $\in$ [0, dim(`operand`, `k`)) for all `k` $\in$ [0,
+* (C4) `slice_sizes[k]` $\in$ [0, dim(`operand`, `k`)] for all `k` $\in$ [0,
   rank(`operand`)).
 * (C5) shape(`result`) $=$ `slice_sizes`.
 
@@ -2356,6 +2356,8 @@ More formally, `result[i0, ..., iR-1] = operand[j0, ..., jR-1]` where:
 //           [1, 1]
 //          ]
 ```
+
+&nbsp;[More Examples](../stablehlo/tests/interpret_dynamic_slice.mlir)
 
 ### dynamic_update_slice
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -84,7 +84,7 @@ one of the following tracking labels.
 | dynamic_iota             | no            | revisit      | infeasible     | yes             | no          |
 | dynamic_pad              | no            | revisit      | no             | yes             | no          |
 | dynamic_reshape          | no            | revisit      | infeasible     | yes             | no          |
-| dynamic_slice            | yes           | yes          | yes            | yes             | no          |
+| dynamic_slice            | yes           | yes          | yes            | yes             | yes         |
 | dynamic_update_slice     | yes           | yes          | yes            | yes             | yes         |
 | einsum                   | no            | revisit      | no             | yes             | no          |
 | exponential              | yes           | yes          | yes            | yes             | no          |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1611,7 +1611,7 @@ def StableHLO_SliceOp: StableHLO_Op<
 }
 
 def StableHLO_DynamicSliceOp: StableHLO_Op<"dynamic_slice",
-      [Pure, AllElementTypesMatch<["operand", "result"]>,
+      [Pure, AllElementTypesMatch<["operand", "result"]> /*dynamic_slice_c1*/,
        InferTensorType]> {
   let summary = "Dynamic Slice operator";
   let description = [{

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1613,7 +1613,7 @@ def StableHLO_SliceOp: StableHLO_Op<
 def StableHLO_DynamicSliceOp: StableHLO_Op<"dynamic_slice",
       [Pure, AllElementTypesMatch<["operand", "result"]> /*dynamic_slice_c1*/,
        InferTensorType]> {
-  let summary = "Dynamic Slice operator";
+  let summary = "DynamicSlice operation";
   let description = [{
     Extracts a slice from the `operand` using dynamically-computed starting
     indices and produces a `result` tensor.

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1628,9 +1628,9 @@ def StableHLO_DynamicSliceOp: StableHLO_Op<"dynamic_slice",
     ```
   }];
   let arguments = (ins
-    HLO_Tensor:$operand,
-    Variadic<HLO_ScalarIntTensor>:$start_indices,
-    I64ElementsAttr:$slice_sizes
+    HLO_Tensor:$operand /*dynamic_slice_i1*/,
+    Variadic<HLO_ScalarIntTensor>:$start_indices /*dynamic_slice_i2*/,
+    I64ElementsAttr:$slice_sizes /*dynamic_slice_i3*/
   );
 
   let results = (outs HLO_Tensor:$result);

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -34,6 +34,8 @@ Tensor evalCeilOp(const Tensor &operand, Type resultType);
 Tensor evalConstantOp(ElementsAttr value);
 Tensor evalConvertOp(const Tensor &operand, Type resultType);
 Tensor evalCosineOp(const Tensor &operand, Type resultType);
+Tensor evalDynamicSliceOp(const Tensor &operand, ArrayRef<Tensor> start_indices,
+                          ArrayRef<int64_t> slice_sizes, Type resultType);
 Tensor evalDynamicUpdateSliceOp(const Tensor &operand, const Tensor &update,
                                 ArrayRef<Tensor> startIndices, Type resultType);
 Tensor evalFloorOp(const Tensor &operand, Type resultType);

--- a/stablehlo/tests/interpret_dynamic_slice.mlir
+++ b/stablehlo/tests/interpret_dynamic_slice.mlir
@@ -1,0 +1,24 @@
+// RUN: stablehlo-interpreter --interpret -split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: Evaluated results of function: dynamic_slice
+func.func @dynamic_slice() -> tensor<3x3xi64> {
+  %operand = stablehlo.constant dense<[[1, 1, 1],
+                                       [1, 1, 1],
+                                       [1, 1, 1]]> : tensor<3x3xi64>
+  %start_indices0 = stablehlo.constant dense<3> : tensor<i64>
+  %start_indices1 = stablehlo.constant dense<3> : tensor<i64>
+  %result = "stablehlo.dynamic_slice"(%operand, %start_indices0, %start_indices1) {
+    slice_sizes = dense<[3, 3]> : tensor<2xi64>
+  } : (tensor<3x3xi64>, tensor<i64>, tensor<i64>) -> tensor<3x3xi64>
+  func.return %result : tensor<3x3xi64>
+  // CHECK-NEXT: tensor<3x3xi64>
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+  // CHECK-NEXT: 1 : i64
+}

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -2287,6 +2287,54 @@ func.func @dynamic_slice(%arg0: tensor<3x4xi32>, %arg1: tensor<i64>, %arg2: tens
 
 // -----
 
+func.func @dynamic_slice_c1(%arg0: tensor<3x4xi32>, %arg1: tensor<i64>, %arg2: tensor<i64>) -> tensor<1x4xf32> {
+  // expected-error@+1 {{failed to verify that all of {operand, result} have same element type}}
+  %0 = "stablehlo.dynamic_slice"(%arg0, %arg1, %arg2) {slice_sizes = dense<[1, 4]> : tensor<2xi64>} : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xf32>
+  func.return %0 : tensor<1x4xf32>
+}
+
+// -----
+
+func.func @dynamic_slice_c2(%arg0: tensor<3x4xi32>, %arg1: tensor<i64>, %arg2: tensor<i64>) -> tensor<1x4xi32> {
+  // expected-error@+1 {{has mismatched number of slice sizes (1) and number of start indices (2)}}
+  %0 = "stablehlo.dynamic_slice"(%arg0, %arg1, %arg2) {slice_sizes = dense<[4]> : tensor<1xi64>} : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xi32>
+  func.return %0 : tensor<1x4xi32>
+}
+
+// -----
+
+func.func @dynamic_slice_c2(%arg0: tensor<3x4xi32>, %arg1: tensor<i64>) -> tensor<1x4xi32> {
+  // expected-error@+1 {{has mismatched number of start indices (1) and the rank of operand (2)}}
+  %0 = "stablehlo.dynamic_slice"(%arg0, %arg1) {slice_sizes = dense<[1]> : tensor<1xi64>} : (tensor<3x4xi32>, tensor<i64>) -> tensor<1x4xi32>
+  func.return %0 : tensor<1x4xi32>
+}
+
+// -----
+
+func.func @dynamic_slice_c3(%arg0: tensor<3x4xi32>, %arg1: tensor<i32>, %arg2: tensor<i64>) -> tensor<1x4xi32> {
+  // expected-error@+1 {{start indices must have same element type}}
+  %0 = "stablehlo.dynamic_slice"(%arg0, %arg1, %arg2) {slice_sizes = dense<[1, 4]> : tensor<2xi64>} : (tensor<3x4xi32>, tensor<i32>, tensor<i64>) -> tensor<1x4xi32>
+  func.return %0 : tensor<1x4xi32>
+}
+
+// -----
+
+func.func @dynamic_slice_c4(%arg0: tensor<3x4xi32>, %arg1: tensor<i64>, %arg2: tensor<i64>) -> tensor<1x4xi32> {
+  // expected-error@+1 {{has negative size index to dynamic slice: -1}}
+  %0 = "stablehlo.dynamic_slice"(%arg0, %arg1, %arg2) {slice_sizes = dense<[-1, 4]> : tensor<2xi64>} : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xi32>
+  func.return %0 : tensor<1x4xi32>
+}
+
+// -----
+
+func.func @dynamic_slice_c4(%arg0: tensor<3x4xi32>, %arg1: tensor<i64>, %arg2: tensor<i64>) -> tensor<1x4xi32> {
+  // expected-error@+1 {{has slice size 10 greater than dimension size 4 in dimension 1 of operand}}
+  %0 = "stablehlo.dynamic_slice"(%arg0, %arg1, %arg2) {slice_sizes = dense<[1, 10]> : tensor<2xi64>} : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xi32>
+  func.return %0 : tensor<1x4xi32>
+}
+
+// -----
+
 // CHECK-LABEL: func @dynamic_slice_dynamic_dim
 func.func @dynamic_slice_dynamic_dim(%arg0: tensor<?x4xi32>, %arg1: tensor<i64>, %arg2: tensor<i64>) -> tensor<1x4xi32> {
   %0 = "stablehlo.dynamic_slice"(%arg0, %arg1, %arg2) {slice_sizes = dense<[1, 4]> : tensor<2xi64>} : (tensor<?x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xi32>
@@ -2295,73 +2343,9 @@ func.func @dynamic_slice_dynamic_dim(%arg0: tensor<?x4xi32>, %arg1: tensor<i64>,
 
 // -----
 
-func.func @dynamic_slice_mismatch_indices(%arg0: tensor<3x4xi32>, %arg1: tensor<i64>, %arg2: tensor<i64>) -> tensor<1x4xi32> {
-  // expected-error@+1 {{has mismatched number of slice sizes (1) and number of start indices (2)}}
-  %0 = "stablehlo.dynamic_slice"(%arg0, %arg1, %arg2) {slice_sizes = dense<[4]> : tensor<1xi64>} : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xi32>
-  func.return %0 : tensor<1x4xi32>
-}
-
-// -----
-
-func.func @dynamic_slice_mismatch_indices_element_type(%arg0: tensor<3x4xi32>, %arg1: tensor<i32>, %arg2: tensor<i64>) -> tensor<1x4xi32> {
-  // expected-error@+1 {{start indices must have same element type}}
-  %0 = "stablehlo.dynamic_slice"(%arg0, %arg1, %arg2) {slice_sizes = dense<[1, 4]> : tensor<2xi64>} : (tensor<3x4xi32>, tensor<i32>, tensor<i64>) -> tensor<1x4xi32>
-  func.return %0 : tensor<1x4xi32>
-}
-
-// -----
-
-func.func @dynamic_slice(%arg0: tensor<3x4xi32>, %arg1: tensor<i64>) -> tensor<1x4xi32> {
-  // expected-error@+1 {{has mismatched number of start indices (1) and the rank of operand (2)}}
-  %0 = "stablehlo.dynamic_slice"(%arg0, %arg1) {slice_sizes = dense<[1]> : tensor<1xi64>} : (tensor<3x4xi32>, tensor<i64>) -> tensor<1x4xi32>
-  func.return %0 : tensor<1x4xi32>
-}
-
-// -----
-
-func.func @dynamic_slice_mismatch_element_types(%arg0: tensor<3x4xi32>, %arg1: tensor<i64>, %arg2: tensor<i64>) -> tensor<1x4xf32> {
-  // expected-error@+1 {{failed to verify that all of {operand, result} have same element type}}
-  %0 = "stablehlo.dynamic_slice"(%arg0, %arg1, %arg2) {slice_sizes = dense<[1, 4]> : tensor<2xi64>} : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xf32>
-  func.return %0 : tensor<1x4xf32>
-}
-
-// -----
-
-func.func @dynamic_slice_mismatch_return_shape(%arg0: tensor<3x4xi32>, %arg1: tensor<i64>, %arg2: tensor<i64>) -> tensor<2x4xi32> {
-  // expected-error@+1 {{inferred type(s) 'tensor<1x4xi32>' are incompatible with return type(s) of operation 'tensor<2x4xi32>'}}
-  %0 = "stablehlo.dynamic_slice"(%arg0, %arg1, %arg2) {slice_sizes = dense<[1, 4]> : tensor<2xi64>} : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<2x4xi32>
-  func.return %0 : tensor<2x4xi32>
-}
-
-// -----
-
-func.func @dynamic_slice_start_not_0d(%arg0: tensor<3x4xi32>, %arg1: tensor<2xi64>) -> tensor<1x4xi32> {
-  // expected-error@+1 {{operand #1 must be 0D tensor of 4/8/16/32/64-bit signless integer or 4/8/16/32/64-bit unsigned integer values, but got 'tensor<2xi64>'}}
-  %0 = "stablehlo.dynamic_slice"(%arg0, %arg1) {slice_sizes = dense<[1, 4]> : tensor<2xi64>} : (tensor<3x4xi32>, tensor<2xi64>) -> tensor<1x4xi32>
-  func.return %0 : tensor<1x4xi32>
-}
-
-// -----
-
-func.func @dynamic_slice_start_not_int(%arg0: tensor<3x4xi32>, %arg1: tensor<f64>, %arg2: tensor<f64>) -> tensor<1x4xi32> {
-  // expected-error@+1 {{operand #1 must be 0D tensor of 4/8/16/32/64-bit signless integer or 4/8/16/32/64-bit unsigned integer values, but got 'tensor<f64>'}}
-  %0 = "stablehlo.dynamic_slice"(%arg0, %arg1, %arg2) {slice_sizes = dense<[1, 4]> : tensor<2xi64>} : (tensor<3x4xi32>, tensor<f64>, tensor<f64>) -> tensor<1x4xi32>
-  func.return %0 : tensor<1x4xi32>
-}
-
-// -----
-
-func.func @dynamic_slice_slice_size_negative(%arg0: tensor<3x4xi32>, %arg1: tensor<i64>, %arg2: tensor<i64>) -> tensor<1x4xi32> {
-  // expected-error@+1 {{has negative size index to dynamic slice: -1}}
-  %0 = "stablehlo.dynamic_slice"(%arg0, %arg1, %arg2) {slice_sizes = dense<[-1, 4]> : tensor<2xi64>} : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xi32>
-  func.return %0 : tensor<1x4xi32>
-}
-
-// -----
-
-func.func @dynamic_slice_slice_size_too_large(%arg0: tensor<3x4xi32>, %arg1: tensor<i64>, %arg2: tensor<i64>) -> tensor<1x4xi32> {
-  // expected-error@+1 {{has slice size 10 greater than dimension size 4 in dimension 1 of operand}}
-  %0 = "stablehlo.dynamic_slice"(%arg0, %arg1, %arg2) {slice_sizes = dense<[1, 10]> : tensor<2xi64>} : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xi32>
+func.func @dynamic_slice_i3(%arg0: tensor<3x4xi32>, %arg1: tensor<i64>, %arg2: tensor<i64>) -> tensor<1x4xi32> {
+  // expected-error@+1 {{slice_sizes should be rank 1, but got rank 0.}}
+  %0 = "stablehlo.dynamic_slice"(%arg0, %arg1, %arg2) {slice_sizes = dense<1> : tensor<i64>} : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xi32>
   func.return %0 : tensor<1x4xi32>
 }
 

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -2287,14 +2287,6 @@ func.func @dynamic_slice(%arg0: tensor<3x4xi32>, %arg1: tensor<i64>, %arg2: tens
 
 // -----
 
-func.func @dynamic_slice_c1(%arg0: tensor<3x4xi32>, %arg1: tensor<i64>, %arg2: tensor<i64>) -> tensor<1x4xf32> {
-  // expected-error@+1 {{failed to verify that all of {operand, result} have same element type}}
-  %0 = "stablehlo.dynamic_slice"(%arg0, %arg1, %arg2) {slice_sizes = dense<[1, 4]> : tensor<2xi64>} : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xf32>
-  func.return %0 : tensor<1x4xf32>
-}
-
-// -----
-
 func.func @dynamic_slice_c2(%arg0: tensor<3x4xi32>, %arg1: tensor<i64>, %arg2: tensor<i64>) -> tensor<1x4xi32> {
   // expected-error@+1 {{has mismatched number of slice sizes (1) and number of start indices (2)}}
   %0 = "stablehlo.dynamic_slice"(%arg0, %arg1, %arg2) {slice_sizes = dense<[4]> : tensor<1xi64>} : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xi32>
@@ -2331,6 +2323,14 @@ func.func @dynamic_slice_c4(%arg0: tensor<3x4xi32>, %arg1: tensor<i64>, %arg2: t
   // expected-error@+1 {{has slice size 10 greater than dimension size 4 in dimension 1 of operand}}
   %0 = "stablehlo.dynamic_slice"(%arg0, %arg1, %arg2) {slice_sizes = dense<[1, 10]> : tensor<2xi64>} : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xi32>
   func.return %0 : tensor<1x4xi32>
+}
+
+// -----
+
+func.func @dynamic_slice_c5(%arg0: tensor<3x4xi32>, %arg1: tensor<i64>, %arg2: tensor<i64>) -> tensor<2x4xi32> {
+  // expected-error@+1 {{inferred type(s) 'tensor<1x4xi32>' are incompatible with return type(s) of operation 'tensor<2x4xi32>'}}
+  %0 = "stablehlo.dynamic_slice"(%arg0, %arg1, %arg2) {slice_sizes = dense<[1, 4]> : tensor<2xi64>} : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<2x4xi32>
+  func.return %0 : tensor<2x4xi32>
 }
 
 // -----


### PR DESCRIPTION
We have the following constraints in the spec:

```
(I1) operand tensor.
(I2) start_indices variadic number of 0-dimensional tensors of integer type.
(I3) slice_sizes 1-dimensional tensor constant of type `si64`.
(C1) `operand` and `result` have the same element type.
(C2) size(`start_indices`) $=$ size(`slice_sizes`) $=$ rank(`operand`).
(C3) All `start_indices` have the same type.
(C4) `slice_sizes[k]` $\in$ [0, dim(`operand`, `k`)] for all `k` $\in$ [0,
rank(`operand`)).
(C5) shape(`result`) $=$ `slice_sizes`.
```

These constraints will be comprehensively covered by the following tests:

```
I1: a) operand is not a tensor. (Covered by ODS).
I2: a) start_indices is not a variadic 0-dimensional tensors. (Covered by ODS).
    b) start_indices does not have integer type. (Covered by ODS).
I3: a) slice_sizes is not a 1-dimensional tensor.
    b) slice_sizes does not have type `si64`. (Covered by ODS).
C1: a) element_type(operand) != element_type(result). (Covered by ODS).
C2: a) size(start_indices) != size(slice_sizes).
    b) size(start_indices) != rank(operand).
C3: a) all start_indices do not have the same type.
C4: a) slice_sizes[i] < 0 for any i.
     b) slice_sizes[i] > dim(operand, i) for any i.
C5: no negative test needed since it's just inferring the shape from slice_sizes.
```

If we drop the "Covered by ODS" pieces, this will leave us with the following test cases:

```
I3a: slice_sizes is not a 1-dimensional tensor.
C2a: size(start_indices) != size(slice_sizes).
C2b: size(start_indices) != rank(operand). 
C3a: all start_indices do not have the same type.
C4a: slice_sizes[i] < 0 for any i.
C4b: slice_sizes[i] > dim(operand, i) for any i.
```

Fixed typo:
```
(C4) `slice_sizes[k]` $\in$ [0, dim(`operand`, `k`)) for all `k` $\in$ [0,
  rank(`operand`)).
```
to
```
(C4) `slice_sizes[k]` $\in$ [0, dim(`operand`, `k`)] for all `k` $\in$ [0,
  rank(`operand`)).
```

closes #973