### PR TITLE
Audit VhloOps.td

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3857,7 +3857,7 @@ sizes of `inputs[k]` corresponding to `dimensions` are not included.
 
 Performs element-wise conversion of `operand` to another floating-point type
 that uses `exponent_bits` and `mantissa_bits` and back to the original
-floating-point type and produces a `result` tensor.
+floating-point type and produces an `output` tensor.
 
 More formally:
 
@@ -3883,11 +3883,11 @@ More formally:
 
 | Name     | Type                          | Constraints |
 |----------|-------------------------------|-------------|
-| `result` | tensor of floating-point type | (C1)        |
+| `output` | tensor of floating-point type | (C1)        |
 
 #### Constraints
 
-* (C1) `operand` and `result` have the same type.
+* (C1) `operand` and `output` have the same type.
 * (C2) `exponent_bits` $\ge$ 1.
 * (C3) `mantissa_bits` $\ge$ 0.
 
@@ -3896,12 +3896,12 @@ More formally:
 ```mlir
 // Logical values: -Inf, +Inf, NaN, ...
 // %operand: [0xFF800000, 0x7F800000, 0x7FFFFFFF, 0.0, 1000.0, 1000000.0]
-%result = "stablehlo.reduce_precision"(%operand) {
+%output = "stablehlo.reduce_precision"(%operand) {
   exponent_bits = 5 : i32,
   mantissa_bits = 2 : i32
 } : (tensor<6xf32>) -> tensor<6xf32>
 // Logical values: -Inf, +Inf, NaN, NaN, 0.0, 1024.0, +Inf
-// %result: [0xFF800000, 0x7F800000, 0x7FFFFFFF, 0.0, 1024.0, 0x7F800000]
+// %output: [0xFF800000, 0x7F800000, 0x7FFFFFFF, 0.0, 1024.0, 0x7F800000]
 ```
 
 ### reduce_scatter
@@ -4307,8 +4307,8 @@ hidden state.
 #### Semantics
 
 Returns an `output` filled with uniform random bits and an updated output state
-`output_state` given an initial state `initial_state` using the pseudorandom
-number generator algorithm `rng_algorithm`. The output is guaranteed to be
+`output_state` using the pseudorandom number generator algorithm `rng_algorithm`
+given an initial state `initial_state`. The output is guaranteed to be
 deterministic function of `initial_state`, but it is not guaranteed to be
 deterministic between implementations.
 
@@ -4325,8 +4325,8 @@ deterministic between implementations.
 
 | Label | Name            | Type                                         | Constraints |
 |-------|-----------------|----------------------------------------------|-------------|
-| (I1)  | `initial_state` | 1-dimensional tensor of type `ui64`          | (C1), (C2)  |
-| (I2)  | `rng_algorithm` | enum of `DEFAULT`, `THREE_FRY`, and `PHILOX` | (C2)        |
+| (I1)  | `rng_algorithm` | enum of `DEFAULT`, `THREE_FRY`, and `PHILOX` | (C2)        |
+| (I2)  | `initial_state` | 1-dimensional tensor of type `ui64`          | (C1), (C2)  |
 
 #### Outputs
 
@@ -5422,7 +5422,7 @@ Produces the output from executing `body` function 0 or more times while the
 using Python-like syntax as follows:
 
 ```python
-internal_state = operands
+internal_state = operand
 while cond(internal_state) == True:
   internal_state = body(internal_state)
 results = internal_state
@@ -5435,7 +5435,7 @@ The behavior of an infinite loop is TBD
 
 | Label | Name       | Type                                 | Constraints |
 |-------|------------|--------------------------------------|-------------|
-| (I1)  | `operands` | variadic number of tensors or tokens | (C1-C3)     |
+| (I1)  | `operand`  | variadic number of tensors or tokens | (C1-C3)     |
 | (I2)  | `cond`     | function                             | (C1)        |
 | (I3)  | `body`     | function                             | (C2)        |
 
@@ -5448,18 +5448,18 @@ The behavior of an infinite loop is TBD
 #### Constraints
 
 * (C1) `cond` has type `(T0, ..., TN-1) -> tensor<i1>`, where
-       `Ti` = `type(operands[i])`.
+       `Ti` = `type(operand[i])`.
 * (C2) `body` has type `(T0, ..., TN-1) -> (T0, ..., TN-1)`, where
-       `Ti` = `type(operands[i])`.
-* (C3) For all `i`, `type(results[i])` = `type(operands[i])`.
+       `Ti` = `type(operand[i])`.
+* (C3) For all `i`, `type(results[i])` = `type(operand[i])`.
 
 #### Examples
 
 ```mlir
 // %constant0: 1
