### PR TITLE
Audit VhloEnums.td

### DIFF
--- a/stablehlo/dialect/VhloEnums.td
+++ b/stablehlo/dialect/VhloEnums.td
@@ -17,112 +17,38 @@ limitations under the License.
 #ifndef STABLEHLO_DIALECT_VHLO_ENUMS
 #define STABLEHLO_DIALECT_VHLO_ENUMS
 
+include "mlir/IR/EnumAttr.td"
+include "mlir/IR/PatternBase.td"
 include "stablehlo/dialect/VhloBase.td"
 include "stablehlo/dialect/VhloAttrs.td"
 
-include "mlir/IR/EnumAttr.td"
-include "mlir/IR/PatternBase.td"
-
-//===----------------------------------------------------------------------===//
-// Enum Versioning
-//===----------------------------------------------------------------------===//
+class VHLO_I32EnumAttr<string name, list<I32EnumAttrCase> cases> :
+    I32EnumAttr<name, name, cases> {
+  let genSpecializedAttr = 0;
+  let cppNamespace = "::mlir::vhlo";
+}
 
 class VHLO_EnumAttr<EnumAttrInfo enumInfo, string name, string minVersion, string maxVersion>
   : EnumAttr<VHLO_Dialect, enumInfo, name, [VHLO_VersionedAttrInterface]> {
   let extraClassDeclaration = [{
     mlir::vhlo::Version getMinVersion() {
-      return *mlir::vhlo::Version::fromString("}] #  minVersion # [{");
+      auto version = mlir::vhlo::Version::fromString("}] #  minVersion # [{");
+      if (failed(version)) llvm::report_fatal_error("invalid version }] # minVersion # [{ in }] # name # [{");
+      return *version;
     }
     mlir::vhlo::Version getMaxVersion() {
       if (!strcmp("}] # maxVersion # [{", "current")) return Version::getCurrentVersion();
-      return *mlir::vhlo::Version::fromString("}] #  maxVersion # [{");
+      auto version = mlir::vhlo::Version::fromString("}] #  maxVersion # [{");
+      if (failed(version)) llvm::report_fatal_error("invalid version }] # maxVersion # [{ in }] # name # [{");
+      return *version;
     }
   }];
 }
 
 //===----------------------------------------------------------------------===//
-// Enumerations
+// ComparisonDirection
 //===----------------------------------------------------------------------===//
 
