### PR TITLE
Add interpreter for RsqrtOp.

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4450,11 +4450,9 @@ produces a `result` tensor. Depending on the element type, does the following:
 // %operand: [[1.0, 4.0], [9.0, 25.0]]
 %result = "stablehlo.rsqrt"(%operand) : (tensor<2x2xf32>) -> tensor<2x2xf32>
 // %result: [[1.0, 0.5], [0.33333343, 0.2]]
-
-// %operand: [(1.0, 2.0)]
-%result = "stablehlo.rsqrt"(%operand) : (tensor<complex<f32>>) -> tensor<complex<f32>>
-// %result: [(0.56886448, -0.35157758)]
 ```
+
+&nbsp;[More Examples](../stablehlo/tests/interpret_rsqrt.mlir)
 
 ### scatter
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -131,7 +131,7 @@ one of the following tracking labels.
 | rng_bit_generator        | yes           | revisit      | infeasible     | yes             | no          |
 | round_nearest_afz        | yes           | yes          | yes            | yes             | no          |
 | round_nearest_even       | yes           | yes          | yes            | yes             | no          |
-| rsqrt                    | yes           | yes          | yes            | yes             | no          |
+| rsqrt                    | yes           | yes          | yes            | yes             | yes         |
 | scatter                  | yes           | revisit      | yes            | no              | no          |
 | select                   | yes           | yes          | yes            | yes             | yes         |
 | select_and_scatter       | yes           | revisit      | yes            | no              | no          |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -556,7 +556,8 @@ def StableHLO_RoundNearestEvenOp: StableHLO_UnaryElementwiseOp<"round_nearest_ev
 }
 
 def StableHLO_RsqrtOp: StableHLO_UnaryElementwiseOp<"rsqrt", [Pure,
-    HLO_CompatibleOperandsAndResultType /* rsqrt_c1 */], HLO_FpOrComplexTensor> {
+    HLO_CompatibleOperandsAndResultType /* rsqrt_c1 */],
+    HLO_FpOrComplexTensor /* rsqrt_i1 */> {
   let summary = "Rsqrt operation";
   let description = [{
     Performs element-wise reciprocal square root operation on `operand` tensor

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -555,9 +555,9 @@ def StableHLO_RoundNearestEvenOp: StableHLO_UnaryElementwiseOp<"round_nearest_ev
   }];
 }
 
-def StableHLO_RsqrtOp: StableHLO_UnaryElementwiseOp<"rsqrt",
-    [Pure, HLO_CompatibleOperandsAndResultType], HLO_FpOrComplexTensor> {
-  let summary = "Reciprocal Square-root operator";
+def StableHLO_RsqrtOp: StableHLO_UnaryElementwiseOp<"rsqrt", [Pure,
+    HLO_CompatibleOperandsAndResultType /* rsqrt_c1 */], HLO_FpOrComplexTensor> {
+  let summary = "Rsqrt operation";
   let description = [{
     Performs element-wise reciprocal square root operation on `operand` tensor
     and produces a `result` tensor, implementing the `rSqrt` operation from the
@@ -568,7 +568,7 @@ def StableHLO_RsqrtOp: StableHLO_UnaryElementwiseOp<"rsqrt",
 
     Example:
     ```mlir