-// %input0: 0
-// %input1: 10
-%results0, %results1 = "stablehlo.while"(%input0, %input1) ({
+// %operand0: 0
+// %operand1: 10
+%results0, %results1 = "stablehlo.while"(%operand0, %operand1) ({
   ^bb0(%arg0: tensor<i32>, %arg1: tensor<i32>):
     %0 = "stablehlo.compare"(%arg0, %arg1) {
       comparison_direction = #stablehlo<comparison_direction LT>

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1247,7 +1247,7 @@ def StableHLO_WhileOp: StableHLO_Op<"while", [
     https://github.com/openxla/stablehlo/blob/main/docs/spec.md#while
 
     Example:
-    %results:2 = "stablehlo.while"(%input0, %input1) ({
+    %results0, %results1 = "stablehlo.while"(%operand0, %operand1) ({
       ^bb0(%arg0: tensor<i32>, %arg1: tensor<i32>):
         %0 = "stablehlo.compare"(%arg0, %arg1) {
           comparison_direction = #stablehlo<comparison_direction LT>
@@ -3097,14 +3097,14 @@ def StableHLO_ReducePrecisionOp :
   let description = [{
     Performs element-wise conversion of `operand` to another floating-point type
     that uses `exponent_bits` and `mantissa_bits` and back to the original
-    floating-point type and produces a `result` tensor.
+    floating-point type and produces an `output` tensor.
 
     See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec.md#reduce_precision
 
     Example:
     ```mlir
-    %result = stablehlo.reduce_precision %operand, format = e5m2 : tensor<6xf32>
+    %output = stablehlo.reduce_precision %operand, format = e5m2 : tensor<6xf32>
     ```
   }];
   let arguments = (ins

--- a/stablehlo/dialect/VhloDialect.td
+++ b/stablehlo/dialect/VhloDialect.td
@@ -22,7 +22,9 @@ def VHLO_Dialect : Dialect {
   let cppNamespace = "::mlir::vhlo";
 
   let description = [{
-    A shim opset of Versioned StableHLO ops for versions 0.x.x and 1.x.x.
+    A "shallow" versioned copy of the StableHLO dialect that has been simplified
+    down to a bare minimum which is used for upgrades, downgrades, and
+    serialization/deserialization.
 
     Version log:
       0.3.0: Bootstrap from MHLO: https://github.com/openxla/stablehlo/pull/1.

--- a/stablehlo/dialect/VhloOps.td
+++ b/stablehlo/dialect/VhloOps.td
@@ -18,17 +18,13 @@ limitations under the License.
 #define STABLEHLO_DIALECT_VHLO_OPS
 
 include "mlir/IR/OpBase.td"
-
-//===----------------------------------------------------------------------===//
-// Dialect and Ops
-//===----------------------------------------------------------------------===//
-
 include "stablehlo/dialect/VhloDialect.td"
 include "stablehlo/dialect/VhloTypes.td"
 include "stablehlo/dialect/VhloEnums.td"
 include "stablehlo/dialect/VhloAttrs.td"
 
-def VersionedOpInterface : OpInterface<"VersionedOpInterface"> {
+def VHLO_VersionedOpInterface : OpInterface<"VersionedOpInterface"> {
+  let cppNamespace = "::mlir::vhlo";
   let methods = [
     InterfaceMethod<
       "Returns the minimum version of the VHLO dialect an op is supported in.",
@@ -39,13 +35,9 @@ def VersionedOpInterface : OpInterface<"VersionedOpInterface"> {
   ];
 }
 
-// Most ops should not use traits. Exceptions are:
-// - ReturnOp needs a trait for Terminator.
-// - ReduceOp/ReduceWindowOp/ScatterOp need a trait since they have
-//   multiple variadic arguments.
 class VHLO_Op<string mnemonic, string minVersion, string maxVersion, list<Trait> traits = []> :
     Op<VHLO_Dialect, mnemonic,
-      [DeclareOpInterfaceMethods<VersionedOpInterface>] # traits> {
+      [DeclareOpInterfaceMethods<VHLO_VersionedOpInterface>] # traits> {
   let extraClassDefinition = [{
     mlir::vhlo::Version $cppClass::getMinVersion() {
       auto version = mlir::vhlo::Version::fromString("}] #  minVersion # [{");
@@ -61,294 +53,33 @@ class VHLO_Op<string mnemonic, string minVersion, string maxVersion, list<Trait>
   }];
 }
 
-def VHLO_ConstantOpV1 : VHLO_Op<"constant", "0.3.0", "current"> {
-  let arguments = (ins VHLO_AnyAttr:$value);
-  let results = (outs VHLO_AnyType:$output);
-}
-
-def VHLO_IotaOpV1 : VHLO_Op<"iota", "0.3.0", "current"> {
-  let arguments = (ins VHLO_AnyAttr:$iota_dimension);
-  let results = (outs VHLO_AnyType:$output);
-}
-
-def VHLO_DynamicIotaOpV1 : VHLO_Op<"dynamic_iota", "0.3.0", "current"> {
-  let arguments = (ins VHLO_AnyType:$output_shape, VHLO_AnyAttr:$iota_dimension);
-  let results = (outs VHLO_AnyType:$result);
-}
-
-def VHLO_CreateTokenOpV1 : VHLO_Op<"create_token", "0.3.0", "current"> {
-  let results = (outs VHLO_AnyType:$output);
-}
+// Design principles for VHLO ops:
+// 1) VHLO is a "shallow" versioned copy of the StableHLO dialect that has been
+//    simplified down to a bare minimum. As a result, the main design principle
+//    is radical minimalism.
+// 2) Don't use traits, except when things will break otherwise, i.e.:
+//      * ReturnOp needs a trait for Terminator.
+//      * ReduceOp/ReduceWindowOp/ScatterOp need a trait since they have
+//      * multiple variadic arguments.
+// 3) Use VHLO_AnyType or Variadic<VHLO_AnyType> for all operands and results.
+// 4) Use VHLO_AnyAttr for all attributes.
+// 5) Use VHLO_AnyRegion for all regions.
+// 6) Don't use verifiers, shape functions, etc. The only exception is
+//    assembly format for FuncOp, because printouts get unreadable otherwise.
 
 def VHLO_AbsOpV1 : VHLO_Op<"abs", "0.3.0", "current"> {
   let arguments = (ins VHLO_AnyType:$operand);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_CbrtOpV1 : VHLO_Op<"cbrt", "0.3.0", "current"> {
-  let arguments = (ins VHLO_AnyType:$operand);
-  let results = (outs VHLO_AnyType:$result);
-}
-
-def VHLO_CeilOpV1 : VHLO_Op<"ceil", "0.3.0", "current"> {
-  let arguments = (ins VHLO_AnyType:$operand);
-  let results = (outs VHLO_AnyType:$result);
-}
-
-def VHLO_ConvertOpV1 : VHLO_Op<"convert", "0.3.0", "current"> {
-  let arguments = (ins VHLO_AnyType:$operand);
-  let results = (outs VHLO_AnyType:$result);
-}
-
-def VHLO_ClzOpV1 : VHLO_Op<"count_leading_zeros", "0.3.0", "current"> {
-  let arguments = (ins VHLO_AnyType:$operand);
-  let results = (outs VHLO_AnyType:$result);
-}
-
-def VHLO_CosineOpV1 : VHLO_Op<"cosine", "0.3.0", "current"> {
-  let arguments = (ins VHLO_AnyType:$operand);
-  let results = (outs VHLO_AnyType:$result);
-}
-
-def VHLO_ExpOpV1 : VHLO_Op<"exponential", "0.3.0", "current"> {
-  let arguments = (ins VHLO_AnyType:$operand);
-  let results = (outs VHLO_AnyType:$result);
-}
-
-def VHLO_Expm1OpV1 : VHLO_Op<"exponential_minus_one", "0.3.0", "current"> {
-  let arguments = (ins VHLO_AnyType:$operand);
-  let results = (outs VHLO_AnyType:$result);
-}
-def VHLO_FloorOpV1 : VHLO_Op<"floor", "0.3.0", "current"> {
-  let arguments = (ins VHLO_AnyType:$operand);
-  let results = (outs VHLO_AnyType:$result);
-}
-
-def VHLO_ImagOpV1 : VHLO_Op<"imag", "0.3.0", "current"> {
-  let arguments = (ins VHLO_AnyType:$operand);
-  let results = (outs VHLO_AnyType:$result);
-}
-
-def VHLO_IsFiniteOpV1 : VHLO_Op<"is_finite", "0.3.0", "current"> {
-  let arguments = (ins VHLO_AnyType:$x);
-  let results = (outs VHLO_AnyType:$y);
-}
-
-def VHLO_LogOpV1 : VHLO_Op<"log", "0.3.0", "current">{
-  let arguments = (ins VHLO_AnyType:$operand);
-  let results = (outs VHLO_AnyType:$result);
-}
-
-def VHLO_Log1pOpV1 : VHLO_Op<"log_plus_one", "0.3.0", "current">{
-  let arguments = (ins VHLO_AnyType:$operand);
-  let results = (outs VHLO_AnyType:$result);
-}
-
-def VHLO_LogisticOpV1 : VHLO_Op<"logistic", "0.3.0", "current">{
-  let arguments = (ins VHLO_AnyType:$operand);
-  let results = (outs VHLO_AnyType:$result);
-}
-
-def VHLO_NotOpV1 : VHLO_Op<"not", "0.3.0", "current">{
-  let arguments = (ins VHLO_AnyType:$operand);
-  let results = (outs VHLO_AnyType:$result);
-}
-
-def VHLO_NegOpV1 : VHLO_Op<"negate", "0.3.0", "current">{
-  let arguments = (ins VHLO_AnyType:$operand);
-  let results = (outs VHLO_AnyType:$result);
-}
-
-def VHLO_PopulationCountOpV1 : VHLO_Op<"popcnt", "0.3.0", "current">{
-  let arguments = (ins VHLO_AnyType:$operand);
-  let results = (outs VHLO_AnyType:$result);
-}
-
-def VHLO_RealOpV1 : VHLO_Op<"real", "0.3.0", "current">{
-  let arguments = (ins VHLO_AnyType:$operand);
-  let results = (outs VHLO_AnyType:$result);
-}
-
-def VHLO_RoundOpV1 : VHLO_Op<"round_nearest_afz", "0.3.0", "current">{
-  let arguments = (ins VHLO_AnyType:$operand);
-  let results = (outs VHLO_AnyType:$result);
-}
-
-def VHLO_RoundNearestEvenOpV1 : VHLO_Op<"round_nearest_even", "0.3.0", "current">{
-  let arguments = (ins VHLO_AnyType:$operand);
-  let results = (outs VHLO_AnyType:$result);
-}
-
-def VHLO_RsqrtOpV1 : VHLO_Op<"rsqrt", "0.3.0", "current">{
-  let arguments = (ins VHLO_AnyType:$operand);
-  let results = (outs VHLO_AnyType:$result);
-}
-
-def VHLO_SignOpV1 : VHLO_Op<"sign", "0.3.0", "current">{
-  let arguments = (ins VHLO_AnyType:$operand);
-  let results = (outs VHLO_AnyType:$result);
-}
-
-def VHLO_SineOpV1 : VHLO_Op<"sine", "0.3.0", "current">{
-  let arguments = (ins VHLO_AnyType:$operand);
-  let results = (outs VHLO_AnyType:$result);
-}
-
-def VHLO_SqrtOpV1 : VHLO_Op<"sqrt", "0.3.0", "current">{
-  let arguments = (ins VHLO_AnyType:$operand);
-  let results = (outs VHLO_AnyType:$result);
-}
-
-def VHLO_TanhOpV1 : VHLO_Op<"tanh", "0.3.0", "current">{
-  let arguments = (ins VHLO_AnyType:$operand);
-  let results = (outs VHLO_AnyType:$result);
-}
-
-// Binary Ops
 def VHLO_AddOpV1 : VHLO_Op<"add", "0.3.0", "current"> {
   let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
   let results = (outs VHLO_AnyType:$result);
 }
-def VHLO_Atan2OpV1 : VHLO_Op<"atan2", "0.3.0", "current"> {
-  let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
-  let results = (outs VHLO_AnyType:$result);
-}
-def VHLO_ComplexOpV1 : VHLO_Op<"complex", "0.3.0", "current"> {
-  let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
-  let results = (outs VHLO_AnyType:$result);
-}
-def VHLO_DivOpV1 : VHLO_Op<"divide", "0.3.0", "current"> {
-  let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
-  let results = (outs VHLO_AnyType:$result);
-}
-def VHLO_MaxOpV1 : VHLO_Op<"maximum", "0.3.0", "current"> {
-  let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
-  let results = (outs VHLO_AnyType:$result);
-}
-def VHLO_MinOpV1 : VHLO_Op<"minimum", "0.3.0", "current"> {
-  let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
-  let results = (outs VHLO_AnyType:$result);
-}
-def VHLO_MulOpV1 : VHLO_Op<"multiply", "0.3.0", "current"> {
-  let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
-  let results = (outs VHLO_AnyType:$result);
-}
-def VHLO_PowOpV1 : VHLO_Op<"power", "0.3.0", "current"> {
-  let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
-  let results = (outs VHLO_AnyType:$result);
-}
-def VHLO_RemOpV1 : VHLO_Op<"remainder", "0.3.0", "current"> {
-  let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
-  let results = (outs VHLO_AnyType:$result);
-}
-def VHLO_ShiftLeftOpV1 : VHLO_Op<"shift_left", "0.3.0", "current"> {
-  let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
-  let results = (outs VHLO_AnyType:$result);
-}
-def VHLO_ShiftRightArithmeticOpV1 : VHLO_Op<"shift_right_arithmetic", "0.3.0", "current"> {
-  let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
-  let results = (outs VHLO_AnyType:$result);
-}
-def VHLO_ShiftRightLogicalOpV1 : VHLO_Op<"shift_right_logical", "0.3.0", "current"> {
-  let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
-  let results = (outs VHLO_AnyType:$result);
-}
-def VHLO_SubtractOpV1 : VHLO_Op<"subtract", "0.3.0", "current"> {
-  let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
-  let results = (outs VHLO_AnyType:$result);
-}
 
-// Logical Ops
-def VHLO_AndOpV1 : VHLO_Op<"and", "0.3.0", "current"> {
-  let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
-  let results = (outs VHLO_AnyType:$result);
-}
-def VHLO_OrOpV1 : VHLO_Op<"or", "0.3.0", "current"> {
-  let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
-  let results = (outs VHLO_AnyType:$result);
-}
-def VHLO_XorOpV1 : VHLO_Op<"xor", "0.3.0", "current"> {
-  let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
-  let results = (outs VHLO_AnyType:$result);
-}
-
-def VHLO_ReturnOpV1 : VHLO_Op<"return", "0.3.0", "current", [Terminator]> {
-  let arguments = (ins
-    Variadic<VHLO_AnyType>:$results
-  );
-  let assemblyFormat = "$results attr-dict (`:` type($results)^)?";
-}
-
-// Communication op definitions.
-def VHLO_InfeedOpV1 : VHLO_Op<"infeed", "0.3.0", "current"> {
-  let arguments = (ins
-    VHLO_AnyType:$token,
-    VHLO_AnyAttr:$infeed_config,
-    OptionalAttr<VHLO_AnyAttr>:$layout
-  );
-  let results = (outs Variadic<VHLO_AnyType>);
-}
-
-def VHLO_OutfeedOpV1 : VHLO_Op<"outfeed", "0.3.0", "current"> {
-  let arguments = (ins
-    Variadic<VHLO_AnyType>:$inputs,
-    VHLO_AnyType:$token,
-    VHLO_AnyAttr:$outfeed_config
-  );
-  let results = (outs VHLO_AnyType);
-}
-
-def VHLO_SendOpV1 : VHLO_Op<"send", "0.3.0", "current"> {
-  let arguments = (ins
-    Variadic<VHLO_AnyType>:$inputs,
-    VHLO_AnyType:$token,
-    VHLO_AnyAttr:$channel_handle,
-    OptionalAttr<VHLO_AnyAttr>:$is_host_transfer
-  );
-  let results = (outs VHLO_AnyType);
-}
-
-def VHLO_RecvOpV1 : VHLO_Op<"recv", "0.3.0", "current"> {
-  let arguments = (ins
-    VHLO_AnyType:$token,
-    VHLO_AnyAttr:$channel_handle,
-    OptionalAttr<VHLO_AnyAttr>:$is_host_transfer
-  );
-  let results = (outs Variadic<VHLO_AnyType>);
-}
-
-// Parallelism related op definitions.
-def VHLO_ReplicaIdOpV1 : VHLO_Op<"replica_id", "0.3.0", "current"> {
-  let results = (outs VHLO_AnyType);
-}
-
-def VHLO_PartitionIdOpV1 : VHLO_Op<"partition_id", "0.4.0", "current"> {
-  let results = (outs VHLO_AnyType);
-}
-
-// Control flow op definitions.
 def VHLO_AfterAllOpV1 : VHLO_Op<"after_all", "0.3.0", "current"> {
   let arguments = (ins Variadic<VHLO_AnyType>:$inputs);
   let results = (outs VHLO_AnyType:$result);
-}
-
-def VHLO_IfOpV1 : VHLO_Op<"if", "0.3.0", "current"> {
-  let arguments = (ins VHLO_AnyType:$pred);
-  let regions = (region VHLO_AnyRegion:$true_branch,
-                        VHLO_AnyRegion:$false_branch);
-  let results = (outs Variadic<VHLO_AnyType>);
-}
-
-def VHLO_CaseOpV1 : VHLO_Op<"case", "0.3.0", "current"> {
-  let arguments = (ins VHLO_AnyType:$index);
-  let regions = (region VariadicRegion<VHLO_AnyRegion>:$branches);
-  let results = (outs Variadic<VHLO_AnyType>);
-}
-
-def VHLO_WhileOpV1 : VHLO_Op<"while", "0.3.0", "current"> {
-  let arguments = (ins Variadic<VHLO_AnyType>:$operand);
-  let regions = (region VHLO_AnyRegion:$cond, VHLO_AnyRegion:$body);
-  let results = (outs Variadic<VHLO_AnyType>);
 }
 
 def VHLO_AllGatherOpV1 : VHLO_Op<"all_gather", "0.3.0", "0.3.0"> {
@@ -358,7 +89,7 @@ def VHLO_AllGatherOpV1 : VHLO_Op<"all_gather", "0.3.0", "0.3.0"> {
     VHLO_AnyAttr:$replica_groups,
     OptionalAttr<VHLO_AnyAttr>:$channel_handle
   );
-  let results = (outs VHLO_AnyType);
+  let results = (outs VHLO_AnyType:$result);
 }
 
 def VHLO_AllGatherOpV2 : VHLO_Op<"all_gather_v2", "0.4.0", "current"> {
@@ -369,7 +100,7 @@ def VHLO_AllGatherOpV2 : VHLO_Op<"all_gather_v2", "0.4.0", "current"> {
     OptionalAttr<VHLO_AnyAttr>:$channel_handle,
     OptionalAttr<VHLO_AnyAttr>:$use_global_device_ids
   );
-  let results = (outs VHLO_AnyType);
+  let results = (outs VHLO_AnyType:$result);
 }
 
 def VHLO_AllReduceOpV1 : VHLO_Op<"all_reduce", "0.3.0", "current"> {
@@ -380,19 +111,7 @@ def VHLO_AllReduceOpV1 : VHLO_Op<"all_reduce", "0.3.0", "current"> {
     OptionalAttr<VHLO_AnyAttr>:$use_global_device_ids
   );
   let regions = (region VHLO_AnyRegion:$computation);
-  let results = (outs VHLO_AnyType);
-}
-
-def VHLO_ReduceScatterOpV1 : VHLO_Op<"reduce_scatter", "0.3.0", "current"> {
-  let arguments = (ins
-    VHLO_AnyType:$operand,
-    VHLO_AnyAttr:$scatter_dimension,
-    VHLO_AnyAttr:$replica_groups,
-    OptionalAttr<VHLO_AnyAttr>:$channel_handle,
-    OptionalAttr<VHLO_AnyAttr>:$use_global_device_ids
-  );
-  let regions = (region VHLO_AnyRegion:$computation);
-  let results = (outs VHLO_AnyType);
+  let results = (outs VHLO_AnyType:$result);
 }
 
 def VHLO_AllToAllOpV1 : VHLO_Op<"all_to_all", "0.3.0", "0.3.0"> {
@@ -403,7 +122,7 @@ def VHLO_AllToAllOpV1 : VHLO_Op<"all_to_all", "0.3.0", "0.3.0"> {
     VHLO_AnyAttr:$split_count,
     VHLO_AnyAttr:$replica_groups
   );
-  let results = (outs VHLO_AnyType);
+  let results = (outs VHLO_AnyType:$result);
 }
 
 def VHLO_AllToAllOpV2 : VHLO_Op<"all_to_all_v2", "0.4.0", "current"> {
@@ -415,75 +134,19 @@ def VHLO_AllToAllOpV2 : VHLO_Op<"all_to_all_v2", "0.4.0", "current"> {
     VHLO_AnyAttr:$replica_groups,
     OptionalAttr<VHLO_AnyAttr>:$channel_handle
   );
-  let results = (outs VHLO_AnyType);
-}
-
-def VHLO_ReduceOpV1 : VHLO_Op<"reduce", "0.3.0", "current", [SameVariadicOperandSize]> {
-  let arguments = (ins
-    Variadic<VHLO_AnyType>:$inputs,
-    Variadic<VHLO_AnyType>:$init_values,
-    VHLO_AnyAttr:$dimensions
-  );
-  let results = (outs Variadic<VHLO_AnyType>);
-  let regions = (region VHLO_AnyRegion:$body);
-}
-
-//===----------------------------------------------------------------------===//
-// VHLO tuple op definitions.
-//===----------------------------------------------------------------------===//
-def VHLO_GetTupleElementOpV1 : VHLO_Op<"get_tuple_element", "0.3.0", "current"> {
-  let arguments = (ins
-    VHLO_AnyType:$operand,
-    VHLO_AnyAttr:$index
-  );
-  let results = (outs VHLO_AnyType);
-}
-
-def VHLO_TupleOpV1 : VHLO_Op<"tuple", "0.3.0", "current"> {
-  let arguments = (ins Variadic<VHLO_AnyType>:$val);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_CompareOpV1 : VHLO_Op<"compare", "0.3.0", "current"> {
-  let arguments = (ins
-    VHLO_AnyType:$lhs,
-    VHLO_AnyType:$rhs,
-    VHLO_AnyAttr:$comparison_direction,
-    OptionalAttr<VHLO_AnyAttr>:$compare_type
-  );
-  let results = (outs VHLO_AnyType);
-}
-
-// Slice ops
-def VHLO_SliceOpV1 : VHLO_Op<"slice", "0.3.0", "current"> {
-  let arguments = (ins
-    VHLO_AnyType:$operand,
-    VHLO_AnyAttr:$start_indices,
-    VHLO_AnyAttr:$limit_indices,
-    VHLO_AnyAttr:$strides
-  );
-  let results = (outs VHLO_AnyType);
-}
-
-def VHLO_DynamicSliceOpV1 : VHLO_Op<"dynamic_slice", "0.3.0", "current"> {
-  let arguments = (ins
-    VHLO_AnyType:$operand,
-    Variadic<VHLO_AnyType>:$start_indices,
-    VHLO_AnyAttr:$slice_sizes
-  );
+def VHLO_AndOpV1 : VHLO_Op<"and", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_DynamicUpdateSliceOpV1 : VHLO_Op<"dynamic_update_slice", "0.3.0", "current"> {
-  let arguments = (ins
-    VHLO_AnyType:$operand,
-    VHLO_AnyType:$update,
-    Variadic<VHLO_AnyType>:$start_indices
-  );
+def VHLO_Atan2OpV1 : VHLO_Op<"atan2", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
   let results = (outs VHLO_AnyType:$result);
 }
 
-// Other op definitions.
 def VHLO_BatchNormGradOpV1 : VHLO_Op<"batch_norm_grad", "0.3.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$operand,
@@ -495,9 +158,10 @@ def VHLO_BatchNormGradOpV1 : VHLO_Op<"batch_norm_grad", "0.3.0", "current"> {
     VHLO_AnyAttr:$feature_index
   );
   let results = (outs
-      VHLO_AnyType:$grad_operand,
-      VHLO_AnyType:$grad_scale,
-      VHLO_AnyType:$grad_offset);
+    VHLO_AnyType:$grad_operand,
+    VHLO_AnyType:$grad_scale,
+    VHLO_AnyType:$grad_offset
+  );
 }
 
 def VHLO_BatchNormInferenceOpV1 : VHLO_Op<"batch_norm_inference", "0.3.0", "current"> {
@@ -522,22 +186,15 @@ def VHLO_BatchNormTrainingOpV1 : VHLO_Op<"batch_norm_training", "0.3.0", "curren
     VHLO_AnyAttr:$feature_index
   );
   let results = (outs
-      VHLO_AnyType:$output,
-      VHLO_AnyType:$batch_mean,
-      VHLO_AnyType:$batch_var);
+    VHLO_AnyType:$output,
+    VHLO_AnyType:$batch_mean,
+    VHLO_AnyType:$batch_var
+  );
 }
 
 def VHLO_BitcastConvertOpV1 : VHLO_Op<"bitcast_convert", "0.3.0", "current"> {
   let arguments = (ins VHLO_AnyType:$operand);
-  let results = (outs VHLO_AnyType);
-}
-
-def VHLO_BroadcastOpV1 : VHLO_Op<"broadcast", "0.3.0", "current"> {
-  let arguments = (ins
-    VHLO_AnyType:$operand,
-    VHLO_AnyAttr:$broadcast_sizes
-  );
-  let results = (outs VHLO_AnyType);
+  let results = (outs VHLO_AnyType:$result);
 }
 
 def VHLO_BroadcastInDimOpV1 : VHLO_Op<"broadcast_in_dim", "0.3.0", "current"> {
@@ -545,18 +202,42 @@ def VHLO_BroadcastInDimOpV1 : VHLO_Op<"broadcast_in_dim", "0.3.0", "current"> {
     VHLO_AnyType:$operand,
     VHLO_AnyAttr:$broadcast_dimensions
   );
-  let results = (outs VHLO_AnyType);
+  let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_DynamicBroadcastInDimOpV1 : VHLO_Op<"dynamic_broadcast_in_dim", "0.3.0", "current"> {
+// TODO(#3): BroadcastOp is not part of the StableHLO spec.
+// This operation is on its way out of StableHLO, so it is not included in
+// the StableHLO specification.
+def VHLO_BroadcastOpV1 : VHLO_Op<"broadcast", "0.3.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$operand,
-    VHLO_AnyType:$output_dimensions,
-    VHLO_AnyAttr:$broadcast_dimensions,
-    OptionalAttr<VHLO_AnyAttr>:$known_expanding_dimensions,
-    OptionalAttr<VHLO_AnyAttr>:$known_nonexpanding_dimensions
+    VHLO_AnyAttr:$broadcast_sizes
   );
-  let results = (outs VHLO_AnyType);
+  let results = (outs VHLO_AnyType:$result);
+}
+
+// TODO(#425): CallOp is not part of the StableHLO spec.
+// We're planning to look into it as part of the work on speccing
+// Module/Func/Call/Return ops in StableHLO.
+def VHLO_CallOpV1 : VHLO_Op<"call", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyAttr:$callee, Variadic<VHLO_AnyType>:$operands);
+  let results = (outs Variadic<VHLO_AnyType>:$results);
+}
+
+def VHLO_CaseOpV1 : VHLO_Op<"case", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$index);
+  let regions = (region VariadicRegion<VHLO_AnyRegion>:$branches);
+  let results = (outs Variadic<VHLO_AnyType>:$results);
+}
+
+def VHLO_CbrtOpV1 : VHLO_Op<"cbrt", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$operand);
+  let results = (outs VHLO_AnyType:$result);
+}
+
+def VHLO_CeilOpV1 : VHLO_Op<"ceil", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$operand);
+  let results = (outs VHLO_AnyType:$result);
 }
 
 def VHLO_CholeskyOpV1 : VHLO_Op<"cholesky", "0.3.0", "current"> {
@@ -576,12 +257,9 @@ def VHLO_ClampOpV1 : VHLO_Op<"clamp", "0.3.0", "current"> {
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_ConcatenateOpV1 : VHLO_Op<"concatenate", "0.3.0", "current"> {
-  let arguments = (ins
-    Variadic<VHLO_AnyType>:$inputs,
-    VHLO_AnyAttr:$dimension
-  );
-  let results = (outs VHLO_AnyType);
+def VHLO_ClzOpV1 : VHLO_Op<"count_leading_zeros", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$operand);
+  let results = (outs VHLO_AnyType:$result);
 }
 
 def VHLO_CollectivePermuteOpV1 : VHLO_Op<"collective_permute", "0.3.0", "0.3.0"> {
@@ -589,7 +267,7 @@ def VHLO_CollectivePermuteOpV1 : VHLO_Op<"collective_permute", "0.3.0", "0.3.0">
     VHLO_AnyType:$operand,
     VHLO_AnyAttr:$source_target_pairs
   );
-  let results = (outs VHLO_AnyType);
+  let results = (outs VHLO_AnyType:$result);
 }
 
 def VHLO_CollectivePermuteOpV2 : VHLO_Op<"collective_permute_v2", "0.4.0", "current"> {
@@ -598,7 +276,48 @@ def VHLO_CollectivePermuteOpV2 : VHLO_Op<"collective_permute_v2", "0.4.0", "curr
     VHLO_AnyAttr:$source_target_pairs,
     OptionalAttr<VHLO_AnyAttr>:$channel_handle
   );
-  let results = (outs VHLO_AnyType);
+  let results = (outs VHLO_AnyType:$result);
+}
+
+def VHLO_CompareOpV1 : VHLO_Op<"compare", "0.3.0", "current"> {
+  let arguments = (ins
+    VHLO_AnyType:$lhs,
+    VHLO_AnyType:$rhs,
+    VHLO_AnyAttr:$comparison_direction,
+    OptionalAttr<VHLO_AnyAttr>:$compare_type
+  );
+  let results = (outs VHLO_AnyType:$result);
+}
+
+def VHLO_ComplexOpV1 : VHLO_Op<"complex", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
+  let results = (outs VHLO_AnyType:$result);
+}
+
+// TODO(#8): ComputeReshapeShapeOp is not part of the StableHLO spec.
+// This operation is a work in progress, so it is not yet included in
+// the StableHLO specification.
+def VHLO_ComputeReshapeShapeOpV1 : VHLO_Op<"compute_reshape_shape", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$num_elements, VHLO_AnyType:$dynamic_shape);
+  let results = (outs VHLO_AnyType:$result);
+}
+
+def VHLO_ConcatenateOpV1 : VHLO_Op<"concatenate", "0.3.0", "current"> {
+  let arguments = (ins
+    Variadic<VHLO_AnyType>:$inputs,
+    VHLO_AnyAttr:$dimension
+  );
+  let results = (outs VHLO_AnyType:$result);
+}
+
+def VHLO_ConstantOpV1 : VHLO_Op<"constant", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyAttr:$value);
+  let results = (outs VHLO_AnyType:$output);
+}
+
+def VHLO_ConvertOpV1 : VHLO_Op<"convert", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$operand);
+  let results = (outs VHLO_AnyType:$result);
 }
 
 def VHLO_ConvolutionOpV1 : VHLO_Op<"convolution", "0.3.0", "current"> {
@@ -607,15 +326,38 @@ def VHLO_ConvolutionOpV1 : VHLO_Op<"convolution", "0.3.0", "current"> {
        VHLO_AnyType:$lhs,
        VHLO_AnyType:$rhs),
     VHLO_ConvolutionAttributesV1.attributes);
