### PR TITLE
Add interpreter for RealOp

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3720,6 +3720,8 @@ tensor. More formally, for each element `x`:
 // %result: [1.0, 3.0]
 ```
 
+&nbsp;[More Examples](../stablehlo/tests/interpret_real.mlir)
+
 ### recv
 
 #### Semantics

--- a/docs/status.md
+++ b/docs/status.md
@@ -115,7 +115,7 @@ one of the following tracking labels.
 | partition_id             | yes           | yes          | yes            | yes             | no          |
 | popcnt                   | yes           | yes          | yes            | yes             | no          |
 | power                    | yes           | yes          | yes            | yes             | no          |
-| real                     | yes           | yes          | yes            | yes             | no          |
+| real                     | yes           | yes          | yes            | yes             | yes         |
 | real_dynamic_slice       | no            | revisit      | no             | yes             | no          |
 | recv                     | yes           | revisit      | infeasible     | no              | no          |
 | reduce                   | yes           | revisit      | yes            | revisit         | no          |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -503,8 +503,8 @@ def StableHLO_PopulationCountOp: StableHLO_UnaryElementwiseOp<"popcnt",
 
 def StableHLO_RealOp: StableHLO_UnaryElementwiseOp<"real",
     [Pure, DeclareOpInterfaceMethods<InferTypeOpInterface>],
-    HLO_FpOrComplexTensor, HLO_FpTensor> {
-  let summary = "Real operator";
+    HLO_FpOrComplexTensor /*real_i1*/, HLO_FpTensor> {/*real_c1*/
+  let summary = "Real operation";
   let description = [{
     Extracts the real part, element-wise, from the `operand` and produces a
     `result` tensor.

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2536,6 +2536,7 @@ LogicalResult inferPartitionIdOp(MLIRContext* context, std::optional<Location>,
 
 LogicalResult inferRealOp(std::optional<Location>, Value operand,
                           SmallVectorImpl<Type>& inferredReturnTypes) {
+  // real_c2
   inferredReturnTypes.push_back(
       createRealType(operand.getType().cast<TensorType>()));
   return success();

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -496,6 +496,15 @@ Element min(const Element &e1, const Element &e2) {
       });
 }
 
+Element real(const Element &el) {
+  if (isSupportedFloatType(el.getType())) return el;
+  if (isSupportedComplexType(el.getType()))
+    return Element(el.getType().cast<ComplexType>().getElementType(),
+                   el.getComplexValue().real());
+  report_fatal_error(invalidArgument("Unsupported element type: %s",
+                                     debugString(el.getType()).c_str()));
+}
+
 Element rsqrt(const Element &el) {
   return mapWithUpcastToDouble(
       el, [](double e) { return 1.0 / std::sqrt(e); },

--- a/stablehlo/reference/Element.h
+++ b/stablehlo/reference/Element.h
@@ -144,7 +144,8 @@ Element max(const Element &e1, const Element &e2);
 /// Returns the minimum between two Element objects.
 Element min(const Element &e1, const Element &e2);
 
-/// Returns the real part extracted from the Element object.
+/// Returns the real part extracted from the Element object with floating-point
+/// or complex type.
 Element real(const Element &e);
 
 /// Returns reverse square root of Element object.

--- a/stablehlo/reference/Element.h
+++ b/stablehlo/reference/Element.h
@@ -144,6 +144,9 @@ Element max(const Element &e1, const Element &e2);
 /// Returns the minimum between two Element objects.
 Element min(const Element &e1, const Element &e2);
 
+/// Returns the real part extracted from the Element object.
+Element real(const Element &e);
+
 /// Returns reverse square root of Element object.
 Element rsqrt(const Element &e);
 

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -275,6 +275,13 @@ Tensor evalPadOp(const Tensor &operand, const Tensor &paddingValue,
   return result;
 }
 
+Tensor evalRealOp(const Tensor &operand, TensorType resultType) {
+  Tensor result(resultType);
+  for (auto it = operand.index_begin(); it != operand.index_end(); ++it)
+    result.set(*it, real(operand.get(*it)));
+  return result;
+}
+
 Tensor evalReshapeOp(const Tensor &operand, TensorType resultType) {
   Tensor result(resultType);
   for (auto resultIt = result.index_begin(), operandIt = operand.index_begin();
@@ -537,6 +544,10 @@ SmallVector<Tensor> eval(
       auto runtimeResults = evalWhileOp(runtimeInputs, whileOp.getCond(),
                                         whileOp.getBody(), scope);
       scope.add(op.getResults(), runtimeResults);
+    } else if (auto realOp = dyn_cast<RealOp>(op)) {
+      Tensor runtimeOperand = scope.find(realOp.getOperand());
+      Tensor runtimeResult = evalRealOp(runtimeOperand, realOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
     } else if (auto reshapeOp = dyn_cast<ReshapeOp>(op)) {
       Tensor runtimeOperand = scope.find(reshapeOp.getOperand());
       Tensor runtimeResult = evalReshapeOp(runtimeOperand, reshapeOp.getType());

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -61,6 +61,7 @@ Tensor evalOrOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType);
 Tensor evalPadOp(const Tensor &operand, const Tensor &paddingValue,
                  Sizes edgePaddingLow, Sizes interiorPadding,
                  TensorType resultType);
+Tensor evalRealOp(const Tensor &operand, TensorType resultType);
 Tensor evalReshapeOp(const Tensor &operand, TensorType resultType);
 Tensor evalReverseOp(const Tensor &operand, Axes dimensions,
                      TensorType resultType);

--- a/stablehlo/tests/interpret_real.mlir
+++ b/stablehlo/tests/interpret_real.mlir
@@ -1,0 +1,17 @@
+// RUN: stablehlo-interpreter --interpret -split-input-file %s
+
+func.func @real_op_test_f64() {
+  %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.1415926535897931, 0x7FF0000000000000, 0xFFF0000000000000, 0x7FFFFFFFFFFFFFFF, 0x0000000000000001, 0x8000000000000001]> : tensor<11xf64>
+  %1 = stablehlo.real %0 : tensor<11xf64>
+  check.almost_eq %1, dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.1415926535897931, 0x7FF0000000000000, 0xFFF0000000000000, 0x7FFFFFFFFFFFFFFF, 0x0000000000000001, 0x8000000000000001]> : tensor<11xf64>
+  func.return
+}
+
+// -----
+
+func.func @real_op_test_c128() {
+  %0 = stablehlo.constant dense<[(1.5, 2.5), (3.5, 4.5)]> : tensor<2xcomplex<f64>>
+  %1 = stablehlo.real %0 : (tensor<2xcomplex<f64>>) -> tensor<2xf64>
+  check.almost_eq %1, dense<[1.5, 3.5]> : tensor<2xf64>
+  func.return
+}

--- a/stablehlo/tests/interpret_real.mlir
+++ b/stablehlo/tests/interpret_real.mlir
@@ -1,17 +1,17 @@
 // RUN: stablehlo-interpreter --interpret -split-input-file %s
 
 func.func @real_op_test_f64() {
-  %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.1415926535897931, 0x7FF0000000000000, 0xFFF0000000000000, 0x7FFFFFFFFFFFFFFF, 0x0000000000000001, 0x8000000000000001]> : tensor<11xf64>
-  %1 = stablehlo.real %0 : tensor<11xf64>
-  check.almost_eq %1, dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.1415926535897931, 0x7FF0000000000000, 0xFFF0000000000000, 0x7FFFFFFFFFFFFFFF, 0x0000000000000001, 0x8000000000000001]> : tensor<11xf64>
+  %0 = stablehlo.constant dense<[1.0, 2.0]> : tensor<2xf64>
+  %1 = stablehlo.real %0 : tensor<2xf64>
+  check.almost_eq %1, dense<[1.0, 2.0]> : tensor<2xf64>
   func.return
 }
 
 // -----
 
 func.func @real_op_test_c128() {
-  %0 = stablehlo.constant dense<[(1.5, 2.5), (3.5, 4.5)]> : tensor<2xcomplex<f64>>
+  %0 = stablehlo.constant dense<[(1.0, 2.0), (3.0, 4.0)]> : tensor<2xcomplex<f64>>
   %1 = stablehlo.real %0 : (tensor<2xcomplex<f64>>) -> tensor<2xf64>
-  check.almost_eq %1, dense<[1.5, 3.5]> : tensor<2xf64>
+  check.almost_eq %1, dense<[1.0, 3.0]> : tensor<2xf64>
   func.return
 }

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -1819,8 +1819,8 @@ func.func @real_complex_input(%arg0: tensor<2x3xcomplex<f32>>) -> tensor<2x3xf32
 
 // -----
 
-// CHECK-LABEL: func @real_fp_input
-func.func @real_fp_input(%arg0: tensor<*xf32>) -> tensor<*xf32> {
+// CHECK-LABEL: func @real_unranked
+func.func @real_unranked(%arg0: tensor<*xf32>) -> tensor<*xf32> {
   %0 = "stablehlo.real"(%arg0) : (tensor<*xf32>) -> tensor<*xf32>
   func.return %0 : tensor<*xf32>
 }

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -1803,18 +1803,10 @@ func.func @outfeed(%arg0: tensor<3x3x3xi32>, %arg1: !stablehlo.token) -> !stable
 
 // -----
 
-// CHECK-LABEL: func @real_fp_input
-func.func @real_fp_input(%arg0: tensor<*xf32>) -> tensor<*xf32> {
-  %0 = "stablehlo.real"(%arg0) : (tensor<*xf32>) -> tensor<*xf32>
-  func.return %0 : tensor<*xf32>
-}
-
-// -----
-
-func.func @real_int_input(%arg0: tensor<*xi32>) -> tensor<*xi32> {
-  // expected-error@+1 {{operand #0 must be tensor of f8E4M3FN type or f8E5M2 type or 16-bit float or 32-bit float or 64-bit float or bfloat16 type or complex type with 32-bit float or 64-bit float elements values, but got 'tensor<*xi32>'}}
-  %0 = "stablehlo.real"(%arg0) : (tensor<*xi32>) -> tensor<*xi32>
-  func.return %0 : tensor<*xi32>
+func.func @real_c2(%arg0: tensor<2x3xcomplex<f32>>) -> tensor<2x3xf16> {
+  // expected-error@+1 {{inferred type(s) 'tensor<2x3xf32>' are incompatible with return type(s) of operation 'tensor<2x3xf16>'}}
+  %0 = "stablehlo.real"(%arg0) : (tensor<2x3xcomplex<f32>>) -> tensor<2x3xf16>
+  func.return %0 : tensor<2x3xf16>
 }
 
 // -----
@@ -1827,18 +1819,10 @@ func.func @real_complex_input(%arg0: tensor<2x3xcomplex<f32>>) -> tensor<2x3xf32
 
 // -----
 
-func.func @real_mismatch_return_shape(%arg0: tensor<2x3xcomplex<f32>>) -> tensor<2x10xf32> {
-  // expected-error@+1 {{all non-scalar operands/results must have the same shape and base type}}
-  %0 = "stablehlo.real"(%arg0) : (tensor<2x3xcomplex<f32>>) -> tensor<2x10xf32>
-  func.return %0 : tensor<2x10xf32>
-}
-
-// -----
-
-func.func @real_mismatch_return_element_type(%arg0: tensor<2x3xcomplex<f32>>) -> tensor<2x3xf16> {
-  // expected-error@+1 {{inferred type(s) 'tensor<2x3xf32>' are incompatible with return type(s) of operation 'tensor<2x3xf16>'}}
-  %0 = "stablehlo.real"(%arg0) : (tensor<2x3xcomplex<f32>>) -> tensor<2x3xf16>
-  func.return %0 : tensor<2x3xf16>
+// CHECK-LABEL: func @real_fp_input
+func.func @real_fp_input(%arg0: tensor<*xf32>) -> tensor<*xf32> {
+  %0 = "stablehlo.real"(%arg0) : (tensor<*xf32>) -> tensor<*xf32>
+  func.return %0 : tensor<*xf32>
 }
 
 // -----


### PR DESCRIPTION
Here are the following constraints:
```
(I1) operand is a tensor of floating-point or complex type.
(C1) shape(`result`) = shape(`operand`).
(C2) element_type(`result`) $=$
     * element_type(`operand`) if it's a floating-point type.
     * real_type(element_type(`operand`)) otherwise.
```
I1 and C1 is covered by the ODS and C2 is covered in inferRealOp() as part of the type inference. Two redundant ODS tests are removed.

closes #1108 