### PR TITLE
Add interpreter for ImagOp

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2919,6 +2919,8 @@ Extracts the imaginary part, element-wise, from the `operand` and produces a
 // %result: [2.0, 4.0]
 ```
 
+&nbsp;[More Examples](../stablehlo/tests/interpret_imag.mlir)
+
 ### infeed
 
 #### Semantics

--- a/docs/status.md
+++ b/docs/status.md
@@ -95,7 +95,7 @@ one of the following tracking labels.
 | get_dimension_size       | yes           | yes          | yes            | yes             | no          |
 | get_tuple_element        | yes           | yes          | yes            | yes             | no          |
 | if                       | yes           | revisit      | yes            | no              | yes         |
-| imag                     | yes           | yes          | yes            | yes             | no          |
+| imag                     | yes           | yes          | yes            | yes             | yes         |
 | infeed                   | yes           | revisit      | infeasible     | no              | no          |
 | iota                     | yes           | yes          | infeasible     | yes             | yes         |
 | is_finite                | yes           | yes          | yes            | yes             | no          |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -359,8 +359,8 @@ def StableHLO_FloorOp: StableHLO_UnaryElementwiseOp<"floor",
 
 def StableHLO_ImagOp: StableHLO_UnaryElementwiseOp<"imag",
     [Pure, DeclareOpInterfaceMethods<InferTypeOpInterface>],
-    HLO_FpOrComplexTensor, HLO_FpTensor> {
-  let summary = "Imag operator";
+    HLO_FpOrComplexTensor /*imag_i1*/, HLO_FpTensor> {/*imag_c1*/
+  let summary = "Imag operation";
   let description = [{
     Extracts the imaginary part, element-wise, from the `operand` and produces a
     `result` tensor.

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2326,6 +2326,7 @@ LogicalResult inferGetTupleElementOp(
 
 LogicalResult inferImagOp(std::optional<Location> location, Value operand,
                           SmallVectorImpl<Type>& inferredReturnTypes) {
+  // imag_c2
   inferredReturnTypes.push_back(
       createRealType(operand.getType().cast<TensorType>()));
   return success();

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -448,6 +448,21 @@ Element floor(const Element &el) {
   return Element(el.getType(), val);
 }
 
+Element imag(const Element &el) {
+  if (isSupportedFloatType(el.getType())) {
+    const llvm::fltSemantics &elSemantics = el.getFloatValue().getSemantics();
+    bool roundingErr;
+    APFloat resultImag(0.0);
+    resultImag.convert(elSemantics, APFloat::rmNearestTiesToEven, &roundingErr);
+    return Element(el.getType(), resultImag);
+  }
+  if (isSupportedComplexType(el.getType()))
+    return Element(el.getType().cast<ComplexType>().getElementType(),
+                   el.getComplexValue().imag());
+  report_fatal_error(invalidArgument("Unsupported element type: %s",
+                                     debugString(el.getType()).c_str()));
+}
+
 Element cosine(const Element &el) {
   return mapWithUpcastToDouble(
       el, [](double e) { return std::cos(e); },

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -450,7 +450,6 @@ Element floor(const Element &el) {
 
 Element imag(const Element &el) {
   if (isSupportedFloatType(el.getType())) {
-    // The following will be simplified in #1154.
     const llvm::fltSemantics &elSemantics = el.getFloatValue().getSemantics();
     bool roundingErr;
     APFloat resultImag(0.0);

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -450,6 +450,7 @@ Element floor(const Element &el) {
 
 Element imag(const Element &el) {
   if (isSupportedFloatType(el.getType())) {
+    // The following will be simplified in #1154.
     const llvm::fltSemantics &elSemantics = el.getFloatValue().getSemantics();
     bool roundingErr;
     APFloat resultImag(0.0);

--- a/stablehlo/reference/Element.h
+++ b/stablehlo/reference/Element.h
@@ -135,7 +135,8 @@ Element exponential(const Element &el);
 /// Returns floor of Element object.
 Element floor(const Element &e);
 
-/// Returns the imaginary part extracted from the Element object.
+/// Returns the imaginary part extracted from the Element object with
+/// floating-point or complex type.
 Element imag(const Element &el);
 
 /// Returns log of Element object.

--- a/stablehlo/reference/Element.h
+++ b/stablehlo/reference/Element.h
@@ -135,6 +135,9 @@ Element exponential(const Element &el);
 /// Returns floor of Element object.
 Element floor(const Element &e);
 
+/// Returns the imaginary part extracted from the Element object.
+Element imag(const Element &el);
+
 /// Returns log of Element object.
 Element log(const Element &el);
 

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -49,6 +49,7 @@ Tensor evalExponentialOp(const Tensor &operand, TensorType resultType);
 Tensor evalFloorOp(const Tensor &operand, TensorType resultType);
 SmallVector<Tensor> evalIfOp(const Tensor &pred, Region &trueBranch,
                              Region &falseBranch, Scope &scope);
+Tensor evalImagOp(const Tensor &operand, TensorType resultType);
 Tensor evalIotaOp(Axis iotaDimension, TensorType resultType);
 Tensor evalLogOp(const Tensor &operand, TensorType resultType);
 Tensor evalMaxOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType);

--- a/stablehlo/tests/interpret_imag.mlir
+++ b/stablehlo/tests/interpret_imag.mlir
@@ -1,0 +1,32 @@
+// RUN: stablehlo-interpreter --interpret -split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: Evaluated results of function: imag_op_test_f64
+func.func @imag_op_test_f64() -> tensor<11xf64> {
+  %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.1415926535897931, 0x7FF0000000000000, 0xFFF0000000000000, 0x7FFFFFFFFFFFFFFF, 0x0000000000000001, 0x8000000000000001]> : tensor<11xf64>
+  %1 = stablehlo.imag %0 : tensor<11xf64>
+  func.return %1 : tensor<11xf64>
+  // CHECK-NEXT: tensor<11xf64>
+  // CHECK-NEXT: 0.000000e+00 : f64
+  // CHECK-NEXT: 0.000000e+00 : f64
+  // CHECK-NEXT: 0.000000e+00 : f64
+  // CHECK-NEXT: 0.000000e+00 : f64
+  // CHECK-NEXT: 0.000000e+00 : f64
+  // CHECK-NEXT: 0.000000e+00 : f64
+  // CHECK-NEXT: 0.000000e+00 : f64
+  // CHECK-NEXT: 0.000000e+00 : f64
+  // CHECK-NEXT: 0.000000e+00 : f64
+  // CHECK-NEXT: 0.000000e+00 : f64
+  // CHECK-NEXT: 0.000000e+00 : f64
+}
+
+// -----
+
+// CHECK-LABEL: Evaluated results of function: imag_op_test_c128
+func.func @imag_op_test_c128() -> tensor<2xf64> {
+  %0 = stablehlo.constant dense<[(1.5, 2.5), (3.5, 4.5)]> : tensor<2xcomplex<f64>>
+  %1 = stablehlo.imag %0 : (tensor<2xcomplex<f64>>) -> tensor<2xf64>
+  func.return %1 : tensor<2xf64>
+  // CHECK-NEXT: tensor<2xf64>
+  // CHECK-NEXT: 2.500000e+00 : f64
+  // CHECK-NEXT: 4.500000e+00 : f64
+}

--- a/stablehlo/tests/interpret_imag.mlir
+++ b/stablehlo/tests/interpret_imag.mlir
@@ -1,23 +1,17 @@
-// RUN: stablehlo-interpreter --interpret -split-input-file %s | FileCheck %s
+// RUN: stablehlo-interpreter --interpret -split-input-file %s
 
-// CHECK-LABEL: Evaluated results of function: imag_op_test_f64
-func.func @imag_op_test_f64() -> tensor<2xf64> {
+func.func @imag_op_test_f64() {
   %0 = stablehlo.constant dense<[1.0, 2.0]> : tensor<2xf64>
   %1 = stablehlo.imag %0 : tensor<2xf64>
-  func.return %1 : tensor<2xf64>
-  // CHECK-NEXT: tensor<2xf64>
-  // CHECK-NEXT: 0.000000e+00 : f64
-  // CHECK-NEXT: 0.000000e+00 : f64
+  check.almost_eq %1, dense<[0.0, 0.0]> : tensor<2xf64>
+  func.return
 }
 
 // -----
 
-// CHECK-LABEL: Evaluated results of function: imag_op_test_c128
-func.func @imag_op_test_c128() -> tensor<2xf64> {
+func.func @imag_op_test_c128() {
   %0 = stablehlo.constant dense<[(1.0, 2.0), (3.0, 4.0)]> : tensor<2xcomplex<f64>>
   %1 = stablehlo.imag %0 : (tensor<2xcomplex<f64>>) -> tensor<2xf64>
-  func.return %1 : tensor<2xf64>
-  // CHECK-NEXT: tensor<2xf64>
-  // CHECK-NEXT: 2.000000e+00 : f64
-  // CHECK-NEXT: 4.000000e+00 : f64
+  check.almost_eq %1, dense<[2.0, 4.0]> : tensor<2xf64>
+  func.return
 }

--- a/stablehlo/tests/interpret_imag.mlir
+++ b/stablehlo/tests/interpret_imag.mlir
@@ -1,20 +1,11 @@
 // RUN: stablehlo-interpreter --interpret -split-input-file %s | FileCheck %s
 
 // CHECK-LABEL: Evaluated results of function: imag_op_test_f64
-func.func @imag_op_test_f64() -> tensor<11xf64> {
-  %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.1415926535897931, 0x7FF0000000000000, 0xFFF0000000000000, 0x7FFFFFFFFFFFFFFF, 0x0000000000000001, 0x8000000000000001]> : tensor<11xf64>
-  %1 = stablehlo.imag %0 : tensor<11xf64>
-  func.return %1 : tensor<11xf64>
-  // CHECK-NEXT: tensor<11xf64>
-  // CHECK-NEXT: 0.000000e+00 : f64
-  // CHECK-NEXT: 0.000000e+00 : f64
-  // CHECK-NEXT: 0.000000e+00 : f64
-  // CHECK-NEXT: 0.000000e+00 : f64
-  // CHECK-NEXT: 0.000000e+00 : f64
-  // CHECK-NEXT: 0.000000e+00 : f64
-  // CHECK-NEXT: 0.000000e+00 : f64
-  // CHECK-NEXT: 0.000000e+00 : f64
-  // CHECK-NEXT: 0.000000e+00 : f64
+func.func @imag_op_test_f64() -> tensor<2xf64> {
+  %0 = stablehlo.constant dense<[1.0, 2.0]> : tensor<2xf64>
+  %1 = stablehlo.imag %0 : tensor<2xf64>
+  func.return %1 : tensor<2xf64>
+  // CHECK-NEXT: tensor<2xf64>
   // CHECK-NEXT: 0.000000e+00 : f64
   // CHECK-NEXT: 0.000000e+00 : f64
 }
@@ -23,10 +14,10 @@ func.func @imag_op_test_f64() -> tensor<11xf64> {
 
 // CHECK-LABEL: Evaluated results of function: imag_op_test_c128
 func.func @imag_op_test_c128() -> tensor<2xf64> {
-  %0 = stablehlo.constant dense<[(1.5, 2.5), (3.5, 4.5)]> : tensor<2xcomplex<f64>>
+  %0 = stablehlo.constant dense<[(1.0, 2.0), (3.0, 4.0)]> : tensor<2xcomplex<f64>>
   %1 = stablehlo.imag %0 : (tensor<2xcomplex<f64>>) -> tensor<2xf64>
   func.return %1 : tensor<2xf64>
   // CHECK-NEXT: tensor<2xf64>
-  // CHECK-NEXT: 2.500000e+00 : f64
-  // CHECK-NEXT: 4.500000e+00 : f64
+  // CHECK-NEXT: 2.000000e+00 : f64
+  // CHECK-NEXT: 4.000000e+00 : f64
 }

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -1569,8 +1569,8 @@ func.func @imag_complex_input(%arg0: tensor<2x3xcomplex<f32>>) -> tensor<2x3xf32
 
 // -----
 
-// CHECK-LABEL: func @imag_fp_input
-func.func @imag_fp_input(%arg0: tensor<*xf32>) -> tensor<*xf32> {
+// CHECK-LABEL: func @imag_unranked
+func.func @imag_unranked(%arg0: tensor<*xf32>) -> tensor<*xf32> {
   %0 = "stablehlo.imag"(%arg0) : (tensor<*xf32>) -> tensor<*xf32>
   func.return %0 : tensor<*xf32>
 }

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -1553,18 +1553,10 @@ func.func @dot_legal_unranked_rank_type(%arg0: tensor<*xf32>, %arg1: tensor<*xf3
 
 // -----
 
-// CHECK-LABEL: func @imag_fp_input
-func.func @imag_fp_input(%arg0: tensor<*xf32>) -> tensor<*xf32> {
-  %0 = "stablehlo.imag"(%arg0) : (tensor<*xf32>) -> tensor<*xf32>
-  func.return %0 : tensor<*xf32>
-}
-
-// -----
-
-func.func @imag_int_input(%arg0: tensor<*xi32>) -> tensor<*xi32> {
-  // expected-error@+1 {{operand #0 must be tensor of f8E4M3FN type or f8E5M2 type or 16-bit float or 32-bit float or 64-bit float or bfloat16 type or complex type with 32-bit float or 64-bit float elements values, but got 'tensor<*xi32>'}}
-  %0 = "stablehlo.imag"(%arg0) : (tensor<*xi32>) -> tensor<*xi32>
-  func.return %0 : tensor<*xi32>
+func.func @imag_c2(%arg0: tensor<2xf32>) -> tensor<2xf16> {
+  // expected-error@+1 {{inferred type(s) 'tensor<2xf32>' are incompatible with return type(s) of operation 'tensor<2xf16>'}}
+  %0 = "stablehlo.imag"(%arg0) : (tensor<2xf32>) -> tensor<2xf16>
+  func.return %0 : tensor<2xf16>
 }
 
 // -----
@@ -1577,18 +1569,10 @@ func.func @imag_complex_input(%arg0: tensor<2x3xcomplex<f32>>) -> tensor<2x3xf32
 
 // -----
 
-func.func @imag_mismatch_return_shape(%arg0: tensor<2xf32>) -> tensor<4xf32> {
-  // expected-error@+1 {{all non-scalar operands/results must have the same shape and base type}}
-  %0 = "stablehlo.imag"(%arg0) : (tensor<2xf32>) -> tensor<4xf32>
-  func.return %0 : tensor<4xf32>
-}
-
-// -----
-
-func.func @imag_mismatch_return_element_type(%arg0: tensor<2xf32>) -> tensor<2xf16> {
-  // expected-error@+1 {{inferred type(s) 'tensor<2xf32>' are incompatible with return type(s) of operation 'tensor<2xf16>'}}
-  %0 = "stablehlo.imag"(%arg0) : (tensor<2xf32>) -> tensor<2xf16>
-  func.return %0 : tensor<2xf16>
+// CHECK-LABEL: func @imag_fp_input
+func.func @imag_fp_input(%arg0: tensor<*xf32>) -> tensor<*xf32> {
+  %0 = "stablehlo.imag"(%arg0) : (tensor<*xf32>) -> tensor<*xf32>
+  func.return %0 : tensor<*xf32>
 }
 
 // -----


### PR DESCRIPTION
Here are the following constraints:
```
(I1) operand is a tensor of floating-point or complex type.
(C1) shape(`result`) = shape(`operand`).
(C2) element_type(`result`) $=$
     * element_type(`operand`) if it's a floating-point type.
     * real_type(element_type(`operand`)) otherwise.
```
I1 and C1 is covered by the ODS and C2 is covered in inferImagOp() as part of the type inference. Two redundant ODS tests are removed.

closes #1103 