-  let results = (outs VHLO_AnyType);
+  let results = (outs VHLO_AnyType:$result);
 }
 
+def VHLO_CosineOpV1 : VHLO_Op<"cosine", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$operand);
+  let results = (outs VHLO_AnyType:$result);
+}
+
+// TODO(#3): CreateTokenOp is not part of the StableHLO spec.
+// This operation is on its way out of StableHLO, so it is not included in
+// the StableHLO specification.
+def VHLO_CreateTokenOpV1 : VHLO_Op<"create_token", "0.3.0", "current"> {
+  let results = (outs VHLO_AnyType:$output);
+}
+
+// TODO(#3): CrossReplicaSumOp is not part of the StableHLO spec.
+// This operation is on its way out of StableHLO, so it is not included in
+// the StableHLO specification.
 def VHLO_CrossReplicaSumOpV1 : VHLO_Op<"cross-replica-sum", "0.3.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$operand,
     VHLO_AnyAttr:$replica_groups
   );
-  let results = (outs VHLO_AnyType);
+  let results = (outs VHLO_AnyType:$result);
+}
+
+// TODO(#8): CstrReshapableOp is not part of the StableHLO spec.
+// This operation is a work in progress, so it is not yet included in
+// the StableHLO specification.
+def VHLO_CstrReshapableOpV1 : VHLO_Op<"cstr_reshapable", "0.3.0", "current"> {
+  let results = (outs VHLO_AnyType:$result);
+  let arguments = (ins VHLO_AnyType:$num_elements, VHLO_AnyType:$dynamic_shape);
 }
 
 def VHLO_CustomCallOpV1 : VHLO_Op<"custom_call", "0.3.0", "0.3.0"> {
@@ -629,9 +371,15 @@ def VHLO_CustomCallOpV1 : VHLO_Op<"custom_call", "0.3.0", "0.3.0"> {
     OptionalAttr<VHLO_AnyAttr>:$operand_layouts,
     OptionalAttr<VHLO_AnyAttr>:$result_layouts
   );
-  let results = (outs Variadic<VHLO_AnyType>);
+  let results = (outs Variadic<VHLO_AnyType>:$results);
 }
 