-// These mirror the XLA PrecisionConfig proto enum.
-def VHLO_PRECISION_DEFAULT : I32EnumAttrCase<"DEFAULT", 0>;
-def VHLO_PRECISION_HIGH    : I32EnumAttrCase<"HIGH", 1>;
-def VHLO_PRECISION_HIGHEST : I32EnumAttrCase<"HIGHEST", 2>;
-
-def VHLO_PrecisionV1 : I32EnumAttr<"PrecisionV1",
-    "XLA precision for an operand. Has backend specific meaning.",
-    [
-      VHLO_PRECISION_DEFAULT,
-      VHLO_PRECISION_HIGH,
-      VHLO_PRECISION_HIGHEST
-    ]> {
-  let genSpecializedAttr = 0;
-  let cppNamespace = "::mlir::vhlo";
-}
-
-def VHLO_PrecisionAttrV1 : VHLO_EnumAttr<VHLO_PrecisionV1, "precision", "0.3.0", "current">;
-
-// TODO(b/129153247) See if it's possible to also validate the size.
-def VHLO_PrecisionConfigAttrV1 :
-    OptionalAttr<
-          TypedArrayAttrBase<VHLO_PrecisionAttrV1, "Precision Config attribute">>;
-
-//===----------------------------------------------------------------------===//
-// Fast Fourier Transform Type enum definitions.
-//===----------------------------------------------------------------------===//
-
-// These mirror the XLA FftType proto enum.
-def VHLO_FFT_TYPE_FFT : I32EnumAttrCase<"FFT", 0>;
-def VHLO_FFT_TYPE_IFFT : I32EnumAttrCase<"IFFT", 1>;
-def VHLO_FFT_TYPE_RFFT : I32EnumAttrCase<"RFFT", 2>;
-def VHLO_FFT_TYPE_IRFFT : I32EnumAttrCase<"IRFFT", 3>;
-
-def VHLO_FftTypeV1 : I32EnumAttr<"FftTypeV1",
-    "XLA fast fourier transform type.",
-    [
-      VHLO_FFT_TYPE_FFT,
-      VHLO_FFT_TYPE_IFFT,
-      VHLO_FFT_TYPE_RFFT,
-      VHLO_FFT_TYPE_IRFFT
-    ]> {
-  let genSpecializedAttr = 0;
-  let cppNamespace = "::mlir::vhlo";
-}
-
-def VHLO_FftTypeAttrV1 : VHLO_EnumAttr<VHLO_FftTypeV1, "fft_type", "0.3.0", "current">;
-
-//===----------------------------------------------------------------------===//
-// Custom call enum definitions.
-//===----------------------------------------------------------------------===//
-
-def VHLO_CUSTOM_CALL_API_VERSION_UNSPECIFIED :
-    I32EnumAttrCase<"API_VERSION_UNSPECIFIED", 0>;
-def VHLO_CUSTOM_CALL_API_VERSION_ORIGINAL :
-    I32EnumAttrCase<"API_VERSION_ORIGINAL", 1>;
-def VHLO_CUSTOM_CALL_API_VERSION_STATUS_RETURNING :
-    I32EnumAttrCase<"API_VERSION_STATUS_RETURNING", 2>;
-def VHLO_CUSTOM_CALL_API_VERSION_STATUS_RETURNING_UNIFIED :
-    I32EnumAttrCase<"API_VERSION_STATUS_RETURNING_UNIFIED", 3>;
-
-def VHLO_CustomCallApiVersionV1 :
-    I32EnumAttr<"CustomCallApiVersionV1", "Custom call API version", [
-        VHLO_CUSTOM_CALL_API_VERSION_UNSPECIFIED,
-        VHLO_CUSTOM_CALL_API_VERSION_ORIGINAL,
-        VHLO_CUSTOM_CALL_API_VERSION_STATUS_RETURNING,
-        VHLO_CUSTOM_CALL_API_VERSION_STATUS_RETURNING_UNIFIED
-    ]> {
-  let genSpecializedAttr = 0;
-  let cppNamespace = "::mlir::vhlo";
-}
-
-def VHLO_CustomCallApiVersionAttrV1
-  : VHLO_EnumAttr<VHLO_CustomCallApiVersionV1, "api_version", "0.3.0", "current">;
-
-//===----------------------------------------------------------------------===//
-// Comparison op definitions.
-//===----------------------------------------------------------------------===//
-
-// These mirror the XLA ComparisonDirection enum.
 def VHLO_COMPARISON_DIRECTION_EQ : I32EnumAttrCase<"EQ", 0>;
 def VHLO_COMPARISON_DIRECTION_NE : I32EnumAttrCase<"NE", 1>;
 def VHLO_COMPARISON_DIRECTION_GE : I32EnumAttrCase<"GE", 2>;
@@ -130,99 +56,146 @@ def VHLO_COMPARISON_DIRECTION_GT : I32EnumAttrCase<"GT", 3>;
 def VHLO_COMPARISON_DIRECTION_LE : I32EnumAttrCase<"LE", 4>;
 def VHLO_COMPARISON_DIRECTION_LT : I32EnumAttrCase<"LT", 5>;
 
-def VHLO_ComparisonDirectionV1 : I32EnumAttr<"ComparisonDirectionV1",
-    "Which comparison operation to perform.",
-    [
-      VHLO_COMPARISON_DIRECTION_EQ,
-      VHLO_COMPARISON_DIRECTION_NE,
-      VHLO_COMPARISON_DIRECTION_GE,
-      VHLO_COMPARISON_DIRECTION_GT,
-      VHLO_COMPARISON_DIRECTION_LE,
-      VHLO_COMPARISON_DIRECTION_LT
-    ]> {
-  let genSpecializedAttr = 0;
-  let cppNamespace = "::mlir::vhlo";
-}
+def VHLO_ComparisonDirectionV1 : VHLO_I32EnumAttr<"ComparisonDirectionV1", [
+  VHLO_COMPARISON_DIRECTION_EQ,
+  VHLO_COMPARISON_DIRECTION_NE,
+  VHLO_COMPARISON_DIRECTION_GE,
+  VHLO_COMPARISON_DIRECTION_GT,
+  VHLO_COMPARISON_DIRECTION_LE,
+  VHLO_COMPARISON_DIRECTION_LT
+]> {}
 
 def VHLO_ComparisonDirectionAttrV1
   : VHLO_EnumAttr<VHLO_ComparisonDirectionV1, "comparison_direction", "0.3.0", "current">;
 
