### PR TITLE
Add support for DynamicConvOp to --stablehlo-refine-shapes

### DIFF
--- a/stablehlo/tests/stablehlo_refine_shapes.mlir
+++ b/stablehlo/tests/stablehlo_refine_shapes.mlir
@@ -157,8 +157,8 @@ func.func @eval_compare_lt() -> tensor<i1> {
 
 // -----
 
-// CHECK-LABEL: func @eval_concatenate
-func.func @eval_concatenate() -> tensor<4xi64> {
+// CHECK-LABEL: func @eval_concatenate_1d
+func.func @eval_concatenate_1d() -> tensor<4xi64> {
   // CHECK-NOT: stablehlo.concatenate
   // CHECK: [[RESULT:%.*]] = stablehlo.constant dense<[1, 2, 3, 4]> : tensor<4xi64>
   // CHECK: return [[RESULT]]
@@ -166,6 +166,19 @@ func.func @eval_concatenate() -> tensor<4xi64> {
   %1 = stablehlo.constant dense<[3, 4]> : tensor<2xi64>
   %2 = stablehlo.concatenate %0, %1, dim = 0 : (tensor<2xi64>, tensor<2xi64>) -> tensor<4xi64>
   func.return %2 : tensor<4xi64>
+}
+
+// -----
+
+// CHECK-LABEL: func @eval_concatenate_2d
+func.func @eval_concatenate_2d() -> tensor<2x2xi64> {
+  // CHECK-NOT: stablehlo.concatenate
+  // CHECK: [[RESULT:%.*]] = stablehlo.constant dense<{{\[}}[1, 2], [3, 4]]> : tensor<2x2xi64>
+  // CHECK: return [[RESULT]]
+  %0 = stablehlo.constant dense<[[1, 2]]> : tensor<1x2xi64>
+  %1 = stablehlo.constant dense<[[3, 4]]> : tensor<1x2xi64>
+  %2 = stablehlo.concatenate %0, %1, dim = 0 : (tensor<1x2xi64>, tensor<1x2xi64>) -> tensor<2x2xi64>
+  func.return %2 : tensor<2x2xi64>
 }
 
 // -----
@@ -178,6 +191,19 @@ func.func @eval_convert() -> tensor<i64> {
   %0 = stablehlo.constant dense<4> : tensor<i32>
   %1 = stablehlo.convert %0 : (tensor<i32>) -> tensor<i64>
   func.return %1 : tensor<i64>
+}
+
+// -----
+
+// CHECK-LABEL: func @eval_divide
+func.func @eval_divide() -> tensor<i64> {
+  // CHECK-NOT: stablehlo.divide
+  // CHECK: [[RESULT:%.*]] = stablehlo.constant dense<1> : tensor<i64>
+  // CHECK: return [[RESULT]]
+  %0 = stablehlo.constant dense<2> : tensor<i64>
+  %1 = stablehlo.constant dense<2> : tensor<i64>
+  %2 = stablehlo.divide %0, %1 : tensor<i64>
+  func.return %2 : tensor<i64>
 }
 
 // -----
@@ -356,6 +382,23 @@ func.func @refine_dynamic_broadcast_in_dim(%arg0: tensor<4xf32>) -> tensor<*xf32
   %0 = stablehlo.constant dense<[3, 4]> : tensor<2xi64>
   %1 = stablehlo.dynamic_broadcast_in_dim %arg0, %0, dims = [1] : (tensor<4xf32>, tensor<2xi64>) -> tensor<*xf32>
   func.return %1 : tensor<*xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @refine_dynamic_conv
+func.func @refine_dynamic_conv(%arg0 : tensor<100x26x26x32xf32>, %arg1 : tensor<3x3x1x32xf32>) -> tensor<*xf32> {
+  // CHECK: stablehlo.dynamic_conv{{.*}} -> tensor<100x28x28x1xf32>
+  %0 = stablehlo.constant dense<[[2, 2], [2, 2]]> : tensor<2x2xi32>
+  %1 = "stablehlo.dynamic_conv"(%arg0, %arg1, %0) {
+    dimension_numbers = #stablehlo.conv<[b, 0, 1, f]x[0, 1, o, i]->[b, 0, 1, f]>,
+    window_strides = dense<[1, 1]> : tensor<2xi64>,
+    lhs_dilation = dense<[1, 1]> : tensor<2xi64>,
+    rhs_dilation = dense<[1, 1]> : tensor<2xi64>,
+    feature_group_count = 1 : i64,
+    batch_group_count = 1 : i64
+  } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>, tensor<2x2xi32>) -> tensor<*xf32>
+  return %1 : tensor<*xf32>
 }
 
 // -----

--- a/stablehlo/transforms/StablehloRefineShapes.cpp
+++ b/stablehlo/transforms/StablehloRefineShapes.cpp
@@ -172,8 +172,8 @@ struct EvalConcatenateOpPattern : public OpRewritePattern<ConcatenateOp> {
   LogicalResult matchAndRewrite(ConcatenateOp op,
                                 PatternRewriter& rewriter) const override {
     auto resultType = op.getResult().getType().dyn_cast<RankedTensorType>();
-    if (!resultType || resultType.getRank() != 1)
-      return rewriter.notifyMatchFailure(op, "expected 1-dimensional type");
+    if (!resultType || op.getDimension() != 0)
+      return rewriter.notifyMatchFailure(op, "expected dimension = 0");
 
     SmallVector<APInt> result;
     for (Value operand : op->getOperands()) {
@@ -212,6 +212,18 @@ struct EvalConvertOpPattern : public OpRewritePattern<ConvertOp> {
     rewriter.replaceOpWithNewOp<ConstantOp>(
         op, DenseIntElementsAttr::get(resultType, result));
     return success();
+  }
+};
+
+struct EvalDivOpPattern : public OpRewritePattern<DivOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(DivOp op,
+                                PatternRewriter& rewriter) const override {
+    auto resultType = op.getResult().getType().cast<ShapedType>();
+    auto isResultUnsigned = resultType.getElementType().isUnsignedInteger();
+    return evalBinary(rewriter, op, [&](APInt lhs, APInt rhs) {
+      return isResultUnsigned ? lhs.udiv(rhs) : lhs.sdiv(rhs);
+    });
   }
 };
 
@@ -599,6 +611,40 @@ struct RefineDynamicBroadcastInDimOpPattern
   }
 };
 
+struct RefineDynamicConvOpPattern : public OpRewritePattern<DynamicConvOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(DynamicConvOp op,
+                                PatternRewriter& rewriter) const override {
+    SmallVector<int64_t> padding;
+    if (failed(matchInts(op.getDPadding(), padding)))
+      return rewriter.notifyMatchFailure(op, "expected constant d_padding");
+    if (op.getPadding().has_value())
+      return rewriter.notifyMatchFailure(op, "expected empty padding");
+    auto paddingType = RankedTensorType::get(
+        op.getDPadding().getType().getShape(), rewriter.getIntegerType(64));
+    auto paddingAttr = DenseIntElementsAttr::get(paddingType, padding);
+
+    SmallVector<ShapedTypeComponents> inferredReturnShapes;
+    if (failed(hlo::inferConvolutionOp(
+            /*location=*/{}, op.getLhs(), op.getRhs(), op.getWindowStrides(),
+            paddingAttr, op.getLhsDilation(), op.getRhsDilation(),
+            op.getWindowReversal(),
+            op.getDimensionNumbers().getInputBatchDimension(),
+            op.getDimensionNumbers().getInputFeatureDimension(),
+            op.getDimensionNumbers().getInputSpatialDimensions(),
+            op.getDimensionNumbers().getKernelInputFeatureDimension(),
+            op.getDimensionNumbers().getKernelOutputFeatureDimension(),
+            op.getDimensionNumbers().getKernelSpatialDimensions(),
+            op.getDimensionNumbers().getOutputBatchDimension(),
+            op.getDimensionNumbers().getOutputFeatureDimension(),
+            op.getDimensionNumbers().getOutputSpatialDimensions(),
+            op.getFeatureGroupCount(), op.getBatchGroupCount(),
+            op.getPrecisionConfig(), inferredReturnShapes)))
+      return rewriter.notifyMatchFailure(op, "inferConvolutionOp failed");
+    return refineReturnTypes(rewriter, op, inferredReturnShapes);
+  }
+};
+
 struct RefineDynamicIotaOpPattern : public OpRewritePattern<DynamicIotaOp> {
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(DynamicIotaOp op,
@@ -904,6 +950,7 @@ struct StablehloRefineShapesPass
     patterns.add<EvalCompareOpPattern>(&getContext());
     patterns.add<EvalConcatenateOpPattern>(&getContext());
     patterns.add<EvalConvertOpPattern>(&getContext());
+    patterns.add<EvalDivOpPattern>(&getContext());
     patterns.add<EvalGetDimensionSizeOpPattern>(&getContext());
     patterns.add<EvalMaxOpPattern>(&getContext());
     patterns.add<EvalMulOpPattern>(&getContext());
@@ -917,6 +964,7 @@ struct StablehloRefineShapesPass
     patterns.add<RefineConvolutionOpPattern>(&getContext());
     patterns.add<RefineDotGeneralOpPattern>(&getContext());
     patterns.add<RefineDynamicBroadcastInDimOpPattern>(&getContext());
+    patterns.add<RefineDynamicConvOpPattern>(&getContext());
     patterns.add<RefineDynamicIotaOpPattern>(&getContext());
     patterns.add<RefineDynamicPadOpPattern>(&getContext());
     patterns.add<RefineDynamicReshapeOpPattern>(&getContext());


### PR DESCRIPTION
This PR adds a RefineConvolutionOpPattern pattern that reuses inferConvolutionOp to do shape refinement for DynamicConvOp.

Additionally, it makes some changes to constant folding patterns to support related shape computations.