+// TODO(#1187): api_version is different between VHLO and the StableHLO spec:
+// in VHLO it's an enum, in the spec it's an si32.
+// TODO(#629): operand_layouts/result_layouts are not part of the spec.
+// TODO(#740): output_operand_aliases is not part of the spec.
+// CustomCallOp has proven to be one of the trickiest ops to fully spec.
+// We're aiming to address all these todos by the release of StableHLO v1.0.
 def VHLO_CustomCallOpV2: VHLO_Op<"custom_call_v2", "0.4.0", "current"> {
   let arguments = (ins
     Variadic<VHLO_AnyType>:$inputs,
@@ -644,16 +392,12 @@ def VHLO_CustomCallOpV2: VHLO_Op<"custom_call_v2", "0.4.0", "current"> {
     OptionalAttr<VHLO_AnyAttr>:$result_layouts,
     OptionalAttr<VHLO_AnyAttr>:$output_operand_aliases
   );
-  let results = (outs Variadic<VHLO_AnyType>);
+  let results = (outs Variadic<VHLO_AnyType>:$results);
 }
 
-def VHLO_DotOpV1 : VHLO_Op<"dot", "0.3.0", "current"> {
-  let arguments = (
-    ins VHLO_AnyType:$lhs,
-    VHLO_AnyType:$rhs,
-    OptionalAttr<VHLO_AnyAttr>:$precision_config
-  );
-  let results = (outs VHLO_AnyType);
+def VHLO_DivOpV1 : VHLO_Op<"divide", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
+  let results = (outs VHLO_AnyType:$result);
 }
 
 def VHLO_DotGeneralOpV1 : VHLO_Op<"dot_general", "0.3.0", "current"> {
@@ -663,24 +407,130 @@ def VHLO_DotGeneralOpV1 : VHLO_Op<"dot_general", "0.3.0", "current"> {
     VHLO_AnyAttr:$dot_dimension_numbers,
     OptionalAttr<VHLO_AnyAttr>:$precision_config
   );
-  let results = (outs VHLO_AnyType);
+  let results = (outs VHLO_AnyType:$result);
 }
 
+// TODO(#3): DotOp is not part of the StableHLO spec.
+// This operation is on its way out of StableHLO, so it is not included in
+// the StableHLO specification.
+def VHLO_DotOpV1 : VHLO_Op<"dot", "0.3.0", "current"> {
+  let arguments = (
+    ins VHLO_AnyType:$lhs,
+    VHLO_AnyType:$rhs,
+    OptionalAttr<VHLO_AnyAttr>:$precision_config
+  );
+  let results = (outs VHLO_AnyType:$result);
+}
+
+// TODO(#8): DynamicBroadcastInDimOp is not part of the StableHLO spec.
+// This operation is a work in progress, so it is not yet included in
+// the StableHLO specification.
+def VHLO_DynamicBroadcastInDimOpV1 : VHLO_Op<"dynamic_broadcast_in_dim", "0.3.0", "current"> {
+  let arguments = (ins
+    VHLO_AnyType:$operand,
+    VHLO_AnyType:$output_dimensions,
+    VHLO_AnyAttr:$broadcast_dimensions,
+    OptionalAttr<VHLO_AnyAttr>:$known_expanding_dimensions,
+    OptionalAttr<VHLO_AnyAttr>:$known_nonexpanding_dimensions
+  );
+  let results = (outs VHLO_AnyType:$result);
+}
+
+// TODO(#8): DynamicConvOp is not part of the StableHLO spec.
+// This operation is a work in progress, so it is not yet included in
+// the StableHLO specification.
+def VHLO_DynamicConvOpV1 : VHLO_Op<"dynamic_conv", "0.3.0", "current"> {
+  let arguments = !con(
+    (ins
+       VHLO_AnyType:$lhs,
+       VHLO_AnyType:$rhs,
+       VHLO_AnyType:$d_padding),
+    VHLO_ConvolutionAttributesV1.attributes);
+  let results = (outs VHLO_AnyType:$result);
+}
+
+// TODO(#8): DynamicGatherOp is not part of the StableHLO spec.
+// This operation is a work in progress, so it is not yet included in
+// the StableHLO specification.
+def VHLO_DynamicGatherOpV1 : VHLO_Op<"dynamic_gather", "0.3.0", "current"> {
+  let arguments = (ins
+    VHLO_AnyType:$operand,
+    VHLO_AnyType:$start_indices,
+    VHLO_AnyType:$slice_sizes,
+    VHLO_AnyAttr:$dimension_numbers,
+    OptionalAttr<VHLO_AnyAttr>:$indices_are_sorted
+  );
+  let results = (outs VHLO_AnyType:$result);
+}
+
+// TODO(#8): DynamicIotaOp is not part of the StableHLO spec.
+// This operation is a work in progress, so it is not yet included in
+// the StableHLO specification.
+def VHLO_DynamicIotaOpV1 : VHLO_Op<"dynamic_iota", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$output_shape, VHLO_AnyAttr:$iota_dimension);
+  let results = (outs VHLO_AnyType:$result);
+}
+
+// TODO(#8): DynamicPadOp is not part of the StableHLO spec.
+// This operation is a work in progress, so it is not yet included in
+// the StableHLO specification.
+def VHLO_DynamicPadOpV1 : VHLO_Op<"dynamic_pad", "0.3.0", "current"> {
+  let arguments = (ins
+    VHLO_AnyType:$operand,
+    VHLO_AnyType:$padding_value,
+    VHLO_AnyType:$edge_padding_low,
+    VHLO_AnyType:$edge_padding_high,
+    VHLO_AnyType:$interior_padding
+  );
+  let results = (outs VHLO_AnyType:$result);
+}
+
+// TODO(#8): DynamicReshapeOp is not part of the StableHLO spec.
+// This operation is a work in progress, so it is not yet included in
+// the StableHLO specification.
+def VHLO_DynamicReshapeOpV1 : VHLO_Op<"dynamic_reshape", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$operand, VHLO_AnyType:$output_shape);
+  let results = (outs VHLO_AnyType:$result);
+}
+
+def VHLO_DynamicSliceOpV1 : VHLO_Op<"dynamic_slice", "0.3.0", "current"> {
+  let arguments = (ins
+    VHLO_AnyType:$operand,
+    Variadic<VHLO_AnyType>:$start_indices,
+    VHLO_AnyAttr:$slice_sizes
+  );
+  let results = (outs VHLO_AnyType:$result);
+}
+
+def VHLO_DynamicUpdateSliceOpV1 : VHLO_Op<"dynamic_update_slice", "0.3.0", "current"> {
+  let arguments = (ins
+    VHLO_AnyType:$operand,
+    VHLO_AnyType:$update,
+    Variadic<VHLO_AnyType>:$start_indices
+  );
+  let results = (outs VHLO_AnyType:$result);
+}
+
+// TODO(#3): EinsumOp is not part of the StableHLO spec.
+// This operation is on its way out of StableHLO, so it is not included in
+// the StableHLO specification.
 def VHLO_EinsumOpV1 : VHLO_Op<"einsum", "0.3.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$lhs,
     VHLO_AnyType:$rhs,
     VHLO_AnyAttr:$einsum_config
   );
