### PR TITLE
Add support for folding SignOp in --stablehlo-refine-shapes

### DIFF
--- a/stablehlo/tests/stablehlo_refine_shapes.mlir
+++ b/stablehlo/tests/stablehlo_refine_shapes.mlir
@@ -284,6 +284,18 @@ func.func @eval_select() -> tensor<2xi64> {
 
 // -----
 
+// CHECK-LABEL: func @eval_sign
+func.func @eval_sign() -> tensor<3xi64> {
+  // CHECK-NOT: stablehlo.sign
+  // CHECK: [[RESULT:%.*]] = stablehlo.constant dense<[-1, 0, 1]> : tensor<3xi64>
+  // CHECK: return [[RESULT]]
+  %0 = stablehlo.constant dense<[-1, 0, 1]> : tensor<3xi64>
+  %1 = stablehlo.sign %0 : (tensor<3xi64>) -> tensor<3xi64>
+  func.return %1 : tensor<3xi64>
+}
+
+// -----
+
 // CHECK-LABEL: func @eval_slice
 func.func @eval_slice() -> tensor<2xi64> {
   // CHECK-NOT: stablehlo.slice

--- a/stablehlo/transforms/StablehloRefineShapes.cpp
+++ b/stablehlo/transforms/StablehloRefineShapes.cpp
@@ -335,9 +335,9 @@ struct EvalSignOpPattern : public OpRewritePattern<SignOp> {
     auto resultBitwidth = resultType.getElementType().getIntOrFloatBitWidth();
     return evalUnary(rewriter, op, [&](APInt operand) {
       int64_t result;
-      if (operand.slt(0))
+      if (operand.isNegative())
         result = -1;
-      else if (operand.getSExtValue() == 0)
+      else if (operand.isZero())
         result = 0;
       else
         result = 1;


### PR DESCRIPTION
This follows up on the recent DynamicConvOp pull request and introduces additional functionality to handle accompanying shape computations.