### PR TITLE
Allow zero dimensional slice_size in DynamicSliceOp

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2316,11 +2316,11 @@ More formally, `result[i0, ..., iR-1] = operand[j0, ..., jR-1]` where:
 
 #### Inputs
 
-| Label | Name            | Type                                                     | Constraints      |
-|-------|-----------------|----------------------------------------------------------|------------------|
-| (I1)  | `operand`       | tensor                                                   | (C1), (C2), (C4) |
-| (I2)  | `start_indices` | variadic number of 0-dimensional tensors of integer type | (C2), (C3)       |
-| (I3)  | `slice_sizes`   | 1-dimensional tensor constant of type `si64`             | (C2), (C4), (C5) |
+| Label | Name            | Type                                                          | Constraints      |
+|-------|-----------------|---------------------------------------------------------------|------------------|
+| (I1)  | `operand`       | tensor                                                        | (C1), (C2), (C4) |
+| (I2)  | `start_indices` | variadic number of 0-dimensional tensors of integer type      | (C2), (C3)       |
+| (I3)  | `slice_sizes`   | 0-dimensional or 1-dimensional tensor constant of type `si64` | (C2), (C4), (C5) |
 
 #### Outputs
 

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2026,9 +2026,9 @@ LogicalResult inferDynamicSliceOp(
     TypeRange startIndicesTypes, DenseIntElementsAttr sliceSizes,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   // dynamic_slice_i3
-  if (sliceSizes.getType().getRank() != 1)
+  if (sliceSizes.getType().getRank() > 1)
     return emitOptionalError(location,
-                             "slice_sizes should be rank 1, but got rank ",
+                             "slice_sizes should be rank 0 or 1, but got rank ",
                              sliceSizes.getType().getRank(), ".");
   // dynamic_slice_c2
   int numSliceSizes = sliceSizes.getNumElements();

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -2328,8 +2328,8 @@ func.func @dynamic_slice_dynamic_dim(%arg0: tensor<?x4xi32>, %arg1: tensor<i64>,
 // -----
 
 func.func @dynamic_slice_i3(%arg0: tensor<3x4xi32>, %arg1: tensor<i64>, %arg2: tensor<i64>) -> tensor<1x4xi32> {
-  // expected-error@+1 {{slice_sizes should be rank 1, but got rank 0.}}
-  %0 = "stablehlo.dynamic_slice"(%arg0, %arg1, %arg2) {slice_sizes = dense<1> : tensor<i64>} : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xi32>
+  // expected-error@+1 {{slice_sizes should be rank 0 or 1, but got rank 2.}}
+  %0 = "stablehlo.dynamic_slice"(%arg0, %arg1, %arg2) {slice_sizes = dense<1> : tensor<1x1xi64>} : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xi32>
   func.return %0 : tensor<1x4xi32>
 }
 


### PR DESCRIPTION
1 dimensional tensors with 1 element are often represented as scalar tensors (0 dimensional), to support this kind of lowering allow 0 dimensional tensor as slice_size.

  * 0-dimensional slice_size `tensor<i64>` is treated same as `tensor<1xi64>`.
  * Updated constraint `dynamic_slice_i3` combined with `dynamic_slice_c2` should fix this.