-  let results = (outs VHLO_AnyType);
+  let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_UnaryEinsumOpV1 : VHLO_Op<"unary_einsum", "0.3.0", "current"> {
-  let arguments = (ins
-    VHLO_AnyType:$operand,
-    VHLO_AnyAttr:$einsum_config
-  );
-  let results = (outs VHLO_AnyType);
+def VHLO_Expm1OpV1 : VHLO_Op<"exponential_minus_one", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$operand);
+  let results = (outs VHLO_AnyType:$result);
+}
+
+def VHLO_ExpOpV1 : VHLO_Op<"exponential", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$operand);
+  let results = (outs VHLO_AnyType:$result);
 }
 
 def VHLO_FftOpV1 : VHLO_Op<"fft", "0.3.0", "current"> {
@@ -689,7 +539,26 @@ def VHLO_FftOpV1 : VHLO_Op<"fft", "0.3.0", "current"> {
     VHLO_AnyAttr:$fft_type,
     VHLO_AnyAttr:$fft_length
   );
-  let results = (outs VHLO_AnyType);
+  let results = (outs VHLO_AnyType:$result);
+}
+
+def VHLO_FloorOpV1 : VHLO_Op<"floor", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$operand);
+  let results = (outs VHLO_AnyType:$result);
+}
+
+// TODO(#425): FuncOp is not part of the StableHLO spec.
+// We're planning to look into it as part of the work on speccing
+// Module/Func/Call/Return ops in StableHLO.
+def VHLO_FuncOpV1 : VHLO_Op<"func", "0.3.0", "current"> {
+  let arguments = (ins
+    VHLO_AnyAttr:$sym_name,
+    VHLO_AnyAttr:$function_type,
+    OptionalAttr<VHLO_AnyAttr>:$sym_visibility,
+    OptionalAttr<VHLO_AnyAttr>:$arg_attrs,
+    OptionalAttr<VHLO_AnyAttr>:$res_attrs);
+  let regions = (region VHLO_AnyRegion:$body);
+  let assemblyFormat = "custom<FunctionBody>($sym_name, $body, $function_type) attr-dict";
 }
 
 def VHLO_GatherOpV1 : VHLO_Op<"gather", "0.3.0", "current"> {
@@ -700,7 +569,7 @@ def VHLO_GatherOpV1 : VHLO_Op<"gather", "0.3.0", "current"> {
     VHLO_AnyAttr:$slice_sizes,
     OptionalAttr<VHLO_AnyAttr>:$indices_are_sorted
   );
-  let results = (outs VHLO_AnyType);
+  let results = (outs VHLO_AnyType:$result);
 }
 
 def VHLO_GetDimensionSizeOpV1 : VHLO_Op<"get_dimension_size", "0.3.0", "current"> {
@@ -708,7 +577,66 @@ def VHLO_GetDimensionSizeOpV1 : VHLO_Op<"get_dimension_size", "0.3.0", "current"
     VHLO_AnyType:$operand,
     VHLO_AnyAttr:$dimension
   );
-  let results = (outs VHLO_AnyType);
+  let results = (outs VHLO_AnyType:$result);
+}
+
+def VHLO_GetTupleElementOpV1 : VHLO_Op<"get_tuple_element", "0.3.0", "current"> {
+  let arguments = (ins
+    VHLO_AnyType:$operand,
+    VHLO_AnyAttr:$index
+  );
+  let results = (outs VHLO_AnyType:$result);
+}
+
+def VHLO_IfOpV1 : VHLO_Op<"if", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$pred);
+  let regions = (region
+    VHLO_AnyRegion:$true_branch,
+    VHLO_AnyRegion:$false_branch
+  );
+  let results = (outs Variadic<VHLO_AnyType>:$results);
+}
+
+def VHLO_ImagOpV1 : VHLO_Op<"imag", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$operand);
+  let results = (outs VHLO_AnyType:$result);
+}
+
+// TODO(#629): layout is not part of the StableHLO spec.
+// The notion of layouts is a work in progress, so it is not yet included in
+// the StableHLO specification.
+def VHLO_InfeedOpV1 : VHLO_Op<"infeed", "0.3.0", "current"> {
+  let arguments = (ins
+    VHLO_AnyType:$token,
+    VHLO_AnyAttr:$infeed_config,
+    OptionalAttr<VHLO_AnyAttr>:$layout
+  );
+  let results = (outs Variadic<VHLO_AnyType>:$results);
+}
+
+def VHLO_IotaOpV1 : VHLO_Op<"iota", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyAttr:$iota_dimension);
+  let results = (outs VHLO_AnyType:$output);
+}
+
+def VHLO_IsFiniteOpV1 : VHLO_Op<"is_finite", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$x);
+  let results = (outs VHLO_AnyType:$y);
+}
+
+def VHLO_Log1pOpV1 : VHLO_Op<"log_plus_one", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$operand);
+  let results = (outs VHLO_AnyType:$result);
+}
+
+def VHLO_LogisticOpV1 : VHLO_Op<"logistic", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$operand);
+  let results = (outs VHLO_AnyType:$result);
+}
+
+def VHLO_LogOpV1 : VHLO_Op<"log", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$operand);
+  let results = (outs VHLO_AnyType:$result);
 }
 
 def VHLO_MapOpV1 : VHLO_Op<"map", "0.3.0", "current"> {
@@ -717,77 +645,52 @@ def VHLO_MapOpV1 : VHLO_Op<"map", "0.3.0", "current"> {
     VHLO_AnyAttr:$dimensions
   );
   let regions = (region VHLO_AnyRegion:$computation);
-  let results = (outs VHLO_AnyType);
+  let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_ReshapeOpV1 : VHLO_Op<"reshape", "0.3.0", "current"> {
+def VHLO_MaxOpV1 : VHLO_Op<"maximum", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
+  let results = (outs VHLO_AnyType:$result);
+}
+
+def VHLO_MinOpV1 : VHLO_Op<"minimum", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
+  let results = (outs VHLO_AnyType:$result);
+}
+
+def VHLO_MulOpV1 : VHLO_Op<"multiply", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
+  let results = (outs VHLO_AnyType:$result);
+}
+
+def VHLO_NegOpV1 : VHLO_Op<"negate", "0.3.0", "current"> {
   let arguments = (ins VHLO_AnyType:$operand);
-  let results = (outs VHLO_AnyType);
-}
-
-def VHLO_DynamicReshapeOpV1 : VHLO_Op<"dynamic_reshape", "0.3.0", "current"> {
-  let arguments = (ins VHLO_AnyType:$operand, VHLO_AnyType:$output_shape);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_ScatterOpV1 : VHLO_Op<"scatter", "0.3.0", "current", [SameVariadicOperandSize]> {
-  let arguments = (ins
-    Variadic<VHLO_AnyType>:$inputs,
-    VHLO_AnyType:$scatter_indices,
-    Variadic<VHLO_AnyType>:$updates,
-    VHLO_AnyAttr:$scatter_dimension_numbers,
-    OptionalAttr<VHLO_AnyAttr>:$indices_are_sorted,
-    OptionalAttr<VHLO_AnyAttr>:$unique_indices
-  );
-  let regions = (region VHLO_AnyRegion:$update_computation);
-  let results = (outs Variadic<VHLO_AnyType>);
-}
-
-def VHLO_SelectOpV1 : VHLO_Op<"select", "0.3.0", "current"> {
-  let arguments = (ins
-    VHLO_AnyType:$pred,
-    VHLO_AnyType:$on_true,
-    VHLO_AnyType:$on_false
-  );
+def VHLO_NotOpV1 : VHLO_Op<"not", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$operand);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_SelectAndScatterOpV1 : VHLO_Op<"select_and_scatter", "0.3.0", "current"> {
-  let arguments = (ins
-    VHLO_AnyType:$operand,
-    VHLO_AnyType:$source,
-    VHLO_AnyType:$init_value,
-    OptionalAttr<VHLO_AnyAttr>:$window_dimensions,
-    OptionalAttr<VHLO_AnyAttr>:$window_strides,
-    OptionalAttr<VHLO_AnyAttr>:$padding
-  );
-  let regions = (region VHLO_AnyRegion:$select, VHLO_AnyRegion:$scatter);
-  let results = (outs VHLO_AnyType);
+def VHLO_OptimizationBarrierOpV1 : VHLO_Op<"optimization_barrier", "0.3.0", "current"> {
+  let arguments = (ins Variadic<VHLO_AnyType>:$operand);
+  let results = (outs Variadic<VHLO_AnyType>:$result);
 }
 
-def VHLO_SetDimensionSizeOpV1 : VHLO_Op<"set_dimension_size", "0.3.0", "current"> {
-  let arguments = (ins
-    VHLO_AnyType:$operand,
-    VHLO_AnyType:$size,
-    VHLO_AnyAttr:$dimension
-  );
-  let results = (outs VHLO_AnyType);
+def VHLO_OrOpV1 : VHLO_Op<"or", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
+  let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_SortOpV1 : VHLO_Op<"sort", "0.3.0", "current"> {
+// TODO(#629): layout is not part of the StableHLO spec.
+// The notion of layouts is a work in progress, so it is not yet included in
+// the StableHLO specification.
+def VHLO_OutfeedOpV1 : VHLO_Op<"outfeed", "0.3.0", "current"> {
   let arguments = (ins
     Variadic<VHLO_AnyType>:$inputs,
-    OptionalAttr<VHLO_AnyAttr>:$dimension,
-    OptionalAttr<VHLO_AnyAttr>:$is_stable
-  );
-  let regions = (region VHLO_AnyRegion:$comparator);
-  let results = (outs Variadic<VHLO_AnyType>);
-}
-
-def VHLO_ReverseOpV1 : VHLO_Op<"reverse", "0.3.0", "current"> {
-  let arguments = (ins
-    VHLO_AnyType:$operand,
-    VHLO_AnyAttr:$dimensions
+    VHLO_AnyType:$token,
+    VHLO_AnyAttr:$outfeed_config
   );
   let results = (outs VHLO_AnyType:$result);
 }
@@ -800,34 +703,79 @@ def VHLO_PadOpV1 : VHLO_Op<"pad", "0.3.0", "current"> {
     VHLO_AnyAttr:$edge_padding_high,
     VHLO_AnyAttr:$interior_padding
   );
-  let results = (outs VHLO_AnyType);
+  let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_TraceOpV1 : VHLO_Op<"trace", "0.3.0", "current"> {
+def VHLO_PartitionIdOpV1 : VHLO_Op<"partition_id", "0.4.0", "current"> {
+  let results = (outs VHLO_AnyType:$result);
+}
+
+def VHLO_PopulationCountOpV1 : VHLO_Op<"popcnt", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$operand);
+  let results = (outs VHLO_AnyType:$result);
+}
+
+def VHLO_PowOpV1 : VHLO_Op<"power", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
+  let results = (outs VHLO_AnyType:$result);
+}
+
+// TODO(#8): RealDynamicSliceOp is not part of the StableHLO spec.
+// This operation is a work in progress, so it is not yet included in
+// the StableHLO specification.
+def VHLO_RealDynamicSliceOpV1 : VHLO_Op<"real_dynamic_slice", "0.3.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$operand,
-    VHLO_AnyAttr:$tag
+    VHLO_AnyType:$start_indices,
+    VHLO_AnyType:$limit_indices,
+    VHLO_AnyType:$strides
   );
+  let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_TransposeOpV1 : VHLO_Op<"transpose", "0.3.0", "current"> {
+def VHLO_RealOpV1 : VHLO_Op<"real", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$operand);
+  let results = (outs VHLO_AnyType:$result);
+}
+
+def VHLO_RecvOpV1 : VHLO_Op<"recv", "0.3.0", "current"> {
+  let arguments = (ins
+    VHLO_AnyType:$token,
+    VHLO_AnyAttr:$channel_handle,
+    OptionalAttr<VHLO_AnyAttr>:$is_host_transfer
+  );
+  let results = (outs Variadic<VHLO_AnyType>:$results);
+}
+
+def VHLO_ReduceOpV1 : VHLO_Op<"reduce", "0.3.0", "current", [SameVariadicOperandSize]> {
+  let arguments = (ins
+    Variadic<VHLO_AnyType>:$inputs,
+    Variadic<VHLO_AnyType>:$init_values,
+    VHLO_AnyAttr:$dimensions
+  );
+  let regions = (region VHLO_AnyRegion:$body);
+  let results = (outs Variadic<VHLO_AnyType>:$results);
+}
+
+def VHLO_ReducePrecisionOpV1 : VHLO_Op<"reduce_precision", "0.3.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$operand,
-    VHLO_AnyAttr:$permutation
+    VHLO_AnyAttr:$exponent_bits,
+    VHLO_AnyAttr:$mantissa_bits
   );