-    %result = stablehlo.rsqrt %operand : tensor<2xf32>
+    %result = stablehlo.rsqrt %operand : tensor<2x2xf32>
     ```
   }];
 }

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -364,10 +364,8 @@ Element min(const Element &e1, const Element &e2) {
 
 Element rsqrt(const Element &el) {
   return mapWithUpcastToDouble(
-      el, [](double e) { return static_cast<double>(1) / std::sqrt(e); },
-      [](std::complex<double> e) {
-        return static_cast<double>(1) / std::sqrt(e);
-      });
+      el, [](double e) { return 1.0 / std::sqrt(e); },
+      [](std::complex<double> e) { return 1.0 / std::sqrt(e); });
 }
 
 Element sine(const Element &el) {

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -362,6 +362,14 @@ Element min(const Element &e1, const Element &e2) {
       });
 }
 
+Element rsqrt(const Element &el) {
+  return mapWithUpcastToDouble(
+      el, [](double e) { return static_cast<double>(1) / std::sqrt(e); },
+      [](std::complex<double> e) {
+        return static_cast<double>(1) / std::sqrt(e);
+      });
+}
+
 Element sine(const Element &el) {
   return mapWithUpcastToDouble(
       el, [](double e) { return std::sin(e); },

--- a/stablehlo/reference/Element.h
+++ b/stablehlo/reference/Element.h
@@ -124,6 +124,9 @@ Element max(const Element &e1, const Element &e2);
 /// Returns the minimum between two Element objects.
 Element min(const Element &e1, const Element &e2);
 
+/// Returns reverse square root of Element object.
+Element rsqrt(const Element &e);
+
 /// Returns sine of Element object.
 Element sine(const Element &e);
 

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -289,10 +289,11 @@ Tensor evalReverseOp(const Tensor &operand, Axes dimensions,
   return result;
 }
 
-Tensor evalRsqrtOp(const Tensor &operand, Type resultType) {
+Tensor evalRsqrtOp(const Tensor &operand, TensorType resultType) {
   Tensor result(resultType);
-  for (auto it = result.index_begin(); it != result.index_end(); ++it)
-    result.set(*it, rsqrt(operand.get(*it)));
+  for (auto resultIt = result.index_begin(); resultIt != result.index_end();
+       ++resultIt)
+    result.set(*resultIt, rsqrt(operand.get(*resultIt)));
   return result;
 }
 
@@ -307,7 +308,7 @@ Tensor evalSelectOp(const Tensor &pred, const Tensor &onTrue,
   return result;
 }
 
-Tensor evalSineOp(const Tensor &operand, Type resultType) {
+Tensor evalSineOp(const Tensor &operand, TensorType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, sine(operand.get(*it)));
@@ -538,6 +539,10 @@ SmallVector<Tensor> eval(Region &region, ArrayRef<Tensor> args, Scope *parent) {
       Tensor runtimeResult = evalSelectOp(
           scope.find(selectOp.getPred()), scope.find(selectOp.getOnTrue()),
           scope.find(selectOp.getOnFalse()), selectOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto rsqrtOp = dyn_cast<RsqrtOp>(op)) {
+      Tensor runtimeOperand = scope.find(rsqrtOp.getOperand());
+      Tensor runtimeResult = evalRsqrtOp(runtimeOperand, rsqrtOp.getType());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto sineOp = dyn_cast<SineOp>(op)) {
       Tensor runtimeOperand = scope.find(sineOp.getOperand());

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -289,6 +289,13 @@ Tensor evalReverseOp(const Tensor &operand, Axes dimensions,
   return result;
 }
 
+Tensor evalRsqrtOp(const Tensor &operand, Type resultType) {
+  Tensor result(resultType);
+  for (auto it = result.index_begin(); it != result.index_end(); ++it)
+    result.set(*it, rsqrt(operand.get(*it)));
+  return result;
+}
+
 Tensor evalSelectOp(const Tensor &pred, const Tensor &onTrue,
                     const Tensor &onFalse, TensorType resultType) {
   Tensor result(resultType);
@@ -300,7 +307,7 @@ Tensor evalSelectOp(const Tensor &pred, const Tensor &onTrue,
   return result;
 }
 
-Tensor evalSineOp(const Tensor &operand, TensorType resultType) {
+Tensor evalSineOp(const Tensor &operand, Type resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, sine(operand.get(*it)));

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -62,6 +62,7 @@ Tensor evalPadOp(const Tensor &operand, const Tensor &paddingValue,
 Tensor evalReshapeOp(const Tensor &operand, TensorType resultType);
 Tensor evalReverseOp(const Tensor &operand, Axes dimensions,
                      TensorType resultType);
+Tensor evalRsqrtOp(const Tensor &operand, Type resultType);
 Tensor evalSelectOp(const Tensor &pred, const Tensor &onTrue,
                     const Tensor &onFalse, TensorType resultType);
 Tensor evalSineOp(const Tensor &operand, TensorType resultType);

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -62,7 +62,7 @@ Tensor evalPadOp(const Tensor &operand, const Tensor &paddingValue,
 Tensor evalReshapeOp(const Tensor &operand, TensorType resultType);
 Tensor evalReverseOp(const Tensor &operand, Axes dimensions,
                      TensorType resultType);
-Tensor evalRsqrtOp(const Tensor &operand, Type resultType);
+Tensor evalRsqrtOp(const Tensor &operand, TensorType resultType);
 Tensor evalSelectOp(const Tensor &pred, const Tensor &onTrue,
                     const Tensor &onFalse, TensorType resultType);
 Tensor evalSineOp(const Tensor &operand, TensorType resultType);

--- a/stablehlo/tests/interpret_rsqrt.mlir
+++ b/stablehlo/tests/interpret_rsqrt.mlir
@@ -1,0 +1,25 @@
+// RUN: stablehlo-interpreter --interpret -split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: Evaluated results of function: rsqrt_op_test_f64
+func.func @rsqrt_op_test_f64() -> tensor<2x2xf64> {
+  %operand = stablehlo.constant dense<[[1.0, 4.0], [9.0, 25.0]]> : tensor<2x2xf64>
+  %result = stablehlo.rsqrt %operand : tensor<2x2xf64>
+  func.return %result : tensor<2x2xf64>
+  // CHECK-NEXT: tensor<2x2xf64>
+  // CHECK-NEXT: 1.000000e+00 : f64
+  // CHECK-NEXT: 5.000000e-01 : f64
+  // CHECK-NEXT: 0.33333333333333331 : f64
+  // CHECK-NEXT: 2.000000e-01 : f64
+}
+
+// -----
+
+// CHECK-LABEL: Evaluated results of function: rsqrt_op_test_c128
+func.func @rsqrt_op_test_c128() -> tensor<2xcomplex<f64>> {
+  %operand = stablehlo.constant dense<[(-1.0, 0.0), (3.0, 4.0)]> : tensor<2xcomplex<f64>>
+  %result = stablehlo.rsqrt %operand : tensor<2xcomplex<f64>>
+  func.return %result : tensor<2xcomplex<f64>>
+  // CHECK-NEXT: tensor<2xcomplex<f64>>
+  // CHECK-NEXT: [0.000000e+00 : f64, -1.000000e+00 : f64]
+  // CHECK-NEXT: [4.000000e-01 : f64, -2.000000e-01 : f64]
+}


### PR DESCRIPTION
closes #986 

We have the following constraints in the spec:

```
(I1) operand is a tensor of floating-point or complex type.
(C1) operand and result have the same type.
```

These constraints are covered by the following tests

```
(I1) operand is not a tensor of floating-point or complex type. (covered by ODS)
(C1) operand and result do not have the same type. (covered by ODS)
```