### PR TITLE
Add interpreter for CaseOp

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1320,10 +1320,10 @@ returned.
 
 #### Inputs
 
-| Label | Name       | Type                                | Constraints |
-|-------|------------|-------------------------------------|-------------|
-| (I1)  | `index`    | 1-dimensional tensor of type `si32` |             |
-| (I2)  | `branches` | variadic number of functions        | (C1-C4)     |
+| Label | Name       | Type                                         | Constraints |
+|-------|------------|----------------------------------------------|-------------|
+| (I1)  | `index`    | 0-dimensional tensor constant of type `si32` |             |
+| (I2)  | `branches` | variadic number of functions                 | (C1-C4)     |
 
 #### Outputs
 
@@ -1336,7 +1336,7 @@ returned.
 * (C1) `branches` have at least one function.
 * (C2) All functions in `branches` have 0 inputs.
 * (C3) All functions in `branches` have the same output types.
-* (C4) For all `i`, `type(results[i]) = type(branches[0]).outputs[i]`.
+* (C4) For all `i`, `type(results[i]) = type(branches[0].outputs[i])`.
 
 #### Examples
 
@@ -1351,6 +1351,8 @@ returned.
 }) : (tensor<i32>) -> tensor<i32>
 // %result: 11
 ```
+
+&nbsp;[More Examples](../stablehlo/tests/interpret_case.mlir)
 
 ### cbrt
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1342,14 +1342,15 @@ returned.
 
 ```mlir
 // %index: -1
-// %result_branch0: 0
-// %result_branch1: 1
-%result = "stablehlo.case"(%index) ({
-  "stablehlo.return"(%result_branch0) : (tensor<2xi64>) -> ()
+// %result_branch0: [0, 0]
+// %result_branch1: [1, 1]
+%result0, %result1 = "stablehlo.case"(%index) ({
+  "stablehlo.return"(%result_branch0, %result_branch0) : (tensor<2xi64>, tensor<2xi64>) -> ()
 }, {
-  "stablehlo.return"(%result_branch1) : (tensor<2xi64>) -> ()
-}) : (tensor<i32>) -> tensor<2xi64>
-// %result: [1, 1]
+  "stablehlo.return"(%result_branch1, %result_branch1) : (tensor<2xi64>, tensor<2xi64>) -> ()
+}) : (tensor<i32>) -> (tensor<2xi64>, tensor<2xi64>)
+// %result0: [1, 1]
+// %result1: [1, 1]
 ```
 
 &nbsp;[More Examples](../stablehlo/tests/interpret_case.mlir)

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1341,15 +1341,15 @@ returned.
 #### Examples
 
 ```mlir
