### PR TITLE
Add VHLO Python/C Bindings

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -798,6 +798,86 @@ cc_library(
     ],
 )
 
+VHLO_CAPI_SOURCES = [
+    "stablehlo/integrations/c/VhloDialect.cpp",
+]
+
+VHLO_CAPI_HEADERS = [
+    "stablehlo/integrations/c/VhloDialect.h",
+]
+
+cc_library(
+    name = "vhlo_capi",
+    srcs = VHLO_CAPI_SOURCES,
+    hdrs = VHLO_CAPI_HEADERS,
+    strip_include_prefix = ".",
+    deps = [
+        ":vhlo_ops",
+        "@llvm-project//mlir:CAPIIR",
+    ],
+)
+
+# Header-only target, used when using the C API from a separate shared library.
+cc_library(
+    name = "vhlo_capi_headers",
+    hdrs = VHLO_CAPI_HEADERS,
+    strip_include_prefix = ".",
+    deps = [
+        "@llvm-project//mlir:CAPIIRHeaders",
+    ],
+)
+
+# Alwayslink target, used when exporting the C API from a shared library.
+cc_library(
+    name = "vhlo_capi_objects",
+    srcs = VHLO_CAPI_SOURCES,
+    hdrs = VHLO_CAPI_HEADERS,
+    strip_include_prefix = ".",
+    deps = [
+        ":vhlo_ops",
+        "@llvm-project//mlir:CAPIIRObjects",
+    ],
+    alwayslink = True,
+)
+
+filegroup(
+    name = "vhlo_ops_py_files",
+    srcs = [
+        "stablehlo/integrations/python/mlir/dialects/vhlo.py",
+        ":vhlo_ops_py_gen",
+    ],
+)
+
+gentbl_filegroup(
+    name = "vhlo_ops_py_gen",
+    tbl_outs = [
+        (
+            [
+                "-gen-python-op-bindings",
+                "-bind-dialect=vhlo",
+            ],
+            "stablehlo/integrations/python/mlir/dialects/_vhlo_ops_gen.py",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "stablehlo/integrations/python/mlir/dialects/VhloOps.td",
+    deps = [
+        ":vhlo_ops_py_td_files",
+    ],
+)
+
+td_library(
+    name = "vhlo_ops_py_td_files",
+    srcs = [
+        "@llvm-project//mlir:include/mlir/Bindings/Python/Attributes.td",
+    ],
+    includes = ["include", "."],
+    deps = [
+        ":vhlo_ops_td_files",
+        "@llvm-project//mlir:OpBaseTdFiles",
+    ],
+)
+
 gentbl_cc_library(
     name = "vhlo_attr_interfaces_inc_gen",
     tbl_outs = [

--- a/stablehlo/dialect/CMakeLists.txt
+++ b/stablehlo/dialect/CMakeLists.txt
@@ -184,6 +184,8 @@ add_mlir_dialect_library(VhloOps
 
   LINK_LIBS PUBLIC
   StablehloAssemblyFormat
+  VhloVersion
+  VhloTypes
   MLIRIR
   MLIRQuantDialect
   MLIRShapeDialect

--- a/stablehlo/dialect/CMakeLists.txt
+++ b/stablehlo/dialect/CMakeLists.txt
@@ -184,8 +184,8 @@ add_mlir_dialect_library(VhloOps
 
   LINK_LIBS PUBLIC
   StablehloAssemblyFormat
-  VhloVersion
   VhloTypes
+  VhloVersion
   MLIRIR
   MLIRQuantDialect
   MLIRShapeDialect

--- a/stablehlo/integrations/c/CMakeLists.txt
+++ b/stablehlo/integrations/c/CMakeLists.txt
@@ -31,3 +31,11 @@ add_mlir_public_c_api_library(StablehloCAPI
   LINK_LIBS PUBLIC
   StablehloOps
 )
+
+add_mlir_public_c_api_library(VhloCAPI
+  PARTIAL_SOURCES_INTENDED
+  VhloDialect.cpp
+
+  LINK_LIBS PUBLIC
+  VhloOps
+)

--- a/stablehlo/integrations/c/VhloDialect.cpp
+++ b/stablehlo/integrations/c/VhloDialect.cpp
@@ -1,0 +1,19 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+   Copyright 2022 The StableHLO Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "stablehlo/integrations/c/VhloDialect.h"
+
+#include "mlir/CAPI/Registration.h"
+#include "stablehlo/dialect/VhloOps.h"
+
+MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(Vhlo, vhlo, mlir::vhlo::VhloDialect)

--- a/stablehlo/integrations/c/VhloDialect.cpp
+++ b/stablehlo/integrations/c/VhloDialect.cpp
@@ -1,5 +1,4 @@
-/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
-   Copyright 2022 The StableHLO Authors.
+/* Copyright 2023 The StableHLO Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/stablehlo/integrations/c/VhloDialect.h
+++ b/stablehlo/integrations/c/VhloDialect.h
@@ -1,0 +1,28 @@
+/*  Copyright 2023 The StableHLO Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef STABLEHLO_INTEGRATIONS_C_VHLO_DIALECT_H
+#define STABLEHLO_INTEGRATIONS_C_VHLO_DIALECT_H
+
+#include "mlir-c/RegisterEverything.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(Vhlo, vhlo);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // STABLEHLO_INTEGRATIONS_C_VHLO_DIALECT_H

--- a/stablehlo/integrations/python/CMakeLists.txt
+++ b/stablehlo/integrations/python/CMakeLists.txt
@@ -46,6 +46,18 @@ declare_mlir_dialect_python_bindings(
   SOURCES dialects/stablehlo.py
   DIALECT_NAME stablehlo)
 
+declare_mlir_python_sources(VhloPythonSources)
+declare_mlir_python_sources(VhloPythonSources.Dialects
+  ADD_TO_PARENT VhloPythonSources
+)
+
+declare_mlir_dialect_python_bindings(
+  ADD_TO_PARENT VhloPythonSources.Dialects
+  ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/mlir"
+  TD_FILE dialects/VhloOps.td
+  SOURCES dialects/vhlo.py
+  DIALECT_NAME vhlo)
+
 ################################################################################
 # Extensions
 ################################################################################
@@ -74,6 +86,18 @@ declare_mlir_python_extension(StablehloPythonExtensions.Main
     LLVMSupport
 )
 
+declare_mlir_python_sources(VhloPythonExtensions)
+declare_mlir_python_extension(VhloPythonExtensions.Main
+  MODULE_NAME _vhlo
+  ADD_TO_PARENT VhloPythonExtensions
+  SOURCES
+    VhloModule.cpp
+  EMBED_CAPI_LINK_LIBS
+    VhloCAPI
+  PRIVATE_LINK_LIBS
+    LLVMSupport
+)
+
 ################################################################################
 # Generate packages and shared libraries
 ################################################################################
@@ -95,6 +119,8 @@ add_mlir_python_common_capi_library(StablehloUnifiedPythonCAPI
     ChloPythonExtensions
     StablehloPythonSources
     StablehloPythonExtensions
+    VhloPythonSources
+    VhloPythonExtensions
 )
 
 add_mlir_python_modules(StablehloUnifiedPythonModules
@@ -107,6 +133,8 @@ add_mlir_python_modules(StablehloUnifiedPythonModules
     ChloPythonExtensions
     StablehloPythonSources
     StablehloPythonExtensions
+    VhloPythonSources
+    VhloPythonExtensions
   COMMON_CAPI_LINK_LIBS
     StablehloUnifiedPythonCAPI
   )

--- a/stablehlo/integrations/python/VhloModule.cpp
+++ b/stablehlo/integrations/python/VhloModule.cpp
@@ -1,0 +1,37 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+   Copyright 2022 The StableHLO Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "mlir-c/IR.h"
+#include "mlir/Bindings/Python/PybindAdaptors.h"
+#include "stablehlo/integrations/c/VhloDialect.h"
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(_vhlo, m) {
+  m.doc() = "vhlo main python extension";
+
+  //
+  // Dialects.
+  //
+
+  m.def(
+      "register_dialect",
+      [](MlirContext context, bool load) {
+        MlirDialectHandle dialect = mlirGetDialectHandle__vhlo__();
+        mlirDialectHandleRegisterDialect(dialect, context);
+        if (load) {
+          mlirDialectHandleLoadDialect(dialect, context);
+        }
+      },
+      py::arg("context"), py::arg("load") = true);
+}

--- a/stablehlo/integrations/python/VhloModule.cpp
+++ b/stablehlo/integrations/python/VhloModule.cpp
@@ -1,5 +1,4 @@
-/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
-   Copyright 2022 The StableHLO Authors.
+/* Copyright 2023 The StableHLO Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/stablehlo/integrations/python/mlir/dialects/VhloOps.td
+++ b/stablehlo/integrations/python/mlir/dialects/VhloOps.td
@@ -1,0 +1,22 @@
+/* Copyright 2023 The StableHLO Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef STABLEHLO_INTEGRATIONS_PYTHON_VHLO_OPS
+#define STABLEHLO_INTEGRATIONS_PYTHON_VHLO_OPS
+
+include "mlir/Bindings/Python/Attributes.td"
+include "stablehlo/dialect/VhloOps.td"
+
+#endif

--- a/stablehlo/integrations/python/mlir/dialects/vhlo.py
+++ b/stablehlo/integrations/python/mlir/dialects/vhlo.py
@@ -17,8 +17,3 @@
 # pylint: disable=wildcard-import,relative-beyond-top-level,g-import-not-at-top
 from ._vhlo_ops_gen import *
 from .._mlir_libs._vhlo import *
-
-
-# Backward compatibility with the old way of registering VHLO dialect
-def register_vhlo_dialect(context, load=True):
-  register_dialect(context, load)

--- a/stablehlo/integrations/python/mlir/dialects/vhlo.py
+++ b/stablehlo/integrations/python/mlir/dialects/vhlo.py
@@ -1,0 +1,24 @@
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2022 The StableHLO Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+# pylint: disable=wildcard-import,relative-beyond-top-level,g-import-not-at-top
+from ._vhlo_ops_gen import *
+from .._mlir_libs._vhlo import *
+
+
+# Backward compatibility with the old way of registering VHLO dialect
+def register_vhlo_dialect(context, load=True):
+  register_dialect(context, load)

--- a/stablehlo/integrations/python/tests/CMakeLists.txt
+++ b/stablehlo/integrations/python/tests/CMakeLists.txt
@@ -27,5 +27,6 @@ endfunction()
 add_stablehlo_python_test(stablehlo-python-chlo chlo.py)
 add_stablehlo_python_test(stablehlo-python-smoketest smoketest.py)
 add_stablehlo_python_test(stablehlo-python-stablehlo stablehlo.py)
+add_stablehlo_python_test(stablehlo-python-vhlo vhlo.py)
 
 add_dependencies(check-stablehlo check-stablehlo-python)

--- a/stablehlo/integrations/python/tests/vhlo.py
+++ b/stablehlo/integrations/python/tests/vhlo.py
@@ -1,5 +1,5 @@
 # Copyright 2021 The TensorFlow Authors. All Rights Reserved.
-# Copyright 2022 The StableHLO Authors.
+# Copyright 2023 The StableHLO Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Tests for CHLO Python APIs."""
+"""Tests for VHLO Python APIs."""
 
 # pylint: disable=wildcard-import,undefined-variable
 
@@ -28,7 +28,7 @@ def run(f):
   return f
 
 @run
-def test_asm_parse():
+def test_parse():
   asm = """
     vhlo.func @main() -> () {
       vhlo.return 

--- a/stablehlo/integrations/python/tests/vhlo.py
+++ b/stablehlo/integrations/python/tests/vhlo.py
@@ -1,0 +1,37 @@
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2022 The StableHLO Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for CHLO Python APIs."""
+
+# pylint: disable=wildcard-import,undefined-variable
+
+from mlir import ir
+from mlir.dialects import vhlo
+
+
+def run(f):
+  with ir.Context() as context:
+    vhlo.register_dialect(context)
+    f()
+  return f
+
+@run
+def test_asm_parse():
+  asm = """
+    vhlo.func @main() -> () {
+      vhlo.return 
+    }
+  """
+  ir.Module.parse(asm)


### PR DESCRIPTION
These are pretty minimal VHLO bindings. We don't intend for Python/C users to directly interact with VHLO attributes / types, so we only need the ability for Python to register the dialect to parse and serialize.

Currently this is based on CHLO bindings, except only Dialect-related bindings are provided currently, no attributes or types.