### PR TITLE
Minor refactoring for FuncOp-related attributes

### DIFF
--- a/stablehlo/dialect/VhloAttrs.td
+++ b/stablehlo/dialect/VhloAttrs.td
@@ -184,7 +184,8 @@ def VHLO_ArrayAttrV1 : VHLO_AttrDef<"ArrayV1", "0.3.0", "current"> {
   let assemblyFormat = "`<` custom<AttributeArray>($value) `>`";
 }
 
-def VHLO_DictionaryAttr : VHLO_AttrDef<"DictionaryV1", "0.3.0", "current"> {
+// TODO(#425): DictionaryConstant is not part of the StableHLO spec.
+def VHLO_DictionaryAttrV1 : VHLO_AttrDef<"DictionaryV1", "0.3.0", "current"> {
   let mnemonic = "dict";
   let parameters = (ins ArrayRefParameter<"std::pair<mlir::Attribute, mlir::Attribute>", "">:$value);
   let genVerifyDecl = 1;
@@ -266,6 +267,7 @@ def VHLO_TensorAttrV1 : VHLO_AttrDef<"TensorV1", "0.3.0", "current"> {
   let hasCustomAssemblyFormat = 1;
 }
 
+// TODO(#425): TypeConstant is not part of the StableHLO spec.
 def VHLO_TypeAttrV1 : VHLO_AttrDef<"TypeV1", "0.3.0", "current"> {
   let mnemonic = "type";
   let parameters = (ins "::mlir::Type":$value);


### PR DESCRIPTION
Minor refactoring for FuncOp-related attributes

VHLO_DictionaryAttrV1 didn't have "V1" appended to its name, unlike
other nearby attributes.

Also, since neither VHLO_DictionaryAttr nor VHLO_TypeAttr are called
out in the spec yet, I've added corresponding todos that link to
the appropriate ticket. See #1047.