-def VHLO_DEFAULT_COMPARISON_TYPE : NativeCodeCall<"::mlir::vhlo::ComparisonTypeAttr()">;
+//===----------------------------------------------------------------------===//
+// ComparisonType
+//===----------------------------------------------------------------------===//
+
+// TODO(#1186): NOTYPE is not part of the StableHLO spec.
 def VHLO_COMPARISON_TYPE_NOTYPE : I32EnumAttrCase<"NOTYPE", 0>;
 def VHLO_COMPARISON_TYPE_FLOAT : I32EnumAttrCase<"FLOAT", 1>;
 def VHLO_COMPARISON_TYPE_FLOAT_TOTAL_ORDER : I32EnumAttrCase<"TOTALORDER", 2>;
 def VHLO_COMPARISON_TYPE_SIGNED : I32EnumAttrCase<"SIGNED", 3>;
 def VHLO_COMPARISON_TYPE_UNSIGNED : I32EnumAttrCase<"UNSIGNED", 4>;
 
-def VHLO_ComparisonTypeV1 : I32EnumAttr<"ComparisonTypeV1",
-    "Which comparison type to use.",
-    [
-      VHLO_COMPARISON_TYPE_NOTYPE,
-      VHLO_COMPARISON_TYPE_FLOAT,
-      VHLO_COMPARISON_TYPE_FLOAT_TOTAL_ORDER,
-      VHLO_COMPARISON_TYPE_SIGNED,
-      VHLO_COMPARISON_TYPE_UNSIGNED
-    ]> {
-  let genSpecializedAttr = 0;
-  let cppNamespace = "::mlir::vhlo";
-}
+def VHLO_ComparisonTypeV1 : VHLO_I32EnumAttr<"ComparisonTypeV1", [
+  VHLO_COMPARISON_TYPE_NOTYPE,
+  VHLO_COMPARISON_TYPE_FLOAT,
+  VHLO_COMPARISON_TYPE_FLOAT_TOTAL_ORDER,
+  VHLO_COMPARISON_TYPE_SIGNED,
+  VHLO_COMPARISON_TYPE_UNSIGNED
+]> {}
 
 def VHLO_ComparisonTypeAttrV1
   : VHLO_EnumAttr<VHLO_ComparisonTypeV1, "comparison_type", "0.3.0", "current">;
 
-// These mirror the XLA Transpose enum in Triangular Solve options.
-def VHLO_TRANSPOSE_INVALID : I32EnumAttrCase<"TRANSPOSE_INVALID", 0>;
-def VHLO_NO_TRANSPOSE : I32EnumAttrCase<"NO_TRANSPOSE", 1>;
-def VHLO_TRANSPOSE : I32EnumAttrCase<"TRANSPOSE", 2>;
-def VHLO_ADJOINT : I32EnumAttrCase<"ADJOINT", 3>;
+//===----------------------------------------------------------------------===//
+// CustomCallApiVersion
+//===----------------------------------------------------------------------===//
 
-def VHLO_TransposeV1 : I32EnumAttr<"TransposeV1",
-    "Transpose options",
-    [
-      VHLO_TRANSPOSE_INVALID,
-      VHLO_NO_TRANSPOSE,
-      VHLO_TRANSPOSE,
-      VHLO_ADJOINT
-    ]> {
-  let genSpecializedAttr = 0;
-  let cppNamespace = "::mlir::vhlo";
-}
+// TODO(#1187): CustomCallApiVersion is not part of the StableHLO spec.
+def VHLO_CUSTOM_CALL_API_VERSION_UNSPECIFIED : I32EnumAttrCase<"API_VERSION_UNSPECIFIED", 0>;
+def VHLO_CUSTOM_CALL_API_VERSION_ORIGINAL : I32EnumAttrCase<"API_VERSION_ORIGINAL", 1>;
+def VHLO_CUSTOM_CALL_API_VERSION_STATUS_RETURNING : I32EnumAttrCase<"API_VERSION_STATUS_RETURNING", 2>;
+def VHLO_CUSTOM_CALL_API_VERSION_STATUS_RETURNING_UNIFIED : I32EnumAttrCase<"API_VERSION_STATUS_RETURNING_UNIFIED", 3>;
 
