### PR TITLE
Print escaped string to preserve binary data

### DIFF
--- a/stablehlo/dialect/VhloAttrs.td
+++ b/stablehlo/dialect/VhloAttrs.td
@@ -264,7 +264,7 @@ def VHLO_IntegerAttrV1  : VHLO_AttrDef<"IntegerV1", "0.3.0", "current"> {
 def VHLO_StringAttrV1 : VHLO_AttrDef<"StringV1", "0.3.0", "current"> {
   let mnemonic = "string";
   let parameters = (ins StringRefParameter<"">:$value);
-  let assemblyFormat = "`<` $value `>`";
+  let assemblyFormat = "`<` custom<EscapedString>($value) `>`";
 }
 
 def VHLO_TypeAttrV1 : VHLO_AttrDef<"TypeV1", "0.3.0", "current"> {

--- a/stablehlo/dialect/VhloOps.cpp
+++ b/stablehlo/dialect/VhloOps.cpp
@@ -20,6 +20,8 @@ limitations under the License.
 
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "mlir/Dialect/Quant/QuantOps.h"
 #include "mlir/Dialect/Shape/IR/Shape.h"
@@ -193,6 +195,16 @@ Attribute DenseIntOrFPElementsV1Attr::parse(AsmParser& parser, mlir::Type) {
   return DenseIntOrFPElementsV1Attr::get(
       parser.getContext(), convertTypeToVhloForParse(attr.getType()),
       attr.getRawData());
+}
+
+void printEscapedString(AsmPrinter& p, llvm::StringRef value) {
+  p << "\"";
+  llvm::printEscapedString(value, p.getStream());
+  p << "\"";
+}
+
+ParseResult parseEscapedString(AsmParser& parser, std::string& value) {
+  return parser.parseString(&value);
 }
 
 }  // namespace vhlo

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.mlir
@@ -663,7 +663,7 @@ func.func @called_computation() { func.return }
 func.func @op_custom_call(%arg0: tensor<f32>) -> tensor<f32> {
   //      CHECK: "vhlo.custom_call_v2"(%arg0) {
   // CHECK-SAME:   api_version = #vhlo<api_version API_VERSION_ORIGINAL>,
-  // CHECK-SAME:   backend_config = #vhlo.string<"">,
+  // CHECK-SAME:   backend_config = #vhlo.string<"\08\03\1A\02">,
   // CHECK-SAME:   call_target_name = #vhlo.string<"foo">,
   // CHECK-SAME:   called_computations = #vhlo.array<[#vhlo.sym<#vhlo.string<"foo">>]>,
   // CHECK-SAME:   has_side_effect = #vhlo.integer<false>,
@@ -678,7 +678,7 @@ func.func @op_custom_call(%arg0: tensor<f32>) -> tensor<f32> {
   %0 = "stablehlo.custom_call"(%arg0) {
     call_target_name = "foo",
     has_side_effect = false,
-    backend_config = "",
+    backend_config = "\08\03\1A\02",
     api_version = 1 : i32,
     called_computations = [@foo],
     operand_layouts = [dense<> : tensor<0xindex>],


### PR DESCRIPTION
Need to escape string with unprintable characters because it can cause printer/parser issues.

Namely, I recently was parsing a string where the binary data included the ascii for `"`, which caused the string to be malformed as `vhlo.string<"ab"cd">`