-  let results = (outs VHLO_AnyType);
+  let results = (outs VHLO_AnyType:$output);
 }
 
-def VHLO_TriangularSolveOpV1 : VHLO_Op<"triangular_solve", "0.3.0", "current"> {
+def VHLO_ReduceScatterOpV1 : VHLO_Op<"reduce_scatter", "0.3.0", "current"> {
   let arguments = (ins
-    VHLO_AnyType:$a,
-    VHLO_AnyType:$b,
-    VHLO_AnyAttr:$left_side,
-    VHLO_AnyAttr:$lower,
-    VHLO_AnyAttr:$unit_diagonal,
-    VHLO_AnyAttr:$transpose_a
+    VHLO_AnyType:$operand,
+    VHLO_AnyAttr:$scatter_dimension,
+    VHLO_AnyAttr:$replica_groups,
+    OptionalAttr<VHLO_AnyAttr>:$channel_handle,
+    OptionalAttr<VHLO_AnyAttr>:$use_global_device_ids
   );
-  let results = (outs VHLO_AnyType);
+  let regions = (region VHLO_AnyRegion:$computation);
+  let results = (outs VHLO_AnyType:$result);
 }
 
 def VHLO_ReduceWindowOpV1 : VHLO_Op<"reduce_window", "0.3.0", "current", [SameVariadicOperandSize]> {
@@ -840,35 +788,35 @@ def VHLO_ReduceWindowOpV1 : VHLO_Op<"reduce_window", "0.3.0", "current", [SameVa
     OptionalAttr<VHLO_AnyAttr>:$window_dilations,
     OptionalAttr<VHLO_AnyAttr>:$padding
   );
-  let results = (outs Variadic<VHLO_AnyType>);
   let regions = (region VHLO_AnyRegion:$body);
+  let results = (outs Variadic<VHLO_AnyType>:$results);
 }
 
-def VHLO_TorchIndexSelectOpV1 : VHLO_Op<"torch_index_select", "0.3.0", "current"> {
+def VHLO_RemOpV1 : VHLO_Op<"remainder", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
+  let results = (outs VHLO_AnyType:$result);
+}
+
+def VHLO_ReplicaIdOpV1 : VHLO_Op<"replica_id", "0.3.0", "current"> {
+  let results = (outs VHLO_AnyType:$result);
+}
+
+def VHLO_ReshapeOpV1 : VHLO_Op<"reshape", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$operand);
+  let results = (outs VHLO_AnyType:$result);
+}
+
+// TODO(#425): ReturnOp is not part of the StableHLO spec.
+// We're planning to look into it as part of the work on speccing
+// Module/Func/Call/Return ops in StableHLO.
+def VHLO_ReturnOpV1 : VHLO_Op<"return", "0.3.0", "current", [Terminator]> {
+  let arguments = (ins Variadic<VHLO_AnyType>:$results);
+}
+
+def VHLO_ReverseOpV1 : VHLO_Op<"reverse", "0.3.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$operand,
-    VHLO_AnyType:$index,
-    VHLO_AnyAttr:$dim,
-    VHLO_AnyAttr:$batch_dims
-  );
-  let results = (outs VHLO_AnyType);
-}
-
-def VHLO_OptimizationBarrierOpV1 : VHLO_Op<"optimization_barrier", "0.3.0", "current"> {
-  let arguments = (ins Variadic<VHLO_AnyType>:$operand);
-  let results = (outs Variadic<VHLO_AnyType>:$result);
-}
-
-//===----------------------------------------------------------------------===//
-// VHLO RNG Operators.
-//===----------------------------------------------------------------------===//
-
-def VHLO_RngOpV1 : VHLO_Op<"rng", "0.3.0", "current"> {
-  let arguments = (ins
-    VHLO_AnyType:$a,
-    VHLO_AnyType:$b,
-    VHLO_AnyType:$shape,
-    VHLO_AnyAttr:$rng_distribution
+    VHLO_AnyAttr:$dimensions
   );
   let results = (outs VHLO_AnyType:$result);
 }
@@ -884,91 +832,229 @@ def VHLO_RngBitGeneratorOpV1 : VHLO_Op<"rng_bit_generator", "0.3.0", "current"> 
   );
 }
 