-def VHLO_TransposeAttrV1
-  : VHLO_EnumAttr<VHLO_TransposeV1, "transpose", "0.3.0", "current">;
+def VHLO_CustomCallApiVersionV1 : VHLO_I32EnumAttr<"CustomCallApiVersionV1", [
+    VHLO_CUSTOM_CALL_API_VERSION_UNSPECIFIED,
+    VHLO_CUSTOM_CALL_API_VERSION_ORIGINAL,
+    VHLO_CUSTOM_CALL_API_VERSION_STATUS_RETURNING,
+    VHLO_CUSTOM_CALL_API_VERSION_STATUS_RETURNING_UNIFIED
+]> {}
 
-def VHLO_RNG_DISTRIBUTION_UNIFORM : I32EnumAttrCase<"UNIFORM", 1>;
-def VHLO_RNG_DISTRIBUTION_NORMAL : I32EnumAttrCase<"NORMAL", 2>;
+def VHLO_CustomCallApiVersionAttrV1
+  : VHLO_EnumAttr<VHLO_CustomCallApiVersionV1, "api_version", "0.3.0", "current">;
 
-def VHLO_RngDistributionV1 : I32EnumAttr<"RngDistributionV1",
-    "XLA PRNG distribution to be used.",
-    [
-      VHLO_RNG_DISTRIBUTION_UNIFORM,
-      VHLO_RNG_DISTRIBUTION_NORMAL
-    ]> {
-  let genSpecializedAttr = 0;
-  let cppNamespace = "::mlir::vhlo";
-}
+//===----------------------------------------------------------------------===//
+// FftType
+//===----------------------------------------------------------------------===//
 
-def VHLO_RngDistributionAttrV1
-  : VHLO_EnumAttr<VHLO_RngDistributionV1, "rng_distribution", "0.3.0", "current">;
+def VHLO_FFT_TYPE_FFT : I32EnumAttrCase<"FFT", 0>;
+def VHLO_FFT_TYPE_IFFT : I32EnumAttrCase<"IFFT", 1>;
+def VHLO_FFT_TYPE_RFFT : I32EnumAttrCase<"RFFT", 2>;
+def VHLO_FFT_TYPE_IRFFT : I32EnumAttrCase<"IRFFT", 3>;
+
+def VHLO_FftTypeV1 : VHLO_I32EnumAttr<"FftTypeV1", [
+  VHLO_FFT_TYPE_FFT,
+  VHLO_FFT_TYPE_IFFT,
+  VHLO_FFT_TYPE_RFFT,
+  VHLO_FFT_TYPE_IRFFT
+]> {}
+
+def VHLO_FftTypeAttrV1
+  : VHLO_EnumAttr<VHLO_FftTypeV1, "fft_type", "0.3.0", "current">;
+
+//===----------------------------------------------------------------------===//
+// Precision
+//===----------------------------------------------------------------------===//
+
+def VHLO_PRECISION_DEFAULT : I32EnumAttrCase<"DEFAULT", 0>;
+def VHLO_PRECISION_HIGH : I32EnumAttrCase<"HIGH", 1>;
+def VHLO_PRECISION_HIGHEST : I32EnumAttrCase<"HIGHEST", 2>;
+
+def VHLO_PrecisionV1 : VHLO_I32EnumAttr<"PrecisionV1", [
+  VHLO_PRECISION_DEFAULT,
+  VHLO_PRECISION_HIGH,
+  VHLO_PRECISION_HIGHEST
+]> {}
+
+def VHLO_PrecisionAttrV1
+  : VHLO_EnumAttr<VHLO_PrecisionV1, "precision", "0.3.0", "current">;
+
+//===----------------------------------------------------------------------===//
+// RngAlgorithm
+//===----------------------------------------------------------------------===//
 
 def VHLO_RNG_ALGORITHM_DEFAULT : I32EnumAttrCase<"DEFAULT", 0>;
 def VHLO_RNG_ALGORITHM_THREE_FRY : I32EnumAttrCase<"THREE_FRY", 1>;
 def VHLO_RNG_ALGORITHM_PHILOX : I32EnumAttrCase<"PHILOX", 2>;
 
