### PR TITLE
Add interpreter for RemOp

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4141,7 +4141,7 @@ nearest to the exact value of `lhs/rhs` with ties to even.
 // %result: [2, -2, 2, -2]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret_remainder.mlir)
+&nbsp;[More Examples](../stablehlo/tests/interpret_rem.mlir)
 
 ### replica_id
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4146,6 +4146,8 @@ nearest to the exact value of `lhs/rhs` with ties to even.
 // %result: [2, -2, 2, -2]
 ```
 
+&nbsp;[More Examples](../stablehlo/tests/interpret_remainder.mlir)
+
 ### replica_id
 
 #### Semantics

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4135,14 +4135,9 @@ nearest to the exact value of `lhs/rhs` with ties to even.
 #### Examples
 
 ```mlir
-// %lhs: [17.1, -17.1, 17.1, -17.1]
-// %rhs: [3.0, 3.0, -3.0, -3.0]
-%result = "stablehlo.remainder"(%lhs, %rhs) : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
-// %result: [2.1, -2.1, 2.1, -2.1]
-
 // %lhs: [17, -17, 17, -17]
 // %rhs: [3, 3, -3, -3]
-%result = "stablehlo.remainder"(%lhs, %rhs) : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi32>
+%result = "stablehlo.remainder"(%lhs, %rhs) : (tensor<4xi64>, tensor<4xi64>) -> tensor<4xi64>
 // %result: [2, -2, 2, -2]
 ```
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -122,7 +122,7 @@ one of the following tracking labels.
 | reduce_precision         | yes           | yes          | yes            | yes             | no          |
 | reduce_scatter           | yes           | revisit      | no             | no              | no          |
 | reduce_window            | yes           | revisit      | yes            | no              | no          |
-| remainder                | yes           | yes          | yes            | yes             | no          |
+| remainder                | yes           | yes          | yes            | yes             | yes         |
 | replica_id               | yes           | yes          | yes            | yes             | no          |
 | reshape                  | yes           | yes          | infeasible     | yes             | yes         |
 | return                   | no            | revisit      | infeasible     | yes             | no          |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -827,7 +827,7 @@ def StableHLO_PowOp : StableHLO_BinaryElementwiseOp<"power",
 
 def StableHLO_RemOp : StableHLO_BinaryElementwiseOp<"remainder",
       [Pure, HLO_CompatibleOperandsAndResultType /*remainder_c1*/],
-       HLO_IntFpOrComplexTensor /*remainder_i1*/> {
+       HLO_IntFpOrComplexTensor /*remainder_i1, remainder_i2*/> {
   let summary = "Remainder operation";
   let description = [{
     Performs element-wise remainder of dividend `lhs` and divisor `rhs` tensors

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -826,8 +826,9 @@ def StableHLO_PowOp : StableHLO_BinaryElementwiseOp<"power",
 }
 
 def StableHLO_RemOp : StableHLO_BinaryElementwiseOp<"remainder",
-      [Pure, HLO_CompatibleOperandsAndResultType], HLO_IntFpOrComplexTensor> {
-  let summary = "Remainder operator";
+      [Pure, HLO_CompatibleOperandsAndResultType /* remainder_c1 */],
+       HLO_IntFpOrComplexTensor> {
+  let summary = "Remainder operation";
   let description = [{
     Performs element-wise remainder of dividend `lhs` and divisor `rhs` tensors
     and produces a `result` tensor.

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -826,8 +826,8 @@ def StableHLO_PowOp : StableHLO_BinaryElementwiseOp<"power",
 }
 
 def StableHLO_RemOp : StableHLO_BinaryElementwiseOp<"remainder",
-      [Pure, HLO_CompatibleOperandsAndResultType /* remainder_c1 */],
-       HLO_IntFpOrComplexTensor> {
+      [Pure, HLO_CompatibleOperandsAndResultType /*remainder_c1*/],
+       HLO_IntFpOrComplexTensor /*remainder_i1*/> {
   let summary = "Remainder operation";
   let description = [{
     Performs element-wise remainder of dividend `lhs` and divisor `rhs` tensors

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -533,7 +533,7 @@ Element rem(const Element &e1, const Element &e2) {
                                                           : lhs.urem(rhs);
       },
       [](bool lhs, bool rhs) -> bool {
-        llvm::report_fatal_error("bool \% bool is unsupported");
+        llvm::report_fatal_error("reminder of two bool numbers is unsupported");
       },
       [](APFloat lhs, APFloat rhs) {
         lhs.mod(rhs);
@@ -542,7 +542,8 @@ Element rem(const Element &e1, const Element &e2) {
       [](std::complex<APFloat> lhs,
          std::complex<APFloat> rhs) -> std::complex<APFloat> {
         // TODO(#997): remove support for complex
-        llvm::report_fatal_error("complex \% complex is unsupported");
+        llvm::report_fatal_error(
+            "reminder of two complex numbers is unsupported");
       });
 }
 

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -520,10 +520,6 @@ Element real(const Element &el) {
                                      debugString(el.getType()).c_str()));
 }
 
-// These cases are implementation-defined, and the behavior of this interpreter:
-// For integers: if rhs is 0, the result is the same as `lhs`.
-//   For signed integers, if lhs is INT_MAX and rhs is -1, the result is 0.
-// For floats: use APFloat.mod(). If rhs is 0, the result is 0x7FF8000000000000
 Element rem(const Element &e1, const Element &e2) {
   return map(
       e1, e2,
@@ -535,9 +531,9 @@ Element rem(const Element &e1, const Element &e2) {
         llvm::report_fatal_error("rem(bool, bool) is unsupported");
       },
       [](APFloat lhs, APFloat rhs) {
-        // std::fmod VS std:remainder: the returned value of the latter is not 
-        // guaranteed to have the same sign as lhs. So mod() is preferred here.
-        // The returned "APFloat::opStatus" is ignored.
+        // APFloat::fmod VS APFloat:remainder: the returned value of the latter
+        // is not guaranteed to have the same sign as lhs. So mod() is preferred
+        // here. The returned "APFloat::opStatus" is ignored.
         (void)lhs.mod(rhs);
         return lhs;
       },

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -528,12 +528,11 @@ Element rem(const Element &e1, const Element &e2) {
   return map(
       e1, e2,
       [&](APInt lhs, APInt rhs) {
-        if (rhs == 0) return lhs;
         return isSupportedSignedIntegerType(e1.getType()) ? lhs.srem(rhs)
                                                           : lhs.urem(rhs);
       },
       [](bool lhs, bool rhs) -> bool {
-        llvm::report_fatal_error("reminder of two bool numbers is unsupported");
+        llvm::report_fatal_error("rem(bool, bool) is unsupported");
       },
       [](APFloat lhs, APFloat rhs) {
         lhs.mod(rhs);
@@ -542,8 +541,7 @@ Element rem(const Element &e1, const Element &e2) {
       [](std::complex<APFloat> lhs,
          std::complex<APFloat> rhs) -> std::complex<APFloat> {
         // TODO(#997): remove support for complex
-        llvm::report_fatal_error(
-            "reminder of two complex numbers is unsupported");
+        llvm::report_fatal_error("rem(complex, complex) is not implemented");
       });
 }
 

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -535,7 +535,10 @@ Element rem(const Element &e1, const Element &e2) {
         llvm::report_fatal_error("rem(bool, bool) is unsupported");
       },
       [](APFloat lhs, APFloat rhs) {
-        lhs.mod(rhs);
+        // std::fmod VS std:remainder: the returned value of the latter is not 
+        // guaranteed to have the same sign as lhs. So mod() is preferred here.
+        // The returned "APFloat::opStatus" is ignored.
+        (void)lhs.mod(rhs);
         return lhs;
       },
       [](std::complex<APFloat> lhs,

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -520,10 +520,15 @@ Element real(const Element &el) {
                                      debugString(el.getType()).c_str()));
 }
 
+// These cases are implementation-defined, and the behavior of this interpreter:
+// For integers: if rhs is 0, the result is the same as `lhs`.
+//   For signed integers, if lhs is INT_MAX and rhs is -1, the result is 0.
+// For floats: use APFloat.mod(). If rhs is 0, the result is 0x7FF8000000000000
 Element rem(const Element &e1, const Element &e2) {
   return map(
       e1, e2,
       [&](APInt lhs, APInt rhs) {
+        if (rhs == 0) return lhs;
         return isSupportedSignedIntegerType(e1.getType()) ? lhs.srem(rhs)
                                                           : lhs.urem(rhs);
       },

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -520,6 +520,27 @@ Element real(const Element &el) {
                                      debugString(el.getType()).c_str()));
 }
 
+Element rem(const Element &e1, const Element &e2) {
+  return map(
+      e1, e2,
+      [&](APInt lhs, APInt rhs) {
+        return isSupportedSignedIntegerType(e1.getType()) ? lhs.srem(rhs)
+                                                          : lhs.urem(rhs);
+      },
+      [](bool lhs, bool rhs) -> bool {
+        llvm::report_fatal_error("bool \% bool is unsupported");
+      },
+      [](APFloat lhs, APFloat rhs) {
+        lhs.mod(rhs);
+        return lhs;
+      },
+      [](std::complex<APFloat> lhs,
+         std::complex<APFloat> rhs) -> std::complex<APFloat> {
+        // TODO(#997): remove support for complex
+        llvm::report_fatal_error("complex \% complex is unsupported");
+      });
+}
+
 Element rsqrt(const Element &el) {
   return mapWithUpcastToDouble(
       el, [](double e) { return 1.0 / std::sqrt(e); },

--- a/stablehlo/reference/Element.h
+++ b/stablehlo/reference/Element.h
@@ -152,6 +152,9 @@ Element min(const Element &e1, const Element &e2);
 /// or complex type.
 Element real(const Element &e);
 
+/// Returns the reminder for two Element objects.
+Element rem(const Element &e1, const Element &e2);
+
 /// Returns reverse square root of Element object.
 Element rsqrt(const Element &e);
 

--- a/stablehlo/reference/Element.h
+++ b/stablehlo/reference/Element.h
@@ -152,7 +152,7 @@ Element min(const Element &e1, const Element &e2);
 /// or complex type.
 Element real(const Element &e);
 
-/// Returns the reminder for two Element objects.
+/// Returns the remainder for two Element objects.
 Element rem(const Element &e1, const Element &e2);
 
 /// Returns reverse square root of Element object.

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -295,6 +295,12 @@ Tensor evalPadOp(const Tensor &operand, const Tensor &paddingValue,
     if (resultIdx.inBounds(result.getShape()))
       result.set(resultIdx, operand.get(*operandIt));
   }
+}
+
+Tensor evalRemOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType) {
+  Tensor result(resultType);
+  for (auto it = result.index_begin(); it != result.index_end(); ++it)
+    result.set(*it, rem(lhs.get(*it), rhs.get(*it)));
   return result;
 }
 

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -298,17 +298,17 @@ Tensor evalPadOp(const Tensor &operand, const Tensor &paddingValue,
   return result;
 }
 
-Tensor evalRemOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType) {
-  Tensor result(resultType);
-  for (auto it = result.index_begin(); it != result.index_end(); ++it)
-    result.set(*it, rem(lhs.get(*it), rhs.get(*it)));
-  return result;
-}
-
 Tensor evalRealOp(const Tensor &operand, TensorType resultType) {
   Tensor result(resultType);
   for (auto it = operand.index_begin(); it != operand.index_end(); ++it)
     result.set(*it, real(operand.get(*it)));
+  return result;
+}
+
+Tensor evalRemOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType) {
+  Tensor result(resultType);
+  for (auto it = result.index_begin(); it != result.index_end(); ++it)
+    result.set(*it, rem(lhs.get(*it), rhs.get(*it)));
   return result;
 }
 

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -295,6 +295,7 @@ Tensor evalPadOp(const Tensor &operand, const Tensor &paddingValue,
     if (resultIdx.inBounds(result.getShape()))
       result.set(resultIdx, operand.get(*operandIt));
   }
+  return result;
 }
 
 Tensor evalRemOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType) {
@@ -575,6 +576,11 @@ SmallVector<Tensor> eval(
       Tensor runtimeResult =
           evalPadOp(runtimeOperand, runtimePaddingValue, edgePaddingLow,
                     interiorPadding, padOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto remOp = dyn_cast<RemOp>(op)) {
+      Tensor runtimeLhs = scope.find(remOp.getLhs());
+      Tensor runtimeRhs = scope.find(remOp.getRhs());
+      Tensor runtimeResult = evalRemOp(runtimeLhs, runtimeRhs, remOp.getType());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto whileOp = dyn_cast<WhileOp>(op)) {
       SmallVector<Value> runtimeOperands(whileOp.getOperand().begin(),

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -65,6 +65,7 @@ Tensor evalPadOp(const Tensor &operand, const Tensor &paddingValue,
                  Sizes edgePaddingLow, Sizes interiorPadding,
                  TensorType resultType);
 Tensor evalRealOp(const Tensor &operand, TensorType resultType);
+Tensor evalRemOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType);
 Tensor evalReshapeOp(const Tensor &operand, TensorType resultType);
 Tensor evalReverseOp(const Tensor &operand, Axes dimensions,
                      TensorType resultType);

--- a/stablehlo/tests/interpret_rem.mlir
+++ b/stablehlo/tests/interpret_rem.mlir
@@ -1,44 +1,29 @@
-// RUN: stablehlo-interpreter --interpret -split-input-file %s | FileCheck %s
+// RUN: stablehlo-interpreter --interpret -split-input-file %s
 
-// CHECK-LABEL: Evaluated results of function: remainder_op_test_si64
-func.func @remainder_op_test_si64() -> tensor<4xi64> {
+func.func @remainder_op_test_si64() {
   %lhs = stablehlo.constant dense<[17, -17, 17, -17]> : tensor<4xi64>
   %rhs = stablehlo.constant dense<[3, 3, -3, -3]> : tensor<4xi64>
   %result = stablehlo.remainder %lhs, %rhs : tensor<4xi64>
-  func.return %result : tensor<4xi64>
-  // CHECK-NEXT: tensor<4xi64>
-  // CHECK-NEXT: 2 : i64
-  // CHECK-NEXT: -2 : i64
-  // CHECK-NEXT: 2 : i64
-  // CHECK-NEXT: -2 : i64
+  check.eq %result, dense<[2, -2, 2, -2]> : tensor<4xi64>
+  func.return
 }
 
 // -----
 
-// CHECK-LABEL: Evaluated results of function: remainder_op_test_ui64
-func.func @remainder_op_test_ui64() -> tensor<4xui64> {
+func.func @remainder_op_test_ui64() {
   %lhs = stablehlo.constant dense<[17, 18, 19, 20]> : tensor<4xui64>
   %rhs = stablehlo.constant dense<[3, 4, 5, 7]> : tensor<4xui64>
   %result = stablehlo.remainder %lhs, %rhs : tensor<4xui64>
-  func.return %result : tensor<4xui64>
-  // CHECK-NEXT: tensor<4xui64>
-  // CHECK-NEXT: 2 : ui64
-  // CHECK-NEXT: 2 : ui64
-  // CHECK-NEXT: 4 : ui64
-  // CHECK-NEXT: 6 : ui64
+  check.eq %result, dense<[2, 2, 4, 6]> : tensor<4xui64>
+  func.return
 }
 
 // -----
 
-// CHECK-LABEL: Evaluated results of function: remainder_op_test_f64
-func.func @remainder_op_test_f64() -> tensor<4xf64> {
+func.func @remainder_op_test_f64() {
   %lhs = stablehlo.constant dense<[17.1, -17.1, 17.1, -17.1]> : tensor<4xf64>
   %rhs = stablehlo.constant dense<[3.0, 3.0, -3.0, -3.0]> : tensor<4xf64>
   %result = stablehlo.remainder %lhs, %rhs : tensor<4xf64>
-  func.return %result : tensor<4xf64>
-  // CHECK-NEXT: tensor<4xf64>
-  // CHECK-NEXT: 2.1000000000000014 : f64
-  // CHECK-NEXT: -2.1000000000000014 : f64
-  // CHECK-NEXT: 2.1000000000000014 : f64
-  // CHECK-NEXT: -2.1000000000000014 : f64
+  check.eq %result, dense<[2.1000000000000014, -2.1000000000000014, 2.1000000000000014, -2.1000000000000014]> : tensor<4xf64>
+  func.return
 }

--- a/stablehlo/tests/interpret_rem.mlir
+++ b/stablehlo/tests/interpret_rem.mlir
@@ -31,13 +31,12 @@ func.func @remainder_op_test_ui64() -> tensor<4xui64> {
 // -----
 
 // CHECK-LABEL: Evaluated results of function: remainder_op_test_f64
-func.func @remainder_op_test_f64() -> tensor<5xf64> {
-  %lhs = stablehlo.constant dense<[1.0, 17.1, -17.1, 17.1, -17.1]> : tensor<5xf64>
-  %rhs = stablehlo.constant dense<[0.0, 3.0, 3.0, -3.0, -3.0]> : tensor<5xf64>
-  %result = stablehlo.remainder %lhs, %rhs : tensor<5xf64>
-  func.return %result : tensor<5xf64>
-  // CHECK-NEXT: 0x7FF8000000000000 : f64
-  // CHECK-NEXT: tensor<5xf64>
+func.func @remainder_op_test_f64() -> tensor<4xf64> {
+  %lhs = stablehlo.constant dense<[17.1, -17.1, 17.1, -17.1]> : tensor<4xf64>
+  %rhs = stablehlo.constant dense<[3.0, 3.0, -3.0, -3.0]> : tensor<4xf64>
+  %result = stablehlo.remainder %lhs, %rhs : tensor<4xf64>
+  func.return %result : tensor<4xf64>
+  // CHECK-NEXT: tensor<4xf64>
   // CHECK-NEXT: 2.1000000000000014 : f64
   // CHECK-NEXT: -2.1000000000000014 : f64
   // CHECK-NEXT: 2.1000000000000014 : f64

--- a/stablehlo/tests/interpret_rem.mlir
+++ b/stablehlo/tests/interpret_rem.mlir
@@ -1,0 +1,45 @@
+// RUN: stablehlo-interpreter --interpret -split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: Evaluated results of function: remainder_op_test_si64
+func.func @remainder_op_test_si64() -> tensor<4xi64> {
+  %lhs = stablehlo.constant dense<[17, -17, 17, -17]> : tensor<4xi64>
+  %rhs = stablehlo.constant dense<[3, 3, -3, -3]> : tensor<4xi64>
+  %result = stablehlo.remainder %lhs, %rhs : tensor<4xi64>
+  func.return %result : tensor<4xi64>
+  // CHECK-NEXT: tensor<4xi64>
+  // CHECK-NEXT: 2 : i64
+  // CHECK-NEXT: -2 : i64
+  // CHECK-NEXT: 2 : i64
+  // CHECK-NEXT: -2 : i64
+}
+
+// -----
+
+// CHECK-LABEL: Evaluated results of function: remainder_op_test_ui64
+func.func @remainder_op_test_ui64() -> tensor<4xui64> {
+  %lhs = stablehlo.constant dense<[17, 18, 19, 20]> : tensor<4xui64>
+  %rhs = stablehlo.constant dense<[3, 4, 5, 7]> : tensor<4xui64>
+  %result = stablehlo.remainder %lhs, %rhs : tensor<4xui64>
+  func.return %result : tensor<4xui64>
+  // CHECK-NEXT: tensor<4xui64>
+  // CHECK-NEXT: 2 : ui64
+  // CHECK-NEXT: 2 : ui64
+  // CHECK-NEXT: 4 : ui64
+  // CHECK-NEXT: 6 : ui64
+}
+
+// -----
+
+// CHECK-LABEL: Evaluated results of function: remainder_op_test_f64
+func.func @remainder_op_test_f64() -> tensor<5xf64> {
+  %lhs = stablehlo.constant dense<[1.0, 17.1, -17.1, 17.1, -17.1]> : tensor<5xf64>
+  %rhs = stablehlo.constant dense<[0.0, 3.0, 3.0, -3.0, -3.0]> : tensor<5xf64>
+  %result = stablehlo.remainder %lhs, %rhs : tensor<5xf64>
+  func.return %result : tensor<5xf64>
+  // CHECK-NEXT: 0x7FF8000000000000 : f64
+  // CHECK-NEXT: tensor<5xf64>
+  // CHECK-NEXT: 2.1000000000000014 : f64
+  // CHECK-NEXT: -2.1000000000000014 : f64
+  // CHECK-NEXT: 2.1000000000000014 : f64
+  // CHECK-NEXT: -2.1000000000000014 : f64
+}


### PR DESCRIPTION
(I1) lhs tensor of integer, floating-point or complex type (covered by ODS)
(I2) rhs tensor of integer, floating-point or complex type (covered by ODS)
(C1) lhs, rhs and result have the same type. (covered by ODS)

Note that all constraints are covered by ODS, so no tests in ops_stablehlo.mlir.

It is expected that `hlo_evaluator` and `mlir_interpreter` handle corner case differently ([hlo_evaluator](https://github.com/tensorflow/tensorflow/blob/c4c3c066d48983f57afd9e8fbe3734b03ee98018/tensorflow/compiler/xla/hlo/evaluator/hlo_evaluator_typed_visitor.h#L686) vs [mlir_interpreter](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/xla/mlir_hlo/tools/mlir_interpreter/dialects/cwise_math.h#L83)). Here is our way (same as comment in code):

// These cases are implementation-defined, and the behavior of this interpreter:
// For integers: if rhs is 0, the result is the same as `lhs`.
//   For signed integers, if lhs is INT_MAX and rhs is -1, the result is 0.
// For floats: use APFloat.mod(). If rhs is 0, the result is 0x7FF8000000000000

There are tests for corner cases and NOT included in test file (on purpose).
```
// Results from hlo interpreter

// CHECK-LABEL: Evaluated results of function: remainder_op_test_si64
func.func @remainder_op_test_si64() -> tensor<2xi64> {
  %lhs = stablehlo.constant dense<[17, 0x7FFFFFFFFFFFFFFF]> : tensor<2xi64>
  %rhs = stablehlo.constant dense<[0, -1]> : tensor<2xi64>
  %result = stablehlo.remainder %lhs, %rhs : tensor<2xi64>
  func.return %result : tensor<2xi64>
}

  17 : i64
  0 : i64

// Results from mlir interpreter

// CHECK-LABEL: Evaluated results of function: remainder_op_test_f64
func.func @remainder_op_test_f64() -> tensor<1xf64> {
  %lhs = stablehlo.constant dense<[1.0]> : tensor<1xf64>
  %rhs = stablehlo.constant dense<[0.0]> : tensor<1xf64>
  %result = stablehlo.remainder %lhs, %rhs : tensor<1xf64>
  func.return %result : tensor<1xf64>
}

0x7FF8000000000000 : f64
```
