### PR TITLE
Add support for collective ops in --stablehlo-refine-shapes

### DIFF
--- a/stablehlo/tests/stablehlo_refine_shapes.mlir
+++ b/stablehlo/tests/stablehlo_refine_shapes.mlir
@@ -313,6 +313,45 @@ func.func @eval_subtract() -> tensor<i64> {
 
 // -----
 
+// CHECK-LABEL: func @refine_all_gather_cross_replica
+func.func @refine_all_gather_cross_replica(%arg0: tensor<4x4xf32>) -> tensor<4x?xf32> {
+  // CHECK: "stablehlo.all_gather"{{.*}} -> tensor<4x16xf32>
+  %0 = "stablehlo.all_gather"(%arg0) {
+    all_gather_dim = 1 : i64,
+    replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>
+  } : (tensor<4x4xf32>) -> tensor<4x?xf32>
+  func.return %0 : tensor<4x?xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func @refine_all_gather_cross_replica_and_partition
+func.func @refine_all_gather_cross_replica_and_partition(%arg0: tensor<4x4xf32>) -> tensor<4x?xf32> {
+  // CHECK: "stablehlo.all_gather"{{.*}} -> tensor<4x?xf32>
+  %0 = "stablehlo.all_gather"(%arg0) {
+    all_gather_dim = 1 : i64,
+    channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
+    replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>
+  } : (tensor<4x4xf32>) -> tensor<4x?xf32>
+  func.return %0 : tensor<4x?xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func @refine_all_gather_flattened_ids
+func.func @refine_all_gather_flattened_ids(%arg0: tensor<4x4xf32>) -> tensor<4x?xf32> {
+  // CHECK: "stablehlo.all_gather"{{.*}} -> tensor<4x16xf32>
+  %0 = "stablehlo.all_gather"(%arg0) {
+    all_gather_dim = 1 : i64,
+    channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
+    replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>,
+    use_global_device_ids
+  } : (tensor<4x4xf32>) -> tensor<4x?xf32>
+  func.return %0 : tensor<4x?xf32>
+}
+
+// -----
+
 // CHECK-LABEL: func @refine_bitcast_convert_different_bitwidths
 func.func @refine_bitcast_convert_different_bitwidths(%arg0 : tensor<4xf32>) -> tensor<*xi8> {
   // CHECK: stablehlo.bitcast_convert{{.*}} -> tensor<*xi8>
@@ -503,6 +542,60 @@ func.func @refine_real_dynamic_slice_using_slice(%arg0: tensor<4xf32>) -> tensor
   %3 = stablehlo.real_dynamic_slice %arg0, %0, %1, %2
            : (tensor<4xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<*xf32>
   func.return %3 : tensor<*xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @refine_reduce_scatter_cross_replica
+func.func @refine_reduce_scatter_cross_replica(%data: tensor<4x16xf32>) -> tensor<4x?xf32> {
+  // CHECK: "stablehlo.reduce_scatter"{{.*}}
+  // CHECK: -> tensor<4x4xf32>
+  %0 = "stablehlo.reduce_scatter"(%data) ({
+  ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
+    %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
+    stablehlo.return %1 : tensor<f32>
+  }) {
+    replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>,
+    scatter_dimension = 1 : i64
+  } : (tensor<4x16xf32>) -> tensor<4x?xf32>
+  func.return %0 : tensor<4x?xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @refine_reduce_scatter_cross_replica_and_partition
+func.func @refine_reduce_scatter_cross_replica_and_partition(%data: tensor<4x16xf32>) -> tensor<4x?xf32> {
+  // CHECK: "stablehlo.reduce_scatter"{{.*}}
+  // CHECK: -> tensor<4x?xf32>
+  %0 = "stablehlo.reduce_scatter"(%data) ({
+  ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
+    %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
+    stablehlo.return %1 : tensor<f32>
+  }) {
+    replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>,
+    scatter_dimension = 1 : i64,
+    channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>
+  } : (tensor<4x16xf32>) -> tensor<4x?xf32>
+  func.return %0 : tensor<4x?xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @refine_reduce_scatter_flattened_ids
+func.func @refine_reduce_scatter_flattened_ids(%data: tensor<4x16xf32>) -> tensor<4x?xf32> {
+  // CHECK: "stablehlo.reduce_scatter"{{.*}}
+  // CHECK: -> tensor<4x4xf32>
+  %0 = "stablehlo.reduce_scatter"(%data) ({
+  ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
+    %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
+    stablehlo.return %1 : tensor<f32>
+  }) {
+    replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>,
+    scatter_dimension = 1 : i64,
+    channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
+    use_global_device_ids
+  } : (tensor<4x16xf32>) -> tensor<4x?xf32>
+  func.return %0 : tensor<4x?xf32>
 }
 
 // -----

--- a/stablehlo/transforms/StablehloRefineShapes.cpp
+++ b/stablehlo/transforms/StablehloRefineShapes.cpp
@@ -526,6 +526,28 @@ LogicalResult refineReturnShape(PatternRewriter& rewriter, OpType op,
   return refineReturnShape(rewriter, op, shape);
 }
 
+struct RefineAllGatherOpPattern : public OpRewritePattern<AllGatherOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(AllGatherOp op,
+                                PatternRewriter& rewriter) const override {
+    auto operandType = op.getOperand().getType().cast<ShapedType>();
+    if (!operandType.hasRank())
+      return rewriter.notifyMatchFailure(op, "expected ranked operand type");
+
+    if (op.getChannelHandle() && !op.getUseGlobalDeviceIds())
+      return rewriter.notifyMatchFailure(op, "unsupported strategy");
+    DenseIntElementsAttr replicaGroups = op.getReplicaGroups();
+    if (!replicaGroups || replicaGroups.getType().getRank() != 2)
+      return rewriter.notifyMatchFailure(op, "unsupported replica_groups");
+    auto shardCount = replicaGroups.getType().getDimSize(1);
+
+    SmallVector<int64_t> refinement(operandType.getShape());
+    if (!operandType.isDynamicDim(op.getAllGatherDim()))
+      refinement[op.getAllGatherDim()] *= shardCount;
+    return refineReturnShape(rewriter, op, refinement);
+  }
+};
+
 struct RefineBitcastConvertOpPattern
     : public OpRewritePattern<BitcastConvertOp> {
   using OpRewritePattern::OpRewritePattern;
@@ -811,6 +833,28 @@ struct RefineRealDynamicSliceOpPattern
   }
 };
 
+struct RefineReduceScatterOpPattern : public OpRewritePattern<ReduceScatterOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(ReduceScatterOp op,
+                                PatternRewriter& rewriter) const override {
+    auto operandType = op.getOperand().getType().cast<ShapedType>();
+    if (!operandType.hasRank())
+      return rewriter.notifyMatchFailure(op, "expected ranked operand type");
+
+    if (op.getChannelHandle() && !op.getUseGlobalDeviceIds())
+      return rewriter.notifyMatchFailure(op, "unsupported strategy");
+    DenseIntElementsAttr replicaGroups = op.getReplicaGroups();
+    if (!replicaGroups || replicaGroups.getType().getRank() != 2)
+      return rewriter.notifyMatchFailure(op, "unsupported replica_groups");
+    auto shardCount = replicaGroups.getType().getDimSize(1);
+
+    SmallVector<int64_t> refinement(operandType.getShape());
+    if (!operandType.isDynamicDim(op.getScatterDimension()))
+      refinement[op.getScatterDimension()] /= shardCount;
+    return refineReturnShape(rewriter, op, refinement);
+  }
+};
+
 struct RefineRngOpPattern : public OpRewritePattern<RngOp> {
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(RngOp op,
@@ -985,6 +1029,7 @@ struct StablehloRefineShapesPass
     patterns.add<EvalSelectOpPattern>(&getContext());
     patterns.add<EvalSliceOpPattern>(&getContext());
     patterns.add<EvalSubtractOpPattern>(&getContext());
+    patterns.add<RefineAllGatherOpPattern>(&getContext());
     patterns.add<RefineBitcastConvertOpPattern>(&getContext());
     patterns.add<RefineConvertOpPattern>(&getContext());
     patterns.add<RefineConvolutionOpPattern>(&getContext());
@@ -997,6 +1042,7 @@ struct StablehloRefineShapesPass
     patterns.add<RefineDynamicReshapeOpPattern>(&getContext());
     patterns.add<RefineInferTypeOpInterfacePattern>(&getContext());
     patterns.add<RefineRealDynamicSliceOpPattern>(&getContext());
+    patterns.add<RefineReduceScatterOpPattern>(&getContext());
     patterns.add<RefineRngOpPattern>(&getContext());
     patterns.add<RefineUniformQuantizeOpPattern>(&getContext());
     patterns.add<RefineWhileOpPattern>(&getContext());

--- a/stablehlo/transforms/StablehloRefineShapes.cpp
+++ b/stablehlo/transforms/StablehloRefineShapes.cpp
@@ -534,11 +534,12 @@ struct RefineAllGatherOpPattern : public OpRewritePattern<AllGatherOp> {
     if (!operandType.hasRank())
       return rewriter.notifyMatchFailure(op, "expected ranked operand type");
 
+    // This represents the cross_replica_and_partition process grouping strategy
+    // that requires num_partitions to compute shardCount. Since we don't know
+    // num_partitions at this point, we error out.
     if (op.getChannelHandle() && !op.getUseGlobalDeviceIds())
       return rewriter.notifyMatchFailure(op, "unsupported strategy");
     DenseIntElementsAttr replicaGroups = op.getReplicaGroups();
-    if (!replicaGroups || replicaGroups.getType().getRank() != 2)
-      return rewriter.notifyMatchFailure(op, "unsupported replica_groups");
     auto shardCount = replicaGroups.getType().getDimSize(1);
 
     SmallVector<int64_t> refinement(operandType.getShape());
@@ -841,11 +842,12 @@ struct RefineReduceScatterOpPattern : public OpRewritePattern<ReduceScatterOp> {
     if (!operandType.hasRank())
       return rewriter.notifyMatchFailure(op, "expected ranked operand type");
 
+    // This represents the cross_replica_and_partition process grouping strategy
+    // that requires num_partitions to compute shardCount. Since we don't know
+    // num_partitions at this point, we error out.
     if (op.getChannelHandle() && !op.getUseGlobalDeviceIds())
       return rewriter.notifyMatchFailure(op, "unsupported strategy");
     DenseIntElementsAttr replicaGroups = op.getReplicaGroups();
-    if (!replicaGroups || replicaGroups.getType().getRank() != 2)
-      return rewriter.notifyMatchFailure(op, "unsupported replica_groups");
     auto shardCount = replicaGroups.getType().getDimSize(1);
 
     SmallVector<int64_t> refinement(operandType.getShape());


### PR DESCRIPTION
At the moment, AllGatherOp and ReduceScatterOp don't have shape functions because they rely on `dim(process_groups, 1)` which in its full generality requires knowledge of `num_partitions`.

(Per https://github.com/openxla/stablehlo/blob/main/docs/spec.md: For cross_replica and flattened_ids process grouping strategies, `dim(process_groups, 1)` is equal to `dim(replica_groups, 1)`. However, for cross_replica_and_partition `dim(process_groups, 1)` is equal to `dim(replica_groups, 1) * num_partitions`).

Even though we cannot have shape functions for these two ops without changing the StableHLO spec, we can still make best effort at refining their shapes for cross_replica and flattened_ids cases. This is what this PR implements.