-// %result_branch0: 10
-// %result_branch1: 11
-// %index: 1
+// %index: -1
+// %result_branch0: 0
+// %result_branch1: 1
 %result = "stablehlo.case"(%index) ({
-  "stablehlo.return"(%result_branch0) : (tensor<i32>) -> ()
+  "stablehlo.return"(%result_branch0) : (tensor<2xi64>) -> ()
 }, {
-  "stablehlo.return"(%result_branch1) : (tensor<i32>) -> ()
-}) : (tensor<i32>) -> tensor<i32>
-// %result: 11
+  "stablehlo.return"(%result_branch1) : (tensor<2xi64>) -> ()
+}) : (tensor<i32>) -> tensor<2xi64>
+// %result: [1, 1]
 ```
 
 &nbsp;[More Examples](../stablehlo/tests/interpret_case.mlir)

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1320,10 +1320,10 @@ returned.
 
 #### Inputs
 
-| Label | Name       | Type                                         | Constraints |
-|-------|------------|----------------------------------------------|-------------|
-| (I1)  | `index`    | 0-dimensional tensor constant of type `si32` |             |
-| (I2)  | `branches` | variadic number of functions                 | (C1-C4)     |
+| Label | Name       | Type                                | Constraints |
+|-------|------------|-------------------------------------|-------------|
+| (I1)  | `index`    | 0-dimensional tensor of type `si32` |             |
+| (I2)  | `branches` | variadic number of functions        | (C1-C4)     |
 
 #### Outputs
 
@@ -1336,7 +1336,7 @@ returned.
 * (C1) `branches` have at least one function.
 * (C2) All functions in `branches` have 0 inputs.
 * (C3) All functions in `branches` have the same output types.
-* (C4) For all `i`, `type(results[i]) = type(branches[0].outputs[i])`.
+* (C4) For all `i`, `type(results[i]) = type(branches[0]).outputs[i]`.
 
 #### Examples
 
@@ -5425,11 +5425,11 @@ The behavior of an infinite loop is TBD
 
 #### Inputs
 
-| Label | Name       | Type                                 | Constraints |
-|-------|------------|--------------------------------------|-------------|
-| (I1)  | `operand`  | variadic number of tensors or tokens | (C1-C3)     |
-| (I2)  | `cond`     | function                             | (C1)        |
-| (I3)  | `body`     | function                             | (C2)        |
+| Label | Name      | Type                                 | Constraints |
+|-------|-----------|--------------------------------------|-------------|
+| (I1)  | `operand` | variadic number of tensors or tokens | (C1-C3)     |
+| (I2)  | `cond`    | function                             | (C1)        |
+| (I3)  | `body`    | function                             | (C2)        |
 
 #### Outputs
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -56,7 +56,7 @@ one of the following tracking labels.
 | bitcast_convert          | yes           | yes          | infeasible     | yes             | no          |
 | broadcast                | no            | yes\*        | yes\*          | yes             | no          |
 | broadcast_in_dim         | yes           | yes          | infeasible     | yes             | yes         |
-| case                     | yes           | revisit      | yes            | no              | no          |
+| case                     | yes           | revisit      | yes            | no              | yes         |
 | cbrt                     | yes           | yes          | yes            | yes             | no          |
 | ceil                     | yes           | yes          | yes            | yes             | yes         |
 | cholesky                 | yes           | yes          | yes            | yes             | no          |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1207,7 +1207,7 @@ def StableHLO_IfOp: StableHLO_Op<"if", [
 def StableHLO_CaseOp: StableHLO_Op<"case", [
       RecursiveMemoryEffects,
       SingleBlockImplicitTerminator<"ReturnOp">,
-      DeclareOpInterfaceMethods<InferTypeOpInterface>
+      DeclareOpInterfaceMethods<InferTypeOpInterface> /*case_c4*/
     ]> {
   let summary = "Case operation";
   let description = [{

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1209,7 +1209,7 @@ def StableHLO_CaseOp: StableHLO_Op<"case", [
       SingleBlockImplicitTerminator<"ReturnOp">,
       DeclareOpInterfaceMethods<InferTypeOpInterface>
     ]> {
-  let summary = "Switch-Case operator";
+  let summary = "Case operation";
   let description = [{
     Produces the output from executing exactly one `function` from `branches`
     depending on the value of `index`.
@@ -1228,10 +1228,10 @@ def StableHLO_CaseOp: StableHLO_Op<"case", [
   }];
 
   let arguments = (ins
-    I32Tensor:$index
+    I32Tensor:$index /*case_i1*/
   );
 
-  let regions = (region VariadicRegion<SizedRegion<1>>:$branches);
+  let regions = (region VariadicRegion<SizedRegion<1>>:$branches /*case_i2*/);
 
   let results = (outs Variadic<HLO_TensorOrToken>);
 }

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1219,11 +1219,11 @@ def StableHLO_CaseOp: StableHLO_Op<"case", [
 
     Example:
     ```mlir
