### PR TITLE
Prototype a mechanism to customize shape refinement for CustomCallOp

### DIFF
--- a/stablehlo/tests/stablehlo_refine_shapes.mlir
+++ b/stablehlo/tests/stablehlo_refine_shapes.mlir
@@ -360,6 +360,19 @@ func.func @refine_convolution(%arg0 : tensor<100x26x26x32xf32>, %arg1 : tensor<3
 
 // -----
 
+// CHECK-LABEL: @refine_custom_call
+func.func @refine_custom_call(%arg0: tensor<4xf32>) -> (tensor<*xf32>, tensor<*xf32>) {
+  // CHECK: stablehlo.custom_call{{.*}} -> (tensor<1x2xf32>, tensor<3x4xf32>)
+  %0 = stablehlo.constant dense<[1, 2]> : tensor<2xi64>
+  %1 = stablehlo.constant dense<[3, 4]> : tensor<2xi64>
+  %2:2 = stablehlo.custom_call @foo(%arg0, %0, %1) {
+    indices_of_shape_operands = dense<[1, 2]> : tensor<2xi64>
+  } : (tensor<4xf32>, tensor<2xi64>, tensor<2xi64>) -> (tensor<*xf32>, tensor<*xf32>)
+  func.return %2#0, %2#1 : tensor<*xf32>, tensor<*xf32>
+}
+
+// -----
+
 // CHECK-LABEL: @refine_dot_general
 func.func @refine_dot_general(%arg0: tensor<2x3x4xf32>, %arg1: tensor<2x3x5xf32>) -> tensor<*xf32> {
   // CHECK: "stablehlo.dot_general"{{.*}} -> tensor<2x4x5xf32>

--- a/stablehlo/transforms/StablehloRefineShapes.cpp
+++ b/stablehlo/transforms/StablehloRefineShapes.cpp
@@ -603,6 +603,8 @@ struct RefineCustomCallOpPattern : public OpRewritePattern<CustomCallOp> {
       SmallVector<int64_t> refinement;
       if (failed(matchInts(op->getOperand(operandIndex), refinement)))
         return rewriter.notifyMatchFailure(op, "expected constant operand");
+      if (llvm::any_of(refinement, [&](int64_t x) { return x < 0; }))
+        return rewriter.notifyMatchFailure(op, "expected non-negative sizes");
       refinements.emplace_back(refinement);
     }
     return refineReturnTypes(rewriter, op, refinements);

--- a/stablehlo/transforms/StablehloRefineShapes.cpp
+++ b/stablehlo/transforms/StablehloRefineShapes.cpp
@@ -585,6 +585,30 @@ struct RefineConvolutionOpPattern : public OpRewritePattern<ConvolutionOp> {
   }
 };
 
+struct RefineCustomCallOpPattern : public OpRewritePattern<CustomCallOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(CustomCallOp op,
+                                PatternRewriter& rewriter) const override {
+    auto operandIndicesAttr = op->getAttr("indices_of_shape_operands")
+                                  .dyn_cast_or_null<DenseIntElementsAttr>();
+    if (!operandIndicesAttr)
+      return rewriter.notifyMatchFailure(
+          op, "expected an indices_of_shape_operands attribute");
+
+    SmallVector<ShapedTypeComponents> refinements;
+    for (auto operandIndexElt : operandIndicesAttr.getValues<APInt>()) {
+      int64_t operandIndex = operandIndexElt.getSExtValue();
+      if (operandIndex < 0 || operandIndex >= op->getNumOperands())
+        return rewriter.notifyMatchFailure(op, "expected valid operand index");
+      SmallVector<int64_t> refinement;
+      if (failed(matchInts(op->getOperand(operandIndex), refinement)))
+        return rewriter.notifyMatchFailure(op, "expected constant operand");
+      refinements.emplace_back(refinement);
+    }
+    return refineReturnTypes(rewriter, op, refinements);
+  }
+};
+
 struct RefineDotGeneralOpPattern : public OpRewritePattern<DotGeneralOp> {
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(DotGeneralOp op,
@@ -962,6 +986,7 @@ struct StablehloRefineShapesPass
     patterns.add<RefineBitcastConvertOpPattern>(&getContext());
     patterns.add<RefineConvertOpPattern>(&getContext());
     patterns.add<RefineConvolutionOpPattern>(&getContext());
+    patterns.add<RefineCustomCallOpPattern>(&getContext());
     patterns.add<RefineDotGeneralOpPattern>(&getContext());
     patterns.add<RefineDynamicBroadcastInDimOpPattern>(&getContext());
     patterns.add<RefineDynamicConvOpPattern>(&getContext());


### PR DESCRIPTION
This is a prototype of the CustomCallOp shape refinement mechanism to enable specializing dynamically-shaped programs with custom calls to static shapes (#851).

Based on the results of prototyping, I'm planning to propose an RFC to extend CustomCallOp, so that the logic can migrate from using an unregistered attribute to something more solid.