-// Quantize Ops
-def VHLO_UniformQuantizeOpV1 : VHLO_Op<"uniform_quantize", "0.3.0", "current"> {
+def VHLO_RngOpV1 : VHLO_Op<"rng", "0.3.0", "current"> {
+  let arguments = (ins
+    VHLO_AnyType:$a,
+    VHLO_AnyType:$b,
+    VHLO_AnyType:$shape,
+    VHLO_AnyAttr:$rng_distribution
+  );
+  let results = (outs VHLO_AnyType:$result);
+}
+
+def VHLO_RoundNearestEvenOpV1 : VHLO_Op<"round_nearest_even", "0.3.0", "current"> {
   let arguments = (ins VHLO_AnyType:$operand);
   let results = (outs VHLO_AnyType:$result);
 }
 
+def VHLO_RoundOpV1 : VHLO_Op<"round_nearest_afz", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$operand);
+  let results = (outs VHLO_AnyType:$result);
+}
+
+def VHLO_RsqrtOpV1 : VHLO_Op<"rsqrt", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$operand);
+  let results = (outs VHLO_AnyType:$result);
+}
+
+def VHLO_ScatterOpV1 : VHLO_Op<"scatter", "0.3.0", "current", [SameVariadicOperandSize]> {
+  let arguments = (ins
+    Variadic<VHLO_AnyType>:$inputs,
+    VHLO_AnyType:$scatter_indices,
+    Variadic<VHLO_AnyType>:$updates,
+    VHLO_AnyAttr:$scatter_dimension_numbers,
+    OptionalAttr<VHLO_AnyAttr>:$indices_are_sorted,
+    OptionalAttr<VHLO_AnyAttr>:$unique_indices
+  );
+  let regions = (region VHLO_AnyRegion:$update_computation);
+  let results = (outs Variadic<VHLO_AnyType>:$results);
+}
+
+def VHLO_SelectAndScatterOpV1 : VHLO_Op<"select_and_scatter", "0.3.0", "current"> {
+  let arguments = (ins
+    VHLO_AnyType:$operand,
+    VHLO_AnyType:$source,
+    VHLO_AnyType:$init_value,
+    OptionalAttr<VHLO_AnyAttr>:$window_dimensions,
+    OptionalAttr<VHLO_AnyAttr>:$window_strides,
+    OptionalAttr<VHLO_AnyAttr>:$padding
+  );
+  let regions = (region VHLO_AnyRegion:$select, VHLO_AnyRegion:$scatter);
+  let results = (outs VHLO_AnyType:$result);
+}
+
+def VHLO_SelectOpV1 : VHLO_Op<"select", "0.3.0", "current"> {
+  let arguments = (ins
+    VHLO_AnyType:$pred,
+    VHLO_AnyType:$on_true,
+    VHLO_AnyType:$on_false
+  );
+  let results = (outs VHLO_AnyType:$result);
+}
+
+def VHLO_SendOpV1 : VHLO_Op<"send", "0.3.0", "current"> {
+  let arguments = (ins
+    Variadic<VHLO_AnyType>:$inputs,
+    VHLO_AnyType:$token,
+    VHLO_AnyAttr:$channel_handle,
+    OptionalAttr<VHLO_AnyAttr>:$is_host_transfer
+  );
+  let results = (outs VHLO_AnyType:$result);
+}
+
+def VHLO_SetDimensionSizeOpV1 : VHLO_Op<"set_dimension_size", "0.3.0", "current"> {
+  let arguments = (ins
+    VHLO_AnyType:$operand,
+    VHLO_AnyType:$size,
+    VHLO_AnyAttr:$dimension
+  );
+  let results = (outs VHLO_AnyType:$result);
+}
+
+def VHLO_ShiftLeftOpV1 : VHLO_Op<"shift_left", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
+  let results = (outs VHLO_AnyType:$result);
+}
+
+def VHLO_ShiftRightArithmeticOpV1 : VHLO_Op<"shift_right_arithmetic", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
+  let results = (outs VHLO_AnyType:$result);
+}
+
+def VHLO_ShiftRightLogicalOpV1 : VHLO_Op<"shift_right_logical", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
+  let results = (outs VHLO_AnyType:$result);
+}
+
+def VHLO_SignOpV1 : VHLO_Op<"sign", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$operand);
+  let results = (outs VHLO_AnyType:$result);
+}
+
+def VHLO_SineOpV1 : VHLO_Op<"sine", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$operand);
+  let results = (outs VHLO_AnyType:$result);
+}
+
+def VHLO_SliceOpV1 : VHLO_Op<"slice", "0.3.0", "current"> {
+  let arguments = (ins
+    VHLO_AnyType:$operand,
+    VHLO_AnyAttr:$start_indices,
+    VHLO_AnyAttr:$limit_indices,
+    VHLO_AnyAttr:$strides
+  );
+  let results = (outs VHLO_AnyType:$result);
+}
+
+def VHLO_SortOpV1 : VHLO_Op<"sort", "0.3.0", "current"> {
+  let arguments = (ins
+    Variadic<VHLO_AnyType>:$inputs,
+    OptionalAttr<VHLO_AnyAttr>:$dimension,
+    OptionalAttr<VHLO_AnyAttr>:$is_stable
+  );
+  let regions = (region VHLO_AnyRegion:$comparator);
+  let results = (outs Variadic<VHLO_AnyType>:$results);
+}
+
+def VHLO_SqrtOpV1 : VHLO_Op<"sqrt", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$operand);
+  let results = (outs VHLO_AnyType:$result);
+}
+
+def VHLO_SubtractOpV1 : VHLO_Op<"subtract", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
+  let results = (outs VHLO_AnyType:$result);
+}
+
+def VHLO_TanhOpV1 : VHLO_Op<"tanh", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$operand);
+  let results = (outs VHLO_AnyType:$result);
+}
+
+// TODO(#3): TorchIndexSelectOp is not part of the StableHLO spec.
+// This operation is on its way out of StableHLO, so it is not included in
+// the StableHLO specification.
+def VHLO_TorchIndexSelectOpV1 : VHLO_Op<"torch_index_select", "0.3.0", "current"> {
+  let arguments = (ins
+    VHLO_AnyType:$operand,
+    VHLO_AnyType:$index,
+    VHLO_AnyAttr:$dim,
+    VHLO_AnyAttr:$batch_dims
+  );
+  let results = (outs VHLO_AnyType:$result);
+}
+
+// TODO(#3): TraceOp is not part of the StableHLO spec.
+// This operation is on its way out of StableHLO, so it is not included in
+// the StableHLO specification.
+def VHLO_TraceOpV1 : VHLO_Op<"trace", "0.3.0", "current"> {
+  let arguments = (ins
+    VHLO_AnyType:$operand,
+    VHLO_AnyAttr:$tag
+  );
+}
+
+def VHLO_TransposeOpV1 : VHLO_Op<"transpose", "0.3.0", "current"> {
+  let arguments = (ins
+    VHLO_AnyType:$operand,
+    VHLO_AnyAttr:$permutation
+  );
+  let results = (outs VHLO_AnyType:$result);
+}
+
+def VHLO_TriangularSolveOpV1 : VHLO_Op<"triangular_solve", "0.3.0", "current"> {
+  let arguments = (ins
+    VHLO_AnyType:$a,
+    VHLO_AnyType:$b,
+    VHLO_AnyAttr:$left_side,
+    VHLO_AnyAttr:$lower,
+    VHLO_AnyAttr:$unit_diagonal,
+    VHLO_AnyAttr:$transpose_a
+  );
+  let results = (outs VHLO_AnyType:$result);
+}
+
+def VHLO_TupleOpV1 : VHLO_Op<"tuple", "0.3.0", "current"> {
+  let arguments = (ins Variadic<VHLO_AnyType>:$val);
+  let results = (outs VHLO_AnyType:$result);
+}
+
+// TODO(#3): UnaryEinsumOp is not part of the StableHLO spec.
+// This operation is on its way out of StableHLO, so it is not included in
+// the StableHLO specification.
+def VHLO_UnaryEinsumOpV1 : VHLO_Op<"unary_einsum", "0.3.0", "current"> {
+  let arguments = (ins
+    VHLO_AnyType:$operand,
+    VHLO_AnyAttr:$einsum_config
+  );
+  let results = (outs VHLO_AnyType:$result);
+}
+
+// TODO(#588): UniformDequantizeOp is not part of the StableHLO spec.
+// This operation is a work in progress, so it is not yet included in
+// the StableHLO specification.
 def VHLO_UniformDequantizeOpV1 : VHLO_Op<"uniform_dequantize", "0.3.0", "current"> {
   let arguments = (ins VHLO_AnyType:$operand);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_ReducePrecisionOpV1 : VHLO_Op<"reduce_precision", "0.3.0", "current"> {
-  let arguments = (ins
-    VHLO_AnyType:$operand,
-    VHLO_AnyAttr:$exponent_bits,
-    VHLO_AnyAttr:$mantissa_bits
-  );
-  let results = (outs VHLO_AnyType:$output);
-}
-
-def VHLO_RealDynamicSliceOpV1 : VHLO_Op<"real_dynamic_slice", "0.3.0", "current"> {
-  let arguments = (ins
-    VHLO_AnyType:$operand,
-    VHLO_AnyType:$start_indices,
-    VHLO_AnyType:$limit_indices,
-    VHLO_AnyType:$strides
-  );
+// TODO(#588): UniformQuantizeOp is not part of the StableHLO spec.
+// This operation is a work in progress, so it is not yet included in
+// the StableHLO specification.
+def VHLO_UniformQuantizeOpV1 : VHLO_Op<"uniform_quantize", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$operand);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_DynamicPadOpV1 : VHLO_Op<"dynamic_pad", "0.3.0", "current"> {
-  let arguments = (ins
-    VHLO_AnyType:$operand,
-    VHLO_AnyType:$padding_value,
-    VHLO_AnyType:$edge_padding_low,
-    VHLO_AnyType:$edge_padding_high,
-    VHLO_AnyType:$interior_padding
-  );
+def VHLO_WhileOpV1 : VHLO_Op<"while", "0.3.0", "current"> {
+  let arguments = (ins Variadic<VHLO_AnyType>:$operand);
+  let regions = (region VHLO_AnyRegion:$cond, VHLO_AnyRegion:$body);
+  let results = (outs Variadic<VHLO_AnyType>:$results);
+}
+
+def VHLO_XorOpV1 : VHLO_Op<"xor", "0.3.0", "current"> {
+  let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
   let results = (outs VHLO_AnyType:$result);
-}
-
-def VHLO_DynamicGatherOpV1 : VHLO_Op<"dynamic_gather", "0.3.0", "current"> {
-  let arguments = (ins
-    VHLO_AnyType:$operand,
-    VHLO_AnyType:$start_indices,
-    VHLO_AnyType:$slice_sizes,
-    VHLO_AnyAttr:$dimension_numbers,
-    OptionalAttr<VHLO_AnyAttr>:$indices_are_sorted
-  );
-  let results = (outs VHLO_AnyType);
-}
-
-def VHLO_DynamicConvOpV1 : VHLO_Op<"dynamic_conv", "0.3.0", "current"> {
-  let arguments = !con(
-    (ins
-       VHLO_AnyType:$lhs,
-       VHLO_AnyType:$rhs,
-       VHLO_AnyType:$d_padding),
-    VHLO_ConvolutionAttributesV1.attributes);
-  let results = (outs VHLO_AnyType);
-}
-
-def VHLO_ComputeReshapeShapeOpV1 : VHLO_Op<"compute_reshape_shape", "0.3.0", "current"> {
-  let arguments = (ins VHLO_AnyType:$num_elements, VHLO_AnyType:$dynamic_shape);
-  let results = (outs VHLO_AnyType:$result);
-}
-
-def VHLO_CstrReshapableOpV1 : VHLO_Op<"cstr_reshapable", "0.3.0", "current"> {
-  let results = (outs VHLO_AnyType:$result);
-  let arguments = (ins VHLO_AnyType:$num_elements, VHLO_AnyType:$dynamic_shape);
-}
-
-def VHLO_FuncOpV1 : VHLO_Op<"func", "0.3.0", "current"> {
-  let arguments = (ins VHLO_AnyAttr:$sym_name,
-                       VHLO_AnyAttr:$function_type,
-                       OptionalAttr<VHLO_AnyAttr>:$sym_visibility,
-                       OptionalAttr<VHLO_AnyAttr>:$arg_attrs,
-                       OptionalAttr<VHLO_AnyAttr>:$res_attrs);
-  let regions = (region VHLO_AnyRegion:$body);
-  let assemblyFormat = "custom<FunctionBody>($sym_name, $body, $function_type) attr-dict";
-}
-
-def VHLO_CallOpV1 : VHLO_Op<"call", "0.3.0", "current"> {
-  let arguments = (ins VHLO_AnyAttr:$callee, Variadic<VHLO_AnyType>:$operands);
-  let results = (outs Variadic<VHLO_AnyType>);
 }
 
 #endif // STABLEHLO_DIALECT_STABLEHLO_OPS

--- a/stablehlo/integrations/python/tests/vhlo.py
+++ b/stablehlo/integrations/python/tests/vhlo.py
@@ -31,7 +31,7 @@ def run(f):
 def test_parse():
   asm = """
     vhlo.func @main() -> () {
-      vhlo.return 
+      "vhlo.return"() : () -> ()
     }
   """
   ir.Module.parse(asm)

--- a/stablehlo/tests/vhlo_to_version_attrtype_invalid.mlir
+++ b/stablehlo/tests/vhlo_to_version_attrtype_invalid.mlir
@@ -12,7 +12,7 @@
 // expected-error @+1 {{failed to legalize operation 'vhlo.func' that was explicitly marked illegal}}
 vhlo.func @illegal_type_tensor_element(%arg0: !vhlo.tensor<4x16x!vhlo.f8E5M2>) -> () {
   %0 = "vhlo.add"(%arg0, %arg0) : (!vhlo.tensor<4x16x!vhlo.f8E5M2>, !vhlo.tensor<4x16x!vhlo.f8E5M2>) -> !vhlo.tensor<4x16x!vhlo.f8E5M2>
-  vhlo.return
+  "vhlo.return"() : () -> ()
 }
 
 // -----
@@ -20,7 +20,7 @@ vhlo.func @illegal_type_tensor_element(%arg0: !vhlo.tensor<4x16x!vhlo.f8E5M2>) -
 // expected-error @+1 {{failed to legalize operation 'vhlo.func' that was explicitly marked illegal}}
 vhlo.func @illegal_type_unranked_tensor_element(%arg0: !vhlo.unranked_tensor<!vhlo.f8E4M3FN>) -> () {
   %0 = "vhlo.add"(%arg0, %arg0) : (!vhlo.unranked_tensor<!vhlo.f8E4M3FN>, !vhlo.unranked_tensor<!vhlo.f8E4M3FN>) -> !vhlo.unranked_tensor<!vhlo.f8E4M3FN>
-  vhlo.return
+  "vhlo.return"() : () -> ()
 }
 
 // -----
@@ -28,21 +28,21 @@ vhlo.func @illegal_type_unranked_tensor_element(%arg0: !vhlo.unranked_tensor<!vh
 // expected-error @+1 {{failed to legalize operation 'vhlo.func' that was explicitly marked illegal}}
 vhlo.func @illegal_type_complex_element(%arg0: !vhlo.tensor<4x16x!vhlo.complex<!vhlo.f8E5M2>>) -> () {
   %0 = "vhlo.add"(%arg0, %arg0) : (!vhlo.tensor<4x16x!vhlo.complex<!vhlo.f8E5M2>>, !vhlo.tensor<4x16x!vhlo.complex<!vhlo.f8E5M2>>) -> !vhlo.tensor<4x16x!vhlo.complex<!vhlo.f8E5M2>>
-  vhlo.return
+  "vhlo.return"() : () -> ()
 }
 
 // -----
 
 // expected-error @+1 {{failed to legalize operation 'vhlo.func' that was explicitly marked illegal}}
 vhlo.func @illegal_type_function(%arg0: !vhlo.f8E4M3FN) -> () {
-  vhlo.return
+  "vhlo.return"() : () -> ()
 }
 
 // -----
 
 // expected-error @+1 {{failed to legalize operation 'vhlo.func' that was explicitly marked illegal}}
 vhlo.func @illegal_type_function_output() -> (!vhlo.f8E4M3FN) {
-  vhlo.return
+  "vhlo.return"() : () -> ()
 }
 
 // -----
@@ -50,7 +50,7 @@ vhlo.func @illegal_type_function_output() -> (!vhlo.f8E4M3FN) {
 // expected-error @+1 {{failed to legalize operation 'vhlo.func' that was explicitly marked illegal}}
 vhlo.func @illegal_type_tuple_element(%arg0: !vhlo.tuple<!vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f8E5M2>>) -> () {
   %0 = "vhlo.get_tuple_element"(%arg0) {index = #vhlo.integer<0 : i32>} : (!vhlo.tuple<!vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f8E5M2>>) -> !vhlo.tensor<!vhlo.f32>
-  vhlo.return
+  "vhlo.return"() : () -> ()
 }
 
 // -----
@@ -58,7 +58,7 @@ vhlo.func @illegal_type_tuple_element(%arg0: !vhlo.tuple<!vhlo.tensor<!vhlo.f32>
 vhlo.func @illegal_type_quantized_storage(%arg0: !vhlo.tensor<!vhlo.f32>) -> () {
   // expected-error @+1 {{failed to legalize operation 'vhlo.uniform_quantize' that was explicitly marked illegal}}
   %0 = "vhlo.uniform_quantize"(%arg0) : (!vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.quant<!vhlo.f8E4M3FN:!vhlo.f32, 3.400000e+01:16, -128:127, 1>>
-  vhlo.return
+  "vhlo.return"() : () -> ()
 }
 
 // -----
@@ -66,7 +66,7 @@ vhlo.func @illegal_type_quantized_storage(%arg0: !vhlo.tensor<!vhlo.f32>) -> () 
 vhlo.func @illegal_type_quantized_expressed(%arg0: !vhlo.tensor<!vhlo.f32>) -> () {
   // expected-error @+1 {{failed to legalize operation 'vhlo.uniform_quantize' that was explicitly marked illegal}}
   %0 = "vhlo.uniform_quantize"(%arg0) : (!vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.quant<!vhlo.i8:!vhlo.f8E5M2, 3.400000e+01:16, -128:127, 1>>
-  vhlo.return
+  "vhlo.return"() : () -> ()
 }
 
 // -----
@@ -79,7 +79,7 @@ vhlo.func @illegal_attr_array_element(%arg0: !vhlo.tensor<!vhlo.f32>) -> !vhlo.t
     call_target_name = #vhlo.string<"foo">,
     called_computations = #vhlo.array<[#vhlo.float< 1.0 : !vhlo.f8E4M3FN>]>
   } : (!vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
-  vhlo.return %0 : !vhlo.tensor<!vhlo.f32>
+  "vhlo.return"(%0) : (!vhlo.tensor<!vhlo.f32>) -> ()
 }
 
 // -----
@@ -91,7 +91,7 @@ vhlo.func @illegal_attr_float(%arg0: !vhlo.tensor<16x16x16x16x!vhlo.f32>, %arg1:
     epsilon = #vhlo.float<1.000000e-03 : !vhlo.f8E4M3FN>,
     feature_index = #vhlo.integer<0 : i64>
   } : (!vhlo.tensor<16x16x16x16x!vhlo.f32>, !vhlo.tensor<16x!vhlo.f32>, !vhlo.tensor<16x!vhlo.f32>, !vhlo.tensor<16x!vhlo.f32>, !vhlo.tensor<16x!vhlo.f32>) -> !vhlo.tensor<16x16x16x16x!vhlo.f32>
-  vhlo.return %0 : !vhlo.tensor<16x16x16x16x!vhlo.f32>
+  "vhlo.return"(%0) : (!vhlo.tensor<16x16x16x16x!vhlo.f32>) -> ()
 }
 // This simulates version validation if a new attr is used in a dictionary.
 
@@ -106,12 +106,12 @@ vhlo.func @illegal_attr_symbolref(%arg0: !vhlo.tensor<!vhlo.f32>) -> !vhlo.tenso
     call_target_name = #vhlo.string<"foo">,
     called_computations = #vhlo.array<[#vhlo.sym<#vhlo.float<1.0 : !vhlo.f8E4M3FN>>]>
   } : (!vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
-  vhlo.return %0 : !vhlo.tensor<!vhlo.f32>
+  "vhlo.return"(%0) : (!vhlo.tensor<!vhlo.f32>) -> ()
 }
 
 // -----
 
 // expected-error @+1 {{failed to legalize operation 'vhlo.func' that was explicitly marked illegal}}
 vhlo.func @illegal_attr_type(%arg0: !vhlo.tensor<16x16x16x16x!vhlo.f32>) -> () {
-  vhlo.return
+  "vhlo.return"() : () -> ()
 } {arg_attrs = #vhlo.array<[#vhlo.dict<{#vhlo.string<"stablehlo.self"> = #vhlo.type<!vhlo.f8E4M3FN>}>]>}

--- a/stablehlo/tests/vhlo_to_version_upgrade.mlir
+++ b/stablehlo/tests/vhlo_to_version_upgrade.mlir
@@ -10,7 +10,7 @@ vhlo.func @all_to_all_to_v2(%arg0: !vhlo.tensor<4x16x!vhlo.f32>) -> !vhlo.tensor
     split_count = #vhlo.integer<4 : i64>,
     replica_groups = #vhlo.dense<dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>>
   } : (!vhlo.tensor<4x16x!vhlo.f32>) -> !vhlo.tensor<16x4x!vhlo.f32>
-  vhlo.return %0 : !vhlo.tensor<16x4x!vhlo.f32>
+  "vhlo.return"(%0) : (!vhlo.tensor<16x4x!vhlo.f32>) -> ()
 }
 
 // CHECK-LABEL: @all_gather_to_v2
@@ -21,7 +21,7 @@ vhlo.func @all_gather_to_v2(%arg0: !vhlo.tensor<16x8x!vhlo.f32>) -> !vhlo.tensor
     channel_handle = #vhlo.channel_handle<handle = 0, type = 0>,
     replica_groups = #vhlo.dense<dense<[[0], [1]]> : tensor<2x1xi64>>
   } : (!vhlo.tensor<16x8x!vhlo.f32>) -> !vhlo.tensor<16x16x!vhlo.f32>
-  vhlo.return %0 : !vhlo.tensor<16x16x!vhlo.f32>
+  "vhlo.return"(%0) : (!vhlo.tensor<16x16x!vhlo.f32>) -> ()
 }
 
 // CHECK-LABEL: @collective_permute_to_v2
@@ -30,7 +30,7 @@ vhlo.func @collective_permute_to_v2(%arg0: !vhlo.tensor<16x8x!vhlo.f32>) -> !vhl
   %0 = "vhlo.collective_permute"(%arg0) {
     source_target_pairs = #vhlo.dense<dense<[[0, 1], [1, 2], [2, 3]]> : tensor<3x2xi64>>
   } : (!vhlo.tensor<16x8x!vhlo.f32>) -> !vhlo.tensor<16x8x!vhlo.f32>
-  vhlo.return %0 : !vhlo.tensor<16x8x!vhlo.f32>
+  "vhlo.return"(%0) : (!vhlo.tensor<16x8x!vhlo.f32>) -> ()
 }
 
 // CHECK-LABEL: @custom_call_to_v2
@@ -40,5 +40,5 @@ vhlo.func @custom_call_to_v2(%arg0: !vhlo.tensor<2x!vhlo.i1>) -> !vhlo.tensor<2x
     backend_config = #vhlo.string<"">,
     call_target_name = #vhlo.string<"foo">
   } : (!vhlo.tensor<2x!vhlo.i1>) -> !vhlo.tensor<2x!vhlo.i1>
-  vhlo.return %0 : !vhlo.tensor<2x!vhlo.i1>
+  "vhlo.return"(%0) : (!vhlo.tensor<2x!vhlo.i1>) -> ()
 }


### PR DESCRIPTION
Our design principle for VHLO ops has been radical minimalism, and this
PR further streamlines operation definitions:
  1) Sorts all ops alphabetically.
  2) Removes the stray assemblyFormat from ReturnOp.
  3) Spells out VHLO op design principles in a comment in VhloOps.td.
  4) Updates the description of VhloDialect.td to align with the
     design principles.

Using the results of streamlining (the part where all ops got sorted
alphabetically), I completed an audit of VhloOps.td, aligning it as
much as possible with the StableHLO spec and leaving todos where that
is not yet possible.

During that audit, I discovered minor discrepancies between the spec
and StableHLO/VHLO ODS, involving names and order of program elements,
and fixed them as well.