-def VHLO_RngAlgorithmV1 : I32EnumAttr<"RngAlgorithmV1",
-    "XLA PRNG algorithm to be used.",
-    [
-      VHLO_RNG_ALGORITHM_DEFAULT,
-      VHLO_RNG_ALGORITHM_THREE_FRY,
-      VHLO_RNG_ALGORITHM_PHILOX
-    ]> {
-  let genSpecializedAttr = 0;
-  let cppNamespace = "::mlir::vhlo";
-}
+def VHLO_RngAlgorithmV1 : VHLO_I32EnumAttr<"RngAlgorithmV1", [
+  VHLO_RNG_ALGORITHM_DEFAULT,
+  VHLO_RNG_ALGORITHM_THREE_FRY,
+  VHLO_RNG_ALGORITHM_PHILOX
+]> {}
 
 def VHLO_RngAlgorithmAttrV1
   : VHLO_EnumAttr<VHLO_RngAlgorithmV1, "rng_algorithm", "0.3.0", "current">;
+
+//===----------------------------------------------------------------------===//
+// RngDistribution
+//===----------------------------------------------------------------------===//
+
+def VHLO_RNG_DISTRIBUTION_UNIFORM : I32EnumAttrCase<"UNIFORM", 1>;
+def VHLO_RNG_DISTRIBUTION_NORMAL : I32EnumAttrCase<"NORMAL", 2>;
+
+def VHLO_RngDistributionV1 : VHLO_I32EnumAttr<"RngDistributionV1", [
+  VHLO_RNG_DISTRIBUTION_UNIFORM,
+  VHLO_RNG_DISTRIBUTION_NORMAL
+]> {}
+
+def VHLO_RngDistributionAttrV1
+  : VHLO_EnumAttr<VHLO_RngDistributionV1, "rng_distribution", "0.3.0", "current">;
+
+//===----------------------------------------------------------------------===//
+// Transpose
+//===----------------------------------------------------------------------===//
+
+// TODO(#1186): TRANSPOSE_INVALID is not part of the StableHLO spec.
+def VHLO_TRANSPOSE_INVALID : I32EnumAttrCase<"TRANSPOSE_INVALID", 0>;
+def VHLO_NO_TRANSPOSE : I32EnumAttrCase<"NO_TRANSPOSE", 1>;
+def VHLO_TRANSPOSE : I32EnumAttrCase<"TRANSPOSE", 2>;
+def VHLO_ADJOINT : I32EnumAttrCase<"ADJOINT", 3>;
+
+def VHLO_TransposeV1 : VHLO_I32EnumAttr<"TransposeV1", [
+  VHLO_TRANSPOSE_INVALID,
+  VHLO_NO_TRANSPOSE,
+  VHLO_TRANSPOSE,
+  VHLO_ADJOINT
+]> {}
+
+def VHLO_TransposeAttrV1
+  : VHLO_EnumAttr<VHLO_TransposeV1, "transpose", "0.3.0", "current">;
 
 #endif // STABLEHLO_DIALECT_VHLO_ENUMS


### PR DESCRIPTION
As I was auditing the VHLO dialect for the correspondence with the spec, I figured I'd streamline the VhloEnums.td as follows:
  1) Order alphabetically.
  2) Factor out I32EnumAttr boilerplate into VHLO_I32EnumAttr and
     reformat to compress the code a little bit.
  3) Drop summaries from I32EnumAttrs (this is aligned with the notion
     of VHLO being a shallow dialect, e.g. we don't have them for ops).
  4) Removed a few unused definitions.

I've also noticed that getMinVersion/getMaxVersion implementations for VHLO_EnumAttr didn't have explicit error handling - probably this resulted from partially addressed feedback on one of the VHLO PRs? Anyway, I made these implementations consistent with similar VHLO code, using llvm::report_fatal_error instead of llvm_unreachable to forward port the corresponding PR in flight.