### PR TITLE
Remove support for complex types in various ops

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1481,23 +1481,19 @@ value and produces a `result` tensor. More formally, `result[i0, ..., iR-1]` =
 where `min_val = rank(min) == 0 ? min : min[i0, ..., iR-1]`,
 `max_val = rank(max) == 0 ? max : max[i0, ..., iR-1]`.
 
-Imposing an ordering on complex numbers involves surprising semantics,
-so in the future we are planning to remove support for complex numbers
-for this operation ([#560](https://github.com/openxla/stablehlo/issues/560)).
-
 #### Inputs
 
-| Label | Name      | Type   | Constraints |
-|-------|-----------|--------|-------------|
-| (I1)  | `min`     | tensor | (C1), (C3)  |
-| (I2)  | `operand` | tensor | (C1-C4)     |
-| (I3)  | `max`     | tensor | (C2), (C3)  |
+| Label | Name      | Type                                              | Constraints |
+|-------|-----------|---------------------------------------------------|-------------|
+| (I1)  | `min`     | tensor of integer, boolean or floating-point type | (C1), (C3)  |
+| (I2)  | `operand` | tensor of integer, boolean or floating-point type | (C1-C4)     |
+| (I3)  | `max`     | tensor of integer, boolean or floating-point type | (C2), (C3)  |
 
 #### Outputs
 
-| Name     | Type   | Constraints |
-|----------|--------|-------------|
-| `result` | tensor | (C4)        |
+| Name     | Type                                              | Constraints |
+|----------|---------------------------------------------------|-------------|
+| `result` | tensor of integer, boolean or floating-point type | (C4)        |
 
 #### Constraints
 
@@ -3213,23 +3209,19 @@ Performs element-wise max operation on tensors `lhs` and `rhs` and produces a
 * For booleans: logical OR.
 * For integers: integer maximum.
 * For floats: `maximum` from IEEE-754.
-* For complex numbers: lexicographic maximum for the `(real, imaginary)` pair.
-  Imposing an ordering on complex numbers involves surprising semantics,
-  so in the future we are planning to remove support for complex numbers
-  for this operation ([#560](https://github.com/openxla/stablehlo/issues/560)).
 
 #### Inputs
 
-| Label | Name  | Type   | Constraints |
-|-------|-------|--------|-------------|
-| (I1)  | `lhs` | tensor | (C1)        |
-| (I2)  | `rhs` | tensor | (C1)        |
+| Label | Name  | Type                                              | Constraints |
+|-------|-------|---------------------------------------------------|-------------|
+| (I1)  | `lhs` | tensor of integer, boolean or floating-point type | (C1)        |
+| (I2)  | `rhs` | tensor of integer, boolean or floating-point type | (C1)        |
 
 #### Outputs
 
-| Name     | Type   | Constraints |
-|----------|--------|-------------|
-| `result` | tensor | (C1)        |
+| Name     | Type                                              | Constraints |
+|----------|---------------------------------------------------|-------------|
+| `result` | tensor of integer, boolean or floating-point type | (C1)        |
 
 #### Constraints
 
@@ -3256,23 +3248,19 @@ Performs element-wise min operation on tensors `lhs` and `rhs` and produces a
 * For booleans: logical AND.
 * For integers: integer minimum.
 * For floats: `minimum` from IEEE-754.
-* For complex numbers: lexicographic minimum for the `(real, imaginary)` pair.
-  Imposing an ordering on complex numbers involves surprising semantics,
-  so in the future we are planning to remove support for complex numbers
-  for this operation ([#560](https://github.com/openxla/stablehlo/issues/560)).
 
 #### Inputs
 
-| Label | Name  | Type   | Constraints |
-|-------|-------|--------|-------------|
-| (I1)  | `lhs` | tensor | (C1)        |
-| (I2)  | `rhs` | tensor | (C1)        |
+| Label | Name  | Type                                              | Constraints |
+|-------|-------|---------------------------------------------------|-------------|
+| (I1)  | `lhs` | tensor of integer, boolean or floating-point type | (C1)        |
+| (I2)  | `rhs` | tensor of integer, boolean or floating-point type | (C1)        |
 
 #### Outputs
 
-| Name     | Type   | Constraints |
-|----------|--------|-------------|
-| `result` | tensor | (C1)        |
+| Name     | Type                                              | Constraints |
+|----------|---------------------------------------------------|-------------|
+| `result` | tensor of integer, boolean or floating-point type | (C1)        |
 
 #### Constraints
 
@@ -4105,8 +4093,6 @@ The remainder is calculated as `lhs - d * rhs`, where `d` is given by:
 * For integers: `stablehlo.divide(lhs, rhs)`.
 * For floats: `division(lhs, rhs)` from IEEE-754 with rounding attribute
   `roundTowardZero`.
-* For complex numbers: TBD
-  ([#997](https://github.com/openxla/stablehlo/issues/997)).
 
 For floating-point element types, this operation is in contrast with the
 `remainder` operation from IEEE-754 specification where `d` is an integral value
@@ -4114,16 +4100,16 @@ nearest to the exact value of `lhs/rhs` with ties to even.
 
 #### Inputs
 
-| Label | Name  | Type                                              | Constraints |
-|-------|-------|---------------------------------------------------|-------------|
-| (I1)  | `lhs` | tensor of integer, floating-point or complex type | (C1)        |
-| (I2)  | `rhs` | tensor of integer, floating-point or complex type | (C1)        |
+| Label | Name  | Type                                     | Constraints |
+|-------|-------|------------------------------------------|-------------|
+| (I1)  | `lhs` | tensor of integer or floating-point type | (C1)        |
+| (I2)  | `rhs` | tensor of integer or floating-point type | (C1)        |
 
 #### Outputs
 
-| Name     | Type                                              | Constraints |
-|----------|---------------------------------------------------|-------------|
-| `result` | tensor of integer, floating-point or complex type | (C1)        |
+| Name     | Type                                     | Constraints |
+|----------|------------------------------------------|-------------|
+| `result` | tensor of integer or floating-point type | (C1)        |
 
 #### Constraints
 

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -753,7 +753,8 @@ def StableHLO_DivOp : StableHLO_BinaryElementwiseOp<"divide",
 }
 
 def StableHLO_MaxOp : StableHLO_BinaryElementwiseOp<"maximum",
-      [Commutative, Pure, HLO_CompatibleOperandsAndResultType]> {
+      [Commutative, Pure, HLO_CompatibleOperandsAndResultType],
+      HLO_PredIntOrFpTensor> {
   let summary = "Maximum operator";
   let description = [{
     Performs element-wise max operation on tensors `lhs` and `rhs` and produces
@@ -770,7 +771,8 @@ def StableHLO_MaxOp : StableHLO_BinaryElementwiseOp<"maximum",
 }
 
 def StableHLO_MinOp : StableHLO_BinaryElementwiseOp<"minimum",
-      [Commutative, Pure, HLO_CompatibleOperandsAndResultType]> {
+      [Commutative, Pure, HLO_CompatibleOperandsAndResultType],
+      HLO_PredIntOrFpTensor> {
   let summary = "Minimum operator";
   let description = [{
     Performs element-wise min operation on tensors `lhs` and `rhs` and produces a
@@ -821,7 +823,7 @@ def StableHLO_PowOp : StableHLO_BinaryElementwiseOp<"power",
 }
 
 def StableHLO_RemOp : StableHLO_BinaryElementwiseOp<"remainder",
-      [Pure, HLO_CompatibleOperandsAndResultType], HLO_IntFpOrComplexTensor> {
+      [Pure, HLO_CompatibleOperandsAndResultType], HLO_IntOrFpTensor> {
   let summary = "Remainder operator";
   let description = [{
     Performs element-wise remainder of dividend `lhs` and divisor `rhs` tensors
@@ -1553,8 +1555,8 @@ def StableHLO_CompareOp: StableHLO_Op<"compare", [Pure, SameOperandsElementType,
     ```
   }];
   let arguments = (ins
-    HLO_Tensor:$lhs,
-    HLO_Tensor:$rhs,
+    TensorOf<[HLO_Int, HLO_Pred, HLO_Float]>:$lhs,
+    TensorOf<[HLO_Int, HLO_Pred, HLO_Float]>:$rhs,
     StableHLO_ComparisonDirectionAttr:$comparison_direction,
     OptionalAttr<StableHLO_ComparisonTypeAttr>:$compare_type
   );
@@ -1958,9 +1960,9 @@ def StableHLO_ClampOp : StableHLO_ShapedInterfaceOp<"clamp", [Pure,
   }];
 
   let arguments = (ins
-    HLO_Tensor:$min,
-    HLO_Tensor:$operand,
-    HLO_Tensor:$max
+    TensorOf<[HLO_Pred, HLO_Int, HLO_Float, HLO_QuantizedInt]>:$min,
+    TensorOf<[HLO_Pred, HLO_Int, HLO_Float, HLO_QuantizedInt]>:$operand,
+    TensorOf<[HLO_Pred, HLO_Int, HLO_Float, HLO_QuantizedInt]>:$max
   );
   let results = (outs HLO_Tensor:$result);
 

--- a/stablehlo/tests/interpret_maximum.mlir
+++ b/stablehlo/tests/interpret_maximum.mlir
@@ -246,33 +246,3 @@ func.func @max_op_test_f64() -> tensor<11xf64> {
   // CHECK-NEXT: 0x7FF0000000000000 : f64
   // CHECK-NEXT: 0x7FF8000000000000 : f64
 }
-
-// -----
-
-// CHECK-LABEL: Evaluated results of function: max_op_test_c64
-func.func @max_op_test_c64() -> tensor<4xcomplex<f32>> {
-  %0 = stablehlo.constant dense<[(1.5, 2.5), (1.5, 7.5), (0.0, 1.5), (0.0, 1.5)]> : tensor<4xcomplex<f32>>
-  %1 = stablehlo.constant dense<[(7.5, 1.5), (1.5, 2.5), (-0.0, 2.5), (0.0, 1.5)]> : tensor<4xcomplex<f32>>
-  %2 = stablehlo.maximum %0, %1 : tensor<4xcomplex<f32>>
-  func.return %2 : tensor<4xcomplex<f32>>
-  // CHECK-NEXT: tensor<4xcomplex<f32>> {
-  // CHECK-NEXT: [7.500000e+00 : f32, 1.500000e+00 : f32]
-  // CHECK-NEXT: [1.500000e+00 : f32, 7.500000e+00 : f32]
-  // CHECK-NEXT: [-0.000000e+00 : f32, 2.500000e+00 : f32]
-  // CHECK-NEXT: [0.000000e+00 : f32, 1.500000e+00 : f32]
-}
-
-// -----
-
-// CHECK-LABEL: Evaluated results of function: max_op_test_c128
-func.func @max_op_test_c128() -> tensor<4xcomplex<f64>> {
-  %0 = stablehlo.constant dense<[(1.5, 2.5), (1.5, 7.5), (0.0, 1.5), (0.0, 1.5)]> : tensor<4xcomplex<f64>>
-  %1 = stablehlo.constant dense<[(7.5, 1.5), (1.5, 2.5), (-0.0, 2.5), (0.0, 1.5)]> : tensor<4xcomplex<f64>>
-  %2 = stablehlo.maximum %0, %1 : tensor<4xcomplex<f64>>
-  func.return %2 : tensor<4xcomplex<f64>>
-  // CHECK-NEXT: tensor<4xcomplex<f64>> {
-  // CHECK-NEXT:  [7.500000e+00 : f64, 1.500000e+00 : f64]
-  // CHECK-NEXT:  [1.500000e+00 : f64, 7.500000e+00 : f64]
-  // CHECK-NEXT:  [-0.000000e+00 : f64, 2.500000e+00 : f64]
-  // CHECK-NEXT:  [0.000000e+00 : f64, 1.500000e+00 : f64]
-}

--- a/stablehlo/tests/interpret_minimum.mlir
+++ b/stablehlo/tests/interpret_minimum.mlir
@@ -246,33 +246,3 @@ func.func @min_op_test_f64() -> tensor<11xf64> {
   // CHECK-NEXT: 0xFFF0000000000000 : f64
   // CHECK-NEXT: 0x7FF8000000000000 : f64
 }
-
-// -----
-
-// CHECK-LABEL: Evaluated results of function: min_op_test_c64
-func.func @min_op_test_c64() -> tensor<4xcomplex<f32>> {
-  %0 = stablehlo.constant dense<[(1.5, 2.5), (1.5, 7.5), (0.0, 1.5), (0.0, 1.5)]> : tensor<4xcomplex<f32>>
-  %1 = stablehlo.constant dense<[(7.5, 1.5), (1.5, 2.5), (-0.0, 2.5), (0.0, 1.5)]> : tensor<4xcomplex<f32>>
-  %2 = stablehlo.minimum %0, %1 : tensor<4xcomplex<f32>>
-  func.return %2 : tensor<4xcomplex<f32>>
-  // CHECK-NEXT: tensor<4xcomplex<f32>> {
-  // CHECK-NEXT: [1.500000e+00 : f32, 2.500000e+00 : f32]
-  // CHECK-NEXT: [1.500000e+00 : f32, 2.500000e+00 : f32]
-  // CHECK-NEXT: [0.000000e+00 : f32, 1.500000e+00 : f32]
-  // CHECK-NEXT: [0.000000e+00 : f32, 1.500000e+00 : f32]
-}
-
-// -----
-
-// CHECK-LABEL: Evaluated results of function: min_op_test_c128
-func.func @min_op_test_c128() -> tensor<4xcomplex<f64>> {
-  %0 = stablehlo.constant dense<[(1.5, 2.5), (1.5, 7.5), (0.0, 1.5), (0.0, 1.5)]> : tensor<4xcomplex<f64>>
-  %1 = stablehlo.constant dense<[(7.5, 1.5), (1.5, 2.5), (-0.0, 2.5), (0.0, 1.5)]> : tensor<4xcomplex<f64>>
-  %2 = stablehlo.minimum %0, %1 : tensor<4xcomplex<f64>>
-  func.return %2 : tensor<4xcomplex<f64>>
-  // CHECK-NEXT: tensor<4xcomplex<f64>> {
-  // CHECK-NEXT: [1.500000e+00 : f64, 2.500000e+00 : f64]
-  // CHECK-NEXT: [1.500000e+00 : f64, 2.500000e+00 : f64]
-  // CHECK-NEXT: [0.000000e+00 : f64, 1.500000e+00 : f64]
-  // CHECK-NEXT: [0.000000e+00 : f64, 1.500000e+00 : f64]
-}


### PR DESCRIPTION
This PR removes support for complex element types for ClampOp, MaxOp, MinOp, and RemainderOp.

closes #560 
closes #997 