### PR TITLE
Audit VhloTypes.td

### DIFF
--- a/stablehlo/dialect/VhloBytecode.cpp
+++ b/stablehlo/dialect/VhloBytecode.cpp
@@ -240,105 +240,112 @@ enum AttributeCode {
 enum TypeCode {
   // TO ADD TYPE: Add an enum value with doc string for new type.
 
-  ///   TokenType {
+  ///   BooleanV1Type {
   ///   }
-  kTokenType = 0,
+  kBooleanV1Type = 0,
 
-  ///   BFloat16Type {
-  ///   }
-  kBFloat16Type = 1,
-
-  ///   ComplexType {
+  ///   ComplexV1Type {
   ///     elementType: Type
   ///   }
-  kComplexType = 2,
+  kComplexV1Type = 1,
 
-  ///   Float16Type {
+  ///   FloatBF16V1Type {
   ///   }
-  kFloat16Type = 3,
+  kFloatBF16V1Type = 2,
 
-  ///   Float32Type {
+  ///   FloatF16V1Type {
   ///   }
-  kFloat32Type = 4,
+  kFloatF16V1Type = 3,
 
-  ///   Float64Type {
+  ///   FloatF32V1Type {
   ///   }
-  kFloat64Type = 5,
+  kFloatF32V1Type = 4,
 
-  ///   FunctionType {
+  ///   FloatF64V1Type {
+  ///   }
+  kFloatF64V1Type = 5,
+
+  ///   FloatF8E4M3FNV1Type {
+  ///   }
+  kFloatF8E4M3FNV1Type = 6,
+
+  ///   FloatF8E5M2V1Type {
+  ///   }
+  kFloatF8E5M2V1Type = 7,
+
+  ///   FunctionV1Type {
   ///     inputs: Type[]
-  ///     results: Type[]
+  ///     outputs: Type[]
   ///   }
-  kFunctionType = 6,
+  kFunctionV1Type = 8,
 
-  ///   IntegerI1Type {
+  ///   IndexV1Type {
   ///   }
-  kIntegerI1Type = 7,
+  kIndexV1Type = 9,
 
-  ///   IntegerI4Type {
+  ///   IntegerSI4V1Type {
   ///   }
-  kIntegerI4Type = 8,
+  kIntegerSI4V1Type = 10,
 
-  ///   IntegerI8Type {
+  ///   IntegerSI8V1Type {
   ///   }
-  kIntegerI8Type = 9,
+  kIntegerSI8V1Type = 11,
 
-  ///   IntegerI16Type {
+  ///   IntegerSI16V1Type {
   ///   }
-  kIntegerI16Type = 10,
+  kIntegerSI16V1Type = 12,
 
-  ///   IntegerI32Type {
+  ///   IntegerSI32V1Type {
   ///   }
-  kIntegerI32Type = 11,
+  kIntegerSI32V1Type = 13,
 
-  ///   IntegerI64Type {
+  ///   IntegerSI64V1Type {
   ///   }
-  kIntegerI64Type = 12,
+  kIntegerSI64V1Type = 14,
 
-  ///   IntegerUI4Type {
+  ///   IntegerUI4V1Type {
   ///   }
-  kIntegerUI4Type = 13,
+  kIntegerUI4V1Type = 15,
 
-  ///   IntegerUI8Type {
+  ///   IntegerUI8V1Type {
   ///   }
-  kIntegerUI8Type = 14,
+  kIntegerUI8V1Type = 16,
 
-  ///   IntegerUI16Type {
+  ///   IntegerUI16V1Type {
   ///   }
-  kIntegerUI16Type = 15,
+  kIntegerUI16V1Type = 17,
 
-  ///   IntegerUI32Type {
+  ///   IntegerUI32V1Type {
   ///   }
-  kIntegerUI32Type = 16,
+  kIntegerUI32V1Type = 18,
 
-  ///   IntegerUI64Type {
+  ///   IntegerUI64V1Type {
   ///   }
-  kIntegerUI64Type = 17,
+  kIntegerUI64V1Type = 19,
 
-  ///   IndexType {
-  ///   }
-  kIndexType = 18,
-
-  ///   RankedTensorType {
-  ///     shape: svarint[]
-  ///     elementType: Type,
-  ///   }
-  kRankedTensorType = 19,
-
-  ///   RankedTensorTypeWithEncoding {
-  ///     encoding: Attribute
-  ///     shape: svarint[]
+  ///   RankedTensorV1Type {
+  ///     shape: svarint[],
   ///     elementType: Type
   ///   }
-  /// Variant of RankedTensorType with an encoding.
-  kRankedTensorTypeWithEncoding = 20,
+  kRankedTensorV1Type = 20,
 
-  ///   TupleType {
+  ///   RankedTensorV1TypeWithEncoding {
+  ///     encoding: Attribute,
+  ///     shape: svarint[],
+  ///     elementType: Type
+  ///   }
+  kRankedTensorV1TypeWithEncoding = 21,
+
+  ///   TokenV1Type {
+  ///   }
+  kTokenV1Type = 22,
+
+  ///   TupleV1Type {
   ///     elementTypes: Type[]
   ///   }
-  kTupleType = 21,
+  kTupleV1Type = 23,
 
-  ///   UniformQuantizedType {
+  ///   UniformQuantizedV1Type {
   ///     flags: varint
   ///     storageType: Type
   ///     expressedType: Type
@@ -347,24 +354,16 @@ enum TypeCode {
   ///     storageTypeMin: svarint
   ///     storageTypeMax: svarint
   ///   }
-  kUniformQuantizedType = 22,
+  kUniformQuantizedV1Type = 24,
 
-  ///   UnrankedTensorType {
+  ///   UnrankedTensorV1Type {
   ///     elementType: Type
   ///   }
-  kUnrankedTensorType = 23,
+  kUnrankedTensorV1Type = 25,
 
-  ///   WitnessType {
+  ///   WitnessV1Type {
   ///   }
-  kWitnessType = 24,
-
-  ///   Float8E4M3FN {
-  ///   }
-  kFloat8E4M3FN = 25,
-
-  ///   Float8E5M2 {
-  ///   }
-  kFloat8E5M2 = 26,
+  kWitnessV1Type = 26,
 };
 
 }  // namespace vhlo_encoding
@@ -484,27 +483,23 @@ class VhloBytecodeInterface : public BytecodeDialectInterface {
 
   // TO ADD TYPE: Include a read method for each type in VHLO
   // Ex: SomeType readSomeType(DialectBytecodeReader &reader) const;
+  ComplexV1Type readComplexV1Type(DialectBytecodeReader &reader) const;
+  FunctionV1Type readFunctionV1Type(DialectBytecodeReader &reader) const;
+  RankedTensorV1Type readRankedTensorV1Type(DialectBytecodeReader &reader,
+                                            bool hasEncoding) const;
   TokenV1Type readTokenV1Type(DialectBytecodeReader &reader) const;
+  TupleV1Type readTupleV1Type(DialectBytecodeReader &reader) const;
+  UniformQuantizedV1Type readUniformQuantizedV1Type(
+      DialectBytecodeReader &reader) const;
+  UnrankedTensorV1Type readUnrankedTensorV1Type(
+      DialectBytecodeReader &reader) const;
 
   // TO ADD TYPE: Include a write method for each type in VHLO
   // Ex: void write(SomeType attr, DialectBytecodeWriter &writer) const;
-  void write(TokenV1Type type, DialectBytecodeWriter &writer) const;
-
-  //===--------------------------------------------------------------------===//
-  // Forked Types
-  ComplexV1Type readComplexType(DialectBytecodeReader &reader) const;
-  FunctionV1Type readFunctionType(DialectBytecodeReader &reader) const;
-  RankedTensorV1Type readRankedTensorType(DialectBytecodeReader &reader,
-                                          bool hasEncoding) const;
-  TupleV1Type readTupleType(DialectBytecodeReader &reader) const;
-  UniformQuantizedV1Type readUniformQuantizedType(
-      DialectBytecodeReader &reader) const;
-  UnrankedTensorV1Type readUnrankedTensorType(
-      DialectBytecodeReader &reader) const;
-
   void write(ComplexV1Type type, DialectBytecodeWriter &writer) const;
   void write(FunctionV1Type type, DialectBytecodeWriter &writer) const;
   void write(RankedTensorV1Type type, DialectBytecodeWriter &writer) const;
+  void write(TokenV1Type type, DialectBytecodeWriter &writer) const;
   void write(TupleV1Type type, DialectBytecodeWriter &writer) const;
   void write(UniformQuantizedV1Type type, DialectBytecodeWriter &writer) const;
   void write(UnrankedTensorV1Type type, DialectBytecodeWriter &writer) const;
@@ -1036,12 +1031,12 @@ void VhloBytecodeInterface::write(DictionaryV1Attr attr,
 namespace {
 /// Returns the floating semantics for the given type.
 const llvm::fltSemantics &getFloatSemantics(Type type) {
-  if (type.isa<Float8E4M3FNV1Type>()) return APFloat::Float8E4M3FN();
-  if (type.isa<Float8E5M2V1Type>()) return APFloat::Float8E5M2();
-  if (type.isa<BFloat16V1Type>()) return APFloat::BFloat();
-  if (type.isa<Float16V1Type>()) return APFloat::IEEEhalf();
-  if (type.isa<Float32V1Type>()) return APFloat::IEEEsingle();
-  if (type.isa<Float64V1Type>()) return APFloat::IEEEdouble();
+  if (type.isa<FloatBF16V1Type>()) return APFloat::BFloat();
+  if (type.isa<FloatF16V1Type>()) return APFloat::IEEEhalf();
+  if (type.isa<FloatF32V1Type>()) return APFloat::IEEEsingle();
+  if (type.isa<FloatF64V1Type>()) return APFloat::IEEEdouble();
+  if (type.isa<FloatF8E4M3FNV1Type>()) return APFloat::Float8E4M3FN();
+  if (type.isa<FloatF8E5M2V1Type>()) return APFloat::Float8E5M2();
   llvm::report_fatal_error("unsupported floating-point type");
 }
 }  // namespace
@@ -1088,12 +1083,13 @@ void VhloBytecodeInterface::write(FlatSymbolRefV1Attr attr,
 
 namespace {
 unsigned getBitWidthForIntegerType(Type type) {
-  if (type.isa<IntegerI1V1Type>()) return 1;
-  if (type.isa<IntegerI4V1Type>() || type.isa<IntegerUI4V1Type>()) return 4;
-  if (type.isa<IntegerI8V1Type>() || type.isa<IntegerUI8V1Type>()) return 8;
-  if (type.isa<IntegerI16V1Type>() || type.isa<IntegerUI16V1Type>()) return 16;
-  if (type.isa<IntegerI32V1Type>() || type.isa<IntegerUI32V1Type>()) return 32;
-  if (type.isa<IntegerI64V1Type>() || type.isa<IntegerUI64V1Type>()) return 64;
+  // TODO: Remove BooleanV1Type from here once/if BooleanAttr lands.
+  if (type.isa<BooleanV1Type>()) return 1;
+  if (type.isa<IntegerSI4V1Type>() || type.isa<IntegerUI4V1Type>()) return 4;
+  if (type.isa<IntegerSI8V1Type>() || type.isa<IntegerUI8V1Type>()) return 8;
+  if (type.isa<IntegerSI16V1Type>() || type.isa<IntegerUI16V1Type>()) return 16;
+  if (type.isa<IntegerSI32V1Type>() || type.isa<IntegerUI32V1Type>()) return 32;
+  if (type.isa<IntegerSI64V1Type>() || type.isa<IntegerUI64V1Type>()) return 64;
   llvm::report_fatal_error("unsupported integer type");
 }
 }  // namespace
@@ -1189,60 +1185,59 @@ Type VhloBytecodeInterface::readType(DialectBytecodeReader &reader) const {
   if (failed(reader.readVarInt(code))) return Type();
 
   switch (code) {
-    case vhlo_encoding::kTokenType:
-      return readTokenV1Type(reader);
-    // Forked Types:
-    case vhlo_encoding::kBFloat16Type:
-      return BFloat16V1Type::get(getContext());
-    case vhlo_encoding::kComplexType:
-      return readComplexType(reader);
-    case vhlo_encoding::kFloat16Type:
-      return Float16V1Type::get(getContext());
-    case vhlo_encoding::kFloat32Type:
-      return Float32V1Type::get(getContext());
-    case vhlo_encoding::kFloat64Type:
-      return Float64V1Type::get(getContext());
-    case vhlo_encoding::kFloat8E5M2:
-      return Float8E5M2V1Type::get(getContext());
-    case vhlo_encoding::kFloat8E4M3FN:
-      return Float8E4M3FNV1Type::get(getContext());
-    case vhlo_encoding::kFunctionType:
-      return readFunctionType(reader);
-    case vhlo_encoding::kIndexType:
+    case vhlo_encoding::kBooleanV1Type:
+      return BooleanV1Type::get(getContext());
+    case vhlo_encoding::kComplexV1Type:
+      return readComplexV1Type(reader);
+    case vhlo_encoding::kFloatBF16V1Type:
+      return FloatBF16V1Type::get(getContext());
+    case vhlo_encoding::kFloatF16V1Type:
+      return FloatF16V1Type::get(getContext());
+    case vhlo_encoding::kFloatF32V1Type:
+      return FloatF32V1Type::get(getContext());
+    case vhlo_encoding::kFloatF64V1Type:
+      return FloatF64V1Type::get(getContext());
+    case vhlo_encoding::kFloatF8E5M2V1Type:
+      return FloatF8E5M2V1Type::get(getContext());
+    case vhlo_encoding::kFloatF8E4M3FNV1Type:
+      return FloatF8E4M3FNV1Type::get(getContext());
+    case vhlo_encoding::kFunctionV1Type:
+      return readFunctionV1Type(reader);
+    case vhlo_encoding::kIndexV1Type:
       return IndexV1Type::get(getContext());
-    case vhlo_encoding::kIntegerI1Type:
-      return IntegerI1V1Type::get(getContext());
-    case vhlo_encoding::kIntegerI4Type:
-      return IntegerI4V1Type::get(getContext());
-    case vhlo_encoding::kIntegerI8Type:
-      return IntegerI8V1Type::get(getContext());
-    case vhlo_encoding::kIntegerI16Type:
-      return IntegerI16V1Type::get(getContext());
-    case vhlo_encoding::kIntegerI32Type:
-      return IntegerI32V1Type::get(getContext());
-    case vhlo_encoding::kIntegerI64Type:
-      return IntegerI64V1Type::get(getContext());
-    case vhlo_encoding::kIntegerUI4Type:
+    case vhlo_encoding::kIntegerSI4V1Type:
+      return IntegerSI4V1Type::get(getContext());
+    case vhlo_encoding::kIntegerSI8V1Type:
+      return IntegerSI8V1Type::get(getContext());
+    case vhlo_encoding::kIntegerSI16V1Type:
+      return IntegerSI16V1Type::get(getContext());
+    case vhlo_encoding::kIntegerSI32V1Type:
+      return IntegerSI32V1Type::get(getContext());
+    case vhlo_encoding::kIntegerSI64V1Type:
+      return IntegerSI64V1Type::get(getContext());
+    case vhlo_encoding::kIntegerUI4V1Type:
       return IntegerUI4V1Type::get(getContext());
-    case vhlo_encoding::kIntegerUI8Type:
+    case vhlo_encoding::kIntegerUI8V1Type:
       return IntegerUI8V1Type::get(getContext());
-    case vhlo_encoding::kIntegerUI16Type:
+    case vhlo_encoding::kIntegerUI16V1Type:
       return IntegerUI16V1Type::get(getContext());
-    case vhlo_encoding::kIntegerUI32Type:
+    case vhlo_encoding::kIntegerUI32V1Type:
       return IntegerUI32V1Type::get(getContext());
-    case vhlo_encoding::kIntegerUI64Type:
+    case vhlo_encoding::kIntegerUI64V1Type:
       return IntegerUI64V1Type::get(getContext());
-    case vhlo_encoding::kRankedTensorType:
-      return readRankedTensorType(reader, /*hasEncoding=*/false);
-    case vhlo_encoding::kRankedTensorTypeWithEncoding:
-      return readRankedTensorType(reader, /*hasEncoding=*/true);
-    case vhlo_encoding::kTupleType:
-      return readTupleType(reader);
-    case vhlo_encoding::kUniformQuantizedType:
-      return readUniformQuantizedType(reader);
-    case vhlo_encoding::kUnrankedTensorType:
-      return readUnrankedTensorType(reader);
-    case vhlo_encoding::kWitnessType:
+    case vhlo_encoding::kRankedTensorV1Type:
+      return readRankedTensorV1Type(reader, /*hasEncoding=*/false);
+    case vhlo_encoding::kRankedTensorV1TypeWithEncoding:
+      return readRankedTensorV1Type(reader, /*hasEncoding=*/true);
+    case vhlo_encoding::kTokenV1Type:
+      return readTokenV1Type(reader);
+    case vhlo_encoding::kTupleV1Type:
+      return readTupleV1Type(reader);
+    case vhlo_encoding::kUniformQuantizedV1Type:
+      return readUniformQuantizedV1Type(reader);
+    case vhlo_encoding::kUnrankedTensorV1Type:
+      return readUnrankedTensorV1Type(reader);
+    case vhlo_encoding::kWitnessV1Type:
       return WitnessV1Type::get(getContext());
     default:
       reader.emitError() << "unknown vhlo type code: " << code;
@@ -1254,91 +1249,88 @@ Type VhloBytecodeInterface::readType(DialectBytecodeReader &reader) const {
 LogicalResult VhloBytecodeInterface::writeType(
     Type type, DialectBytecodeWriter &writer) const {
   return TypeSwitch<Type, LogicalResult>(type)
-      .Case<TokenV1Type>([&](auto type) {
+      .Case<ComplexV1Type, FunctionV1Type, RankedTensorV1Type, TokenV1Type,
+            TupleV1Type, UnrankedTensorV1Type, UniformQuantizedV1Type>(
+          [&](auto type) {
+            LOG_WRITE_CALL;
+            return write(type, writer), success();
+          })
+      .Case([&](BooleanV1Type) {
         LOG_WRITE_CALL;
-        write(type, writer);
-        return success();
+        return writer.writeVarInt(vhlo_encoding::kBooleanV1Type), success();
       })
-      .Case<ComplexV1Type, FunctionV1Type, RankedTensorV1Type, TupleV1Type,
-            UnrankedTensorV1Type, UniformQuantizedV1Type>([&](auto type) {
+      .Case([&](FloatBF16V1Type) {
         LOG_WRITE_CALL;
-        return write(type, writer), success();
+        return writer.writeVarInt(vhlo_encoding::kFloatBF16V1Type), success();
       })
-      .Case([&](BFloat16V1Type) {
+      .Case([&](FloatF16V1Type) {
         LOG_WRITE_CALL;
-        return writer.writeVarInt(vhlo_encoding::kBFloat16Type), success();
+        return writer.writeVarInt(vhlo_encoding::kFloatF16V1Type), success();
       })
-      .Case([&](Float16V1Type) {
+      .Case([&](FloatF32V1Type) {
         LOG_WRITE_CALL;
-        return writer.writeVarInt(vhlo_encoding::kFloat16Type), success();
+        return writer.writeVarInt(vhlo_encoding::kFloatF32V1Type), success();
       })
-      .Case([&](Float32V1Type) {
+      .Case([&](FloatF64V1Type) {
         LOG_WRITE_CALL;
-        return writer.writeVarInt(vhlo_encoding::kFloat32Type), success();
+        return writer.writeVarInt(vhlo_encoding::kFloatF64V1Type), success();
       })
-      .Case([&](Float64V1Type) {
+      .Case([&](FloatF8E4M3FNV1Type) {
         LOG_WRITE_CALL;
-        return writer.writeVarInt(vhlo_encoding::kFloat64Type), success();
+        return writer.writeVarInt(vhlo_encoding::kFloatF8E4M3FNV1Type),
+               success();
       })
-      .Case([&](Float8E4M3FNV1Type) {
+      .Case([&](FloatF8E5M2V1Type) {
         LOG_WRITE_CALL;
-        return writer.writeVarInt(vhlo_encoding::kFloat8E4M3FN), success();
-      })
-      .Case([&](Float8E5M2V1Type) {
-        LOG_WRITE_CALL;
-        return writer.writeVarInt(vhlo_encoding::kFloat8E5M2), success();
+        return writer.writeVarInt(vhlo_encoding::kFloatF8E5M2V1Type), success();
       })
       .Case([&](IndexV1Type) {
         LOG_WRITE_CALL;
-        return writer.writeVarInt(vhlo_encoding::kIndexType), success();
+        return writer.writeVarInt(vhlo_encoding::kIndexV1Type), success();
       })
-      .Case([&](IntegerI1V1Type) {
+      .Case([&](IntegerSI4V1Type) {
         LOG_WRITE_CALL;
-        return writer.writeVarInt(vhlo_encoding::kIntegerI1Type), success();
+        return writer.writeVarInt(vhlo_encoding::kIntegerSI4V1Type), success();
       })
-      .Case([&](IntegerI4V1Type) {
+      .Case([&](IntegerSI8V1Type) {
         LOG_WRITE_CALL;
-        return writer.writeVarInt(vhlo_encoding::kIntegerI4Type), success();
+        return writer.writeVarInt(vhlo_encoding::kIntegerSI8V1Type), success();
       })
-      .Case([&](IntegerI8V1Type) {
+      .Case([&](IntegerSI16V1Type) {
         LOG_WRITE_CALL;
-        return writer.writeVarInt(vhlo_encoding::kIntegerI8Type), success();
+        return writer.writeVarInt(vhlo_encoding::kIntegerSI16V1Type), success();
       })
-      .Case([&](IntegerI16V1Type) {
+      .Case([&](IntegerSI32V1Type) {
         LOG_WRITE_CALL;
-        return writer.writeVarInt(vhlo_encoding::kIntegerI16Type), success();
+        return writer.writeVarInt(vhlo_encoding::kIntegerSI32V1Type), success();
       })
-      .Case([&](IntegerI32V1Type) {
+      .Case([&](IntegerSI64V1Type) {
         LOG_WRITE_CALL;
-        return writer.writeVarInt(vhlo_encoding::kIntegerI32Type), success();
-      })
-      .Case([&](IntegerI64V1Type) {
-        LOG_WRITE_CALL;
-        return writer.writeVarInt(vhlo_encoding::kIntegerI64Type), success();
+        return writer.writeVarInt(vhlo_encoding::kIntegerSI64V1Type), success();
       })
       .Case([&](IntegerUI4V1Type) {
         LOG_WRITE_CALL;
-        return writer.writeVarInt(vhlo_encoding::kIntegerUI4Type), success();
+        return writer.writeVarInt(vhlo_encoding::kIntegerUI4V1Type), success();
       })
       .Case([&](IntegerUI8V1Type) {
         LOG_WRITE_CALL;
-        return writer.writeVarInt(vhlo_encoding::kIntegerUI8Type), success();
+        return writer.writeVarInt(vhlo_encoding::kIntegerUI8V1Type), success();
       })
       .Case([&](IntegerUI16V1Type) {
         LOG_WRITE_CALL;
-        return writer.writeVarInt(vhlo_encoding::kIntegerUI16Type), success();
+        return writer.writeVarInt(vhlo_encoding::kIntegerUI16V1Type), success();
       })
       .Case([&](IntegerUI32V1Type) {
         LOG_WRITE_CALL;
-        return writer.writeVarInt(vhlo_encoding::kIntegerUI32Type), success();
+        return writer.writeVarInt(vhlo_encoding::kIntegerUI32V1Type), success();
       })
       .Case([&](IntegerUI64V1Type) {
         LOG_WRITE_CALL;
-        return writer.writeVarInt(vhlo_encoding::kIntegerUI64Type), success();
+        return writer.writeVarInt(vhlo_encoding::kIntegerUI64V1Type), success();
       })
       .Case([&](WitnessV1Type) {
         LOG_WRITE_CALL;
-        return writer.writeVarInt(vhlo_encoding::kWitnessType), success();
+        return writer.writeVarInt(vhlo_encoding::kWitnessV1Type), success();
       })
       .Default([&](Type) {
         LOG_NOT_IMPLEMENTED;
@@ -1347,27 +1339,10 @@ LogicalResult VhloBytecodeInterface::writeType(
 }
 
 //===----------------------------------------------------------------------===//
-// TokenV1Type
-
-TokenV1Type VhloBytecodeInterface::readTokenV1Type(
-    DialectBytecodeReader &) const {
-  LOG_READ_CALL;
-  return TokenV1Type::get(getContext());
-}
-
-void VhloBytecodeInterface::write(TokenV1Type type,
-                                  DialectBytecodeWriter &writer) const {
-  writer.writeVarInt(vhlo_encoding::kTokenType);
-}
-
-//===----------------------------------------------------------------------===//
-// Forked Types
-//===----------------------------------------------------------------------===//
-
-//===----------------------------------------------------------------------===//
 // ComplexV1Type
+//===----------------------------------------------------------------------===//
 
-ComplexV1Type VhloBytecodeInterface::readComplexType(
+ComplexV1Type VhloBytecodeInterface::readComplexV1Type(
     DialectBytecodeReader &reader) const {
   LOG_READ_CALL;
   Type elementType;
@@ -1377,35 +1352,37 @@ ComplexV1Type VhloBytecodeInterface::readComplexType(
 
 void VhloBytecodeInterface::write(ComplexV1Type type,
                                   DialectBytecodeWriter &writer) const {
-  writer.writeVarInt(vhlo_encoding::kComplexType);
+  writer.writeVarInt(vhlo_encoding::kComplexV1Type);
   writer.writeType(type.getElementType());
 }
 
 //===----------------------------------------------------------------------===//
 // FunctionV1Type
+//===----------------------------------------------------------------------===//
 
-FunctionV1Type VhloBytecodeInterface::readFunctionType(
+FunctionV1Type VhloBytecodeInterface::readFunctionV1Type(
     DialectBytecodeReader &reader) const {
   LOG_READ_CALL;
   SmallVector<Type> inputs;
-  SmallVector<Type> results;
-  if (failed(reader.readTypes(inputs)) || failed(reader.readTypes(results)))
+  SmallVector<Type> outputs;
+  if (failed(reader.readTypes(inputs)) || failed(reader.readTypes(outputs)))
     return FunctionV1Type();
 
-  return FunctionV1Type::get(getContext(), inputs, results);
+  return FunctionV1Type::get(getContext(), inputs, outputs);
 }
 
 void VhloBytecodeInterface::write(FunctionV1Type type,
                                   DialectBytecodeWriter &writer) const {
-  writer.writeVarInt(vhlo_encoding::kFunctionType);
+  writer.writeVarInt(vhlo_encoding::kFunctionV1Type);
   writer.writeTypes(type.getInputs());
-  writer.writeTypes(type.getResults());
+  writer.writeTypes(type.getOutputs());
 }
 
 //===----------------------------------------------------------------------===//
 // RankedTensorV1Type
+//===----------------------------------------------------------------------===//
 
-RankedTensorV1Type VhloBytecodeInterface::readRankedTensorType(
+RankedTensorV1Type VhloBytecodeInterface::readRankedTensorV1Type(
     DialectBytecodeReader &reader, bool hasEncoding) const {
   LOG_READ_CALL;
   Attribute encoding;
@@ -1424,19 +1401,35 @@ RankedTensorV1Type VhloBytecodeInterface::readRankedTensorType(
 void VhloBytecodeInterface::write(RankedTensorV1Type type,
                                   DialectBytecodeWriter &writer) const {
   if (Attribute encoding = type.getEncoding()) {
-    writer.writeVarInt(vhlo_encoding::kRankedTensorTypeWithEncoding);
+    writer.writeVarInt(vhlo_encoding::kRankedTensorV1TypeWithEncoding);
     writer.writeAttribute(encoding);
   } else {
-    writer.writeVarInt(vhlo_encoding::kRankedTensorType);
+    writer.writeVarInt(vhlo_encoding::kRankedTensorV1Type);
   }
   writer.writeSignedVarInts(type.getShape());
   writer.writeType(type.getElementType());
 }
 
 //===----------------------------------------------------------------------===//
-// TupleV1Type
+// TokenV1Type
+//===----------------------------------------------------------------------===//
 
-TupleV1Type VhloBytecodeInterface::readTupleType(
+TokenV1Type VhloBytecodeInterface::readTokenV1Type(
+    DialectBytecodeReader &) const {
+  LOG_READ_CALL;
+  return TokenV1Type::get(getContext());
+}
+
+void VhloBytecodeInterface::write(TokenV1Type type,
+                                  DialectBytecodeWriter &writer) const {
+  writer.writeVarInt(vhlo_encoding::kTokenV1Type);
+}
+
+//===----------------------------------------------------------------------===//
+// TupleV1Type
+//===----------------------------------------------------------------------===//
+
+TupleV1Type VhloBytecodeInterface::readTupleV1Type(
     DialectBytecodeReader &reader) const {
   LOG_READ_CALL;
   SmallVector<Type> elements;
@@ -1447,14 +1440,15 @@ TupleV1Type VhloBytecodeInterface::readTupleType(
 
 void VhloBytecodeInterface::write(TupleV1Type type,
                                   DialectBytecodeWriter &writer) const {
-  writer.writeVarInt(vhlo_encoding::kTupleType);
+  writer.writeVarInt(vhlo_encoding::kTupleV1Type);
   writer.writeTypes(type.getTypes());
 }
 
 //===----------------------------------------------------------------------===//
 // UniformQuantizedV1Type
+//===----------------------------------------------------------------------===//
 
-UniformQuantizedV1Type VhloBytecodeInterface::readUniformQuantizedType(
+UniformQuantizedV1Type VhloBytecodeInterface::readUniformQuantizedV1Type(
     DialectBytecodeReader &reader) const {
   LOG_READ_CALL;
   uint64_t flags;
@@ -1479,7 +1473,7 @@ UniformQuantizedV1Type VhloBytecodeInterface::readUniformQuantizedType(
 
 void VhloBytecodeInterface::write(UniformQuantizedV1Type type,
                                   DialectBytecodeWriter &writer) const {
-  writer.writeVarInt(vhlo_encoding::kUniformQuantizedType);
+  writer.writeVarInt(vhlo_encoding::kUniformQuantizedV1Type);
   writer.writeVarInt(type.getFlags());
   writer.writeType(type.getStorageType());
   writer.writeType(type.getExpressedType());
@@ -1491,8 +1485,9 @@ void VhloBytecodeInterface::write(UniformQuantizedV1Type type,
 
 //===----------------------------------------------------------------------===//
 // UnrankedTensorV1Type
+//===----------------------------------------------------------------------===//
 
-UnrankedTensorV1Type VhloBytecodeInterface::readUnrankedTensorType(
+UnrankedTensorV1Type VhloBytecodeInterface::readUnrankedTensorV1Type(
     DialectBytecodeReader &reader) const {
   LOG_READ_CALL;
   Type elementType;
@@ -1503,7 +1498,7 @@ UnrankedTensorV1Type VhloBytecodeInterface::readUnrankedTensorType(
 
 void VhloBytecodeInterface::write(UnrankedTensorV1Type type,
                                   DialectBytecodeWriter &writer) const {
-  writer.writeVarInt(vhlo_encoding::kUnrankedTensorType);
+  writer.writeVarInt(vhlo_encoding::kUnrankedTensorV1Type);
   writer.writeType(type.getElementType());
 }
 

--- a/stablehlo/dialect/VhloOps.cpp
+++ b/stablehlo/dialect/VhloOps.cpp
@@ -147,7 +147,7 @@ void printFunctionBody(OpAsmPrinter& p, Operation*, Attribute name,
                         [&](auto arg) { p.printRegionArgument(arg); });
   p << ") -> (";
   auto fnType = funcType.cast<TypeV1Attr>().getValue().cast<FunctionV1Type>();
-  llvm::interleaveComma(fnType.getResults(), p,
+  llvm::interleaveComma(fnType.getOutputs(), p,
                         [&](auto res) { p.printType(res); });
   p << ") ";
   p.printRegion(region, false, true, true);

--- a/stablehlo/dialect/VhloTypes.td
+++ b/stablehlo/dialect/VhloTypes.td
@@ -17,14 +17,9 @@ limitations under the License.
 #ifndef STABLEHLO_DIALECT_VHLO_TYPES
 #define STABLEHLO_DIALECT_VHLO_TYPES
 
+include "mlir/IR/AttrTypeBase.td"
 include "stablehlo/dialect/VhloBase.td"
 include "stablehlo/dialect/VhloDialect.td"
-
-include "mlir/IR/AttrTypeBase.td"
-
-//===----------------------------------------------------------------------===//
-// VHLO Type Versioning
-//===----------------------------------------------------------------------===//
 
 def VHLO_VersionedTypeInterface : TypeInterface<"VersionedTypeInterface"> {
   let cppNamespace = "::mlir::vhlo";
@@ -56,18 +51,10 @@ class VHLO_TypeDef<string cppName, string name, string minVersion, string maxVer
   }];
 }
 
-//===----------------------------------------------------------------------===//
-// VHLO Type Definitions.
-//===----------------------------------------------------------------------===//
+// Corresponds to BooleanType from the StableHLO spec.
+def VHLO_BooleanV1 : VHLO_TypeDef<"BooleanV1", "bool", "0.3.0", "current">;
 
-def VHLO_TokenV1 : VHLO_TypeDef<"TokenV1", "token", "0.3.0", "current">;
-
-//===----------------------------------------------------------------------===//
-// Forked Types
-//===----------------------------------------------------------------------===//
-
-def VHLO_BFloat16V1 : VHLO_TypeDef<"BFloat16V1", "bf16", "0.3.0", "current">;
-
+// Corresponds to ComplexType from the StableHLO spec.
 def VHLO_ComplexV1 : VHLO_TypeDef<"ComplexV1", "complex", "0.3.0", "current"> {
   let parameters = (ins "Type":$elementType);
   let genVerifyDecl = 1;
@@ -81,46 +68,84 @@ def VHLO_ComplexV1 : VHLO_TypeDef<"ComplexV1", "complex", "0.3.0", "current"> {
   let assemblyFormat = "`<` $elementType `>`";
 }
 
-def VHLO_Float16V1 : VHLO_TypeDef<"Float16V1", "f16", "0.3.0", "current">;
-def VHLO_Float32V1 : VHLO_TypeDef<"Float32V1", "f32", "0.3.0", "current">;
-def VHLO_Float64V1 : VHLO_TypeDef<"Float64V1","f64", "0.3.0", "current">;
+// Corresponds to the 'bf16' FloatType from the StableHLO spec.
+def VHLO_FloatBF16V1 : VHLO_TypeDef<"FloatBF16V1", "bf16", "0.3.0", "current">;
 
-def VHLO_Float8E4M3FNV1 : VHLO_TypeDef<"Float8E4M3FNV1", "f8E4M3FN", "0.4.0", "current">;
+// Corresponds to the 'f16' FloatType from the StableHLO spec.
+def VHLO_FloatF16V1 : VHLO_TypeDef<"FloatF16V1", "f16", "0.3.0", "current">;
 
-def VHLO_Float8E5M2V1 : VHLO_TypeDef<"Float8E5M2V1", "f8E5M2", "0.4.0", "current">;
+// Corresponds to the 'f32' FloatType from the StableHLO spec.
+def VHLO_FloatF32V1 : VHLO_TypeDef<"FloatF32V1", "f32", "0.3.0", "current">;
 
+// Corresponds to the 'f64' FloatType from the StableHLO spec.
+def VHLO_FloatF64V1 : VHLO_TypeDef<"FloatF64V1","f64", "0.3.0", "current">;
+
+// Corresponds to the 'f8E4M3FN' FloatType from the StableHLO spec.
+def VHLO_FloatF8E4M3FNV1 : VHLO_TypeDef<"FloatF8E4M3FNV1", "f8E4M3FN", "0.4.0", "current">;
+
+// Corresponds to the 'f8E5M2' FloatType from the StableHLO spec.
+def VHLO_FloatF8E5M2V1 : VHLO_TypeDef<"FloatF8E5M2V1", "f8E5M2", "0.4.0", "current">;
+
+// Corresponds to FunctionType from the StableHLO spec.
 def VHLO_FunctionV1 : VHLO_TypeDef<"FunctionV1", "func", "0.3.0", "current"> {
   let parameters = (ins
     ArrayRefParameter<"::mlir::Type">:$inputs,
-    ArrayRefParameter<"mlir::Type">:$results
+    ArrayRefParameter<"mlir::Type">:$outputs
   );
   let genVerifyDecl = 1;
   let extraClassDefinition = [{
     LogicalResult FunctionV1Type::verify(
         llvm::function_ref<mlir::InFlightDiagnostic ()> errFn,
-        ArrayRef<mlir::Type> inputs, ArrayRef<mlir::Type> results) {
-      if (!allFromVhlo(inputs) || !allFromVhlo(results))
+        ArrayRef<mlir::Type> inputs, ArrayRef<mlir::Type> outputs) {
+      if (!allFromVhlo(inputs) || !allFromVhlo(outputs))
         return errFn() << "expected VHLO types";
       return success();
     }
   }];
-  let assemblyFormat = "`<` `(` custom<TypeArray>($inputs) `)` `->` custom<TypeArray>($results) `>`";
+  let assemblyFormat = "`<` `(` custom<TypeArray>($inputs) `)` `->` custom<TypeArray>($outputs) `>`";
 }
 
+// TODO(#8): Index is not part of the StableHLO spec.
+// At the moment, it is used to represent values participating in shape
+// computations, and we're planning to look into it as part of the work on the
+// dynamism RFC.
 def VHLO_IndexV1 : VHLO_TypeDef<"IndexV1", "index", "0.3.0", "current">;
 
-def VHLO_IntegerI1V1 : VHLO_TypeDef<"IntegerI1V1", "i1", "0.3.0", "current">;
-def VHLO_IntegerI4V1 : VHLO_TypeDef<"IntegerI4V1", "i4", "0.3.0", "current">;
-def VHLO_IntegerI8V1 : VHLO_TypeDef<"IntegerI8V1", "i8", "0.3.0", "current">;
-def VHLO_IntegerI16V1 : VHLO_TypeDef<"IntegerI16V1", "i16", "0.3.0", "current">;
-def VHLO_IntegerI32V1 : VHLO_TypeDef<"IntegerI32V1", "i32", "0.3.0", "current">;
-def VHLO_IntegerI64V1 : VHLO_TypeDef<"IntegerI64V1", "i64", "0.3.0", "current">;
+// Corresponds to the 'si4' FloatType from the StableHLO spec.
+def VHLO_IntegerSI4V1 : VHLO_TypeDef<"IntegerSI4V1", "i4", "0.3.0", "current">;
+
+// Corresponds to the 'si8' FloatType from the StableHLO spec.
+def VHLO_IntegerSI8V1 : VHLO_TypeDef<"IntegerSI8V1", "i8", "0.3.0", "current">;
+
+// Corresponds to the 'si16' FloatType from the StableHLO spec.
+def VHLO_IntegerSI16V1 : VHLO_TypeDef<"IntegerSI16V1", "i16", "0.3.0", "current">;
+
+// Corresponds to the 'si32' FloatType from the StableHLO spec.
+def VHLO_IntegerSI32V1 : VHLO_TypeDef<"IntegerSI32V1", "i32", "0.3.0", "current">;
+
+// Corresponds to the 'si64' FloatType from the StableHLO spec.
+def VHLO_IntegerSI64V1 : VHLO_TypeDef<"IntegerSI64V1", "i64", "0.3.0", "current">;
+
+// Corresponds to the 'ui4' FloatType from the StableHLO spec.
 def VHLO_IntegerUI4V1 : VHLO_TypeDef<"IntegerUI4V1", "ui4", "0.3.0", "current">;
+
+// Corresponds to the 'ui8' FloatType from the StableHLO spec.
 def VHLO_IntegerUI8V1 : VHLO_TypeDef<"IntegerUI8V1", "ui8", "0.3.0", "current">;
+
+// Corresponds to the 'ui16' FloatType from the StableHLO spec.
 def VHLO_IntegerUI16V1 : VHLO_TypeDef<"IntegerUI16V1", "ui16", "0.3.0", "current">;
+
+// Corresponds to the 'ui32' FloatType from the StableHLO spec.
 def VHLO_IntegerUI32V1 : VHLO_TypeDef<"IntegerUI32V1", "ui32", "0.3.0", "current">;
+
+// Corresponds to the 'ui64' FloatType from the StableHLO spec.
 def VHLO_IntegerUI64V1 : VHLO_TypeDef<"IntegerUI64V1", "ui64", "0.3.0", "current">;
 
+// Corresponds to TensorType from the StableHLO spec.
+// TODO(#8): Encoding is not part of the StableHLO spec.
+// At the moment, it is used to represent dimension bounds to support bounded
+// dynamism, and we're planning to look into it as part of the work on the
+// dynamism RFC.
 def VHLO_RankedTensorV1 : VHLO_TypeDef<"RankedTensorV1", "tensor", "0.3.0", "current"> {
   let parameters = (ins
     VHLO_Dims:$shape,
@@ -140,6 +165,10 @@ def VHLO_RankedTensorV1 : VHLO_TypeDef<"RankedTensorV1", "tensor", "0.3.0", "cur
   let assemblyFormat = "`<` custom<Shape>($shape) `` $elementType `` custom<Encoding>($encoding) `>`";
 }
 
+// Corresponds to TokenType from the StableHLO spec.
+def VHLO_TokenV1 : VHLO_TypeDef<"TokenV1", "token", "0.3.0", "current">;
+
+// Corresponds to TupleType from the StableHLO spec.
 def VHLO_TupleV1 : VHLO_TypeDef<"TupleV1", "tuple", "0.3.0", "current"> {
   let parameters = (ins ArrayRefParameter<"::mlir::Type">:$types);
   let genVerifyDecl = 1;
@@ -153,8 +182,10 @@ def VHLO_TupleV1 : VHLO_TypeDef<"TupleV1", "tuple", "0.3.0", "current"> {
   let assemblyFormat = "`<` $types `>`";
 }
 
+// TODO(#8): UniformQuantized is not part of the StableHLO spec.
+// At the moment, it is used to represent uniform quantization, and we're
+// planning to look into it as part of the work on speccing quantization.
 def VHLO_APFloatV1 : APFloatParameter<""> {
-  // Used by UniformQuantizedV1 to have APFloat with custom parser
   let parser = [{
     [&]() -> FailureOr<llvm::APFloat> {
       double value;
@@ -190,6 +221,9 @@ def VHLO_UniformQuantizedV1 : VHLO_TypeDef<"UniformQuantizedV1", "quant", "0.3.0
   let assemblyFormat = "`<` $storageType `` `:` `` $expressedType `,` $scale `` `:` `` $zeroPoint `,` $storageTypeMin `` `:` `` $storageTypeMax `,` $flags `>`";
 }
 
+// TODO(#8): UnrankedTensor is not part of the StableHLO spec.
+// At the moment, it is used to represent unranked dynamism, and we will likely
+// remove it as part of the work on the dynamism RFC.
 def VHLO_UnrankedTensorV1 : VHLO_TypeDef<"UnrankedTensorV1", "unranked_tensor", "0.3.0", "current"> {
   let parameters = (ins "::mlir::Type":$elementType);
   let genVerifyDecl = 1;
@@ -203,6 +237,9 @@ def VHLO_UnrankedTensorV1 : VHLO_TypeDef<"UnrankedTensorV1", "unranked_tensor", 
   let assemblyFormat = "`<` $elementType `>`";
 }
 
+// TODO(#8): Witness is not part of the StableHLO spec.
+// At the moment, it is used to represent constraints for dynamic shapes,
+// and we're planning to look into it as part of the work on the dynamism RFC.
 def VHLO_WitnessV1 : VHLO_TypeDef<"WitnessV1", "witness", "0.3.0", "current">;
 
 #endif // STABLEHLO_DIALECT_VHLO_TYPES

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.mlir
@@ -399,7 +399,7 @@ func.func @op_all_to_all(%arg0: tensor<4x16xf32>) -> tensor<16x4xf32> {
 // CHECK-LABEL: "op_all_to_all"
 
 func.func @op_and(%arg0: tensor<i1>, %arg1: tensor<i1>) -> tensor<i1> {
-  // CHECK: "vhlo.and"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.i1>, !vhlo.tensor<!vhlo.i1>) -> !vhlo.tensor<!vhlo.i1>
+  // CHECK: "vhlo.and"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.bool>, !vhlo.tensor<!vhlo.bool>) -> !vhlo.tensor<!vhlo.bool>
   %0 = "stablehlo.and"(%arg0, %arg1) : (tensor<i1>, tensor<i1>) -> tensor<i1>
   func.return %0 : tensor<i1>
 }
@@ -547,7 +547,7 @@ func.func @op_compare(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<i1> {
   //      CHECK: "vhlo.compare"(%arg0, %arg1) {
   // CHECK-SAME:   compare_type = #vhlo<comparison_type TOTALORDER>,
   // CHECK-SAME:   comparison_direction = #vhlo<comparison_direction EQ>
-  // CHECK-SAME: } : (!vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.i1>
+  // CHECK-SAME: } : (!vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.bool>
   %0 = "stablehlo.compare"(%arg0, %arg1) {
     comparison_direction = #stablehlo<comparison_direction EQ>,
     compare_type = #stablehlo<comparison_type TOTALORDER>
@@ -952,7 +952,7 @@ func.func @op_if(%arg0: tensor<i1>, %arg1: tensor<f32>, %arg2: tensor<f32>) -> t
   // CHECK-NEXT:   "vhlo.return"(%arg1) : (!vhlo.tensor<!vhlo.f32>) -> ()
   // CHECK-NEXT: }, {
   // CHECK-NEXT:   "vhlo.return"(%arg2) : (!vhlo.tensor<!vhlo.f32>) -> ()
-  // CHECK-NEXT: }) : (!vhlo.tensor<!vhlo.i1>) -> !vhlo.tensor<!vhlo.f32>
+  // CHECK-NEXT: }) : (!vhlo.tensor<!vhlo.bool>) -> !vhlo.tensor<!vhlo.f32>
   %0 = "stablehlo.if"(%arg0) ({
     "stablehlo.return"(%arg1) : (tensor<f32>) -> ()
   }, {
@@ -994,7 +994,7 @@ func.func @op_iota() -> tensor<16xf32> {
 // CHECK-LABEL: "op_iota"
 
 func.func @op_is_finite(%arg0: tensor<f32>) -> tensor<i1> {
-  // CHECK: "vhlo.is_finite"(%arg0) : (!vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.i1>
+  // CHECK: "vhlo.is_finite"(%arg0) : (!vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.bool>
   %0 = "stablehlo.is_finite"(%arg0) : (tensor<f32>) -> tensor<i1>
   func.return %0 : tensor<i1>
 }
@@ -1069,7 +1069,7 @@ func.func @op_negate(%arg0: tensor<f32>) -> tensor<f32> {
 // CHECK-LABEL: "op_negate"
 
 func.func @op_not(%arg0: tensor<i1>) -> tensor<i1> {
-  // CHECK: "vhlo.not"(%arg0) : (!vhlo.tensor<!vhlo.i1>) -> !vhlo.tensor<!vhlo.i1>
+  // CHECK: "vhlo.not"(%arg0) : (!vhlo.tensor<!vhlo.bool>) -> !vhlo.tensor<!vhlo.bool>
   %0 = "stablehlo.not"(%arg0) : (tensor<i1>) -> tensor<i1>
   func.return %0 : tensor<i1>
 }
@@ -1083,7 +1083,7 @@ func.func @op_optimization_barrier(%arg0: tensor<f32>) -> tensor<f32> {
 // CHECK-LABEL: "op_optimization_barrier"
 
 func.func @op_or(%arg0: tensor<i1>, %arg1: tensor<i1>) -> tensor<i1> {
-  // CHECK: "vhlo.or"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.i1>, !vhlo.tensor<!vhlo.i1>) -> !vhlo.tensor<!vhlo.i1>
+  // CHECK: "vhlo.or"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.bool>, !vhlo.tensor<!vhlo.bool>) -> !vhlo.tensor<!vhlo.bool>
   %0 = "stablehlo.or"(%arg0, %arg1) : (tensor<i1>, tensor<i1>) -> tensor<i1>
   func.return %0 : tensor<i1>
 }
@@ -1360,8 +1360,8 @@ func.func @op_scatter(%arg0: tensor<200x100x300xf32>, %arg1: tensor<10x2xi32>, %
 func.func @op_select_and_scatter(%arg0: tensor<10x24x24x64xf32>, %arg1: tensor<10x12x12x64xf32>, %arg2: tensor<f32>) -> tensor<10x24x24x64xf32> {
   //      CHECK: "vhlo.select_and_scatter"(%arg0, %arg1, %arg2) ({
   // CHECK-NEXT:   ^[[BB:bb.*]](%[[ARG31:arg.*]]: !vhlo.tensor<!vhlo.f32>, %[[ARG41:arg.*]]: !vhlo.tensor<!vhlo.f32>):
-  // CHECK-NEXT:     %[[VAL11:.*]] = "vhlo.compare"(%[[ARG31]], %[[ARG41]]) {compare_type = #vhlo<comparison_type TOTALORDER>, comparison_direction = #vhlo<comparison_direction GE>} : (!vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.i1>
-  // CHECK-NEXT:     "vhlo.return"(%[[VAL11]]) : (!vhlo.tensor<!vhlo.i1>) -> ()
+  // CHECK-NEXT:     %[[VAL11:.*]] = "vhlo.compare"(%[[ARG31]], %[[ARG41]]) {compare_type = #vhlo<comparison_type TOTALORDER>, comparison_direction = #vhlo<comparison_direction GE>} : (!vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.bool>
+  // CHECK-NEXT:     "vhlo.return"(%[[VAL11]]) : (!vhlo.tensor<!vhlo.bool>) -> ()
   // CHECK-NEXT: }, {
   // CHECK-NEXT:   ^[[BB:bb.*]](%[[ARG32:arg.*]]: !vhlo.tensor<!vhlo.f32>, %[[ARG42:arg.*]]: !vhlo.tensor<!vhlo.f32>):
   // CHECK-NEXT:     %[[VAL12:.*]] = "vhlo.add"(%[[ARG32]], %[[ARG42]]) : (!vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
@@ -1389,7 +1389,7 @@ func.func @op_select_and_scatter(%arg0: tensor<10x24x24x64xf32>, %arg1: tensor<1
 // CHECK-LABEL: "op_select_and_scatter"
 
 func.func @op_select(%arg0: tensor<i1>, %arg1: tensor<f32>, %arg2: tensor<f32>) -> tensor<f32> {
-  // CHECK: "vhlo.select"(%arg0, %arg1, %arg2) : (!vhlo.tensor<!vhlo.i1>, !vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
+  // CHECK: "vhlo.select"(%arg0, %arg1, %arg2) : (!vhlo.tensor<!vhlo.bool>, !vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
   %0 = "stablehlo.select"(%arg0, %arg1, %arg2) : (tensor<i1>, tensor<f32>, tensor<f32>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }
@@ -1472,8 +1472,8 @@ func.func @op_slice(%arg0: tensor<16xf32>) -> tensor<4xf32> {
 func.func @op_sort(%arg0: tensor<16xf32>) -> tensor<16xf32> {
   //      CHECK: "vhlo.sort"(%arg0) ({
   // CHECK-NEXT:   ^[[BB:bb.*]](%[[ARG1:arg.*]]: !vhlo.tensor<!vhlo.f32>, %[[ARG2:arg.*]]: !vhlo.tensor<!vhlo.f32>):
-  // CHECK-NEXT:     %[[VAL1:.*]] = "vhlo.compare"(%[[ARG1]], %[[ARG2]]) {compare_type = #vhlo<comparison_type FLOAT>, comparison_direction = #vhlo<comparison_direction GT>} : (!vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.i1>
-  // CHECK-NEXT:     "vhlo.return"(%[[VAL1]]) : (!vhlo.tensor<!vhlo.i1>) -> ()
+  // CHECK-NEXT:     %[[VAL1:.*]] = "vhlo.compare"(%[[ARG1]], %[[ARG2]]) {compare_type = #vhlo<comparison_type FLOAT>, comparison_direction = #vhlo<comparison_direction GT>} : (!vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.bool>
+  // CHECK-NEXT:     "vhlo.return"(%[[VAL1]]) : (!vhlo.tensor<!vhlo.bool>) -> ()
   // CHECK-NEXT: }) {
   // CHECK-SAME:   dimension = #vhlo.integer<0 : i64>
   // CHECK-SAME:   is_stable = #vhlo.integer<true>
@@ -1597,12 +1597,12 @@ func.func @op_uniform_quantize(%arg0: tensor<f32>) -> tensor<!quant.uniform<i8:f
 
 func.func @op_while(%arg0: tensor<i1>) -> tensor<i1> {
   //      CHECK: "vhlo.while"(%arg0) ({
-  // CHECK-NEXT:   ^[[BB:bb.*]](%[[ARG1:arg.*]]: !vhlo.tensor<!vhlo.i1>):
-  // CHECK-NEXT:     "vhlo.return"(%[[ARG1]]) : (!vhlo.tensor<!vhlo.i1>) -> ()
+  // CHECK-NEXT:   ^[[BB:bb.*]](%[[ARG1:arg.*]]: !vhlo.tensor<!vhlo.bool>):
+  // CHECK-NEXT:     "vhlo.return"(%[[ARG1]]) : (!vhlo.tensor<!vhlo.bool>) -> ()
   // CHECK-NEXT:   }, {
-  // CHECK-NEXT:   ^[[BB:bb.*]](%[[ARG1:arg.*]]: !vhlo.tensor<!vhlo.i1>)
-  // CHECK-NEXT:     "vhlo.return"(%[[ARG1]]) : (!vhlo.tensor<!vhlo.i1>) -> ()
-  // CHECK-NEXT: }) : (!vhlo.tensor<!vhlo.i1>) -> !vhlo.tensor<!vhlo.i1>
+  // CHECK-NEXT:   ^[[BB:bb.*]](%[[ARG1:arg.*]]: !vhlo.tensor<!vhlo.bool>)
+  // CHECK-NEXT:     "vhlo.return"(%[[ARG1]]) : (!vhlo.tensor<!vhlo.bool>) -> ()
+  // CHECK-NEXT: }) : (!vhlo.tensor<!vhlo.bool>) -> !vhlo.tensor<!vhlo.bool>
   %0 = "stablehlo.while"(%arg0) ({
     ^bb0(%arg1: tensor<i1>):
       "stablehlo.return"(%arg1) : (tensor<i1>) -> ()
@@ -1615,7 +1615,7 @@ func.func @op_while(%arg0: tensor<i1>) -> tensor<i1> {
 // CHECK-LABEL: "op_while"
 
 func.func @op_xor(%arg0: tensor<i1>, %arg1: tensor<i1>) -> tensor<i1> {
-  // CHECK: "vhlo.xor"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.i1>, !vhlo.tensor<!vhlo.i1>) -> !vhlo.tensor<!vhlo.i1>
+  // CHECK: "vhlo.xor"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.bool>, !vhlo.tensor<!vhlo.bool>) -> !vhlo.tensor<!vhlo.bool>
   %0 = "stablehlo.xor"(%arg0, %arg1) : (tensor<i1>, tensor<i1>) -> tensor<i1>
   func.return %0 : tensor<i1>
 }
@@ -1624,7 +1624,7 @@ func.func @op_xor(%arg0: tensor<i1>, %arg1: tensor<i1>) -> tensor<i1> {
 // ============ TYPES ============
 
 func.func @type_i1(%arg0: tensor<i1>, %arg1: tensor<i1>) -> tensor<i1> {
-  // CHECK: "vhlo.and"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.i1>, !vhlo.tensor<!vhlo.i1>) -> !vhlo.tensor<!vhlo.i1>
+  // CHECK: "vhlo.and"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.bool>, !vhlo.tensor<!vhlo.bool>) -> !vhlo.tensor<!vhlo.bool>
   %0 = "stablehlo.and"(%arg0, %arg1) : (tensor<i1>, tensor<i1>) -> tensor<i1>
   func.return %0 : tensor<i1>
 }

--- a/stablehlo/tests/vhlo_to_version_upgrade.mlir
+++ b/stablehlo/tests/vhlo_to_version_upgrade.mlir
@@ -34,11 +34,11 @@ vhlo.func @collective_permute_to_v2(%arg0: !vhlo.tensor<16x8x!vhlo.f32>) -> !vhl
 }
 
 // CHECK-LABEL: @custom_call_to_v2
-vhlo.func @custom_call_to_v2(%arg0: !vhlo.tensor<2x!vhlo.i1>) -> !vhlo.tensor<2x!vhlo.i1> {
+vhlo.func @custom_call_to_v2(%arg0: !vhlo.tensor<2x!vhlo.bool>) -> !vhlo.tensor<2x!vhlo.bool> {
   // CHECK-NEXT: %0 = "vhlo.custom_call_v2"(%arg0)
   %0 = "vhlo.custom_call"(%arg0) {
     backend_config = #vhlo.string<"">,
     call_target_name = #vhlo.string<"foo">
-  } : (!vhlo.tensor<2x!vhlo.i1>) -> !vhlo.tensor<2x!vhlo.i1>
-  "vhlo.return"(%0) : (!vhlo.tensor<2x!vhlo.i1>) -> ()
+  } : (!vhlo.tensor<2x!vhlo.bool>) -> !vhlo.tensor<2x!vhlo.bool>
+  "vhlo.return"(%0) : (!vhlo.tensor<2x!vhlo.bool>) -> ()
 }

--- a/stablehlo/transforms/VhloToVersion.cpp
+++ b/stablehlo/transforms/VhloToVersion.cpp
@@ -161,7 +161,7 @@ LogicalResult isLegalType(Type type, const Version& targetVersion) {
       return succeeded(isLegalType(ele, targetVersion));
     };
     return success(llvm::all_of(func.getInputs(), validateType) &&
-                   llvm::all_of(func.getResults(), validateType));
+                   llvm::all_of(func.getOutputs(), validateType));
   }
   if (auto ranked = type.dyn_cast<RankedTensorV1Type>()) {
     auto encoding = ranked.getEncoding();


### PR DESCRIPTION
This pull request completes the audit of VhloTypes.td, including refactorings aimed to align the file with the spec.
  1) Order alphabetically, merging native and forked types.
     (Within the vision that types must correspond 1:1 to the
     specification, there's no difference between where these types
     are originally coming from, so there's no need to separate the
     two categories).
  2) Introduce BooleanType to match the spec.
  3) Rename FunctionType::results to FunctionType::outputs to match
     the spec.
  4) Rename IntegerI...Type to IntegerSI...Type to match the spec.
  5) Rename floating-point types to FloatBF...Type or FloatF...Type
     to match the naming style used for integer types.
  6) Add comments to each attribute, either identifying the
     corresponding program element from the spec or linking a ticket
     that tracks the alignment effort.
  7) Rename kFooType to kFooV1Type to be consistent with the TableGen
     file that defines the attributes.
  8) Renumber kFooAttr in increasing order to match the alphabetical
     order of the names. (This is a breaking change for VHLO, but I
     think it's fine because we haven't officially released it yet).
  9) A few more minor renamings and cleanups.