### PR TITLE
Don't load Tensor dialect in StableHLO dialect constructor

### DIFF
--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -2546,7 +2546,6 @@ StablehloDialect::StablehloDialect(MLIRContext* context)
 #define GET_ATTRDEF_LIST
 #include "stablehlo/dialect/StablehloAttrs.cpp.inc"
       >();
-  context->loadDialect<tensor::TensorDialect>();
 }
 
 Type StablehloDialect::parseType(DialectAsmParser& parser) const {


### PR DESCRIPTION
I recently noticed this code when reviewing #849, and I'm not sure why we need it there.

This seems like a pretty strong statement about a fundamental role of the Tensor dialect in the workings of the StableHLO dialect, and I don't think we have established that yet.

It would seem that we've inherited this from MHLO when bootstrapping StableHLO (#1), but I don't think I understand the reasoning on the MHLO side either. This change was introduced as part of an LLVM integrate (https://github.com/tensorflow/mlir-hlo/commit/ba0346b071f4212008943c50f47766e677992b56), and the commit description doesn't go into detail about motivation.

Given that, I propose to revert this in the StableHLO dialect and see what happens. All tests in this repository are passing, but maybe we'll learn more after downstream integrations.