### PR TITLE
Replace all uses of llvm_unreachable with llvm::report_fatal_error

### DIFF
--- a/stablehlo/dialect/Base.cpp
+++ b/stablehlo/dialect/Base.cpp
@@ -133,7 +133,7 @@ TensorType getSameShapeTensorType(TensorType tensorType, Type elementType) {
                                  rankedTensorTy.getEncoding());
   if (auto unrankedTensorTy = tensorType.dyn_cast<UnrankedTensorType>())
     return UnrankedTensorType::get(elementType);
-  llvm_unreachable("unhandled type");
+  llvm::report_fatal_error("unsupported type");
 }
 
 // createRealType takes a tensor type that may have complex elements and

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -2741,7 +2741,7 @@ char nonSpatialDimToString(NonSpatialDim dim) {
     case KOFeature:
       return 'o';
   }
-  llvm_unreachable("Unknown NonSpatialDim");
+  llvm::report_fatal_error("unsupported NonSpatialDim");
 }
 }  // namespace
 
@@ -3290,7 +3290,7 @@ ParseResult parseWindowAttributes(OpAsmParser& parser,
         } else if (attributeName == "rhs_dilate") {
           rhsDilation = attr;
         } else {
-          llvm_unreachable("Unexpected attribute name");
+          llvm::report_fatal_error("unsupported attribute name");
         }
       }
     }

--- a/stablehlo/dialect/Version.cpp
+++ b/stablehlo/dialect/Version.cpp
@@ -28,7 +28,7 @@ namespace {
 static int64_t parseNumber(llvm::StringRef numRef) {
   int64_t num;
   if (numRef.getAsInteger(/*radix=*/10, num)) {
-    llvm_unreachable("failed to parse version number");
+    llvm::report_fatal_error("failed to parse version number");
   }
   return num;
 }

--- a/stablehlo/dialect/VhloAttrs.td
+++ b/stablehlo/dialect/VhloAttrs.td
@@ -44,13 +44,13 @@ class VHLO_AttrDef<string name, string minVersion, string maxVersion>
   let extraClassDeclaration = [{
     mlir::vhlo::Version getMinVersion() {
       auto version = mlir::vhlo::Version::fromString("}] #  minVersion # [{");
-      if (failed(version)) llvm_unreachable("invalid version }] # minVersion # [{ in }] # name # [{");
+      if (failed(version)) llvm::report_fatal_error("invalid version }] # minVersion # [{ in }] # name # [{");
       return *version;
     }
     mlir::vhlo::Version getMaxVersion() {
       if (!strcmp("}] # maxVersion # [{", "current")) return Version::getCurrentVersion();
       auto version = mlir::vhlo::Version::fromString("}] #  maxVersion # [{");
-      if (failed(version)) llvm_unreachable("invalid version }] # maxVersion # [{ in }] # name # [{");
+      if (failed(version)) llvm::report_fatal_error("invalid version }] # maxVersion # [{ in }] # name # [{");
       return *version;
     }
   }];

--- a/stablehlo/dialect/VhloBytecode.cpp
+++ b/stablehlo/dialect/VhloBytecode.cpp
@@ -1065,7 +1065,7 @@ const llvm::fltSemantics &getFloatSemantics(Type type) {
   if (type.isa<Float16V1Type>()) return APFloat::IEEEhalf();
   if (type.isa<Float32V1Type>()) return APFloat::IEEEsingle();
   if (type.isa<Float64V1Type>()) return APFloat::IEEEdouble();
-  llvm_unreachable("non-floating point type used");
+  llvm::report_fatal_error("unsupported floating-point type");
 }
 }  // namespace
 
@@ -1117,7 +1117,7 @@ unsigned getBitWidthForIntegerType(Type type) {
   if (type.isa<IntegerI16V1Type>() || type.isa<IntegerUI16V1Type>()) return 16;
   if (type.isa<IntegerI32V1Type>() || type.isa<IntegerUI32V1Type>()) return 32;
   if (type.isa<IntegerI64V1Type>() || type.isa<IntegerUI64V1Type>()) return 64;
-  llvm_unreachable("unsupported integer type used in IntegerV1Attr");
+  llvm::report_fatal_error("unsupported integer type");
 }
 }  // namespace
 

