### PR TITLE
Introduce Index class

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -316,6 +316,21 @@ cc_library(
 )
 
 cc_library(
+    name = "reference_index",
+    srcs = [
+        "stablehlo/reference/Index.cpp",
+    ],
+    hdrs = [
+        "stablehlo/reference/Index.h",
+    ],
+    strip_include_prefix = ".",
+    deps = [
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:Support",
+    ],
+)
+
+cc_library(
     name = "reference_ops",
     srcs = [
         "stablehlo/reference/Ops.cpp",
@@ -326,6 +341,7 @@ cc_library(
     strip_include_prefix = ".",
     deps = [
         ":reference_element",
+        ":reference_index",
         ":reference_errors",
         ":reference_scope",
         ":reference_tensor",
@@ -356,17 +372,16 @@ cc_library(
 cc_library(
     name = "reference_tensor",
     srcs = [
-        "stablehlo/reference/Index.cpp",
         "stablehlo/reference/Tensor.cpp",
     ],
     hdrs = [
-        "stablehlo/reference/Index.h",
         "stablehlo/reference/Tensor.h",
     ],
     strip_include_prefix = ".",
     deps = [
         ":reference_element",
         ":reference_errors",
+        ":reference_index",
         ":reference_types",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -286,6 +286,21 @@ cc_library(
 )
 
 cc_library(
+    name = "reference_axes",
+    srcs = [
+        "stablehlo/reference/Axes.cpp",
+    ],
+    hdrs = [
+        "stablehlo/reference/Axes.h",
+    ],
+    strip_include_prefix = ".",
+    deps = [
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:IR",
+    ],
+)
+
+cc_library(
     name = "reference_element",
     srcs = [
         "stablehlo/reference/Element.cpp",
@@ -325,6 +340,7 @@ cc_library(
     ],
     strip_include_prefix = ".",
     deps = [
+        ":reference_sizes",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:Support",
     ],
@@ -340,8 +356,9 @@ cc_library(
     ],
     strip_include_prefix = ".",
     deps = [
+        ":reference_axes",
         ":reference_element",
-        ":reference_index",
+        ":reference_sizes",
         ":reference_errors",
         ":reference_scope",
         ":reference_tensor",
@@ -370,6 +387,21 @@ cc_library(
 )
 
 cc_library(
+    name = "reference_sizes",
+    srcs = [
+        "stablehlo/reference/Sizes.cpp",
+    ],
+    hdrs = [
+        "stablehlo/reference/Sizes.h",
+    ],
+    strip_include_prefix = ".",
+    deps = [
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:IR",
+    ],
+)
+
+cc_library(
     name = "reference_tensor",
     srcs = [
         "stablehlo/reference/Tensor.cpp",
@@ -382,6 +414,7 @@ cc_library(
         ":reference_element",
         ":reference_errors",
         ":reference_index",
+        ":reference_sizes",
         ":reference_types",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",

--- a/stablehlo/reference/Axes.cpp
+++ b/stablehlo/reference/Axes.cpp
@@ -1,0 +1,29 @@
+/* Copyright 2023 The StableHLO Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permutationissions and
+limitations under the License.
+==============================================================================*/
+
+#include "stablehlo/reference/Axes.h"
+
+namespace mlir {
+namespace stablehlo {
+
+raw_ostream &operator<<(raw_ostream &os, const Axes &x) {
+  os << "[";
+  llvm::interleave(x, os, ", ");
+  os << "]";
+  return os;
+}
+
+}  // namespace stablehlo
+}  // namespace mlir

--- a/stablehlo/reference/Axes.h
+++ b/stablehlo/reference/Axes.h
@@ -25,6 +25,7 @@ namespace stablehlo {
 
 using Axis = int64_t;
 
+/// Represents axes of a tensor.
 class Axes : public SmallVector<int64_t> {
  public:
   Axes() = default;

--- a/stablehlo/reference/Axes.h
+++ b/stablehlo/reference/Axes.h
@@ -1,0 +1,45 @@
+/* Copyright 2023 The StableHLO Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef STABLEHLO_REFERENCE_AXES_H
+#define STABLEHLO_REFERENCE_AXES_H
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/raw_ostream.h"
+#include "mlir/IR/BuiltinAttributes.h"
+
+namespace mlir {
+namespace stablehlo {
+
+using Axis = int64_t;
+
+class Axes : public SmallVector<int64_t> {
+ public:
+  Axes() = default;
+  Axes(const Axes &other) = default;
+  Axes &operator=(const Axes &other) = default;
+
+  Axes(std::initializer_list<int64_t> list) : SmallVector(list) {}
+  explicit Axes(ArrayRef<int64_t> array) : SmallVector(array) {}
+  explicit Axes(DenseIntElementsAttr attr)
+      : SmallVector(attr.getValues<int64_t>()) {}
+};
+
+raw_ostream &operator<<(raw_ostream &os, const Axes &x);
+
+}  // namespace stablehlo
+}  // namespace mlir
+
+#endif  // STABLEHLO_REFERENCE_AXES_H

--- a/stablehlo/reference/CMakeLists.txt
+++ b/stablehlo/reference/CMakeLists.txt
@@ -12,6 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+add_mlir_library(StablehloReferenceAxes
+  PARTIAL_SOURCES_INTENDED
+  Sizes.cpp
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+)
+
+add_mlir_library(StablehloReferenceSizes
+  PARTIAL_SOURCES_INTENDED
+  Sizes.cpp
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+)
+
 add_mlir_library(StablehloReferenceTypes
   PARTIAL_SOURCES_INTENDED
   Types.cpp
@@ -37,6 +53,7 @@ add_mlir_library(StablehloReferenceIndex
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRSupport
+  StablehloReferenceSizes
 )
 
 add_mlir_library(StablehloReferenceScope
@@ -56,6 +73,7 @@ add_mlir_library(StablehloReferenceTensor
   MLIRIR
   StablehloReferenceElement
   StablehloReferenceIndex
+  StablehloReferenceSizes
   StablehloReferenceTypes
 )
 
@@ -66,8 +84,10 @@ add_mlir_library(StablehloReferenceOps
   LINK_LIBS PUBLIC
   MLIRFuncDialect
   StablehloOps
+  StablehloReferenceAxes
   StablehloReferenceElement
   StablehloReferenceIndex
   StablehloReferenceScope
+  StablehloReferenceSizes
   StablehloReferenceTensor
 )

--- a/stablehlo/reference/CMakeLists.txt
+++ b/stablehlo/reference/CMakeLists.txt
@@ -67,6 +67,7 @@ add_mlir_library(StablehloReferenceOps
   MLIRFuncDialect
   StablehloOps
   StablehloReferenceElement
+  StablehloReferenceIndex
   StablehloReferenceScope
   StablehloReferenceTensor
 )

--- a/stablehlo/reference/Index.cpp
+++ b/stablehlo/reference/Index.cpp
@@ -9,7 +9,7 @@ You may obtain a copy of the License at
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permutationissions and
+See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 

--- a/stablehlo/reference/Index.cpp
+++ b/stablehlo/reference/Index.cpp
@@ -18,13 +18,13 @@ limitations under the License.
 namespace mlir {
 namespace stablehlo {
 
-const Sizes &IndexSpaceIterator::operator*() const {
+const Index &IndexSpaceIterator::operator*() const {
   if (!index_)
     llvm::report_fatal_error("Dereferencing a past-the-end iterator.");
   return *index_;
 }
 
-const Sizes *IndexSpaceIterator::operator->() const { return &(*index_); }
+const Index *IndexSpaceIterator::operator->() const { return &(*index_); }
 
 IndexSpaceIterator &IndexSpaceIterator::operator++() {
   if (!index_)

--- a/stablehlo/reference/Index.cpp
+++ b/stablehlo/reference/Index.cpp
@@ -15,65 +15,16 @@ limitations under the License.
 
 #include "stablehlo/reference/Index.h"
 
-#include "llvm/Support/Error.h"
-
 namespace mlir {
 namespace stablehlo {
 
-Index Index::operator+(const Index &other) const {
-  if (size() != other.size())
-    llvm::report_fatal_error("Index add expects operands of same size.");
-
-  SmallVector<int64_t> result;
-  for (auto [lhsIdx, rhsIdx] : llvm::zip(index_, other.index_))
-    result.push_back(lhsIdx + rhsIdx);
-  return Index(result);
-}
-
-Index Index::operator+(ArrayRef<int64_t> array) const {
-  if (size() != array.size())
-    llvm::report_fatal_error("Index add expects operands of same size.");
-
-  SmallVector<int64_t> result;
-  for (auto [lhsIdx, rhsIdx] : llvm::zip(index_, array))
-    result.push_back(lhsIdx + rhsIdx);
-  return Index(result);
-}
-
-Index Index::operator*(const Index &other) const {
-  if (size() != other.size())
-    llvm::report_fatal_error("Index product expects operands of same size.");
-
-  SmallVector<int64_t> result;
-  for (auto [lhsIdx, rhsIdx] : llvm::zip(index_, other.index_))
-    result.push_back(lhsIdx * rhsIdx);
-  return Index(result);
-}
-
-Index Index::operator*(ArrayRef<int64_t> array) const {
-  if (size() != array.size())
-    llvm::report_fatal_error("Index product expects operands of same size.");
-
-  SmallVector<int64_t> result;
-  for (auto [lhsIdx, rhsIdx] : llvm::zip(index_, array))
-    result.push_back(lhsIdx * rhsIdx);
-  return Index(result);
-}
-
-LogicalResult verifyIndex(llvm::ArrayRef<int64_t> shape, const Index &index) {
-  if (shape.size() != index.size()) return failure();
-
-  for (auto [shapeDim, indexDim] : llvm::zip(shape, index.getIndexArray()))
-    if (indexDim < 0 || indexDim >= shapeDim) return failure();
-
-  return success();
-}
-
-Index IndexSpaceIterator::operator*() const {
+const Sizes &IndexSpaceIterator::operator*() const {
   if (!index_)
     llvm::report_fatal_error("Dereferencing a past-the-end iterator.");
   return *index_;
 }
+
+const Sizes *IndexSpaceIterator::operator->() const { return &(*index_); }
 
 IndexSpaceIterator &IndexSpaceIterator::operator++() {
   if (!index_)
@@ -101,25 +52,6 @@ IndexSpaceIterator IndexSpaceIterator::operator++(int) {
   IndexSpaceIterator tempIter = *this;
   ++*this;
   return tempIter;
-}
-
-Index Index::permute(ArrayRef<int64_t> permutation) {
-  if (size() != permutation.size())
-    llvm::report_fatal_error(
-        "Index permutationute expects permutation of same size as the index.");
-
-  Index result(size());
-  for (size_t i = 0; i < permutation.size(); i++)
-    result[i] = (*this)[permutation[i]];
-  return result;
-}
-
-Index operator+(ArrayRef<int64_t> array, const Index &index) {
-  return index + array;
-}
-
-Index operator*(ArrayRef<int64_t> array, const Index &index) {
-  return index * array;
 }
 
 }  // namespace stablehlo

--- a/stablehlo/reference/Index.cpp
+++ b/stablehlo/reference/Index.cpp
@@ -20,17 +20,23 @@ limitations under the License.
 namespace mlir {
 namespace stablehlo {
 
-LogicalResult verifyIndex(llvm::ArrayRef<int64_t> shape,
-                          llvm::ArrayRef<int64_t> index) {
+Index Index::operator+(const Index &other) const {
+  SmallVector<int64_t> combined;
+  for (auto [lhsIdx, rhsIdx] : llvm::zip(index_, other.index_))
+    combined.push_back(lhsIdx + rhsIdx);
+  return Index(combined);
+}
+
+LogicalResult verifyIndex(llvm::ArrayRef<int64_t> shape, const Index &index) {
   if (shape.size() != index.size()) return failure();
 
-  for (auto [shapeDim, indexDim] : llvm::zip(shape, index))
-    if (indexDim < 0 || indexDim >= shapeDim) return failure();
+  for (auto [dim, shapeDim] : llvm::enumerate(shape))
+    if (index[dim] < 0 || index[dim] >= shapeDim) return failure();
 
   return success();
 }
 
-llvm::ArrayRef<int64_t> IndexSpaceIterator::operator*() const {
+Index IndexSpaceIterator::operator*() const {
   if (!index_)
     llvm::report_fatal_error("Dereferencing a past-the-end iterator.");
   return *index_;

--- a/stablehlo/reference/Index.h
+++ b/stablehlo/reference/Index.h
@@ -32,7 +32,7 @@ namespace stablehlo {
 class IndexSpaceIterator {
  public:
   /// \name Constructor
-  IndexSpaceIterator(Sizes shape, std::optional<Sizes> index)
+  IndexSpaceIterator(Sizes shape, std::optional<Index> index)
       : shape_(shape), index_(index) {
     if (index && !index->inBounds(shape))
       llvm::report_fatal_error(
@@ -44,8 +44,8 @@ class IndexSpaceIterator {
   /// At any point in time, the iterator can either reference an actual index
   /// or the past-the-end element in the index space.
   /// Dereferencing a past-the-end iterator will result in a fatal error.
-  const Sizes &operator*() const;
-  const Sizes *operator->() const;
+  const Index &operator*() const;
+  const Index *operator->() const;
 
   /// Compare the iterator to another iterator.
   /// Two iterators are equal if they have the same underlying shape and
@@ -69,7 +69,7 @@ class IndexSpaceIterator {
 
   /// Current multi-dimensional index.
   /// If the optional is empty, then we're at the end
-  std::optional<Sizes> index_;
+  std::optional<Index> index_;
 };
 
 }  // namespace stablehlo

--- a/stablehlo/reference/Index.h
+++ b/stablehlo/reference/Index.h
@@ -16,81 +16,13 @@ limitations under the License.
 #ifndef STABLEHLO_REFERENCE_INDEX_H_
 #define STABLEHLO_REFERENCE_INDEX_H_
 
-#include <cstdint>
 #include <optional>
 
-#include "llvm/ADT/ArrayRef.h"
-#include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Error.h"
-#include "mlir/Support/LogicalResult.h"
+#include "stablehlo/reference/Sizes.h"
 
 namespace mlir {
 namespace stablehlo {
-
-/// Represents an index of a tensor.
-class Index {
- public:
-  /// Creates an `Index` of size `size`.
-  explicit Index(size_t size) : index_(size) {}
-
-  /// Create an `Index` whose value at each dimension d is initialized with
-  /// `array`[d].
-  explicit Index(llvm::ArrayRef<int64_t> array) : index_(array) {}
-
-  Index(const Index &other) = default;
-  Index &operator=(const Index &other) = default;
-
-  /// Overloaded indexing operator returns `(*this)[idx]`.
-  int64_t &operator[](int64_t idx) { return index_[idx]; }
-  int64_t operator[](int64_t idx) const { return index_[idx]; }
-
-  /// Overloaded equality operator.
-  bool operator==(const Index &other) const { return index_ == other.index_; }
-
-  /// Overloaded add operator to perform `(*this)[d] + other[d]` for all
-  /// dimension d.
-  Index operator+(const Index &other) const;
-
-  /// Overloaded add operator to perform `(*this)[d] + array[d]` for all
-  /// dimension d.
-  Index operator+(ArrayRef<int64_t> array) const;
-
-  /// Overloaded product operator to perform `(*this)[d] * other[d]` for all
-  /// dimension d.
-  Index operator*(const Index &other) const;
-
-  /// Overloaded product operator to perform `(*this)[d] * array[d]` for all
-  /// dimension d.
-  Index operator*(ArrayRef<int64_t> array) const;
-
-  /// Get the index array.
-  ArrayRef<int64_t> getIndexArray() const { return index_; }
-
-  // Create a new `Index` i with the effect of applying `permutation`  to
-  // `this` object, such that `i[i] = (*this)[perm[i]]`.
-  Index permute(ArrayRef<int64_t> permutation);
-
-  /// Returns the number of dimensions.
-  size_t size() const { return index_.size(); }
-
- private:
-  /// Underlying storage.
-  llvm::SmallVector<int64_t> index_;
-};
-
-/// Overloaded add operator to perform `array[d] + index[d]` for all
-/// dimension d.
-Index operator+(ArrayRef<int64_t> array, const Index &index);
-
-/// Overloaded product operator to perform `array[d] * index[d]` for all
-/// dimension d.
-Index operator*(ArrayRef<int64_t> array, const Index &index);
-
-/// Check if the 'index' is a valid index in the index space of a tensor with
-/// shape 'shape'. Specifically, for a shape '(d0)x(d1)x...x(dR-1)' and an index
-/// '{i0, i1, ..., iR-1}', we check if 0 <= i[k] <= d[k] for k in
-/// {0, 1, ..., R-1}. Note that the check also implies that 'd[k]' >= 1.
-LogicalResult verifyIndex(ArrayRef<int64_t> shape, const Index &index);
 
 /// Iterates over the index space of a tensor with a given shape, producing
 /// indices in lexicographical order. As an example, for a tensor with shape
@@ -100,10 +32,9 @@ LogicalResult verifyIndex(ArrayRef<int64_t> shape, const Index &index);
 class IndexSpaceIterator {
  public:
   /// \name Constructor
-  IndexSpaceIterator(llvm::ArrayRef<int64_t> shape,
-                     std::optional<llvm::SmallVector<int64_t>> index)
+  IndexSpaceIterator(Sizes shape, std::optional<Sizes> index)
       : shape_(shape), index_(index) {
-    if (index && failed(verifyIndex(shape, (*index_))))
+    if (index && !index->inBounds(shape))
       llvm::report_fatal_error(
           "Incompatible index and shape found while creating "
           "an IndexSpaceIterator");
@@ -113,7 +44,8 @@ class IndexSpaceIterator {
   /// At any point in time, the iterator can either reference an actual index
   /// or the past-the-end element in the index space.
   /// Dereferencing a past-the-end iterator will result in a fatal error.
-  Index operator*() const;
+  const Sizes &operator*() const;
+  const Sizes *operator->() const;
 
   /// Compare the iterator to another iterator.
   /// Two iterators are equal if they have the same underlying shape and
@@ -133,11 +65,11 @@ class IndexSpaceIterator {
 
  private:
   /// Shape of the tensor whose index space to be iterated on.
-  llvm::SmallVector<int64_t> shape_;
+  Sizes shape_;
 
   /// Current multi-dimensional index.
   /// If the optional is empty, then we're at the end
-  std::optional<Index> index_;
+  std::optional<Sizes> index_;
 };
 
 }  // namespace stablehlo

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -24,11 +24,20 @@ limitations under the License.
 #include "mlir/Support/DebugStringHelper.h"
 #include "stablehlo/reference/Element.h"
 #include "stablehlo/reference/Errors.h"
-#include "stablehlo/reference/Index.h"
 #include "stablehlo/reference/Types.h"
 
 namespace mlir {
 namespace stablehlo {
+namespace {
+
+Sizes evalIndices(ArrayRef<Tensor> runtimeIndices) {
+  Sizes index(runtimeIndices.size());
+  for (size_t i = 0; i < runtimeIndices.size(); ++i)
+    index[i] = runtimeIndices[i].get({}).getIntegerValue().getSExtValue();
+  return index;
+}
+
+}  // namespace
 
 Tensor evalAbsOp(const Tensor &operand, Type resultType) {
   Tensor result(resultType);
@@ -51,14 +60,13 @@ Tensor evalAndOp(const Tensor &lhs, const Tensor &rhs, Type resultType) {
   return result;
 }
 
-Tensor evalBroadcastInDimOp(const Tensor &operand,
-                            ArrayRef<int64_t> broadcastDimensions,
+Tensor evalBroadcastInDimOp(const Tensor &operand, Axes broadcastDimensions,
                             Type resultType) {
   Tensor result(resultType);
-  auto operandShape = operand.getType().getShape();
+  auto operandShape = operand.getShape();
   for (auto resultIt = result.index_begin(); resultIt != result.index_end();
        ++resultIt) {
-    Index operandIdx(operandShape.size());
+    Sizes operandIdx(operandShape.size());
     for (auto [operandDim, resultDim] : llvm::enumerate(broadcastDimensions))
       operandIdx[operandDim] =
           operandShape[operandDim] == 1 ? 0 : (*resultIt)[resultDim];
@@ -78,10 +86,8 @@ Tensor evalClampOp(const Tensor &min, const Tensor &operand, const Tensor &max,
                    Type resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
-    Element minElement =
-        min.getType().getRank() != 0 ? min.get(*it) : min.get({});
-    Element maxElement =
-        max.getType().getRank() != 0 ? max.get(*it) : max.get({});
+    Element minElement = min.getRank() != 0 ? min.get(*it) : min.get({});
+    Element maxElement = max.getRank() != 0 ? max.get(*it) : max.get({});
     result.set(*it, stablehlo::min(stablehlo::max(operand.get(*it), minElement),
                                    maxElement));
   }
@@ -96,7 +102,7 @@ Tensor evalConstantOp(ElementsAttr value) {
 // with integer to bool conversion. To be updated as part of #969.
 Tensor evalConvertOp(const Tensor &operand, Type resultType) {
   Tensor result(resultType);
-  Type elType = result.getType().getElementType();
+  Type elType = result.getElementType();
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, Element(elType,
                             operand.get(*it).getIntegerValue().getBoolValue()));
@@ -111,17 +117,13 @@ Tensor evalCosineOp(const Tensor &operand, Type resultType) {
 }
 
 Tensor evalDynamicSliceOp(const Tensor &operand, ArrayRef<Tensor> startIndices,
-                          ArrayRef<int64_t> sliceSizes, Type resultType) {
+                          Sizes sliceSizes, Type resultType) {
   Tensor result(resultType);
-  Index adjustedStartIndices(startIndices.size());
-  for (size_t i = 0; i < startIndices.size(); ++i)
-    adjustedStartIndices[i] = std::min(
-        std::max(startIndices[i].get({}).getIntegerValue().getSExtValue(), 0l),
-        operand.getType().getShape()[i] - sliceSizes[i]);
-  for (auto resultItr = result.index_begin(); resultItr != result.index_end();
-       ++resultItr) {
-    auto operandIdx = adjustedStartIndices + *resultItr;
-    result.set(*resultItr, operand.get(operandIdx));
+  auto adjustedStartIndices =
+      clamp(0, evalIndices(startIndices), operand.getShape() - sliceSizes);
+  for (auto resultIt = result.index_begin(); resultIt != result.index_end();
+       ++resultIt) {
+    result.set(*resultIt, operand.get(adjustedStartIndices + *resultIt));
   }
   return result;
 }
@@ -130,13 +132,8 @@ Tensor evalDynamicUpdateSliceOp(const Tensor &operand, const Tensor &update,
                                 ArrayRef<Tensor> startIndices,
                                 Type resultType) {
   Tensor result(resultType);
-  auto operandShape = operand.getType().getShape();
-  auto updateShape = update.getType().getShape();
-  Index adjustedStartIndices(startIndices.size());
-  for (size_t i = 0; i < startIndices.size(); ++i)
-    adjustedStartIndices[i] = std::min(
-        std::max(startIndices[i].get({}).getIntegerValue().getSExtValue(), 0l),
-        operandShape[i] - updateShape[i]);
+  auto adjustedStartIndices = clamp(0, evalIndices(startIndices),
+                                    operand.getShape() - update.getShape());
   for (auto resultIt = result.index_begin(); resultIt != result.index_end();
        ++resultIt)
     result.set(*resultIt, operand.get(*resultIt));
@@ -168,7 +165,7 @@ SmallVector<Tensor> evalIfOp(const Tensor &pred, Region &trueBranch,
 
 Tensor evalIotaOp(int64_t iotaDimension, Type resultType) {
   Tensor result(resultType);
-  Type elType = result.getType().getElementType();
+  Type elType = result.getElementType();
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
     auto iota = (*it)[iotaDimension];
     if (isSupportedSignedIntegerType(elType)) {
@@ -252,17 +249,17 @@ Tensor evalOrOp(const Tensor &lhs, const Tensor &rhs, Type resultType) {
 }
 
 Tensor evalPadOp(const Tensor &operand, const Tensor &paddingValue,
-                 ArrayRef<int64_t> edgePaddingLow,
-                 ArrayRef<int64_t> interiorPadding, Type resultType) {
+                 Sizes edgePaddingLow, Sizes interiorPadding, Type resultType) {
   Tensor result(resultType);
   for (auto resultIt = result.index_begin(); resultIt != result.index_end();
        ++resultIt)
     result.set(*resultIt, paddingValue.get({}));
   for (auto operandIt = operand.index_begin(); operandIt != operand.index_end();
        ++operandIt) {
-    Index resultIdx =
-        edgePaddingLow + *operandIt * interiorPadding + *operandIt;
-    if (succeeded(verifyIndex(result.getType().getShape(), resultIdx)))
+    auto resultIdx = edgePaddingLow + *operandIt * (interiorPadding + 1);
+    // Bound check is needed here because of negative padding which could
+    // swallow some operand indices.
+    if (resultIdx.inBounds(result.getShape()))
       result.set(resultIdx, operand.get(*operandIt));
   }
   return result;
@@ -276,13 +273,12 @@ Tensor evalReshapeOp(const Tensor &operand, Type resultType) {
   return result;
 }
 
-Tensor evalReverseOp(const Tensor &operand, ArrayRef<int64_t> dimensions,
-                     Type resultType) {
+Tensor evalReverseOp(const Tensor &operand, Axes dimensions, Type resultType) {
   Tensor result(resultType);
-  auto resultShape = result.getType().getShape();
+  auto resultShape = result.getShape();
   for (auto resultIt = result.index_begin(); resultIt != result.index_end();
        ++resultIt) {
-    Index operandIdx(*resultIt);
+    Sizes operandIdx(*resultIt);
     for (auto dim : dimensions)
       operandIdx[dim] = (resultShape[dim] - 1) - operandIdx[dim];
     result.set(*resultIt, operand.get(operandIdx));
@@ -294,8 +290,7 @@ Tensor evalSelectOp(const Tensor &pred, const Tensor &onTrue,
                     const Tensor &onFalse, Type resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
-    Element predValue =
-        pred.getType().getRank() != 0 ? pred.get(*it) : pred.get({});
+    Element predValue = pred.getRank() != 0 ? pred.get(*it) : pred.get({});
     result.set(
         *it, predValue.getBooleanValue() ? onTrue.get(*it) : onFalse.get(*it));
   }
@@ -309,13 +304,12 @@ Tensor evalSineOp(const Tensor &operand, Type resultType) {
   return result;
 }
 
-Tensor evalSliceOp(const Tensor &operand, ArrayRef<int64_t> startIndices,
-                   ArrayRef<int64_t> strides, Type resultType) {
+Tensor evalSliceOp(const Tensor &operand, Sizes startIndices, Sizes strides,
+                   Type resultType) {
   Tensor result(resultType);
   for (auto resultIt = result.index_begin(); resultIt != result.index_end();
        ++resultIt) {
-    Index operandIdx = startIndices + *resultIt * strides;
-    result.set(*resultIt, operand.get(operandIdx));
+    result.set(*resultIt, operand.get(startIndices + *resultIt * strides));
   }
   return result;
 }
@@ -341,13 +335,13 @@ Tensor evalTanhOp(const Tensor &operand, Type resultType) {
   return result;
 }
 
-Tensor evalTransposeOp(const Tensor &operand, ArrayRef<int64_t> permutation,
+Tensor evalTransposeOp(const Tensor &operand, const Axes &permutation,
                        Type resultType) {
   Tensor result(resultType);
   for (auto operandIt = operand.index_begin(); operandIt != operand.index_end();
        ++operandIt) {
-    auto resultIndex = (*operandIt).permute(permutation);
-    result.set(resultIndex, operand.get(*operandIt));
+    auto resultIdx = operandIt->permute(permutation);
+    result.set(resultIdx, operand.get(*operandIt));
   }
   return result;
 }
@@ -404,8 +398,8 @@ SmallVector<Tensor> eval(Region &region, ArrayRef<Tensor> args, Scope *parent) {
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto broadcastInDimOp = dyn_cast<BroadcastInDimOp>(op)) {
       Tensor runtimeOperand = scope.find(broadcastInDimOp.getOperand());
-      auto broadcastDimensions = llvm::to_vector(
-          broadcastInDimOp.getBroadcastDimensions().getValues<int64_t>());
+      auto broadcastDimensions =
+          Axes(broadcastInDimOp.getBroadcastDimensions());
       Tensor runtimeResult = evalBroadcastInDimOp(
           runtimeOperand, broadcastDimensions, broadcastInDimOp.getType());
       scope.add(op.getResults(), {runtimeResult});
@@ -434,8 +428,7 @@ SmallVector<Tensor> eval(Region &region, ArrayRef<Tensor> args, Scope *parent) {
     } else if (auto dynamicSliceOp = dyn_cast<DynamicSliceOp>(op)) {
       Tensor runtimeOperand = scope.find(dynamicSliceOp.getOperand());
       auto runtimeStartIndices = scope.find(dynamicSliceOp.getStartIndices());
-      auto runtimeSliceSizes =
-          llvm::to_vector(dynamicSliceOp.getSliceSizes().getValues<int64_t>());
+      auto runtimeSliceSizes = Sizes(dynamicSliceOp.getSliceSizes());
       Tensor runtimeResult =
           evalDynamicSliceOp(runtimeOperand, runtimeStartIndices,
                              runtimeSliceSizes, dynamicSliceOp.getType());
@@ -502,10 +495,8 @@ SmallVector<Tensor> eval(Region &region, ArrayRef<Tensor> args, Scope *parent) {
     } else if (auto padOp = dyn_cast<PadOp>(op)) {
       Tensor runtimeOperand = scope.find(padOp.getOperand());
       Tensor runtimePaddingValue = scope.find(padOp.getPaddingValue());
-      auto edgePaddingLow =
-          llvm::to_vector(padOp.getEdgePaddingLow().getValues<int64_t>());
-      auto interiorPadding =
-          llvm::to_vector(padOp.getInteriorPadding().getValues<int64_t>());
+      auto edgePaddingLow = Sizes(padOp.getEdgePaddingLow());
+      auto interiorPadding = Sizes(padOp.getInteriorPadding());
       Tensor runtimeResult =
           evalPadOp(runtimeOperand, runtimePaddingValue, edgePaddingLow,
                     interiorPadding, padOp.getType());
@@ -523,8 +514,7 @@ SmallVector<Tensor> eval(Region &region, ArrayRef<Tensor> args, Scope *parent) {
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto reverseOp = dyn_cast<ReverseOp>(op)) {
       Tensor runtimeOperand = scope.find(reverseOp.getOperand());
-      auto dimensions =
-          llvm::to_vector(reverseOp.getDimensions().getValues<int64_t>());
+      auto dimensions = Axes(reverseOp.getDimensions());
       Tensor runtimeResult =
           evalReverseOp(runtimeOperand, dimensions, reverseOp.getType());
       scope.add(op.getResults(), {runtimeResult});
@@ -543,9 +533,8 @@ SmallVector<Tensor> eval(Region &region, ArrayRef<Tensor> args, Scope *parent) {
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto sliceOp = dyn_cast<SliceOp>(op)) {
       Tensor runtimeOperand = scope.find(sliceOp.getOperand());
-      auto startIndices =
-          llvm::to_vector(sliceOp.getStartIndices().getValues<int64_t>());
-      auto strides = llvm::to_vector(sliceOp.getStrides().getValues<int64_t>());
+      auto startIndices = Sizes(sliceOp.getStartIndices());
+      auto strides = Sizes(sliceOp.getStrides());
       Tensor runtimeResult =
           evalSliceOp(runtimeOperand, startIndices, strides, sliceOp.getType());
       scope.add(op.getResults(), {runtimeResult});
@@ -565,8 +554,7 @@ SmallVector<Tensor> eval(Region &region, ArrayRef<Tensor> args, Scope *parent) {
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto transposeOp = dyn_cast<TransposeOp>(op)) {
       Tensor runtimeOperand = scope.find(transposeOp.getOperand());
-      auto permutation =
-          llvm::to_vector(transposeOp.getPermutation().getValues<int64_t>());
+      auto permutation = Axes(transposeOp.getPermutation());
       Tensor runtimeResult =
           evalTransposeOp(runtimeOperand, permutation, transposeOp.getType());
       scope.add(op.getResults(), {runtimeResult});

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -39,23 +39,21 @@ Sizes evalIndices(ArrayRef<Tensor> runtimeIndices) {
 
 }  // namespace
 
-Tensor evalAbsOp(const Tensor &operand, RankedTensorType resultType) {
+Tensor evalAbsOp(const Tensor &operand, TensorType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, abs(operand.get(*it)));
   return result;
 }
 
-Tensor evalAddOp(const Tensor &lhs, const Tensor &rhs,
-                 RankedTensorType resultType) {
+Tensor evalAddOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, lhs.get(*it) + rhs.get(*it));
   return result;
 }
 
-Tensor evalAndOp(const Tensor &lhs, const Tensor &rhs,
-                 RankedTensorType resultType) {
+Tensor evalAndOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType) {
   Tensor result(resultType);
   for (auto it = lhs.index_begin(); it != lhs.index_end(); ++it)
     result.set(*it, lhs.get(*it) & rhs.get(*it));
@@ -63,12 +61,12 @@ Tensor evalAndOp(const Tensor &lhs, const Tensor &rhs,
 }
 
 Tensor evalBroadcastInDimOp(const Tensor &operand, Axes broadcastDimensions,
-                            RankedTensorType resultType) {
+                            TensorType resultType) {
   Tensor result(resultType);
   auto operandShape = operand.getShape();
   for (auto resultIt = result.index_begin(); resultIt != result.index_end();
        ++resultIt) {
-    Sizes operandIdx(operandShape.size());
+    Index operandIdx(operandShape.size());
     for (auto [operandDim, resultDim] : llvm::enumerate(broadcastDimensions))
       operandIdx[operandDim] =
           operandShape[operandDim] == 1 ? 0 : (*resultIt)[resultDim];
@@ -77,7 +75,7 @@ Tensor evalBroadcastInDimOp(const Tensor &operand, Axes broadcastDimensions,
   return result;
 }
 
-Tensor evalCeilOp(const Tensor &operand, RankedTensorType resultType) {
+Tensor evalCeilOp(const Tensor &operand, TensorType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, ceil(operand.get(*it)));
@@ -85,7 +83,7 @@ Tensor evalCeilOp(const Tensor &operand, RankedTensorType resultType) {
 }
 
 Tensor evalClampOp(const Tensor &min, const Tensor &operand, const Tensor &max,
-                   RankedTensorType resultType) {
+                   TensorType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
     Element minElement = min.getRank() != 0 ? min.get(*it) : min.get({});
@@ -102,7 +100,7 @@ Tensor evalConstantOp(ElementsAttr value) {
 
 // This is an simplified implementation of convert op semantics dealing only
 // with integer to bool conversion. To be updated as part of #969.
-Tensor evalConvertOp(const Tensor &operand, RankedTensorType resultType) {
+Tensor evalConvertOp(const Tensor &operand, TensorType resultType) {
   Tensor result(resultType);
   Type elType = result.getElementType();
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
@@ -111,7 +109,7 @@ Tensor evalConvertOp(const Tensor &operand, RankedTensorType resultType) {
   return result;
 }
 
-Tensor evalCosineOp(const Tensor &operand, RankedTensorType resultType) {
+Tensor evalCosineOp(const Tensor &operand, TensorType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, cosine(operand.get(*it)));
@@ -119,7 +117,7 @@ Tensor evalCosineOp(const Tensor &operand, RankedTensorType resultType) {
 }
 
 Tensor evalDynamicSliceOp(const Tensor &operand, ArrayRef<Tensor> startIndices,
-                          Sizes sliceSizes, RankedTensorType resultType) {
+                          Sizes sliceSizes, TensorType resultType) {
   Tensor result(resultType);
   auto adjustedStartIndices =
       clamp(0, evalIndices(startIndices), operand.getShape() - sliceSizes);
@@ -132,7 +130,7 @@ Tensor evalDynamicSliceOp(const Tensor &operand, ArrayRef<Tensor> startIndices,
 
 Tensor evalDynamicUpdateSliceOp(const Tensor &operand, const Tensor &update,
                                 ArrayRef<Tensor> startIndices,
-                                RankedTensorType resultType) {
+                                TensorType resultType) {
   Tensor result(resultType);
   auto adjustedStartIndices = clamp(0, evalIndices(startIndices),
                                     operand.getShape() - update.getShape());
@@ -145,14 +143,14 @@ Tensor evalDynamicUpdateSliceOp(const Tensor &operand, const Tensor &update,
   return result;
 }
 
-Tensor evalExponentialOp(const Tensor &operand, RankedTensorType resultType) {
+Tensor evalExponentialOp(const Tensor &operand, TensorType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, exponential(operand.get(*it)));
   return result;
 }
 
-Tensor evalFloorOp(const Tensor &operand, RankedTensorType resultType) {
+Tensor evalFloorOp(const Tensor &operand, TensorType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, floor(operand.get(*it)));
@@ -165,7 +163,7 @@ SmallVector<Tensor> evalIfOp(const Tensor &pred, Region &trueBranch,
                                         : eval(falseBranch, {}, &scope);
 }
 
-Tensor evalIotaOp(int64_t iotaDimension, RankedTensorType resultType) {
+Tensor evalIotaOp(int64_t iotaDimension, TensorType resultType) {
   Tensor result(resultType);
   Type elType = result.getElementType();
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
@@ -201,22 +199,21 @@ Tensor evalIotaOp(int64_t iotaDimension, RankedTensorType resultType) {
   return result;
 }
 
-Tensor evalLogOp(const Tensor &operand, Type resultType) {
+Tensor evalLogOp(const Tensor &operand, TensorType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, log(operand.get(*it)));
   return result;
 }
 
-Tensor evalMaxOp(const Tensor &lhs, const Tensor &rhs, Type resultType) {
+Tensor evalMaxOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, max(lhs.get(*it), rhs.get(*it)));
   return result;
 }
 
-Tensor evalMinOp(const Tensor &lhs, const Tensor &rhs,
-                 RankedTensorType resultType) {
+Tensor evalMinOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, min(lhs.get(*it), rhs.get(*it)));
@@ -224,29 +221,28 @@ Tensor evalMinOp(const Tensor &lhs, const Tensor &rhs,
 }
 
 Tensor evalMultiplyOp(const Tensor &lhs, const Tensor &rhs,
-                      RankedTensorType resultType) {
+                      TensorType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, lhs.get(*it) * rhs.get(*it));
   return result;
 }
 
-Tensor evalNegOp(const Tensor &operand, RankedTensorType resultType) {
+Tensor evalNegOp(const Tensor &operand, TensorType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, -operand.get(*it));
   return result;
 }
 
-Tensor evalNotOp(const Tensor &operand, RankedTensorType resultType) {
+Tensor evalNotOp(const Tensor &operand, TensorType resultType) {
   Tensor result(resultType);
   for (auto it = operand.index_begin(); it != operand.index_end(); ++it)
     result.set(*it, ~operand.get(*it));
   return result;
 }
 
-Tensor evalOrOp(const Tensor &lhs, const Tensor &rhs,
-                RankedTensorType resultType) {
+Tensor evalOrOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType) {
   Tensor result(resultType);
   for (auto it = lhs.index_begin(); it != lhs.index_end(); ++it)
     result.set(*it, lhs.get(*it) | rhs.get(*it));
@@ -255,7 +251,7 @@ Tensor evalOrOp(const Tensor &lhs, const Tensor &rhs,
 
 Tensor evalPadOp(const Tensor &operand, const Tensor &paddingValue,
                  Sizes edgePaddingLow, Sizes interiorPadding,
-                 RankedTensorType resultType) {
+                 TensorType resultType) {
   Tensor result(resultType);
   for (auto resultIt = result.index_begin(); resultIt != result.index_end();
        ++resultIt)
@@ -271,7 +267,7 @@ Tensor evalPadOp(const Tensor &operand, const Tensor &paddingValue,
   return result;
 }
 
-Tensor evalReshapeOp(const Tensor &operand, RankedTensorType resultType) {
+Tensor evalReshapeOp(const Tensor &operand, TensorType resultType) {
   Tensor result(resultType);
   for (auto resultIt = result.index_begin(), operandIt = operand.index_begin();
        resultIt != result.index_end(); ++resultIt, ++operandIt)
@@ -280,20 +276,21 @@ Tensor evalReshapeOp(const Tensor &operand, RankedTensorType resultType) {
 }
 
 Tensor evalReverseOp(const Tensor &operand, Axes dimensions,
-                     RankedTensorType resultType) {
+                     TensorType resultType) {
   Tensor result(resultType);
   auto resultShape = result.getShape();
   for (auto resultIt = result.index_begin(); resultIt != result.index_end();
        ++resultIt) {
     Sizes operandIdx(*resultIt);
-    operandIdx = (resultShape - 1) - operandIdx;
+    for (auto dim : dimensions)
+      operandIdx[dim] = (resultShape[dim] - 1) - operandIdx[dim];
     result.set(*resultIt, operand.get(operandIdx));
   }
   return result;
 }
 
 Tensor evalSelectOp(const Tensor &pred, const Tensor &onTrue,
-                    const Tensor &onFalse, RankedTensorType resultType) {
+                    const Tensor &onFalse, TensorType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
     Element predValue = pred.getRank() != 0 ? pred.get(*it) : pred.get({});
@@ -303,7 +300,7 @@ Tensor evalSelectOp(const Tensor &pred, const Tensor &onTrue,
   return result;
 }
 
-Tensor evalSineOp(const Tensor &operand, RankedTensorType resultType) {
+Tensor evalSineOp(const Tensor &operand, TensorType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, sine(operand.get(*it)));
@@ -311,7 +308,7 @@ Tensor evalSineOp(const Tensor &operand, RankedTensorType resultType) {
 }
 
 Tensor evalSliceOp(const Tensor &operand, Sizes startIndices, Sizes strides,
-                   RankedTensorType resultType) {
+                   TensorType resultType) {
   Tensor result(resultType);
   for (auto resultIt = result.index_begin(); resultIt != result.index_end();
        ++resultIt) {
@@ -320,21 +317,22 @@ Tensor evalSliceOp(const Tensor &operand, Sizes startIndices, Sizes strides,
   return result;
 }
 
-Tensor evalSqrtOp(const Tensor &operand, Type resultType) {
+Tensor evalSqrtOp(const Tensor &operand, TensorType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, sqrt(operand.get(*it)));
   return result;
 }
 
-Tensor evalSubtractOp(const Tensor &lhs, const Tensor &rhs, Type resultType) {
+Tensor evalSubtractOp(const Tensor &lhs, const Tensor &rhs,
+                      TensorType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, lhs.get(*it) - rhs.get(*it));
   return result;
 }
 
-Tensor evalTanhOp(const Tensor &operand, RankedTensorType resultType) {
+Tensor evalTanhOp(const Tensor &operand, TensorType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, tanh(operand.get(*it)));
@@ -342,7 +340,7 @@ Tensor evalTanhOp(const Tensor &operand, RankedTensorType resultType) {
 }
 
 Tensor evalTransposeOp(const Tensor &operand, const Axes &permutation,
-                       RankedTensorType resultType) {
+                       TensorType resultType) {
   Tensor result(resultType);
   for (auto operandIt = operand.index_begin(); operandIt != operand.index_end();
        ++operandIt) {
@@ -370,8 +368,7 @@ SmallVector<Tensor> evalWhileOp(ArrayRef<Tensor> operand, Region &cond,
   return runtimeResults;
 }
 
-Tensor evalXorOp(const Tensor &lhs, const Tensor &rhs,
-                 RankedTensorType resultType) {
+Tensor evalXorOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType) {
   Tensor result(resultType);
   for (auto it = lhs.index_begin(); it != lhs.index_end(); ++it)
     result.set(*it, lhs.get(*it) ^ rhs.get(*it));

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -280,7 +280,7 @@ Tensor evalReverseOp(const Tensor &operand, Axes dimensions,
   auto resultShape = result.getShape();
   for (auto resultIt = result.index_begin(); resultIt != result.index_end();
        ++resultIt) {
-    Sizes operandIdx(*resultIt);
+    Index operandIdx(*resultIt);
     for (auto dim : dimensions)
       operandIdx[dim] = (resultShape[dim] - 1) - operandIdx[dim];
     result.set(*resultIt, operand.get(operandIdx));
@@ -387,62 +387,54 @@ SmallVector<Tensor> eval(Region &region, ArrayRef<Tensor> args, Scope *parent) {
   for (Operation &op : block) {
     if (auto absOp = dyn_cast<AbsOp>(op)) {
       Tensor runtimeOperand = scope.find(absOp.getOperand());
-      Tensor runtimeResult =
-          evalAbsOp(runtimeOperand, absOp.getType().cast<RankedTensorType>());
+      Tensor runtimeResult = evalAbsOp(runtimeOperand, absOp.getType());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto addOp = dyn_cast<AddOp>(op)) {
       Tensor runtimeLhs = scope.find(addOp.getLhs());
       Tensor runtimeRhs = scope.find(addOp.getRhs());
-      Tensor runtimeResult = evalAddOp(
-          runtimeLhs, runtimeRhs, addOp.getType().cast<RankedTensorType>());
+      Tensor runtimeResult = evalAddOp(runtimeLhs, runtimeRhs, addOp.getType());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto andOp = dyn_cast<AndOp>(op)) {
       Tensor runtimeLhs = scope.find(andOp.getLhs());
       Tensor runtimeRhs = scope.find(andOp.getRhs());
-      Tensor runtimeResult = evalAndOp(
-          runtimeLhs, runtimeRhs, andOp.getType().cast<RankedTensorType>());
+      Tensor runtimeResult = evalAndOp(runtimeLhs, runtimeRhs, andOp.getType());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto broadcastInDimOp = dyn_cast<BroadcastInDimOp>(op)) {
       Tensor runtimeOperand = scope.find(broadcastInDimOp.getOperand());
       auto broadcastDimensions =
           Axes(broadcastInDimOp.getBroadcastDimensions());
       Tensor runtimeResult = evalBroadcastInDimOp(
-          runtimeOperand, broadcastDimensions,
-          broadcastInDimOp.getType().cast<RankedTensorType>());
+          runtimeOperand, broadcastDimensions, broadcastInDimOp.getType());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto ceilOp = dyn_cast<CeilOp>(op)) {
       Tensor runtimeOperand = scope.find(ceilOp.getOperand());
-      Tensor runtimeResult =
-          evalCeilOp(runtimeOperand, ceilOp.getType().cast<RankedTensorType>());
+      Tensor runtimeResult = evalCeilOp(runtimeOperand, ceilOp.getType());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto clampOp = dyn_cast<ClampOp>(op)) {
       Tensor runtimeMin = scope.find(clampOp.getMin());
       Tensor runtimeOperand = scope.find(clampOp.getOperand());
       Tensor runtimeMax = scope.find(clampOp.getMax());
-      Tensor runtimeResult =
-          evalClampOp(runtimeMin, runtimeOperand, runtimeMax,
-                      clampOp.getType().cast<RankedTensorType>());
+      Tensor runtimeResult = evalClampOp(runtimeMin, runtimeOperand, runtimeMax,
+                                         clampOp.getType());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto constantOp = dyn_cast<ConstantOp>(op)) {
       Tensor runtimeResult = evalConstantOp(constantOp.getValue());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto convertOp = dyn_cast<ConvertOp>(op)) {
       Tensor runtimeOperand = scope.find(convertOp.getOperand());
-      Tensor runtimeResult = evalConvertOp(
-          runtimeOperand, convertOp.getType().cast<RankedTensorType>());
+      Tensor runtimeResult = evalConvertOp(runtimeOperand, convertOp.getType());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto cosineOp = dyn_cast<CosineOp>(op)) {
       Tensor runtimeOperand = scope.find(cosineOp.getOperand());
-      Tensor runtimeResult = evalCosineOp(
-          runtimeOperand, cosineOp.getType().cast<RankedTensorType>());
+      Tensor runtimeResult = evalCosineOp(runtimeOperand, cosineOp.getType());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto dynamicSliceOp = dyn_cast<DynamicSliceOp>(op)) {
       Tensor runtimeOperand = scope.find(dynamicSliceOp.getOperand());
       auto runtimeStartIndices = scope.find(dynamicSliceOp.getStartIndices());
       auto runtimeSliceSizes = Sizes(dynamicSliceOp.getSliceSizes());
-      Tensor runtimeResult = evalDynamicSliceOp(
-          runtimeOperand, evalIndices(runtimeStartIndices), runtimeSliceSizes,
-          dynamicSliceOp.getType().cast<RankedTensorType>());
+      Tensor runtimeResult =
+          evalDynamicSliceOp(runtimeOperand, evalIndices(runtimeStartIndices),
+                             runtimeSliceSizes, dynamicSliceOp.getType());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto dynamicUpdateSliceOp = dyn_cast<DynamicUpdateSliceOp>(op)) {
       Tensor runtimeOperand = scope.find(dynamicUpdateSliceOp.getOperand());
@@ -451,17 +443,15 @@ SmallVector<Tensor> eval(Region &region, ArrayRef<Tensor> args, Scope *parent) {
           scope.find(dynamicUpdateSliceOp.getStartIndices());
       Tensor runtimeResult = evalDynamicUpdateSliceOp(
           runtimeOperand, runtimeUpdate, evalIndices(runtimeStartIndices),
-          dynamicUpdateSliceOp.getType().cast<RankedTensorType>());
+          dynamicUpdateSliceOp.getType());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto expOp = dyn_cast<ExpOp>(op)) {
       Tensor runtimeOperand = scope.find(expOp.getOperand());
-      Tensor runtimeResult = evalExponentialOp(
-          runtimeOperand, expOp.getType().cast<RankedTensorType>());
+      Tensor runtimeResult = evalExponentialOp(runtimeOperand, expOp.getType());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto floorOp = dyn_cast<FloorOp>(op)) {
       Tensor runtimeOperand = scope.find(floorOp.getOperand());
-      Tensor runtimeResult = evalFloorOp(
-          runtimeOperand, floorOp.getType().cast<RankedTensorType>());
+      Tensor runtimeResult = evalFloorOp(runtimeOperand, floorOp.getType());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto ifOp = dyn_cast<IfOp>(op)) {
       Tensor runtimePred = scope.find(ifOp.getPred());
@@ -469,8 +459,8 @@ SmallVector<Tensor> eval(Region &region, ArrayRef<Tensor> args, Scope *parent) {
                                      ifOp.getFalseBranch(), scope);
       scope.add(op.getResults(), runtimeResults);
     } else if (auto iotaOp = dyn_cast<IotaOp>(op)) {
-      Tensor runtimeResult = evalIotaOp(
-          iotaOp.getIotaDimension(), iotaOp.getType().cast<RankedTensorType>());
+      Tensor runtimeResult =
+          evalIotaOp(iotaOp.getIotaDimension(), iotaOp.getType());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto logOp = dyn_cast<LogOp>(op)) {
       Tensor runtimeOperand = scope.find(logOp.getOperand());
@@ -479,37 +469,31 @@ SmallVector<Tensor> eval(Region &region, ArrayRef<Tensor> args, Scope *parent) {
     } else if (auto maxOp = dyn_cast<MaxOp>(op)) {
       Tensor runtimeLhs = scope.find(maxOp.getLhs());
       Tensor runtimeRhs = scope.find(maxOp.getRhs());
-      Tensor runtimeResult = evalMaxOp(
-          runtimeLhs, runtimeRhs, maxOp.getType().cast<RankedTensorType>());
+      Tensor runtimeResult = evalMaxOp(runtimeLhs, runtimeRhs, maxOp.getType());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto minOp = dyn_cast<MinOp>(op)) {
       Tensor runtimeLhs = scope.find(minOp.getLhs());
       Tensor runtimeRhs = scope.find(minOp.getRhs());
-      Tensor runtimeResult = evalMinOp(
-          runtimeLhs, runtimeRhs, minOp.getType().cast<RankedTensorType>());
+      Tensor runtimeResult = evalMinOp(runtimeLhs, runtimeRhs, minOp.getType());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto multiplyOp = dyn_cast<MulOp>(op)) {
       Tensor runtimeLhs = scope.find(multiplyOp.getLhs());
       Tensor runtimeRhs = scope.find(multiplyOp.getRhs());
       Tensor runtimeResult =
-          evalMultiplyOp(runtimeLhs, runtimeRhs,
-                         multiplyOp.getType().cast<RankedTensorType>());
+          evalMultiplyOp(runtimeLhs, runtimeRhs, multiplyOp.getType());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto negOp = dyn_cast<NegOp>(op)) {
       Tensor runtimeOperand = scope.find(negOp.getOperand());
-      Tensor runtimeResult =
-          evalNegOp(runtimeOperand, negOp.getType().cast<RankedTensorType>());
+      Tensor runtimeResult = evalNegOp(runtimeOperand, negOp.getType());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto notOp = dyn_cast<NotOp>(op)) {
       Tensor runtimeOperand = scope.find(notOp.getOperand());
-      Tensor runtimeResult =
-          evalNotOp(runtimeOperand, notOp.getType().cast<RankedTensorType>());
+      Tensor runtimeResult = evalNotOp(runtimeOperand, notOp.getType());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto orOp = dyn_cast<OrOp>(op)) {
       Tensor runtimeLhs = scope.find(orOp.getLhs());
       Tensor runtimeRhs = scope.find(orOp.getRhs());
-      Tensor runtimeResult = evalOrOp(runtimeLhs, runtimeRhs,
-                                      orOp.getType().cast<RankedTensorType>());
+      Tensor runtimeResult = evalOrOp(runtimeLhs, runtimeRhs, orOp.getType());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto padOp = dyn_cast<PadOp>(op)) {
       Tensor runtimeOperand = scope.find(padOp.getOperand());
@@ -518,7 +502,7 @@ SmallVector<Tensor> eval(Region &region, ArrayRef<Tensor> args, Scope *parent) {
       auto interiorPadding = Sizes(padOp.getInteriorPadding());
       Tensor runtimeResult =
           evalPadOp(runtimeOperand, runtimePaddingValue, edgePaddingLow,
-                    interiorPadding, padOp.getType().cast<RankedTensorType>());
+                    interiorPadding, padOp.getType());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto whileOp = dyn_cast<WhileOp>(op)) {
       SmallVector<Value> runtimeOperands(whileOp.getOperand().begin(),
@@ -529,15 +513,13 @@ SmallVector<Tensor> eval(Region &region, ArrayRef<Tensor> args, Scope *parent) {
       scope.add(op.getResults(), runtimeResults);
     } else if (auto reshapeOp = dyn_cast<ReshapeOp>(op)) {
       Tensor runtimeOperand = scope.find(reshapeOp.getOperand());
-      Tensor runtimeResult = evalReshapeOp(
-          runtimeOperand, reshapeOp.getType().cast<RankedTensorType>());
+      Tensor runtimeResult = evalReshapeOp(runtimeOperand, reshapeOp.getType());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto reverseOp = dyn_cast<ReverseOp>(op)) {
       Tensor runtimeOperand = scope.find(reverseOp.getOperand());
       auto dimensions = Axes(reverseOp.getDimensions());
       Tensor runtimeResult =
-          evalReverseOp(runtimeOperand, dimensions,
-                        reverseOp.getType().cast<RankedTensorType>());
+          evalReverseOp(runtimeOperand, dimensions, reverseOp.getType());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto returnOp = dyn_cast<func::ReturnOp>(op)) {
       return scope.find(returnOp.getOperands());
@@ -546,21 +528,18 @@ SmallVector<Tensor> eval(Region &region, ArrayRef<Tensor> args, Scope *parent) {
     } else if (auto selectOp = dyn_cast<SelectOp>(op)) {
       Tensor runtimeResult = evalSelectOp(
           scope.find(selectOp.getPred()), scope.find(selectOp.getOnTrue()),
-          scope.find(selectOp.getOnFalse()),
-          selectOp.getType().cast<RankedTensorType>());
+          scope.find(selectOp.getOnFalse()), selectOp.getType());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto sineOp = dyn_cast<SineOp>(op)) {
       Tensor runtimeOperand = scope.find(sineOp.getOperand());
-      Tensor runtimeResult =
-          evalSineOp(runtimeOperand, sineOp.getType().cast<RankedTensorType>());
+      Tensor runtimeResult = evalSineOp(runtimeOperand, sineOp.getType());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto sliceOp = dyn_cast<SliceOp>(op)) {
       Tensor runtimeOperand = scope.find(sliceOp.getOperand());
       auto startIndices = Sizes(sliceOp.getStartIndices());
       auto strides = Sizes(sliceOp.getStrides());
       Tensor runtimeResult =
-          evalSliceOp(runtimeOperand, startIndices, strides,
-                      sliceOp.getType().cast<RankedTensorType>());
+          evalSliceOp(runtimeOperand, startIndices, strides, sliceOp.getType());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto sqrtOp = dyn_cast<SqrtOp>(op)) {
       Tensor runtimeOperand = scope.find(sqrtOp.getOperand());
@@ -570,26 +549,22 @@ SmallVector<Tensor> eval(Region &region, ArrayRef<Tensor> args, Scope *parent) {
       Tensor runtimeLhs = scope.find(subtractOp.getLhs());
       Tensor runtimeRhs = scope.find(subtractOp.getRhs());
       Tensor runtimeResult =
-          evalSubtractOp(runtimeLhs, runtimeRhs,
-                         subtractOp.getType().cast<RankedTensorType>());
+          evalSubtractOp(runtimeLhs, runtimeRhs, subtractOp.getType());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto tanhOp = dyn_cast<TanhOp>(op)) {
       Tensor runtimeOperand = scope.find(tanhOp.getOperand());
-      Tensor runtimeResult =
-          evalTanhOp(runtimeOperand, tanhOp.getType().cast<RankedTensorType>());
+      Tensor runtimeResult = evalTanhOp(runtimeOperand, tanhOp.getType());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto transposeOp = dyn_cast<TransposeOp>(op)) {
       Tensor runtimeOperand = scope.find(transposeOp.getOperand());
       auto permutation = Axes(transposeOp.getPermutation());
       Tensor runtimeResult =
-          evalTransposeOp(runtimeOperand, permutation,
-                          transposeOp.getType().cast<RankedTensorType>());
+          evalTransposeOp(runtimeOperand, permutation, transposeOp.getType());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto xorOp = dyn_cast<XorOp>(op)) {
       Tensor runtimeLhs = scope.find(xorOp.getLhs());
       Tensor runtimeRhs = scope.find(xorOp.getRhs());
-      Tensor runtimeResult = evalXorOp(
-          runtimeLhs, runtimeRhs, xorOp.getType().cast<RankedTensorType>());
+      Tensor runtimeResult = evalXorOp(runtimeLhs, runtimeRhs, xorOp.getType());
       scope.add(op.getResults(), {runtimeResult});
     } else {
       report_fatal_error(

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -279,8 +279,7 @@ Tensor evalReverseOp(const Tensor &operand, Axes dimensions, Type resultType) {
   for (auto resultIt = result.index_begin(); resultIt != result.index_end();
        ++resultIt) {
     Sizes operandIdx(*resultIt);
-    for (auto dim : dimensions)
-      operandIdx[dim] = (resultShape[dim] - 1) - operandIdx[dim];
+    operandIdx = (resultShape - 1) - operandIdx;
     result.set(*resultIt, operand.get(operandIdx));
   }
   return result;

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -430,19 +430,20 @@ SmallVector<Tensor> eval(Region &region, ArrayRef<Tensor> args, Scope *parent) {
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto dynamicSliceOp = dyn_cast<DynamicSliceOp>(op)) {
       Tensor runtimeOperand = scope.find(dynamicSliceOp.getOperand());
-      auto runtimeStartIndices = scope.find(dynamicSliceOp.getStartIndices());
+      Index runtimeStartIndices =
+          evalIndices(scope.find(dynamicSliceOp.getStartIndices()));
       auto runtimeSliceSizes = Sizes(dynamicSliceOp.getSliceSizes());
       Tensor runtimeResult =
-          evalDynamicSliceOp(runtimeOperand, evalIndices(runtimeStartIndices),
+          evalDynamicSliceOp(runtimeOperand, runtimeStartIndices,
                              runtimeSliceSizes, dynamicSliceOp.getType());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto dynamicUpdateSliceOp = dyn_cast<DynamicUpdateSliceOp>(op)) {
       Tensor runtimeOperand = scope.find(dynamicUpdateSliceOp.getOperand());
       Tensor runtimeUpdate = scope.find(dynamicUpdateSliceOp.getUpdate());
-      SmallVector<Tensor> runtimeStartIndices =
-          scope.find(dynamicUpdateSliceOp.getStartIndices());
+      Index runtimeStartIndices =
+          evalIndices(scope.find(dynamicUpdateSliceOp.getStartIndices()));
       Tensor runtimeResult = evalDynamicUpdateSliceOp(
-          runtimeOperand, runtimeUpdate, evalIndices(runtimeStartIndices),
+          runtimeOperand, runtimeUpdate, runtimeStartIndices,
           dynamicUpdateSliceOp.getType());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto expOp = dyn_cast<ExpOp>(op)) {

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -39,21 +39,23 @@ Sizes evalIndices(ArrayRef<Tensor> runtimeIndices) {
 
 }  // namespace
 
-Tensor evalAbsOp(const Tensor &operand, Type resultType) {
+Tensor evalAbsOp(const Tensor &operand, RankedTensorType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, abs(operand.get(*it)));
   return result;
 }
 
-Tensor evalAddOp(const Tensor &lhs, const Tensor &rhs, Type resultType) {
+Tensor evalAddOp(const Tensor &lhs, const Tensor &rhs,
+                 RankedTensorType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, lhs.get(*it) + rhs.get(*it));
   return result;
 }
 
-Tensor evalAndOp(const Tensor &lhs, const Tensor &rhs, Type resultType) {
+Tensor evalAndOp(const Tensor &lhs, const Tensor &rhs,
+                 RankedTensorType resultType) {
   Tensor result(resultType);
   for (auto it = lhs.index_begin(); it != lhs.index_end(); ++it)
     result.set(*it, lhs.get(*it) & rhs.get(*it));
@@ -61,7 +63,7 @@ Tensor evalAndOp(const Tensor &lhs, const Tensor &rhs, Type resultType) {
 }
 
 Tensor evalBroadcastInDimOp(const Tensor &operand, Axes broadcastDimensions,
-                            Type resultType) {
+                            RankedTensorType resultType) {
   Tensor result(resultType);
   auto operandShape = operand.getShape();
   for (auto resultIt = result.index_begin(); resultIt != result.index_end();
@@ -75,7 +77,7 @@ Tensor evalBroadcastInDimOp(const Tensor &operand, Axes broadcastDimensions,
   return result;
 }
 
-Tensor evalCeilOp(const Tensor &operand, Type resultType) {
+Tensor evalCeilOp(const Tensor &operand, RankedTensorType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, ceil(operand.get(*it)));
@@ -83,7 +85,7 @@ Tensor evalCeilOp(const Tensor &operand, Type resultType) {
 }
 
 Tensor evalClampOp(const Tensor &min, const Tensor &operand, const Tensor &max,
-                   Type resultType) {
+                   RankedTensorType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
     Element minElement = min.getRank() != 0 ? min.get(*it) : min.get({});
@@ -100,7 +102,7 @@ Tensor evalConstantOp(ElementsAttr value) {
 
 // This is an simplified implementation of convert op semantics dealing only
 // with integer to bool conversion. To be updated as part of #969.
-Tensor evalConvertOp(const Tensor &operand, Type resultType) {
+Tensor evalConvertOp(const Tensor &operand, RankedTensorType resultType) {
   Tensor result(resultType);
   Type elType = result.getElementType();
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
@@ -109,7 +111,7 @@ Tensor evalConvertOp(const Tensor &operand, Type resultType) {
   return result;
 }
 
-Tensor evalCosineOp(const Tensor &operand, Type resultType) {
+Tensor evalCosineOp(const Tensor &operand, RankedTensorType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, cosine(operand.get(*it)));
@@ -117,7 +119,7 @@ Tensor evalCosineOp(const Tensor &operand, Type resultType) {
 }
 
 Tensor evalDynamicSliceOp(const Tensor &operand, ArrayRef<Tensor> startIndices,
-                          Sizes sliceSizes, Type resultType) {
+                          Sizes sliceSizes, RankedTensorType resultType) {
   Tensor result(resultType);
   auto adjustedStartIndices =
       clamp(0, evalIndices(startIndices), operand.getShape() - sliceSizes);
@@ -130,7 +132,7 @@ Tensor evalDynamicSliceOp(const Tensor &operand, ArrayRef<Tensor> startIndices,
 
 Tensor evalDynamicUpdateSliceOp(const Tensor &operand, const Tensor &update,
                                 ArrayRef<Tensor> startIndices,
-                                Type resultType) {
+                                RankedTensorType resultType) {
   Tensor result(resultType);
   auto adjustedStartIndices = clamp(0, evalIndices(startIndices),
                                     operand.getShape() - update.getShape());
@@ -143,14 +145,14 @@ Tensor evalDynamicUpdateSliceOp(const Tensor &operand, const Tensor &update,
   return result;
 }
 
-Tensor evalExponentialOp(const Tensor &operand, Type resultType) {
+Tensor evalExponentialOp(const Tensor &operand, RankedTensorType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, exponential(operand.get(*it)));
   return result;
 }
 
-Tensor evalFloorOp(const Tensor &operand, Type resultType) {
+Tensor evalFloorOp(const Tensor &operand, RankedTensorType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, floor(operand.get(*it)));
@@ -163,7 +165,7 @@ SmallVector<Tensor> evalIfOp(const Tensor &pred, Region &trueBranch,
                                         : eval(falseBranch, {}, &scope);
 }
 
-Tensor evalIotaOp(int64_t iotaDimension, Type resultType) {
+Tensor evalIotaOp(int64_t iotaDimension, RankedTensorType resultType) {
   Tensor result(resultType);
   Type elType = result.getElementType();
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
@@ -213,35 +215,38 @@ Tensor evalMaxOp(const Tensor &lhs, const Tensor &rhs, Type resultType) {
   return result;
 }
 
-Tensor evalMinOp(const Tensor &lhs, const Tensor &rhs, Type resultType) {
+Tensor evalMinOp(const Tensor &lhs, const Tensor &rhs,
+                 RankedTensorType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, min(lhs.get(*it), rhs.get(*it)));
   return result;
 }
 
-Tensor evalMultiplyOp(const Tensor &lhs, const Tensor &rhs, Type resultType) {
+Tensor evalMultiplyOp(const Tensor &lhs, const Tensor &rhs,
+                      RankedTensorType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, lhs.get(*it) * rhs.get(*it));
   return result;
 }
 
-Tensor evalNegOp(const Tensor &operand, Type resultType) {
+Tensor evalNegOp(const Tensor &operand, RankedTensorType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, -operand.get(*it));
   return result;
 }
 
-Tensor evalNotOp(const Tensor &operand, Type resultType) {
+Tensor evalNotOp(const Tensor &operand, RankedTensorType resultType) {
   Tensor result(resultType);
   for (auto it = operand.index_begin(); it != operand.index_end(); ++it)
     result.set(*it, ~operand.get(*it));
   return result;
 }
 
-Tensor evalOrOp(const Tensor &lhs, const Tensor &rhs, Type resultType) {
+Tensor evalOrOp(const Tensor &lhs, const Tensor &rhs,
+                RankedTensorType resultType) {
   Tensor result(resultType);
   for (auto it = lhs.index_begin(); it != lhs.index_end(); ++it)
     result.set(*it, lhs.get(*it) | rhs.get(*it));
@@ -249,7 +254,8 @@ Tensor evalOrOp(const Tensor &lhs, const Tensor &rhs, Type resultType) {
 }
 
 Tensor evalPadOp(const Tensor &operand, const Tensor &paddingValue,
-                 Sizes edgePaddingLow, Sizes interiorPadding, Type resultType) {
+                 Sizes edgePaddingLow, Sizes interiorPadding,
+                 RankedTensorType resultType) {
   Tensor result(resultType);
   for (auto resultIt = result.index_begin(); resultIt != result.index_end();
        ++resultIt)
@@ -265,7 +271,7 @@ Tensor evalPadOp(const Tensor &operand, const Tensor &paddingValue,
   return result;
 }
 
-Tensor evalReshapeOp(const Tensor &operand, Type resultType) {
+Tensor evalReshapeOp(const Tensor &operand, RankedTensorType resultType) {
   Tensor result(resultType);
   for (auto resultIt = result.index_begin(), operandIt = operand.index_begin();
        resultIt != result.index_end(); ++resultIt, ++operandIt)
@@ -273,7 +279,8 @@ Tensor evalReshapeOp(const Tensor &operand, Type resultType) {
   return result;
 }
 
-Tensor evalReverseOp(const Tensor &operand, Axes dimensions, Type resultType) {
+Tensor evalReverseOp(const Tensor &operand, Axes dimensions,
+                     RankedTensorType resultType) {
   Tensor result(resultType);
   auto resultShape = result.getShape();
   for (auto resultIt = result.index_begin(); resultIt != result.index_end();
@@ -286,7 +293,7 @@ Tensor evalReverseOp(const Tensor &operand, Axes dimensions, Type resultType) {
 }
 
 Tensor evalSelectOp(const Tensor &pred, const Tensor &onTrue,
-                    const Tensor &onFalse, Type resultType) {
+                    const Tensor &onFalse, RankedTensorType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
     Element predValue = pred.getRank() != 0 ? pred.get(*it) : pred.get({});
@@ -296,7 +303,7 @@ Tensor evalSelectOp(const Tensor &pred, const Tensor &onTrue,
   return result;
 }
 
-Tensor evalSineOp(const Tensor &operand, Type resultType) {
+Tensor evalSineOp(const Tensor &operand, RankedTensorType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, sine(operand.get(*it)));
@@ -304,7 +311,7 @@ Tensor evalSineOp(const Tensor &operand, Type resultType) {
 }
 
 Tensor evalSliceOp(const Tensor &operand, Sizes startIndices, Sizes strides,
-                   Type resultType) {
+                   RankedTensorType resultType) {
   Tensor result(resultType);
   for (auto resultIt = result.index_begin(); resultIt != result.index_end();
        ++resultIt) {
@@ -327,7 +334,7 @@ Tensor evalSubtractOp(const Tensor &lhs, const Tensor &rhs, Type resultType) {
   return result;
 }
 
-Tensor evalTanhOp(const Tensor &operand, Type resultType) {
+Tensor evalTanhOp(const Tensor &operand, RankedTensorType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, tanh(operand.get(*it)));
@@ -335,7 +342,7 @@ Tensor evalTanhOp(const Tensor &operand, Type resultType) {
 }
 
 Tensor evalTransposeOp(const Tensor &operand, const Axes &permutation,
-                       Type resultType) {
+                       RankedTensorType resultType) {
   Tensor result(resultType);
   for (auto operandIt = operand.index_begin(); operandIt != operand.index_end();
        ++operandIt) {
@@ -363,7 +370,8 @@ SmallVector<Tensor> evalWhileOp(ArrayRef<Tensor> operand, Region &cond,
   return runtimeResults;
 }
 
-Tensor evalXorOp(const Tensor &lhs, const Tensor &rhs, Type resultType) {
+Tensor evalXorOp(const Tensor &lhs, const Tensor &rhs,
+                 RankedTensorType resultType) {
   Tensor result(resultType);
   for (auto it = lhs.index_begin(); it != lhs.index_end(); ++it)
     result.set(*it, lhs.get(*it) ^ rhs.get(*it));
@@ -383,54 +391,62 @@ SmallVector<Tensor> eval(Region &region, ArrayRef<Tensor> args, Scope *parent) {
   for (Operation &op : block) {
     if (auto absOp = dyn_cast<AbsOp>(op)) {
       Tensor runtimeOperand = scope.find(absOp.getOperand());
-      Tensor runtimeResult = evalAbsOp(runtimeOperand, absOp.getType());
+      Tensor runtimeResult =
+          evalAbsOp(runtimeOperand, absOp.getType().cast<RankedTensorType>());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto addOp = dyn_cast<AddOp>(op)) {
       Tensor runtimeLhs = scope.find(addOp.getLhs());
       Tensor runtimeRhs = scope.find(addOp.getRhs());
-      Tensor runtimeResult = evalAddOp(runtimeLhs, runtimeRhs, addOp.getType());
+      Tensor runtimeResult = evalAddOp(
+          runtimeLhs, runtimeRhs, addOp.getType().cast<RankedTensorType>());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto andOp = dyn_cast<AndOp>(op)) {
       Tensor runtimeLhs = scope.find(andOp.getLhs());
       Tensor runtimeRhs = scope.find(andOp.getRhs());
-      Tensor runtimeResult = evalAndOp(runtimeLhs, runtimeRhs, andOp.getType());
+      Tensor runtimeResult = evalAndOp(
+          runtimeLhs, runtimeRhs, andOp.getType().cast<RankedTensorType>());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto broadcastInDimOp = dyn_cast<BroadcastInDimOp>(op)) {
       Tensor runtimeOperand = scope.find(broadcastInDimOp.getOperand());
       auto broadcastDimensions =
           Axes(broadcastInDimOp.getBroadcastDimensions());
       Tensor runtimeResult = evalBroadcastInDimOp(
-          runtimeOperand, broadcastDimensions, broadcastInDimOp.getType());
+          runtimeOperand, broadcastDimensions,
+          broadcastInDimOp.getType().cast<RankedTensorType>());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto ceilOp = dyn_cast<CeilOp>(op)) {
       Tensor runtimeOperand = scope.find(ceilOp.getOperand());
-      Tensor runtimeResult = evalCeilOp(runtimeOperand, ceilOp.getType());
+      Tensor runtimeResult =
+          evalCeilOp(runtimeOperand, ceilOp.getType().cast<RankedTensorType>());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto clampOp = dyn_cast<ClampOp>(op)) {
       Tensor runtimeMin = scope.find(clampOp.getMin());
       Tensor runtimeOperand = scope.find(clampOp.getOperand());
       Tensor runtimeMax = scope.find(clampOp.getMax());
-      Tensor runtimeResult = evalClampOp(runtimeMin, runtimeOperand, runtimeMax,
-                                         clampOp.getType());
+      Tensor runtimeResult =
+          evalClampOp(runtimeMin, runtimeOperand, runtimeMax,
+                      clampOp.getType().cast<RankedTensorType>());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto constantOp = dyn_cast<ConstantOp>(op)) {
       Tensor runtimeResult = evalConstantOp(constantOp.getValue());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto convertOp = dyn_cast<ConvertOp>(op)) {
       Tensor runtimeOperand = scope.find(convertOp.getOperand());
-      Tensor runtimeResult = evalConvertOp(runtimeOperand, convertOp.getType());
+      Tensor runtimeResult = evalConvertOp(
+          runtimeOperand, convertOp.getType().cast<RankedTensorType>());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto cosineOp = dyn_cast<CosineOp>(op)) {
       Tensor runtimeOperand = scope.find(cosineOp.getOperand());
-      Tensor runtimeResult = evalCosineOp(runtimeOperand, cosineOp.getType());
+      Tensor runtimeResult = evalCosineOp(
+          runtimeOperand, cosineOp.getType().cast<RankedTensorType>());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto dynamicSliceOp = dyn_cast<DynamicSliceOp>(op)) {
       Tensor runtimeOperand = scope.find(dynamicSliceOp.getOperand());
       auto runtimeStartIndices = scope.find(dynamicSliceOp.getStartIndices());
       auto runtimeSliceSizes = Sizes(dynamicSliceOp.getSliceSizes());
-      Tensor runtimeResult =
-          evalDynamicSliceOp(runtimeOperand, runtimeStartIndices,
-                             runtimeSliceSizes, dynamicSliceOp.getType());
+      Tensor runtimeResult = evalDynamicSliceOp(
+          runtimeOperand, runtimeStartIndices, runtimeSliceSizes,
+          dynamicSliceOp.getType().cast<RankedTensorType>());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto dynamicUpdateSliceOp = dyn_cast<DynamicUpdateSliceOp>(op)) {
       Tensor runtimeOperand = scope.find(dynamicUpdateSliceOp.getOperand());
@@ -439,15 +455,17 @@ SmallVector<Tensor> eval(Region &region, ArrayRef<Tensor> args, Scope *parent) {
           scope.find(dynamicUpdateSliceOp.getStartIndices());
       Tensor runtimeResult = evalDynamicUpdateSliceOp(
           runtimeOperand, runtimeUpdate, runtimeStartIndices,
-          dynamicUpdateSliceOp.getType());
+          dynamicUpdateSliceOp.getType().cast<RankedTensorType>());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto expOp = dyn_cast<ExpOp>(op)) {
       Tensor runtimeOperand = scope.find(expOp.getOperand());
-      Tensor runtimeResult = evalExponentialOp(runtimeOperand, expOp.getType());
+      Tensor runtimeResult = evalExponentialOp(
+          runtimeOperand, expOp.getType().cast<RankedTensorType>());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto floorOp = dyn_cast<FloorOp>(op)) {
       Tensor runtimeOperand = scope.find(floorOp.getOperand());
-      Tensor runtimeResult = evalFloorOp(runtimeOperand, floorOp.getType());
+      Tensor runtimeResult = evalFloorOp(
+          runtimeOperand, floorOp.getType().cast<RankedTensorType>());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto ifOp = dyn_cast<IfOp>(op)) {
       Tensor runtimePred = scope.find(ifOp.getPred());
@@ -455,8 +473,8 @@ SmallVector<Tensor> eval(Region &region, ArrayRef<Tensor> args, Scope *parent) {
                                      ifOp.getFalseBranch(), scope);
       scope.add(op.getResults(), runtimeResults);
     } else if (auto iotaOp = dyn_cast<IotaOp>(op)) {
-      Tensor runtimeResult =
-          evalIotaOp(iotaOp.getIotaDimension(), iotaOp.getType());
+      Tensor runtimeResult = evalIotaOp(
+          iotaOp.getIotaDimension(), iotaOp.getType().cast<RankedTensorType>());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto logOp = dyn_cast<LogOp>(op)) {
       Tensor runtimeOperand = scope.find(logOp.getOperand());
@@ -465,31 +483,37 @@ SmallVector<Tensor> eval(Region &region, ArrayRef<Tensor> args, Scope *parent) {
     } else if (auto maxOp = dyn_cast<MaxOp>(op)) {
       Tensor runtimeLhs = scope.find(maxOp.getLhs());
       Tensor runtimeRhs = scope.find(maxOp.getRhs());
-      Tensor runtimeResult = evalMaxOp(runtimeLhs, runtimeRhs, maxOp.getType());
+      Tensor runtimeResult = evalMaxOp(
+          runtimeLhs, runtimeRhs, maxOp.getType().cast<RankedTensorType>());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto minOp = dyn_cast<MinOp>(op)) {
       Tensor runtimeLhs = scope.find(minOp.getLhs());
       Tensor runtimeRhs = scope.find(minOp.getRhs());
-      Tensor runtimeResult = evalMinOp(runtimeLhs, runtimeRhs, minOp.getType());
+      Tensor runtimeResult = evalMinOp(
+          runtimeLhs, runtimeRhs, minOp.getType().cast<RankedTensorType>());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto multiplyOp = dyn_cast<MulOp>(op)) {
       Tensor runtimeLhs = scope.find(multiplyOp.getLhs());
       Tensor runtimeRhs = scope.find(multiplyOp.getRhs());
       Tensor runtimeResult =
-          evalMultiplyOp(runtimeLhs, runtimeRhs, multiplyOp.getType());
+          evalMultiplyOp(runtimeLhs, runtimeRhs,
+                         multiplyOp.getType().cast<RankedTensorType>());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto negOp = dyn_cast<NegOp>(op)) {
       Tensor runtimeOperand = scope.find(negOp.getOperand());
-      Tensor runtimeResult = evalNegOp(runtimeOperand, negOp.getType());
+      Tensor runtimeResult =
+          evalNegOp(runtimeOperand, negOp.getType().cast<RankedTensorType>());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto notOp = dyn_cast<NotOp>(op)) {
       Tensor runtimeOperand = scope.find(notOp.getOperand());
-      Tensor runtimeResult = evalNotOp(runtimeOperand, notOp.getType());
+      Tensor runtimeResult =
+          evalNotOp(runtimeOperand, notOp.getType().cast<RankedTensorType>());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto orOp = dyn_cast<OrOp>(op)) {
       Tensor runtimeLhs = scope.find(orOp.getLhs());
       Tensor runtimeRhs = scope.find(orOp.getRhs());
-      Tensor runtimeResult = evalOrOp(runtimeLhs, runtimeRhs, orOp.getType());
+      Tensor runtimeResult = evalOrOp(runtimeLhs, runtimeRhs,
+                                      orOp.getType().cast<RankedTensorType>());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto padOp = dyn_cast<PadOp>(op)) {
       Tensor runtimeOperand = scope.find(padOp.getOperand());
@@ -498,7 +522,7 @@ SmallVector<Tensor> eval(Region &region, ArrayRef<Tensor> args, Scope *parent) {
       auto interiorPadding = Sizes(padOp.getInteriorPadding());
       Tensor runtimeResult =
           evalPadOp(runtimeOperand, runtimePaddingValue, edgePaddingLow,
-                    interiorPadding, padOp.getType());
+                    interiorPadding, padOp.getType().cast<RankedTensorType>());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto whileOp = dyn_cast<WhileOp>(op)) {
       SmallVector<Value> runtimeOperands(whileOp.getOperand().begin(),
@@ -509,13 +533,15 @@ SmallVector<Tensor> eval(Region &region, ArrayRef<Tensor> args, Scope *parent) {
       scope.add(op.getResults(), runtimeResults);
     } else if (auto reshapeOp = dyn_cast<ReshapeOp>(op)) {
       Tensor runtimeOperand = scope.find(reshapeOp.getOperand());
-      Tensor runtimeResult = evalReshapeOp(runtimeOperand, reshapeOp.getType());
+      Tensor runtimeResult = evalReshapeOp(
+          runtimeOperand, reshapeOp.getType().cast<RankedTensorType>());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto reverseOp = dyn_cast<ReverseOp>(op)) {
       Tensor runtimeOperand = scope.find(reverseOp.getOperand());
       auto dimensions = Axes(reverseOp.getDimensions());
       Tensor runtimeResult =
-          evalReverseOp(runtimeOperand, dimensions, reverseOp.getType());
+          evalReverseOp(runtimeOperand, dimensions,
+                        reverseOp.getType().cast<RankedTensorType>());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto returnOp = dyn_cast<func::ReturnOp>(op)) {
       return scope.find(returnOp.getOperands());
@@ -524,18 +550,21 @@ SmallVector<Tensor> eval(Region &region, ArrayRef<Tensor> args, Scope *parent) {
     } else if (auto selectOp = dyn_cast<SelectOp>(op)) {
       Tensor runtimeResult = evalSelectOp(
           scope.find(selectOp.getPred()), scope.find(selectOp.getOnTrue()),
-          scope.find(selectOp.getOnFalse()), selectOp.getType());
+          scope.find(selectOp.getOnFalse()),
+          selectOp.getType().cast<RankedTensorType>());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto sineOp = dyn_cast<SineOp>(op)) {
       Tensor runtimeOperand = scope.find(sineOp.getOperand());
-      Tensor runtimeResult = evalSineOp(runtimeOperand, sineOp.getType());
+      Tensor runtimeResult =
+          evalSineOp(runtimeOperand, sineOp.getType().cast<RankedTensorType>());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto sliceOp = dyn_cast<SliceOp>(op)) {
       Tensor runtimeOperand = scope.find(sliceOp.getOperand());
       auto startIndices = Sizes(sliceOp.getStartIndices());
       auto strides = Sizes(sliceOp.getStrides());
       Tensor runtimeResult =
-          evalSliceOp(runtimeOperand, startIndices, strides, sliceOp.getType());
+          evalSliceOp(runtimeOperand, startIndices, strides,
+                      sliceOp.getType().cast<RankedTensorType>());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto sqrtOp = dyn_cast<SqrtOp>(op)) {
       Tensor runtimeOperand = scope.find(sqrtOp.getOperand());
@@ -545,22 +574,26 @@ SmallVector<Tensor> eval(Region &region, ArrayRef<Tensor> args, Scope *parent) {
       Tensor runtimeLhs = scope.find(subtractOp.getLhs());
       Tensor runtimeRhs = scope.find(subtractOp.getRhs());
       Tensor runtimeResult =
-          evalSubtractOp(runtimeLhs, runtimeRhs, subtractOp.getType());
+          evalSubtractOp(runtimeLhs, runtimeRhs,
+                         subtractOp.getType().cast<RankedTensorType>());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto tanhOp = dyn_cast<TanhOp>(op)) {
       Tensor runtimeOperand = scope.find(tanhOp.getOperand());
-      Tensor runtimeResult = evalTanhOp(runtimeOperand, tanhOp.getType());
+      Tensor runtimeResult =
+          evalTanhOp(runtimeOperand, tanhOp.getType().cast<RankedTensorType>());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto transposeOp = dyn_cast<TransposeOp>(op)) {
       Tensor runtimeOperand = scope.find(transposeOp.getOperand());
       auto permutation = Axes(transposeOp.getPermutation());
       Tensor runtimeResult =
-          evalTransposeOp(runtimeOperand, permutation, transposeOp.getType());
+          evalTransposeOp(runtimeOperand, permutation,
+                          transposeOp.getType().cast<RankedTensorType>());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto xorOp = dyn_cast<XorOp>(op)) {
       Tensor runtimeLhs = scope.find(xorOp.getLhs());
       Tensor runtimeRhs = scope.find(xorOp.getRhs());
-      Tensor runtimeResult = evalXorOp(runtimeLhs, runtimeRhs, xorOp.getType());
+      Tensor runtimeResult = evalXorOp(
+          runtimeLhs, runtimeRhs, xorOp.getType().cast<RankedTensorType>());
       scope.add(op.getResults(), {runtimeResult});
     } else {
       report_fatal_error(

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -116,11 +116,11 @@ Tensor evalCosineOp(const Tensor &operand, TensorType resultType) {
   return result;
 }
 
-Tensor evalDynamicSliceOp(const Tensor &operand, Index startIndices,
+Tensor evalDynamicSliceOp(const Tensor &operand, ArrayRef<Tensor> startIndices,
                           Sizes sliceSizes, TensorType resultType) {
   Tensor result(resultType);
   auto adjustedStartIndices =
-      clamp(0, startIndices, operand.getShape() - sliceSizes);
+      clamp(0, evalIndices(startIndices), operand.getShape() - sliceSizes);
   for (auto resultIt = result.index_begin(); resultIt != result.index_end();
        ++resultIt) {
     result.set(*resultIt, operand.get(adjustedStartIndices + *resultIt));
@@ -129,10 +129,11 @@ Tensor evalDynamicSliceOp(const Tensor &operand, Index startIndices,
 }
 
 Tensor evalDynamicUpdateSliceOp(const Tensor &operand, const Tensor &update,
-                                Index startIndices, TensorType resultType) {
+                                ArrayRef<Tensor> startIndices,
+                                TensorType resultType) {
   Tensor result(resultType);
-  auto adjustedStartIndices =
-      clamp(0, startIndices, operand.getShape() - update.getShape());
+  auto adjustedStartIndices = clamp(0, evalIndices(startIndices),
+                                    operand.getShape() - update.getShape());
   for (auto resultIt = result.index_begin(); resultIt != result.index_end();
        ++resultIt)
     result.set(*resultIt, operand.get(*resultIt));
@@ -430,8 +431,8 @@ SmallVector<Tensor> eval(Region &region, ArrayRef<Tensor> args, Scope *parent) {
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto dynamicSliceOp = dyn_cast<DynamicSliceOp>(op)) {
       Tensor runtimeOperand = scope.find(dynamicSliceOp.getOperand());
-      Index runtimeStartIndices =
-          evalIndices(scope.find(dynamicSliceOp.getStartIndices()));
+      SmallVector<Tensor> runtimeStartIndices =
+          scope.find(dynamicSliceOp.getStartIndices());
       auto runtimeSliceSizes = Sizes(dynamicSliceOp.getSliceSizes());
       Tensor runtimeResult =
           evalDynamicSliceOp(runtimeOperand, runtimeStartIndices,
@@ -440,8 +441,8 @@ SmallVector<Tensor> eval(Region &region, ArrayRef<Tensor> args, Scope *parent) {
     } else if (auto dynamicUpdateSliceOp = dyn_cast<DynamicUpdateSliceOp>(op)) {
       Tensor runtimeOperand = scope.find(dynamicUpdateSliceOp.getOperand());
       Tensor runtimeUpdate = scope.find(dynamicUpdateSliceOp.getUpdate());
-      Index runtimeStartIndices =
-          evalIndices(scope.find(dynamicUpdateSliceOp.getStartIndices()));
+      SmallVector<Tensor> runtimeStartIndices =
+          scope.find(dynamicUpdateSliceOp.getStartIndices());
       Tensor runtimeResult = evalDynamicUpdateSliceOp(
           runtimeOperand, runtimeUpdate, runtimeStartIndices,
           dynamicUpdateSliceOp.getType());

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -27,23 +27,26 @@ namespace mlir {
 namespace stablehlo {
 
 // Evaluators for StableHLO ops.
-Tensor evalAbsOp(const Tensor &operand, Type resultType);
-Tensor evalAddOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
-Tensor evalAndOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
+Tensor evalAbsOp(const Tensor &operand, RankedTensorType resultType);
+Tensor evalAddOp(const Tensor &lhs, const Tensor &rhs,
+                 RankedTensorType resultType);
+Tensor evalAndOp(const Tensor &lhs, const Tensor &rhs,
+                 RankedTensorType resultType);
 Tensor evalBroadcastInDimOp(const Tensor &operand, Axes broadcastDimensions,
-                            Type resultType);
-Tensor evalCeilOp(const Tensor &operand, Type resultType);
+                            RankedTensorType resultType);
+Tensor evalCeilOp(const Tensor &operand, RankedTensorType resultType);
 Tensor evalClampOp(const Tensor &min, const Tensor &operand, const Tensor &max,
-                   Type resultType);
+                   RankedTensorType resultType);
 Tensor evalConstantOp(ElementsAttr value);
-Tensor evalConvertOp(const Tensor &operand, Type resultType);
-Tensor evalCosineOp(const Tensor &operand, Type resultType);
+Tensor evalConvertOp(const Tensor &operand, RankedTensorType resultType);
+Tensor evalCosineOp(const Tensor &operand, RankedTensorType resultType);
 Tensor evalDynamicSliceOp(const Tensor &operand, ArrayRef<Tensor> startIndices,
-                          Sizes sliceSizes, Type resultType);
+                          Sizes sliceSizes, RankedTensorType resultType);
 Tensor evalDynamicUpdateSliceOp(const Tensor &operand, const Tensor &update,
-                                ArrayRef<Tensor> startIndices, Type resultType);
-Tensor evalExponentialOp(const Tensor &operand, Type resultType);
-Tensor evalFloorOp(const Tensor &operand, Type resultType);
+                                ArrayRef<Tensor> startIndices,
+                                RankedTensorType resultType);
+Tensor evalExponentialOp(const Tensor &operand, RankedTensorType resultType);
+Tensor evalFloorOp(const Tensor &operand, RankedTensorType resultType);
 SmallVector<Tensor> evalIfOp(const Tensor &pred, Region &trueBranch,
                              Region &falseBranch, Scope &scope);
 Tensor evalIotaOp(Axis iotaDimension, Type resultType);
@@ -55,22 +58,25 @@ Tensor evalNegOp(const Tensor &operand, Type resultType);
 Tensor evalNotOp(const Tensor &operand, Type resultType);
 Tensor evalOrOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
 Tensor evalPadOp(const Tensor &operand, const Tensor &paddingValue,
-                 Sizes edgePaddingLow, Sizes interiorPadding, Type resultType);
-Tensor evalReshapeOp(const Tensor &operand, Type resultType);
-Tensor evalReverseOp(const Tensor &operand, Axes dimensions, Type resultType);
+                 Sizes edgePaddingLow, Sizes interiorPadding,
+                 RankedTensorType resultType);
+Tensor evalReshapeOp(const Tensor &operand, RankedTensorType resultType);
+Tensor evalReverseOp(const Tensor &operand, Axes dimensions,
+                     RankedTensorType resultType);
 Tensor evalSelectOp(const Tensor &pred, const Tensor &onTrue,
                     const Tensor &onFalse, Type resultType);
 Tensor evalSineOp(const Tensor &operand, Type resultType);
-Tensor evalSliceOp(const Tensor &operand, Sizes startIndices,
-                   Sizes strides, Type resultType);
+Tensor evalSliceOp(const Tensor &operand, Sizes startIndices, Sizes strides,
+                   Type resultType);
 Tensor evalSqrtOp(const Tensor &operand, Type resultType);
 Tensor evalSubtractOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
 Tensor evalTanhOp(const Tensor &operand, Type resultType);
 Tensor evalTransposeOp(const Tensor &operand, const Axes &permutation,
-                       Type resultType);
+                       RankedTensorType resultType);
 SmallVector<Tensor> evalWhileOp(ArrayRef<Tensor> operand, Region &cond,
                                 Region &body, Scope &scope);
-Tensor evalXorOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
+Tensor evalXorOp(const Tensor &lhs, const Tensor &rhs,
+                 RankedTensorType resultType);
 
 /// Evaluates an mlir::Region `region` using the runtime values `args`
 /// corresponding to the arguments of the entry block of the region.

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -27,56 +27,55 @@ namespace mlir {
 namespace stablehlo {
 
 // Evaluators for StableHLO ops.
-Tensor evalAbsOp(const Tensor &operand, RankedTensorType resultType);
-Tensor evalAddOp(const Tensor &lhs, const Tensor &rhs,
-                 RankedTensorType resultType);
-Tensor evalAndOp(const Tensor &lhs, const Tensor &rhs,
-                 RankedTensorType resultType);
+Tensor evalAbsOp(const Tensor &operand, TensorType resultType);
+Tensor evalAddOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType);
+Tensor evalAndOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType);
 Tensor evalBroadcastInDimOp(const Tensor &operand, Axes broadcastDimensions,
-                            RankedTensorType resultType);
-Tensor evalCeilOp(const Tensor &operand, RankedTensorType resultType);
+                            TensorType resultType);
+Tensor evalCeilOp(const Tensor &operand, TensorType resultType);
 Tensor evalClampOp(const Tensor &min, const Tensor &operand, const Tensor &max,
-                   RankedTensorType resultType);
+                   TensorType resultType);
 Tensor evalConstantOp(ElementsAttr value);
-Tensor evalConvertOp(const Tensor &operand, RankedTensorType resultType);
-Tensor evalCosineOp(const Tensor &operand, RankedTensorType resultType);
+Tensor evalConvertOp(const Tensor &operand, TensorType resultType);
+Tensor evalCosineOp(const Tensor &operand, TensorType resultType);
 Tensor evalDynamicSliceOp(const Tensor &operand, ArrayRef<Tensor> startIndices,
-                          Sizes sliceSizes, RankedTensorType resultType);
+                          Sizes sliceSizes, TensorType resultType);
 Tensor evalDynamicUpdateSliceOp(const Tensor &operand, const Tensor &update,
                                 ArrayRef<Tensor> startIndices,
-                                RankedTensorType resultType);
-Tensor evalExponentialOp(const Tensor &operand, RankedTensorType resultType);
-Tensor evalFloorOp(const Tensor &operand, RankedTensorType resultType);
+                                TensorType resultType);
+Tensor evalExponentialOp(const Tensor &operand, TensorType resultType);
+Tensor evalFloorOp(const Tensor &operand, TensorType resultType);
 SmallVector<Tensor> evalIfOp(const Tensor &pred, Region &trueBranch,
                              Region &falseBranch, Scope &scope);
-Tensor evalIotaOp(Axis iotaDimension, Type resultType);
-Tensor evalLogOp(const Tensor &operand, Type resultType);
-Tensor evalMaxOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
-Tensor evalMinOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
-Tensor evalMultiplyOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
-Tensor evalNegOp(const Tensor &operand, Type resultType);
-Tensor evalNotOp(const Tensor &operand, Type resultType);
-Tensor evalOrOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
+Tensor evalIotaOp(Axis iotaDimension, TensorType resultType);
+Tensor evalLogOp(const Tensor &operand, TensorType resultType);
+Tensor evalMaxOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType);
+Tensor evalMinOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType);
+Tensor evalMultiplyOp(const Tensor &lhs, const Tensor &rhs,
+                      TensorType resultType);
+Tensor evalNegOp(const Tensor &operand, TensorType resultType);
+Tensor evalNotOp(const Tensor &operand, TensorType resultType);
+Tensor evalOrOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType);
 Tensor evalPadOp(const Tensor &operand, const Tensor &paddingValue,
                  Sizes edgePaddingLow, Sizes interiorPadding,
-                 RankedTensorType resultType);
-Tensor evalReshapeOp(const Tensor &operand, RankedTensorType resultType);
+                 TensorType resultType);
+Tensor evalReshapeOp(const Tensor &operand, TensorType resultType);
 Tensor evalReverseOp(const Tensor &operand, Axes dimensions,
-                     RankedTensorType resultType);
+                     TensorType resultType);
 Tensor evalSelectOp(const Tensor &pred, const Tensor &onTrue,
-                    const Tensor &onFalse, Type resultType);
-Tensor evalSineOp(const Tensor &operand, Type resultType);
+                    const Tensor &onFalse, TensorType resultType);
+Tensor evalSineOp(const Tensor &operand, TensorType resultType);
 Tensor evalSliceOp(const Tensor &operand, Sizes startIndices, Sizes strides,
-                   Type resultType);
-Tensor evalSqrtOp(const Tensor &operand, Type resultType);
-Tensor evalSubtractOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
-Tensor evalTanhOp(const Tensor &operand, Type resultType);
+                   TensorType resultType);
+Tensor evalSqrtOp(const Tensor &operand, TensorType resultType);
+Tensor evalSubtractOp(const Tensor &lhs, const Tensor &rhs,
+                      TensorType resultType);
+Tensor evalTanhOp(const Tensor &operand, TensorType resultType);
 Tensor evalTransposeOp(const Tensor &operand, const Axes &permutation,
-                       RankedTensorType resultType);
+                       TensorType resultType);
 SmallVector<Tensor> evalWhileOp(ArrayRef<Tensor> operand, Region &cond,
                                 Region &body, Scope &scope);
-Tensor evalXorOp(const Tensor &lhs, const Tensor &rhs,
-                 RankedTensorType resultType);
+Tensor evalXorOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType);
 
 /// Evaluates an mlir::Region `region` using the runtime values `args`
 /// corresponding to the arguments of the entry block of the region.

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -38,11 +38,10 @@ Tensor evalClampOp(const Tensor &min, const Tensor &operand, const Tensor &max,
 Tensor evalConstantOp(ElementsAttr value);
 Tensor evalConvertOp(const Tensor &operand, TensorType resultType);
 Tensor evalCosineOp(const Tensor &operand, TensorType resultType);
-Tensor evalDynamicSliceOp(const Tensor &operand, ArrayRef<Tensor> startIndices,
+Tensor evalDynamicSliceOp(const Tensor &operand, Index startIndices,
                           Sizes sliceSizes, TensorType resultType);
 Tensor evalDynamicUpdateSliceOp(const Tensor &operand, const Tensor &update,
-                                ArrayRef<Tensor> startIndices,
-                                TensorType resultType);
+                                Index startIndices, TensorType resultType);
 Tensor evalExponentialOp(const Tensor &operand, TensorType resultType);
 Tensor evalFloorOp(const Tensor &operand, TensorType resultType);
 SmallVector<Tensor> evalIfOp(const Tensor &pred, Region &trueBranch,
@@ -65,7 +64,7 @@ Tensor evalReverseOp(const Tensor &operand, Axes dimensions,
 Tensor evalSelectOp(const Tensor &pred, const Tensor &onTrue,
                     const Tensor &onFalse, TensorType resultType);
 Tensor evalSineOp(const Tensor &operand, TensorType resultType);
-Tensor evalSliceOp(const Tensor &operand, Sizes startIndices, Sizes strides,
+Tensor evalSliceOp(const Tensor &operand, Index startIndices, Sizes strides,
                    TensorType resultType);
 Tensor evalSqrtOp(const Tensor &operand, TensorType resultType);
 Tensor evalSubtractOp(const Tensor &lhs, const Tensor &rhs,

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -18,7 +18,9 @@ limitations under the License.
 
 #include "mlir/IR/BuiltinAttributes.h"
 #include "stablehlo/dialect/StablehloOps.h"
+#include "stablehlo/reference/Axes.h"
 #include "stablehlo/reference/Scope.h"
+#include "stablehlo/reference/Sizes.h"
 #include "stablehlo/reference/Tensor.h"
 
 namespace mlir {
@@ -28,8 +30,7 @@ namespace stablehlo {
 Tensor evalAbsOp(const Tensor &operand, Type resultType);
 Tensor evalAddOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
 Tensor evalAndOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
-Tensor evalBroadcastInDimOp(const Tensor &operand,
-                            ArrayRef<int64_t> broadcastDimensions,
+Tensor evalBroadcastInDimOp(const Tensor &operand, Axes broadcastDimensions,
                             Type resultType);
 Tensor evalCeilOp(const Tensor &operand, Type resultType);
 Tensor evalClampOp(const Tensor &min, const Tensor &operand, const Tensor &max,
@@ -38,14 +39,14 @@ Tensor evalConstantOp(ElementsAttr value);
 Tensor evalConvertOp(const Tensor &operand, Type resultType);
 Tensor evalCosineOp(const Tensor &operand, Type resultType);
 Tensor evalDynamicSliceOp(const Tensor &operand, ArrayRef<Tensor> startIndices,
-                          ArrayRef<int64_t> sliceSizes, Type resultType);
+                          Sizes sliceSizes, Type resultType);
 Tensor evalDynamicUpdateSliceOp(const Tensor &operand, const Tensor &update,
                                 ArrayRef<Tensor> startIndices, Type resultType);
 Tensor evalExponentialOp(const Tensor &operand, Type resultType);
 Tensor evalFloorOp(const Tensor &operand, Type resultType);
 SmallVector<Tensor> evalIfOp(const Tensor &pred, Region &trueBranch,
                              Region &falseBranch, Scope &scope);
-Tensor evalIotaOp(int64_t iotaDimension, Type resultType);
+Tensor evalIotaOp(Axis iotaDimension, Type resultType);
 Tensor evalLogOp(const Tensor &operand, Type resultType);
 Tensor evalMaxOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
 Tensor evalMinOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
@@ -54,20 +55,18 @@ Tensor evalNegOp(const Tensor &operand, Type resultType);
 Tensor evalNotOp(const Tensor &operand, Type resultType);
 Tensor evalOrOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
 Tensor evalPadOp(const Tensor &operand, const Tensor &paddingValue,
-                 ArrayRef<int64_t> edgePaddingLow,
-                 ArrayRef<int64_t> interiorPadding, Type resultType);
+                 Sizes edgePaddingLow, Sizes interiorPadding, Type resultType);
 Tensor evalReshapeOp(const Tensor &operand, Type resultType);
-Tensor evalReverseOp(const Tensor &operand, ArrayRef<int64_t> dimensions,
-                     Type resultType);
+Tensor evalReverseOp(const Tensor &operand, Axes dimensions, Type resultType);
 Tensor evalSelectOp(const Tensor &pred, const Tensor &onTrue,
                     const Tensor &onFalse, Type resultType);
 Tensor evalSineOp(const Tensor &operand, Type resultType);
-Tensor evalSliceOp(const Tensor &operand, ArrayRef<int64_t> startIndices,
-                   ArrayRef<int64_t> strides, Type resultType);
+Tensor evalSliceOp(const Tensor &operand, Sizes startIndices,
+                   Sizes strides, Type resultType);
 Tensor evalSqrtOp(const Tensor &operand, Type resultType);
 Tensor evalSubtractOp(const Tensor &lhs, const Tensor &rhs, Type resultType);
 Tensor evalTanhOp(const Tensor &operand, Type resultType);
-Tensor evalTransposeOp(const Tensor &operand, ArrayRef<int64_t> permutation,
+Tensor evalTransposeOp(const Tensor &operand, const Axes &permutation,
                        Type resultType);
 SmallVector<Tensor> evalWhileOp(ArrayRef<Tensor> operand, Region &cond,
                                 Region &body, Scope &scope);

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -38,10 +38,11 @@ Tensor evalClampOp(const Tensor &min, const Tensor &operand, const Tensor &max,
 Tensor evalConstantOp(ElementsAttr value);
 Tensor evalConvertOp(const Tensor &operand, TensorType resultType);
 Tensor evalCosineOp(const Tensor &operand, TensorType resultType);
-Tensor evalDynamicSliceOp(const Tensor &operand, Index startIndices,
+Tensor evalDynamicSliceOp(const Tensor &operand, ArrayRef<Tensor> startIndices,
                           Sizes sliceSizes, TensorType resultType);
 Tensor evalDynamicUpdateSliceOp(const Tensor &operand, const Tensor &update,
-                                Index startIndices, TensorType resultType);
+                                ArrayRef<Tensor> startIndices,
+                                TensorType resultType);
 Tensor evalExponentialOp(const Tensor &operand, TensorType resultType);
 Tensor evalFloorOp(const Tensor &operand, TensorType resultType);
 SmallVector<Tensor> evalIfOp(const Tensor &pred, Region &trueBranch,

--- a/stablehlo/reference/Sizes.cpp
+++ b/stablehlo/reference/Sizes.cpp
@@ -1,0 +1,106 @@
+/* Copyright 2023 The StableHLO Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permutationissions and
+limitations under the License.
+==============================================================================*/
+
+#include "stablehlo/reference/Sizes.h"
+
+#include "llvm/ADT/STLExtras.h"
+
+namespace mlir {
+namespace stablehlo {
+
+raw_ostream &operator<<(raw_ostream &os, const Sizes &x) {
+  os << "[";
+  llvm::interleave(x, os, ", ");
+  os << "]";
+  return os;
+}
+
+Sizes Sizes::permute(ArrayRef<int64_t> permutation) const {
+  Sizes result(size());
+  for (size_t i = 0; i < permutation.size(); i++)
+    result[i] = (*this)[permutation[i]];
+  return result;
+}
+
+bool Sizes::inBounds(const Sizes &bounds) const {
+  if (size() != bounds.size()) return false;
+  for (auto [size, bound] : llvm::zip(*this, bounds))
+    if (size < 0 || size >= bound) return false;
+  return true;
+}
+
+Sizes operator+(const Sizes &x, const Sizes &y) {
+  if (x.size() != y.size()) llvm::report_fatal_error("expected same size");
+  Sizes result(x.size());
+  for (size_t i = 0; i < x.size(); ++i) {
+    result[i] = x[i] + y[i];
+  }
+  return result;
+}
+
+Sizes operator+(const Sizes &x, int64_t y) { return x + Sizes(x.size(), y); }
+
+Sizes operator+(int64_t x, const Sizes &y) { return y + x; }
+
+Sizes operator-(const Sizes &x, const Sizes &y) {
+  if (x.size() != y.size()) llvm::report_fatal_error("expected same size");
+  Sizes result(x.size());
+  for (size_t i = 0; i < x.size(); ++i) {
+    result[i] = x[i] - y[i];
+  }
+  return result;
+}
+
+Sizes operator-(const Sizes &x, int64_t y) { return x - Sizes(x.size(), y); }
+
+Sizes operator-(int64_t x, const Sizes &y) { return Sizes(y.size(), x) - y; }
+
+Sizes operator*(const Sizes &x, const Sizes &y) {
+  if (x.size() != y.size()) llvm::report_fatal_error("expected same size");
+  Sizes result(x.size());
+  for (size_t i = 0; i < x.size(); ++i) {
+    result[i] = x[i] * y[i];
+  }
+  return result;
+}
+
+Sizes operator*(const Sizes &x, int64_t y) { return x * Sizes(x.size(), y); }
+
+Sizes operator*(int64_t &x, const Sizes &y) { return y + x; }
+
+Sizes clamp(int64_t min, const Sizes &x, int64_t max) {
+  return clamp(Sizes(x.size(), min), x, Sizes(x.size(), max));
+}
+
+Sizes clamp(int64_t min, const Sizes &x, const Sizes &max) {
+  return clamp(Sizes(x.size(), min), x, max);
+}
+
+Sizes clamp(const Sizes &min, const Sizes &x, int64_t max) {
+  return clamp(min, x, Sizes(x.size(), max));
+}
+
+Sizes clamp(const Sizes &min, const Sizes &x, const Sizes &max) {
+  if (min.size() != x.size() || x.size() != max.size())
+    llvm::report_fatal_error("expected same size");
+  Sizes result(x.size());
+  for (size_t i = 0; i < x.size(); ++i) {
+    result[i] = std::min(std::max(x[i], min[i]), max[i]);
+  }
+  return result;
+}
+
+}  // namespace stablehlo
+}  // namespace mlir

--- a/stablehlo/reference/Sizes.h
+++ b/stablehlo/reference/Sizes.h
@@ -60,6 +60,7 @@ Sizes clamp(int64_t min, const Sizes &x, const Sizes &max);
 Sizes clamp(const Sizes &min, const Sizes &x, int64_t max);
 Sizes clamp(const Sizes &min, const Sizes &x, const Sizes &max);
 
+/// Represents index of a tensor.
 using Index = Sizes;
 
 }  // namespace stablehlo

--- a/stablehlo/reference/Sizes.h
+++ b/stablehlo/reference/Sizes.h
@@ -1,0 +1,65 @@
+/* Copyright 2023 The StableHLO Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef STABLEHLO_REFERENCE_SIZES_H
+#define STABLEHLO_REFERENCE_SIZES_H
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/raw_ostream.h"
+#include "mlir/IR/BuiltinAttributes.h"
+
+namespace mlir {
+namespace stablehlo {
+
+class Sizes : public SmallVector<int64_t> {
+ public:
+  Sizes() = default;
+  Sizes(const Sizes &other) = default;
+  Sizes &operator=(const Sizes &other) = default;
+
+  Sizes(std::initializer_list<int64_t> list) : SmallVector(list) {}
+  explicit Sizes(size_t size, int64_t element = 0)
+      : SmallVector(size, element) {}
+  explicit Sizes(ArrayRef<int64_t> array) : SmallVector(array) {}
+  explicit Sizes(DenseIntElementsAttr attr)
+      : SmallVector(attr.getValues<int64_t>()) {}
+
+  Sizes permute(ArrayRef<int64_t> permutation) const;
+  bool inBounds(const Sizes &bounds) const;
+};
+
+raw_ostream &operator<<(raw_ostream &os, const Sizes &x);
+
+Sizes operator+(const Sizes &x, const Sizes &y);
+Sizes operator+(const Sizes &x, int64_t y);
+Sizes operator+(int64_t x, const Sizes &y);
+
+Sizes operator-(const Sizes &x, const Sizes &y);
+Sizes operator-(const Sizes &x, int64_t y);
+Sizes operator-(int64_t x, const Sizes &y);
+
+Sizes operator*(const Sizes &x, const Sizes &y);
+Sizes operator*(const Sizes &x, int64_t y);
+Sizes operator*(int64_t x, const Sizes &y);
+
+Sizes clamp(int64_t min, const Sizes &x, int64_t max);
+Sizes clamp(int64_t min, const Sizes &x, const Sizes &max);
+Sizes clamp(const Sizes &min, const Sizes &x, int64_t max);
+Sizes clamp(const Sizes &min, const Sizes &x, const Sizes &max);
+
+}  // namespace stablehlo
+}  // namespace mlir
+
+#endif  // STABLEHLO_REFERENCE_SIZES_H

--- a/stablehlo/reference/Sizes.h
+++ b/stablehlo/reference/Sizes.h
@@ -23,6 +23,7 @@ limitations under the License.
 namespace mlir {
 namespace stablehlo {
 
+/// Represets per axis metadata (e.g. tensor shape, slice sizes etc.).
 class Sizes : public SmallVector<int64_t> {
  public:
   Sizes() = default;
@@ -58,6 +59,8 @@ Sizes clamp(int64_t min, const Sizes &x, int64_t max);
 Sizes clamp(int64_t min, const Sizes &x, const Sizes &max);
 Sizes clamp(const Sizes &min, const Sizes &x, int64_t max);
 Sizes clamp(const Sizes &min, const Sizes &x, const Sizes &max);
+
+using Index = Sizes;
 
 }  // namespace stablehlo
 }  // namespace mlir

--- a/stablehlo/reference/Sizes.h
+++ b/stablehlo/reference/Sizes.h
@@ -23,7 +23,8 @@ limitations under the License.
 namespace mlir {
 namespace stablehlo {
 
-/// Represets per axis metadata (e.g. tensor shape, slice sizes etc.).
+/// Represents per axis metadata (e.g. tensor shape, slice sizes etc.) of type
+/// `int64_t`.
 class Sizes : public SmallVector<int64_t> {
  public:
   Sizes() = default;
@@ -37,28 +38,68 @@ class Sizes : public SmallVector<int64_t> {
   explicit Sizes(DenseIntElementsAttr attr)
       : SmallVector(attr.getValues<int64_t>()) {}
 
+  // Returns `s` with the effect of applying `permutation`
+  // to `this` object, that is, `s[i] = (*this)[permutation[i]]`.
   Sizes permute(ArrayRef<int64_t> permutation) const;
+
+  /// Checks if an element `e` at kth axis of `this` object follows
+  /// `0 <= e <= bounds[k]`.
   bool inBounds(const Sizes &bounds) const;
 };
 
 raw_ostream &operator<<(raw_ostream &os, const Sizes &x);
 
+/// Overloaded add operator to return `Sizes` object `z` such that
+/// `z[k] = x[k] + y[k]` for all axis k.
 Sizes operator+(const Sizes &x, const Sizes &y);
+
+/// Overloaded add operator to return `Sizes` object `z` such that
+/// `z[k] = x[k] + y` for all axis k.
 Sizes operator+(const Sizes &x, int64_t y);
+
+/// Overloaded add operator to return `Sizes` object `z` such that
+/// `z[k] = x + y[k]` for all axis k.
 Sizes operator+(int64_t x, const Sizes &y);
 
+/// Overloaded add operator to return `Sizes` object `z` such that
+/// `z[k] = x[k] - y[k]` for all axis k.
 Sizes operator-(const Sizes &x, const Sizes &y);
+
+/// Overloaded add operator to return `Sizes` object `z` such that
+/// `z[k] = x[k] - y` for all axis k.
 Sizes operator-(const Sizes &x, int64_t y);
+
+/// Overloaded add operator to return `Sizes` object `z` such that
+/// `z[k] = x - y[k]` for all axis k.
 Sizes operator-(int64_t x, const Sizes &y);
 
+/// Overloaded add operator to return `Sizes` object `z` such that
+/// `z[k] = x[k] * y[k]` for all axis k.
 Sizes operator*(const Sizes &x, const Sizes &y);
+
+/// Overloaded add operator to return `Sizes` object `z` such that
+/// `z[k] = x[k] * y` for all axis k.
 Sizes operator*(const Sizes &x, int64_t y);
+
+/// Overloaded add operator to return `Sizes` object `z` such that
+/// `z[k] = x * y[k]` for all axis k.
 Sizes operator*(int64_t x, const Sizes &y);
 
-Sizes clamp(int64_t min, const Sizes &x, int64_t max);
-Sizes clamp(int64_t min, const Sizes &x, const Sizes &max);
-Sizes clamp(const Sizes &min, const Sizes &x, int64_t max);
+/// Clamp operator to return `Sizes` object `z` such that
+/// `z[k] = std::min(std::max(x[k], min[k]), max[k])` for all axis k.
 Sizes clamp(const Sizes &min, const Sizes &x, const Sizes &max);
+
+/// Clamp operator to return `Sizes` object `z` such that
+/// `z[k] = std::min(std::max(x[k], min), max)` for all axis k.
+Sizes clamp(int64_t min, const Sizes &x, int64_t max);
+
+/// Clamp operator to return `Sizes` object `z` such that
+/// `z[k] = std::min(std::max(x[k], min), max[k])` for all axis k.
+Sizes clamp(int64_t min, const Sizes &x, const Sizes &max);
+
+/// Clamp operator to return `Sizes` object `z` such that
+/// `z[k] = std::min(std::max(x[k], min[k]), max)` for all axis k.
+Sizes clamp(const Sizes &min, const Sizes &x, int64_t max);
 
 /// Represents index of a tensor.
 using Index = Sizes;

--- a/stablehlo/reference/Tensor.cpp
+++ b/stablehlo/reference/Tensor.cpp
@@ -46,7 +46,7 @@ int64_t getSizeInBytes(Type type) {
 
 // Flattens multi-dimensional index 'index' of a tensor to a linearized index
 // into the underlying storage where elements are laid out in canonical order.
-int64_t flattenIndex(const Sizes &shape, const Sizes &index) {
+int64_t flattenIndex(const Sizes &shape, const Index &index) {
   if (!index.inBounds(shape))
     llvm::report_fatal_error(
         "Incompatible index and shape found while flattening index");
@@ -93,7 +93,7 @@ Tensor::Tensor(TensorType type)
 Tensor::Tensor(TensorType type, AsmResourceBlob blob)
     : impl_(llvm::makeIntrusiveRefCnt<detail::Buffer>(type, std::move(blob))) {}
 
-Element Tensor::get(const Sizes &index) const {
+Element Tensor::get(const Index &index) const {
   Type elementType = getType().getElementType();
   const char *elementPtr =
       impl_->getData().data() +
@@ -200,7 +200,7 @@ Element Tensor::get(const Sizes &index) const {
                                      debugString(elementType).c_str()));
 }
 
-void Tensor::set(const Sizes &index, const Element &element) {
+void Tensor::set(const Index &index, const Element &element) {
   Type elementType = getType().getElementType();
   char *elementPtr =
       impl_->getMutableData().data() +
@@ -329,7 +329,7 @@ IndexSpaceIterator Tensor::index_begin() const {
   if (any_of(shape, [](int64_t dimSize) { return dimSize == 0; }))
     return IndexSpaceIterator(shape, std::nullopt);
 
-  Sizes initialIndex(shape.size());
+  Index initialIndex(shape.size());
   return IndexSpaceIterator(shape, initialIndex);
 }
 

--- a/stablehlo/reference/Tensor.cpp
+++ b/stablehlo/reference/Tensor.cpp
@@ -18,10 +18,10 @@ limitations under the License.
 #include <complex>
 
 #include "llvm/ADT/APFloat.h"
+#include "llvm/ADT/APInt.h"
 #include "llvm/Support/Error.h"
 #include "mlir/Support/DebugStringHelper.h"
 #include "stablehlo/reference/Errors.h"
-#include "stablehlo/reference/Index.h"
 #include "stablehlo/reference/Types.h"
 
 namespace mlir {
@@ -46,8 +46,8 @@ int64_t getSizeInBytes(Type type) {
 
 // Flattens multi-dimensional index 'index' of a tensor to a linearized index
 // into the underlying storage where elements are laid out in canonical order.
-int64_t flattenIndex(ArrayRef<int64_t> shape, const Index &index) {
-  if (failed(verifyIndex(shape, index)))
+int64_t flattenIndex(const Sizes &shape, const Sizes &index) {
+  if (!index.inBounds(shape))
     llvm::report_fatal_error(
         "Incompatible index and shape found while flattening index");
 
@@ -75,31 +75,29 @@ int64_t flattenIndex(ArrayRef<int64_t> shape, const Index &index) {
 
 namespace detail {
 
-Buffer::Buffer(ShapedType type)
+Buffer::Buffer(RankedTensorType type)
     : type_(type),
       blob_(
           HeapAsmResourceBlob::allocate(getSizeInBytes(type), alignof(char))) {}
 
-Buffer::Buffer(ShapedType type, AsmResourceBlob blob)
+Buffer::Buffer(RankedTensorType type, AsmResourceBlob blob)
     : type_(type), blob_(std::move(blob)) {}
 
 }  // namespace detail
 
 Tensor::Tensor() {}
 
-Tensor::Tensor(ShapedType type)
+Tensor::Tensor(RankedTensorType type)
     : impl_(llvm::makeIntrusiveRefCnt<detail::Buffer>(type)) {}
 
-Tensor::Tensor(ShapedType type, AsmResourceBlob blob)
+Tensor::Tensor(RankedTensorType type, AsmResourceBlob blob)
     : impl_(llvm::makeIntrusiveRefCnt<detail::Buffer>(type, std::move(blob))) {}
 
-int64_t Tensor::getNumElements() const { return getType().getNumElements(); }
-
-Element Tensor::get(const Index &index) const {
+Element Tensor::get(const Sizes &index) const {
   Type elementType = getType().getElementType();
   const char *elementPtr =
       impl_->getData().data() +
-      getSizeInBytes(elementType) * flattenIndex(getType().getShape(), index);
+      getSizeInBytes(elementType) * flattenIndex(getShape(), index);
 
   // Handle floating-point types.
   if (elementType.isF16()) {
@@ -202,11 +200,11 @@ Element Tensor::get(const Index &index) const {
                                      debugString(elementType).c_str()));
 }
 
-void Tensor::set(const Index &index, const Element &element) {
+void Tensor::set(const Sizes &index, const Element &element) {
   Type elementType = getType().getElementType();
   char *elementPtr =
       impl_->getMutableData().data() +
-      getSizeInBytes(elementType) * flattenIndex(getType().getShape(), index);
+      getSizeInBytes(elementType) * flattenIndex(getShape(), index);
 
   // Handle floating-point types.
   if (elementType.isF16() || elementType.isBF16()) {
@@ -325,23 +323,18 @@ void Tensor::set(const Index &index, const Element &element) {
                                      debugString(elementType).c_str()));
 }
 
-void Tensor::set(ArrayRef<int64_t> index, const Element &element) {
-  set(Index(index), element);
-}
-
 IndexSpaceIterator Tensor::index_begin() const {
-  auto shape = getType().getShape();
+  auto shape = getShape();
 
   if (any_of(shape, [](int64_t dimSize) { return dimSize == 0; }))
-    return IndexSpaceIterator(shape, {});
+    return IndexSpaceIterator(shape, std::nullopt);
 
-  SmallVector<int64_t> index(shape.size());
-  return IndexSpaceIterator(shape, index);
+  Sizes initialIndex(shape.size());
+  return IndexSpaceIterator(shape, initialIndex);
 }
 
 IndexSpaceIterator Tensor::index_end() const {
-  auto shape = getType().getShape();
-  return IndexSpaceIterator(shape, {});
+  return IndexSpaceIterator(getShape(), std::nullopt);
 }
 
 void Tensor::print(raw_ostream &os) const {
@@ -357,7 +350,7 @@ void Tensor::print(raw_ostream &os) const {
 void Tensor::dump() const { print(llvm::errs()); }
 
 Tensor makeTensor(DenseElementsAttr attr) {
-  auto type = attr.getType();
+  auto type = attr.getType().cast<RankedTensorType>();
   auto elemType = type.getElementType();
 
   // Handle floating-point types.

--- a/stablehlo/reference/Tensor.cpp
+++ b/stablehlo/reference/Tensor.cpp
@@ -75,22 +75,22 @@ int64_t flattenIndex(const Sizes &shape, const Sizes &index) {
 
 namespace detail {
 
-Buffer::Buffer(RankedTensorType type)
+Buffer::Buffer(TensorType type)
     : type_(type),
       blob_(
           HeapAsmResourceBlob::allocate(getSizeInBytes(type), alignof(char))) {}
 
-Buffer::Buffer(RankedTensorType type, AsmResourceBlob blob)
+Buffer::Buffer(TensorType type, AsmResourceBlob blob)
     : type_(type), blob_(std::move(blob)) {}
 
 }  // namespace detail
 
 Tensor::Tensor() {}
 
-Tensor::Tensor(RankedTensorType type)
+Tensor::Tensor(TensorType type)
     : impl_(llvm::makeIntrusiveRefCnt<detail::Buffer>(type)) {}
 
-Tensor::Tensor(RankedTensorType type, AsmResourceBlob blob)
+Tensor::Tensor(TensorType type, AsmResourceBlob blob)
     : impl_(llvm::makeIntrusiveRefCnt<detail::Buffer>(type, std::move(blob))) {}
 
 Element Tensor::get(const Sizes &index) const {
@@ -350,7 +350,7 @@ void Tensor::print(raw_ostream &os) const {
 void Tensor::dump() const { print(llvm::errs()); }
 
 Tensor makeTensor(DenseElementsAttr attr) {
-  auto type = attr.getType().cast<RankedTensorType>();
+  auto type = attr.getType().cast<TensorType>();
   auto elemType = type.getElementType();
 
   // Handle floating-point types.

--- a/stablehlo/reference/Tensor.cpp
+++ b/stablehlo/reference/Tensor.cpp
@@ -325,6 +325,10 @@ void Tensor::set(const Index &index, const Element &element) {
                                      debugString(elementType).c_str()));
 }
 
+void Tensor::set(ArrayRef<int64_t> index, const Element &element) {
+  set(Index(index), element);
+}
+
 IndexSpaceIterator Tensor::index_begin() const {
   auto shape = getType().getShape();
 

--- a/stablehlo/reference/Tensor.cpp
+++ b/stablehlo/reference/Tensor.cpp
@@ -46,7 +46,7 @@ int64_t getSizeInBytes(Type type) {
 
 // Flattens multi-dimensional index 'index' of a tensor to a linearized index
 // into the underlying storage where elements are laid out in canonical order.
-int64_t flattenIndex(ArrayRef<int64_t> shape, ArrayRef<int64_t> index) {
+int64_t flattenIndex(ArrayRef<int64_t> shape, const Index &index) {
   if (failed(verifyIndex(shape, index)))
     llvm::report_fatal_error(
         "Incompatible index and shape found while flattening index");
@@ -95,7 +95,7 @@ Tensor::Tensor(ShapedType type, AsmResourceBlob blob)
 
 int64_t Tensor::getNumElements() const { return getType().getNumElements(); }
 
-Element Tensor::get(ArrayRef<int64_t> index) const {
+Element Tensor::get(const Index &index) const {
   Type elementType = getType().getElementType();
   const char *elementPtr =
       impl_->getData().data() +
@@ -202,7 +202,7 @@ Element Tensor::get(ArrayRef<int64_t> index) const {
                                      debugString(elementType).c_str()));
 }
 
-void Tensor::set(ArrayRef<int64_t> index, const Element &element) {
+void Tensor::set(const Index &index, const Element &element) {
   Type elementType = getType().getElementType();
   char *elementPtr =
       impl_->getMutableData().data() +

--- a/stablehlo/reference/Tensor.h
+++ b/stablehlo/reference/Tensor.h
@@ -70,8 +70,6 @@ class Tensor {
   /// \name Constructors
   /// @{
   Tensor();
-  // TODO: Remove the need in having this constructor.
-  explicit Tensor(Type type) : Tensor(type.cast<RankedTensorType>()) {}
   explicit Tensor(RankedTensorType type);
   explicit Tensor(RankedTensorType type, AsmResourceBlob blob);
   Tensor(const Tensor &other) = default;

--- a/stablehlo/reference/Tensor.h
+++ b/stablehlo/reference/Tensor.h
@@ -94,14 +94,14 @@ class Tensor {
   Type getElementType() const { return impl_->getType().getElementType(); };
 
   /// Provides read access to the tensor element indexed at 'index'.
-  Element get(const Sizes &index) const;
+  Element get(const Index &index) const;
 
   /// Provides write access to the tensor element indexed at 'index'.
   ///
   /// \param index The multi-dimensional index to write to.
   /// \param element The Element object \a element is used to update the
   /// underlying storage pointed to by \a index.
-  void set(const Sizes &index, const Element &element);
+  void set(const Index &index, const Element &element);
 
   /// Prints Tensor objects.
   void print(raw_ostream &os) const;

--- a/stablehlo/reference/Tensor.h
+++ b/stablehlo/reference/Tensor.h
@@ -24,8 +24,10 @@ limitations under the License.
 #include "llvm/Support/raw_ostream.h"
 #include "mlir/IR/AsmState.h"
 #include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "stablehlo/reference/Element.h"
 #include "stablehlo/reference/Index.h"
+#include "stablehlo/reference/Sizes.h"
 
 namespace mlir {
 namespace stablehlo {
@@ -37,8 +39,8 @@ class Buffer : public llvm::RefCountedBase<Buffer> {
  public:
   /// \name Constructors
   /// @{
-  explicit Buffer(ShapedType type);
-  Buffer(ShapedType type, AsmResourceBlob blob);
+  explicit Buffer(RankedTensorType type);
+  Buffer(RankedTensorType type, AsmResourceBlob blob);
   Buffer(Buffer &&other) = default;
   /// @}
 
@@ -46,7 +48,7 @@ class Buffer : public llvm::RefCountedBase<Buffer> {
   Buffer &operator=(Buffer &&other) = delete;
 
   /// Returns type of the Buffer object.
-  ShapedType getType() { return type_; }
+  RankedTensorType getType() { return type_; }
 
   /// Provides access to the underlying non-mutable storage.
   ArrayRef<char> getData() const { return blob_.getData(); }
@@ -55,7 +57,7 @@ class Buffer : public llvm::RefCountedBase<Buffer> {
   MutableArrayRef<char> getMutableData() { return blob_.getMutableData(); }
 
  private:
-  ShapedType type_;
+  RankedTensorType type_;
   AsmResourceBlob blob_;
 };
 
@@ -68,8 +70,10 @@ class Tensor {
   /// \name Constructors
   /// @{
   Tensor();
-  explicit Tensor(ShapedType type);
-  explicit Tensor(ShapedType type, AsmResourceBlob blob);
+  // TODO: Remove the need in having this constructor.
+  explicit Tensor(Type type) : Tensor(type.cast<RankedTensorType>()) {}
+  explicit Tensor(RankedTensorType type);
+  explicit Tensor(RankedTensorType type, AsmResourceBlob blob);
   Tensor(const Tensor &other) = default;
   /// @}
 
@@ -77,22 +81,29 @@ class Tensor {
   Tensor &operator=(const Tensor &other) = default;
 
   /// Returns type of the Tensor object.
-  ShapedType getType() const { return impl_->getType(); };
+  RankedTensorType getType() const { return impl_->getType(); };
+
+  /// Returns rank of the Tensor object.
+  int64_t getRank() const { return impl_->getType().getRank(); }
+
+  /// Returns shape of the Tensor object.
+  Sizes getShape() const { return Sizes(impl_->getType().getShape()); }
 
   /// Returns the number of elements.
-  int64_t getNumElements() const;
+  int64_t getNumElements() const { return impl_->getType().getNumElements(); }
+
+  /// Returns element type of the Tensor object.
+  Type getElementType() const { return impl_->getType().getElementType(); };
 
   /// Provides read access to the tensor element indexed at 'index'.
-  Element get(const Index &index) const;
-  Element get(ArrayRef<int64_t> index) const { return get(Index(index)); }
+  Element get(const Sizes &index) const;
 
   /// Provides write access to the tensor element indexed at 'index'.
   ///
   /// \param index The multi-dimensional index to write to.
   /// \param element The Element object \a element is used to update the
   /// underlying storage pointed to by \a index.
-  void set(const Index &index, const Element &element);
-  void set(ArrayRef<int64_t> index, const Element &element);
+  void set(const Sizes &index, const Element &element);
 
   /// Prints Tensor objects.
   void print(raw_ostream &os) const;

--- a/stablehlo/reference/Tensor.h
+++ b/stablehlo/reference/Tensor.h
@@ -39,8 +39,8 @@ class Buffer : public llvm::RefCountedBase<Buffer> {
  public:
   /// \name Constructors
   /// @{
-  explicit Buffer(RankedTensorType type);
-  Buffer(RankedTensorType type, AsmResourceBlob blob);
+  explicit Buffer(TensorType type);
+  Buffer(TensorType type, AsmResourceBlob blob);
   Buffer(Buffer &&other) = default;
   /// @}
 
@@ -48,7 +48,7 @@ class Buffer : public llvm::RefCountedBase<Buffer> {
   Buffer &operator=(Buffer &&other) = delete;
 
   /// Returns type of the Buffer object.
-  RankedTensorType getType() { return type_; }
+  TensorType getType() { return type_; }
 
   /// Provides access to the underlying non-mutable storage.
   ArrayRef<char> getData() const { return blob_.getData(); }
@@ -57,7 +57,7 @@ class Buffer : public llvm::RefCountedBase<Buffer> {
   MutableArrayRef<char> getMutableData() { return blob_.getMutableData(); }
 
  private:
-  RankedTensorType type_;
+  TensorType type_;
   AsmResourceBlob blob_;
 };
 
@@ -70,8 +70,8 @@ class Tensor {
   /// \name Constructors
   /// @{
   Tensor();
-  explicit Tensor(RankedTensorType type);
-  explicit Tensor(RankedTensorType type, AsmResourceBlob blob);
+  explicit Tensor(TensorType type);
+  explicit Tensor(TensorType type, AsmResourceBlob blob);
   Tensor(const Tensor &other) = default;
   /// @}
 
@@ -79,7 +79,7 @@ class Tensor {
   Tensor &operator=(const Tensor &other) = default;
 
   /// Returns type of the Tensor object.
-  RankedTensorType getType() const { return impl_->getType(); };
+  TensorType getType() const { return impl_->getType(); };
 
   /// Returns rank of the Tensor object.
   int64_t getRank() const { return impl_->getType().getRank(); }

--- a/stablehlo/reference/Tensor.h
+++ b/stablehlo/reference/Tensor.h
@@ -84,6 +84,7 @@ class Tensor {
 
   /// Provides read access to the tensor element indexed at 'index'.
   Element get(const Index &index) const;
+  Element get(ArrayRef<int64_t> index) const { return get(Index(index)); }
 
   /// Provides write access to the tensor element indexed at 'index'.
   ///
@@ -91,6 +92,7 @@ class Tensor {
   /// \param element The Element object \a element is used to update the
   /// underlying storage pointed to by \a index.
   void set(const Index &index, const Element &element);
+  void set(ArrayRef<int64_t> index, const Element &element);
 
   /// Prints Tensor objects.
   void print(raw_ostream &os) const;

--- a/stablehlo/reference/Tensor.h
+++ b/stablehlo/reference/Tensor.h
@@ -83,14 +83,14 @@ class Tensor {
   int64_t getNumElements() const;
 
   /// Provides read access to the tensor element indexed at 'index'.
-  Element get(ArrayRef<int64_t> index) const;
+  Element get(const Index &index) const;
 
   /// Provides write access to the tensor element indexed at 'index'.
   ///
   /// \param index The multi-dimensional index to write to.
   /// \param element The Element object \a element is used to update the
   /// underlying storage pointed to by \a index.
-  void set(ArrayRef<int64_t> index, const Element &element);
+  void set(const Index &index, const Element &element);
 
   /// Prints Tensor objects.
   void print(raw_ostream &os) const;


### PR DESCRIPTION
closes https://github.com/openxla/stablehlo/issues/1163

The PR:
1. Introduces a class `Index` to represent the index vector of a `Tensor`. That is to replace the explicit use of `ArrayRef<int64>` for the purpose. 
2. `Tensor::begin_index` and `Tensor::end_index` to return `Index` objects instead.
3. Promote the use of `Index` in various `evalFooOp`. The use of overload `Index::operator+` is handy for `DynamicSlice`  and `DynamicUpdateSlice` op. 