### PR TITLE
Use const reference for loop variable to avoid copy

### DIFF
--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -2821,7 +2821,7 @@ void printConvolutionDimensions(AsmPrinter& p, ConvDimensionNumbersAttr dnums) {
         for (const std::pair<int64_t, NonSpatialDim>& nonSpatialDim :
              non_spatialDims)
           dims[nonSpatialDim.first] = nonSpatialDim.second;
-        for (auto spatial_dim : llvm::enumerate(spatialDims))
+        for (const auto& spatial_dim : llvm::enumerate(spatialDims))
           dims[spatial_dim.value()] = static_cast<int64_t>(spatial_dim.index());
 
         // Each dimension numbers will be printed as a comma separated list


### PR DESCRIPTION
Manually fixing as part of clang-tidy check which is currently not supported in StableHLO #61