--- a/stablehlo/dialect/VhloOps.td
+++ b/stablehlo/dialect/VhloOps.td
@@ -49,13 +49,13 @@ class VHLO_Op<string mnemonic, string minVersion, string maxVersion, list<Trait>
   let extraClassDefinition = [{
     mlir::vhlo::Version $cppClass::getMinVersion() {
       auto version = mlir::vhlo::Version::fromString("}] #  minVersion # [{");
-      if (failed(version)) llvm_unreachable("invalid version }] # minVersion # [{ in }] # mnemonic # [{");
+      if (failed(version)) llvm::report_fatal_error("invalid version }] # minVersion # [{ in }] # mnemonic # [{");
       return *version;
     }
     mlir::vhlo::Version $cppClass::getMaxVersion() {
       if (!strcmp("}] # maxVersion # [{", "current")) return Version::getCurrentVersion();
       auto version = mlir::vhlo::Version::fromString("}] #  maxVersion # [{");
-      if (failed(version)) llvm_unreachable("invalid version }] # maxVersion # [{ in }] # mnemonic # [{");
+      if (failed(version)) llvm::report_fatal_error("invalid version }] # maxVersion # [{ in }] # mnemonic # [{");
       return *version;
     }
   }];

--- a/stablehlo/dialect/VhloTypes.td
+++ b/stablehlo/dialect/VhloTypes.td
@@ -44,13 +44,13 @@ class VHLO_TypeDef<string cppName, string name, string minVersion, string maxVer
   let extraClassDeclaration = [{
     mlir::vhlo::Version getMinVersion() {
       auto version = mlir::vhlo::Version::fromString("}] #  minVersion # [{");
-      if (failed(version)) llvm_unreachable("invalid version }] # minVersion # [{ in }] # name # [{");
+      if (failed(version)) llvm::report_fatal_error("invalid version }] # minVersion # [{ in }] # name # [{");
       return *version;
     }
     mlir::vhlo::Version getMaxVersion() {
       if (!strcmp("}] # maxVersion # [{", "current")) return Version::getCurrentVersion();
       auto version = mlir::vhlo::Version::fromString("}] #  maxVersion # [{");
-      if (failed(version)) llvm_unreachable("invalid version }] # maxVersion # [{ in }] # name # [{");
+      if (failed(version)) llvm::report_fatal_error("invalid version }] # maxVersion # [{ in }] # name # [{");
       return *version;
     }
   }];

--- a/stablehlo/integrations/c/ChloAttributes.cpp
+++ b/stablehlo/integrations/c/ChloAttributes.cpp
@@ -27,7 +27,7 @@ MlirAttribute chloComparisonDirectionAttrGet(MlirContext ctx,
                                              MlirStringRef value) {
   std::optional<mlir::chlo::ComparisonDirection> comparisonDirection =
       mlir::chlo::symbolizeComparisonDirection(unwrap(value));
-  if (!comparisonDirection) llvm_unreachable("Invalid value.");
+  if (!comparisonDirection) llvm::report_fatal_error("Invalid value.");
   return wrap(mlir::chlo::ComparisonDirectionAttr::get(
       unwrap(ctx), comparisonDirection.value()));
 }