-    %result = "stablehlo.case"(%index) ({
-      stablehlo.return %result_branch0 : tensor<2xi64>
+    %result0, %result1 = "stablehlo.case"(%index) ({
+      stablehlo.return %result_branch0, %result_branch0 : tensor<2xi64>, tensor<2xi64>
     }, {
-      stablehlo.return %result_branch1 : tensor<2xi64>
-    }) : (tensor<i32>) -> tensor<2xi64>
+      stablehlo.return %result_branch1, %result_branch1 : tensor<2xi64>, tensor<2xi64>
+    }) : (tensor<i32>) -> (tensor<2xi64>, tensor<2xi64>)
     ```
   }];
 

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1220,10 +1220,10 @@ def StableHLO_CaseOp: StableHLO_Op<"case", [
     Example:
     ```mlir
     %result = "stablehlo.case"(%index) ({
-      stablehlo.return %result_branch0 : tensor<i32>
+      stablehlo.return %result_branch0 : tensor<2xi64>
     }, {
-      stablehlo.return %result_branch1 : tensor<i32>
-    }) : (tensor<i32>) -> tensor<i32>
+      stablehlo.return %result_branch1 : tensor<2xi64>
+    }) : (tensor<i32>) -> tensor<2xi64>
     ```
   }];
 

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -77,8 +77,10 @@ Tensor evalBroadcastInDimOp(const Tensor &operand, Axes broadcastDimensions,
 
 SmallVector<Tensor> evalCaseOp(const Tensor &index,
                                MutableArrayRef<Region> branches, Scope &scope) {
-  return eval(branches[index.get({}).getIntegerValue().getSExtValue()], {},
-              &scope);
+  int64_t idx = index.get({}).getIntegerValue().getSExtValue();
+  if (idx < 0 || idx >= static_cast<int64_t>(branches.size()))
+    return eval(branches[branches.size() - 1], {}, &scope);
+  return eval(branches[idx], {}, &scope);
 }
 
 Tensor evalCeilOp(const Tensor &operand, TensorType resultType) {

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -79,7 +79,7 @@ SmallVector<Tensor> evalCaseOp(const Tensor &index, RegionRange branches,
                                Scope &scope) {
   int64_t idx = index.get({}).getIntegerValue().getSExtValue();
   if (idx < 0 || idx >= static_cast<int64_t>(branches.size()))
-    return eval(*branches[branches.size() - 1], {}, &scope);
+    idx = branches.size() - 1;
   return eval(*branches[idx], {}, &scope);
 }
 

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -75,12 +75,12 @@ Tensor evalBroadcastInDimOp(const Tensor &operand, Axes broadcastDimensions,
   return result;
 }
 
-SmallVector<Tensor> evalCaseOp(const Tensor &index,
-                               MutableArrayRef<Region> branches, Scope &scope) {
+SmallVector<Tensor> evalCaseOp(const Tensor &index, RegionRange branches,
+                               Scope &scope) {
   int64_t idx = index.get({}).getIntegerValue().getSExtValue();
   if (idx < 0 || idx >= static_cast<int64_t>(branches.size()))
-    return eval(branches[branches.size() - 1], {}, &scope);
-  return eval(branches[idx], {}, &scope);
+    return eval(*branches[branches.size() - 1], {}, &scope);
+  return eval(*branches[idx], {}, &scope);
 }
 
 Tensor evalCeilOp(const Tensor &operand, TensorType resultType) {

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -32,8 +32,8 @@ Tensor evalAddOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType);
 Tensor evalAndOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType);
 Tensor evalBroadcastInDimOp(const Tensor &operand, Axes broadcastDimensions,
                             TensorType resultType);
-SmallVector<Tensor> evalCaseOp(const Tensor &index,
-                               MutableArrayRef<Region> branches, Scope &scope);
+SmallVector<Tensor> evalCaseOp(const Tensor &index, RegionRange branches,
+                               Scope &scope);
 Tensor evalCeilOp(const Tensor &operand, TensorType resultType);
 Tensor evalClampOp(const Tensor &min, const Tensor &operand, const Tensor &max,
                    TensorType resultType);

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -32,6 +32,8 @@ Tensor evalAddOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType);
 Tensor evalAndOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType);
 Tensor evalBroadcastInDimOp(const Tensor &operand, Axes broadcastDimensions,
                             TensorType resultType);
+SmallVector<Tensor> evalCaseOp(const Tensor &index,
+                               MutableArrayRef<Region> branches, Scope &scope);
 Tensor evalCeilOp(const Tensor &operand, TensorType resultType);
 Tensor evalClampOp(const Tensor &min, const Tensor &operand, const Tensor &max,
                    TensorType resultType);

--- a/stablehlo/tests/interpret_case.mlir
+++ b/stablehlo/tests/interpret_case.mlir
@@ -1,7 +1,6 @@
-// RUN: stablehlo-interpreter --interpret -split-input-file %s | FileCheck %s
+// RUN: stablehlo-interpreter --interpret -split-input-file %s
 
-// CHECK-LABEL: Evaluated results of function: case
-func.func @case() -> (tensor<2xi64>, tensor<2xi64>) {
+func.func @case() {
   %index = stablehlo.constant dense<-1> : tensor<i32>
   %result_branch0 = stablehlo.constant dense<0> : tensor<2xi64>
   %result_branch1 = stablehlo.constant dense<1> : tensor<2xi64>
@@ -10,11 +9,7 @@ func.func @case() -> (tensor<2xi64>, tensor<2xi64>) {
   }, {
     stablehlo.return %result_branch1, %result_branch1 : tensor<2xi64>, tensor<2xi64>
   }) : (tensor<i32>) -> (tensor<2xi64>, tensor<2xi64>)
-  func.return %result0, %result1 : tensor<2xi64>, tensor<2xi64>
+  check.eq %result0, dense<[1, 1]> : tensor<2xi64>
+  check.eq %result1, dense<[1, 1]> : tensor<2xi64>
+  func.return
 }
-// CHECK-NEXT: tensor<2xi64>
-// CHECK-NEXT: 1 : i64
-// CHECK-NEXT: 1 : i64
-// CHECK-NEXT: tensor<2xi64>
-// CHECK-NEXT: 1 : i64
-// CHECK-NEXT: 1 : i64

--- a/stablehlo/tests/interpret_case.mlir
+++ b/stablehlo/tests/interpret_case.mlir
@@ -1,7 +1,39 @@
 // RUN: stablehlo-interpreter --interpret -split-input-file %s
 
-func.func @case() {
+func.func @case_negative_index_default() {
   %index = stablehlo.constant dense<-1> : tensor<i32>
+  %result_branch0 = stablehlo.constant dense<0> : tensor<2xi64>
+  %result_branch1 = stablehlo.constant dense<1> : tensor<2xi64>
+  %result0, %result1 = "stablehlo.case"(%index) ({
+    stablehlo.return %result_branch0, %result_branch0 : tensor<2xi64>, tensor<2xi64>
+  }, {
+    stablehlo.return %result_branch1, %result_branch1 : tensor<2xi64>, tensor<2xi64>
+  }) : (tensor<i32>) -> (tensor<2xi64>, tensor<2xi64>)
+  check.eq %result0, dense<[1, 1]> : tensor<2xi64>
+  check.eq %result1, dense<[1, 1]> : tensor<2xi64>
+  func.return
+}
+
+// -----
+
+func.func @case_in_bound_index() {
+  %index = stablehlo.constant dense<0> : tensor<i32>
+  %result_branch0 = stablehlo.constant dense<0> : tensor<2xi64>
+  %result_branch1 = stablehlo.constant dense<1> : tensor<2xi64>
+  %result0, %result1 = "stablehlo.case"(%index) ({
+    stablehlo.return %result_branch0, %result_branch0 : tensor<2xi64>, tensor<2xi64>
+  }, {
+    stablehlo.return %result_branch1, %result_branch1 : tensor<2xi64>, tensor<2xi64>
+  }) : (tensor<i32>) -> (tensor<2xi64>, tensor<2xi64>)
+  check.eq %result0, dense<[0, 0]> : tensor<2xi64>
+  check.eq %result1, dense<[0, 0]> : tensor<2xi64>
+  func.return
+}
+
+// -----
+
+func.func @case_out_of_bound_index_default() {
+  %index = stablehlo.constant dense<2> : tensor<i32>
   %result_branch0 = stablehlo.constant dense<0> : tensor<2xi64>
   %result_branch1 = stablehlo.constant dense<1> : tensor<2xi64>
   %result0, %result1 = "stablehlo.case"(%index) ({

--- a/stablehlo/tests/interpret_case.mlir
+++ b/stablehlo/tests/interpret_case.mlir
@@ -1,0 +1,27 @@
+// RUN: stablehlo-interpreter --interpret -split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: Evaluated results of function: case
+func.func @case() -> (tensor<2xi64>, tensor<2xi64>) {
+  %index = stablehlo.constant dense<1> : tensor<i32>
+  %result_branch0 = stablehlo.constant dense<0> : tensor<2xi64>
+  %result_branch1 = stablehlo.constant dense<1> : tensor<2xi64>
+  %result0, %result1 = "stablehlo.case"(%index) ({
+    "stablehlo.return"(%result_branch0, %result_branch0) : (tensor<2xi64>, tensor<2xi64>) -> ()
+  }, {
+    %case_result = "stablehlo.case"(%index) ({
+      "stablehlo.return"(%result_branch0) : (tensor<2xi64>) -> ()
+    }, {
+      "stablehlo.return"(%result_branch1) : (tensor<2xi64>) -> ()
+    }) : (tensor<i32>) -> tensor<2xi64>
+    "stablehlo.return"(%case_result, %case_result) : (tensor<2xi64>, tensor<2xi64>) -> ()
+  }, {
+    "stablehlo.return"(%result_branch0, %result_branch0) : (tensor<2xi64>, tensor<2xi64>) -> ()
+  }) : (tensor<i32>) -> (tensor<2xi64>, tensor<2xi64>)
+  func.return %result0, %result1 : tensor<2xi64>, tensor<2xi64>
+}
+// CHECK-NEXT: tensor<2xi64>
+// CHECK-NEXT: 1 : i64
+// CHECK-NEXT: 1 : i64
+// CHECK-NEXT: tensor<2xi64>
+// CHECK-NEXT: 1 : i64
+// CHECK-NEXT: 1 : i64

--- a/stablehlo/tests/interpret_case.mlir
+++ b/stablehlo/tests/interpret_case.mlir
@@ -2,7 +2,7 @@
 
 // CHECK-LABEL: Evaluated results of function: case
 func.func @case() -> (tensor<2xi64>, tensor<2xi64>) {
-  %index = stablehlo.constant dense<0> : tensor<i32>
+  %index = stablehlo.constant dense<-1> : tensor<i32>
   %result_branch0 = stablehlo.constant dense<0> : tensor<2xi64>
   %result_branch1 = stablehlo.constant dense<1> : tensor<2xi64>
   %result0, %result1 = "stablehlo.case"(%index) ({
@@ -13,26 +13,8 @@ func.func @case() -> (tensor<2xi64>, tensor<2xi64>) {
   func.return %result0, %result1 : tensor<2xi64>, tensor<2xi64>
 }
 // CHECK-NEXT: tensor<2xi64>
-// CHECK-NEXT: 0 : i64
-// CHECK-NEXT: 0 : i64
-// CHECK-NEXT: tensor<2xi64>
-// CHECK-NEXT: 0 : i64
-// CHECK-NEXT: 0 : i64
-
-// -----
-
-// CHECK-LABEL: Evaluated results of function: case_default
-func.func @case_default() -> (tensor<2xi64>) {
-  %index = stablehlo.constant dense<-1> : tensor<i32>
-  %result_branch0 = stablehlo.constant dense<0> : tensor<2xi64>
-  %result_branch1 = stablehlo.constant dense<1> : tensor<2xi64>
-  %result = "stablehlo.case"(%index) ({
-    stablehlo.return %result_branch0 : tensor<2xi64>
-  }, {
-    stablehlo.return %result_branch1 : tensor<2xi64>
-  }) : (tensor<i32>) -> tensor<2xi64>
-  func.return %result : tensor<2xi64>
-}
+// CHECK-NEXT: 1 : i64
+// CHECK-NEXT: 1 : i64
 // CHECK-NEXT: tensor<2xi64>
 // CHECK-NEXT: 1 : i64
 // CHECK-NEXT: 1 : i64

--- a/stablehlo/tests/interpret_case.mlir
+++ b/stablehlo/tests/interpret_case.mlir
@@ -8,12 +8,7 @@ func.func @case() -> (tensor<2xi64>, tensor<2xi64>) {
   %result0, %result1 = "stablehlo.case"(%index) ({
     "stablehlo.return"(%result_branch0, %result_branch0) : (tensor<2xi64>, tensor<2xi64>) -> ()
   }, {
-    %case_result = "stablehlo.case"(%index) ({
-      "stablehlo.return"(%result_branch0) : (tensor<2xi64>) -> ()
-    }, {
-      "stablehlo.return"(%result_branch1) : (tensor<2xi64>) -> ()
-    }) : (tensor<i32>) -> tensor<2xi64>
-    "stablehlo.return"(%case_result, %case_result) : (tensor<2xi64>, tensor<2xi64>) -> ()
+    "stablehlo.return"(%result_branch1, %result_branch1) : (tensor<2xi64>, tensor<2xi64>) -> ()
   }, {
     "stablehlo.return"(%result_branch0, %result_branch0) : (tensor<2xi64>, tensor<2xi64>) -> ()
   }) : (tensor<i32>) -> (tensor<2xi64>, tensor<2xi64>)
@@ -25,3 +20,27 @@ func.func @case() -> (tensor<2xi64>, tensor<2xi64>) {
 // CHECK-NEXT: tensor<2xi64>
 // CHECK-NEXT: 1 : i64
 // CHECK-NEXT: 1 : i64
+
+// -----
+
+// CHECK-LABEL: Evaluated results of function: case_default
+func.func @case_default() -> (tensor<2xi64>, tensor<2xi64>) {
+  %index = stablehlo.constant dense<-1> : tensor<i32>
+  %result_branch0 = stablehlo.constant dense<0> : tensor<2xi64>
+  %result_branch1 = stablehlo.constant dense<1> : tensor<2xi64>
+  %result_branch2 = stablehlo.constant dense<2> : tensor<2xi64>
+  %result0, %result1 = "stablehlo.case"(%index) ({
+    "stablehlo.return"(%result_branch0, %result_branch0) : (tensor<2xi64>, tensor<2xi64>) -> ()
+  }, {
+    "stablehlo.return"(%result_branch1, %result_branch1) : (tensor<2xi64>, tensor<2xi64>) -> ()
+  }, {
+    "stablehlo.return"(%result_branch2, %result_branch2) : (tensor<2xi64>, tensor<2xi64>) -> ()
+  }) : (tensor<i32>) -> (tensor<2xi64>, tensor<2xi64>)
+  func.return %result0, %result1 : tensor<2xi64>, tensor<2xi64>
+}
+// CHECK-NEXT: tensor<2xi64>
+// CHECK-NEXT: 2 : i64
+// CHECK-NEXT: 2 : i64
+// CHECK-NEXT: tensor<2xi64>
+// CHECK-NEXT: 2 : i64
+// CHECK-NEXT: 2 : i64

--- a/stablehlo/tests/interpret_case.mlir
+++ b/stablehlo/tests/interpret_case.mlir
@@ -2,45 +2,37 @@
 
 // CHECK-LABEL: Evaluated results of function: case
 func.func @case() -> (tensor<2xi64>, tensor<2xi64>) {
-  %index = stablehlo.constant dense<1> : tensor<i32>
+  %index = stablehlo.constant dense<0> : tensor<i32>
   %result_branch0 = stablehlo.constant dense<0> : tensor<2xi64>
   %result_branch1 = stablehlo.constant dense<1> : tensor<2xi64>
   %result0, %result1 = "stablehlo.case"(%index) ({
-    "stablehlo.return"(%result_branch0, %result_branch0) : (tensor<2xi64>, tensor<2xi64>) -> ()
+    stablehlo.return %result_branch0, %result_branch0 : tensor<2xi64>, tensor<2xi64>
   }, {
-    "stablehlo.return"(%result_branch1, %result_branch1) : (tensor<2xi64>, tensor<2xi64>) -> ()
-  }, {
-    "stablehlo.return"(%result_branch0, %result_branch0) : (tensor<2xi64>, tensor<2xi64>) -> ()
+    stablehlo.return %result_branch1, %result_branch1 : tensor<2xi64>, tensor<2xi64>
   }) : (tensor<i32>) -> (tensor<2xi64>, tensor<2xi64>)
   func.return %result0, %result1 : tensor<2xi64>, tensor<2xi64>
 }
 // CHECK-NEXT: tensor<2xi64>
-// CHECK-NEXT: 1 : i64
-// CHECK-NEXT: 1 : i64
+// CHECK-NEXT: 0 : i64
+// CHECK-NEXT: 0 : i64
 // CHECK-NEXT: tensor<2xi64>
-// CHECK-NEXT: 1 : i64
-// CHECK-NEXT: 1 : i64
+// CHECK-NEXT: 0 : i64
+// CHECK-NEXT: 0 : i64
 
 // -----
 
 // CHECK-LABEL: Evaluated results of function: case_default
-func.func @case_default() -> (tensor<2xi64>, tensor<2xi64>) {
+func.func @case_default() -> (tensor<2xi64>) {
   %index = stablehlo.constant dense<-1> : tensor<i32>
   %result_branch0 = stablehlo.constant dense<0> : tensor<2xi64>
   %result_branch1 = stablehlo.constant dense<1> : tensor<2xi64>
-  %result_branch2 = stablehlo.constant dense<2> : tensor<2xi64>
-  %result0, %result1 = "stablehlo.case"(%index) ({
-    "stablehlo.return"(%result_branch0, %result_branch0) : (tensor<2xi64>, tensor<2xi64>) -> ()
+  %result = "stablehlo.case"(%index) ({
+    stablehlo.return %result_branch0 : tensor<2xi64>
   }, {
-    "stablehlo.return"(%result_branch1, %result_branch1) : (tensor<2xi64>, tensor<2xi64>) -> ()
-  }, {
-    "stablehlo.return"(%result_branch2, %result_branch2) : (tensor<2xi64>, tensor<2xi64>) -> ()
-  }) : (tensor<i32>) -> (tensor<2xi64>, tensor<2xi64>)
-  func.return %result0, %result1 : tensor<2xi64>, tensor<2xi64>
+    stablehlo.return %result_branch1 : tensor<2xi64>
+  }) : (tensor<i32>) -> tensor<2xi64>
+  func.return %result : tensor<2xi64>
 }
 // CHECK-NEXT: tensor<2xi64>
-// CHECK-NEXT: 2 : i64
-// CHECK-NEXT: 2 : i64
-// CHECK-NEXT: tensor<2xi64>
-// CHECK-NEXT: 2 : i64
-// CHECK-NEXT: 2 : i64
+// CHECK-NEXT: 1 : i64
+// CHECK-NEXT: 1 : i64

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -1050,12 +1050,9 @@ func.func @if_unranked(%pred : tensor<i1>, %true_branch_operand: tensor<2xf32>, 
 // CHECK-LABEL: @case
 func.func @case(%index : tensor<i32>, %branch_operand : tensor<f32>) -> (tensor<f32>, tensor<f32>) {
   %0, %1 = "stablehlo.case"(%index) ({
-      "stablehlo.return"(%branch_operand, %branch_operand) : (tensor<f32>, tensor<f32>) -> ()
+    "stablehlo.return"(%branch_operand, %branch_operand) : (tensor<f32>, tensor<f32>) -> ()
   }, {
-      %2 = "stablehlo.case"(%index) ({
-          "stablehlo.return"(%index) : (tensor<i32>) -> ()
-      }) : (tensor<i32>) -> tensor<i32>
-      "stablehlo.return"(%branch_operand, %branch_operand) : (tensor<f32>, tensor<f32>) -> ()
+    "stablehlo.return"(%branch_operand, %branch_operand) : (tensor<f32>, tensor<f32>) -> ()
   }) : (tensor<i32>) -> (tensor<f32>, tensor<f32>)
   func.return %0, %1 : tensor<f32>, tensor<f32>
 }
@@ -1091,11 +1088,7 @@ func.func @case_c3(%index: tensor<i32>, %operand_1: tensor<f32>, %operand_2: ten
     },  {
       %1 = stablehlo.constant dense<2> : tensor<i32>
       "stablehlo.return"(%1) : (tensor<i32>) -> ()
-    },  {
-      %1 = "stablehlo.floor"(%operand_3) : (tensor<f32>) -> tensor<f32>
-      "stablehlo.return"(%1) : (tensor<f32>) -> ()
-    }
-  ) : (tensor<i32>) -> tensor<f32>
+    }) : (tensor<i32>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }
 


### PR DESCRIPTION
We have the following constraints in the spec:

```
(I1) index 0-dimensional tensor constant of type `si32`.
(I2) branches variadic number of functions.
(C1) `branches` have at least one function.
(C2) All functions in `branches` have 0 inputs.
(C3) All functions in `branches` have the same output types.
(C4) For all `i`, `type(results[i]) = type(branches[0].outputs[i])`.
```

These constraints will be comprehensively covered by the following tests:

```
I1: a) index is not 0-dimensional tensor.
    b) element_type(index) != `si32`. (Covered by ODS).
I2: a) branches is not variadic functions. (Covered by ODS).
C1: a) size(branches) < 1.
C2: a) not all functions in `branches` have 0 inputs.
C3: a) not all functions in `branches` have the same output types.
C4: a) type(results[i]) != type(branches[0].outputs[i]) for any i.
```

If we drop the "Covered by ODS" pieces, this will leave us with the following test cases:

```
I1a: index is not 0-dimensional tensor.
C1a: size(branches) < 1.
C2a: not all functions in `branches` have 0 inputs.
C3a: not all functions in `branches` have the same output types.
C4a: type(results[i]) != type(branches[0].outputs[i]) for any i.
```

Notes:
* Fixed typo:
```
`index` | 1-dimensional tensor of type `si32`
```
to
```
`index` | 0-dimensional tensor constant of type `si32`
```

* The status for verification remains `revisit` due to #365 and #581.

closes #965