@@ -48,7 +48,7 @@ MlirStringRef chloComparisonDirectionAttrGetValue(MlirAttribute attr) {
 MlirAttribute chloComparisonTypeAttrGet(MlirContext ctx, MlirStringRef value) {
   std::optional<mlir::chlo::ComparisonType> comparisonType =
       mlir::chlo::symbolizeComparisonType(unwrap(value));
-  if (!comparisonType) llvm_unreachable("Invalid value.");
+  if (!comparisonType) llvm::report_fatal_error("Invalid value.");
   return wrap(
       mlir::chlo::ComparisonTypeAttr::get(unwrap(ctx), comparisonType.value()));
 }

--- a/stablehlo/integrations/c/StablehloAttributes.cpp
+++ b/stablehlo/integrations/c/StablehloAttributes.cpp
@@ -411,7 +411,7 @@ MlirAttribute stablehloComparisonDirectionAttrGet(MlirContext ctx,
                                                   MlirStringRef value) {
   std::optional<mlir::stablehlo::ComparisonDirection> comparisonDirection =
       mlir::stablehlo::symbolizeComparisonDirection(unwrap(value));
-  if (!comparisonDirection) llvm_unreachable("Invalid value.");
+  if (!comparisonDirection) llvm::report_fatal_error("Invalid value.");
   return wrap(mlir::stablehlo::ComparisonDirectionAttr::get(
       unwrap(ctx), comparisonDirection.value()));
 }
@@ -435,7 +435,7 @@ MlirAttribute stablehloComparisonTypeAttrGet(MlirContext ctx,
                                              MlirStringRef value) {
   std::optional<mlir::stablehlo::ComparisonType> comparisonType =
       mlir::stablehlo::symbolizeComparisonType(unwrap(value));
-  if (!comparisonType) llvm_unreachable("Invalid value.");
+  if (!comparisonType) llvm::report_fatal_error("Invalid value.");
   return wrap(mlir::stablehlo::ComparisonTypeAttr::get(unwrap(ctx),
                                                        comparisonType.value()));
 }
@@ -456,7 +456,7 @@ MlirStringRef stablehloComparisonTypeAttrGetValue(MlirAttribute attr) {
 MlirAttribute stablehloPrecisionAttrGet(MlirContext ctx, MlirStringRef value) {
   std::optional<mlir::stablehlo::Precision> precision =
       mlir::stablehlo::symbolizePrecision(unwrap(value));
-  if (!precision) llvm_unreachable("Invalid value.");
+  if (!precision) llvm::report_fatal_error("Invalid value.");
   return wrap(
       mlir::stablehlo::PrecisionAttr::get(unwrap(ctx), precision.value()));
 }
@@ -477,7 +477,7 @@ MlirStringRef stablehloPrecisionAttrGetValue(MlirAttribute attr) {
 MlirAttribute stablehloFftTypeAttrGet(MlirContext ctx, MlirStringRef value) {
   std::optional<mlir::stablehlo::FftType> fftType =
       mlir::stablehlo::symbolizeFftType(unwrap(value));
-  if (!fftType) llvm_unreachable("Invalid value.");
+  if (!fftType) llvm::report_fatal_error("Invalid value.");
   return wrap(mlir::stablehlo::FftTypeAttr::get(unwrap(ctx), fftType.value()));
 }
 
@@ -497,7 +497,7 @@ MlirStringRef stablehloFftTypeAttrGetValue(MlirAttribute attr) {
 MlirAttribute stablehloTransposeAttrGet(MlirContext ctx, MlirStringRef value) {
   std::optional<mlir::stablehlo::Transpose> transpose =
       mlir::stablehlo::symbolizeTranspose(unwrap(value));
-  if (!transpose) llvm_unreachable("Invalid value.");
+  if (!transpose) llvm::report_fatal_error("Invalid value.");
   return wrap(
       mlir::stablehlo::TransposeAttr::get(unwrap(ctx), transpose.value()));
 }
@@ -519,7 +519,7 @@ MlirAttribute stablehloRngDistributionAttrGet(MlirContext ctx,
                                               MlirStringRef value) {
   std::optional<mlir::stablehlo::RngDistribution> rngDistribution =
       mlir::stablehlo::symbolizeRngDistribution(unwrap(value));
-  if (!rngDistribution) llvm_unreachable("Invalid value.");
+  if (!rngDistribution) llvm::report_fatal_error("Invalid value.");
   return wrap(mlir::stablehlo::RngDistributionAttr::get(
       unwrap(ctx), rngDistribution.value()));
 }
@@ -541,7 +541,7 @@ MlirAttribute stablehloRngAlgorithmAttrGet(MlirContext ctx,
                                            MlirStringRef value) {
   std::optional<mlir::stablehlo::RngAlgorithm> rngAlgorithm =
       mlir::stablehlo::symbolizeRngAlgorithm(unwrap(value));
-  if (!rngAlgorithm) llvm_unreachable("Invalid value.");
+  if (!rngAlgorithm) llvm::report_fatal_error("Invalid value.");
   return wrap(mlir::stablehlo::RngAlgorithmAttr::get(unwrap(ctx),
                                                      rngAlgorithm.value()));
 }


### PR DESCRIPTION
See https://discourse.llvm.org/t/llvm-unreachable-is-widely-misused/60587 for motivation.