### PR TITLE
Inline VHLO_ConvDimensionNumbersAttr and friends

### DIFF
--- a/stablehlo/dialect/VhloAttrs.td
+++ b/stablehlo/dialect/VhloAttrs.td
@@ -60,42 +60,6 @@ class VHLO_AttrDef<string name, string minVersion, string maxVersion>
 // VHLO Attributes
 //===----------------------------------------------------------------------===//
 
-def VHLO_ScatterDimensionNumbersAttrV1 : VHLO_AttrDef<"ScatterDimensionNumbersV1", "0.3.0", "current"> {
-  let cppNamespace = "::mlir::vhlo";
-  let mnemonic = "scatter";
-  let parameters = (ins
-      VHLO_Dims:$updateWindowDims,
-      VHLO_Dims:$insertedWindowDims,
-      VHLO_Dims:$scatterDimsToOperandDims,
-      "int64_t":$indexVectorDim
-  );
-  let assemblyFormat = "`<` struct(params) `>`";
-}
-
-def VHLO_GatherDimensionNumbersAttrV1 : VHLO_AttrDef<"GatherDimensionNumbersV1", "0.3.0", "current"> {
-  let cppNamespace = "::mlir::vhlo";
-  let mnemonic = "gather";
-  let parameters = (ins
-      VHLO_Dims:$offsetDims,
-      VHLO_Dims:$collapsedSliceDims,
-      VHLO_Dims:$startIndexMap,
-      "int64_t":$indexVectorDim
-  );
-  let assemblyFormat = "`<` struct(params) `>`";
-}
-
-def VHLO_DotDimensionNumbersAttrV1 : VHLO_AttrDef<"DotDimensionNumbersV1", "0.3.0", "current"> {
-  let cppNamespace = "::mlir::vhlo";
-  let mnemonic = "dot";
-  let parameters = (ins
-      VHLO_Dims:$lhsBatchingDimensions,
-      VHLO_Dims:$rhsBatchingDimensions,
-      VHLO_Dims:$lhsContractingDimensions,
-      VHLO_Dims:$rhsContractingDimensions
-  );
-  let assemblyFormat = "`<` struct(params) `>`";
-}
-
 def VHLO_OutputOperandAliasAttrV1 : VHLO_AttrDef<"OutputOperandAliasV1", "0.4.0", "current"> {
   let cppNamespace = "::mlir::vhlo";
   let mnemonic = "output_operand_alias";
@@ -119,51 +83,11 @@ def VHLO_ArgResultAliasAttrV1 : VHLO_AttrDef<"ArgResultAliasV1", "0.3.0", "curre
   let assemblyFormat = "`<` struct(params) `>`";
 }
 
-def VHLO_ChannelHandleAttrV1 : VHLO_AttrDef<"ChannelHandleV1", "0.3.0", "current"> {
-  let cppNamespace = "::mlir::vhlo";
-  let mnemonic = "channel_handle";
-  let parameters = (ins "int64_t":$handle, "int64_t":$type);
-  let assemblyFormat = "`<` struct(params) `>`";
-}
-
 def VHLO_TypeExtensionsAttrV1 : VHLO_AttrDef<"TypeExtensionsV1", "0.3.0", "current"> {
   let cppNamespace = "::mlir::vhlo";
   let mnemonic = "type_extensions";
   let parameters = (ins VHLO_Dims:$bounds);
   let assemblyFormat = "`<` struct(params) `>`";
-}
-
-def VHLO_ConvDimensionNumbersAttrV1 : VHLO_AttrDef<"ConvDimensionNumbersV1", "0.3.0", "current"> {
-  let cppNamespace = "::mlir::vhlo";
-  let mnemonic = "conv";
-  let parameters = (ins
-    "int64_t":$inputBatchDimension,
-    "int64_t":$inputFeatureDimension,
-    VHLO_Dims:$inputSpatialDimensions,
-
-    "int64_t":$kernelInputFeatureDimension,
-    "int64_t":$kernelOutputFeatureDimension,
-    VHLO_Dims:$kernelSpatialDimensions,
-
-    "int64_t":$outputBatchDimension,
-    "int64_t":$outputFeatureDimension,
-    VHLO_Dims:$outputSpatialDimensions
-  );
-  let assemblyFormat = "`<` struct(params) `>`";
-}
-
-def VHLO_ConvolutionAttributesV1 {
-  dag attributes = (ins
-    OptionalAttr<VHLO_AnyAttr>:$window_strides,
-    OptionalAttr<VHLO_AnyAttr>:$padding,
-    OptionalAttr<VHLO_AnyAttr>:$lhs_dilation,
-    OptionalAttr<VHLO_AnyAttr>:$rhs_dilation,
-    OptionalAttr<VHLO_AnyAttr>:$window_reversal,
-    VHLO_AnyAttr:$dimension_numbers,
-    VHLO_AnyAttr:$feature_group_count,
-    VHLO_AnyAttr:$batch_group_count,
-    OptionalAttr<VHLO_AnyAttr>:$precision_config
-  );
 }
 
 //===----------------------------------------------------------------------===//

--- a/stablehlo/dialect/VhloBytecode.cpp
+++ b/stablehlo/dialect/VhloBytecode.cpp
@@ -86,12 +86,6 @@ enum AttributeCode {
   ///   }
   kArgResultAliasAttr = 0,
 
-  ///   ChannelHandleAttr {
-  ///     handle: svarint
-  ///     type: svarint
-  ///   }
-  kChannelHandleAttr = 1,
-
   ///   ComparisonDirectionAttr
   ///     value: varint (encoded enum)
   ///   }
@@ -102,39 +96,10 @@ enum AttributeCode {
   ///   }
   kComparisonTypeAttr = 3,
 
-  ///   ConvDimensionNumbersAttr {
-  ///     inputBatchDimension: svarint
-  ///     inputFeatureDimension: svarint
-  ///     inputSpatialDimensions: svarint[]
-  ///     kernelInputFeatureDimension: svarint
-  ///     kernelOutputFeatureDimension: svarint
-  ///     kernelSpatialDimensions: svarint[]
-  ///     outputBatchDimension: svarint
-  ///     outputFeatureDimension: svarint
-  ///     outputSpatialDimensions: svarint[]
-  ///   }
-  kConvDimensionNumbersAttr = 4,
-
-  ///   DotDimensionNumbersAttr {
-  ///     lhsBatchingDimensions: svarint[]
-  ///     rhsBatchingDimensions: svarint[]
-  ///     lhsContractingDimensions: svarint[]
-  ///     rhsContractingDimensions: svarint[]
-  ///   }
-  kDotDimensionNumbers = 5,
-
   ///   FftTypeAttr
   ///     value: varint (encoded enum)
   ///   }
   kFftTypeAttr = 6,
-
-  ///   GatherDimensionNumbersAttr {
-  ///     offsetDims: svarint[]
-  ///     collapsedSliceDims: svarint[]
-  ///     startIndexMap: svarint[]
-  ///     indexVectorDim: svarint
-  ///   }
-  kGatherDimensionNumbers = 7,
 
   ///   PrecisionAttr {
   ///     value: varint (encoded enum)
@@ -150,14 +115,6 @@ enum AttributeCode {
   ///     value: varint (encoded enum)
   ///   }
   kRngDistributionAttr = 10,
-
-  ///   ScatterDimensionNumbersAttr {
-  ///     updateWindowDims: svarint[]
-  ///     insertedWindowDims: svarint[]
-  ///     scatterDimsToOperandDims: svarint[]
-  ///     indexVectorDim: svarint
-  ///   }
-  kScatterDimensionNumbersAttr = 11,
 
   ///   TransposeAttr {
   ///     value: varint (encoded enum)
@@ -391,29 +348,19 @@ class VhloBytecodeInterface : public BytecodeDialectInterface {
   // Ex: SomeAttr readSomeAttr(DialectBytecodeReader &reader) const;
   ArgResultAliasV1Attr readArgResultAliasV1Attr(
       DialectBytecodeReader &reader) const;
-  ChannelHandleV1Attr readChannelHandleV1Attr(
-      DialectBytecodeReader &reader) const;
   ComparisonDirectionV1Attr readComparisonDirectionV1Attr(
       DialectBytecodeReader &reader) const;
   ComparisonTypeV1Attr readComparisonTypeV1Attr(
       DialectBytecodeReader &reader) const;
-  ConvDimensionNumbersV1Attr readConvDimensionNumbersV1Attr(
-      DialectBytecodeReader &reader) const;
   CustomCallApiVersionV1Attr readCustomCallApiVersionV1Attr(
       DialectBytecodeReader &reader) const;
-  DotDimensionNumbersV1Attr readDotDimensionNumbersV1Attr(
-      DialectBytecodeReader &reader) const;
   FftTypeV1Attr readFftTypeV1Attr(DialectBytecodeReader &reader) const;
-  GatherDimensionNumbersV1Attr readGatherDimensionNumbersV1Attr(
-      DialectBytecodeReader &reader) const;
   OutputOperandAliasV1Attr readOutputOperandAliasV1Attr(
       DialectBytecodeReader &reader) const;
   PrecisionV1Attr readPrecisionV1Attr(DialectBytecodeReader &reader) const;
   RngAlgorithmV1Attr readRngAlgorithmV1Attr(
       DialectBytecodeReader &reader) const;
   RngDistributionV1Attr readRngDistributionV1Attr(
-      DialectBytecodeReader &reader) const;
-  ScatterDimensionNumbersV1Attr readScatterDimensionNumbersV1Attr(
       DialectBytecodeReader &reader) const;
   TransposeV1Attr readTransposeV1Attr(DialectBytecodeReader &reader) const;
   TypeExtensionsV1Attr readTypeExtensionsV1Attr(
@@ -422,26 +369,17 @@ class VhloBytecodeInterface : public BytecodeDialectInterface {
   // TO ADD ATTRIBUTE: Include a write method for each attribute in VHLO
   // Ex: void write(SomeAttr attr, DialectBytecodeWriter &writer) const;
   void write(ArgResultAliasV1Attr attr, DialectBytecodeWriter &writer) const;
-  void write(ChannelHandleV1Attr attr, DialectBytecodeWriter &writer) const;
   void write(ComparisonDirectionV1Attr attr,
              DialectBytecodeWriter &writer) const;
   void write(ComparisonTypeV1Attr attr, DialectBytecodeWriter &writer) const;
-  void write(ConvDimensionNumbersV1Attr attr,
-             DialectBytecodeWriter &writer) const;
   void write(CustomCallApiVersionV1Attr attr,
              DialectBytecodeWriter &writer) const;
-  void write(DotDimensionNumbersV1Attr attr,
-             DialectBytecodeWriter &writer) const;
   void write(FftTypeV1Attr attr, DialectBytecodeWriter &writer) const;
-  void write(GatherDimensionNumbersV1Attr attr,
-             DialectBytecodeWriter &writer) const;
   void write(OutputOperandAliasV1Attr attr,
              DialectBytecodeWriter &writer) const;
   void write(PrecisionV1Attr attr, DialectBytecodeWriter &writer) const;
   void write(RngAlgorithmV1Attr attr, DialectBytecodeWriter &writer) const;
   void write(RngDistributionV1Attr attr, DialectBytecodeWriter &writer) const;
-  void write(ScatterDimensionNumbersV1Attr attr,
-             DialectBytecodeWriter &writer) const;
   void write(TransposeV1Attr attr, DialectBytecodeWriter &writer) const;
   void write(TypeExtensionsV1Attr attr, DialectBytecodeWriter &writer) const;
 
@@ -510,22 +448,14 @@ Attribute VhloBytecodeInterface::readAttribute(
   switch (code) {
     case vhlo_encoding::kArgResultAliasAttr:
       return readArgResultAliasV1Attr(reader);
-    case vhlo_encoding::kChannelHandleAttr:
-      return readChannelHandleV1Attr(reader);
     case vhlo_encoding::kComparisonDirectionAttr:
       return readComparisonDirectionV1Attr(reader);
     case vhlo_encoding::kComparisonTypeAttr:
       return readComparisonTypeV1Attr(reader);
-    case vhlo_encoding::kConvDimensionNumbersAttr:
-      return readConvDimensionNumbersV1Attr(reader);
     case vhlo_encoding::kCustomCallApiVersionAttr:
       return readCustomCallApiVersionV1Attr(reader);
-    case vhlo_encoding::kDotDimensionNumbers:
-      return readDotDimensionNumbersV1Attr(reader);
     case vhlo_encoding::kFftTypeAttr:
       return readFftTypeV1Attr(reader);
-    case vhlo_encoding::kGatherDimensionNumbers:
-      return readGatherDimensionNumbersV1Attr(reader);
     case vhlo_encoding::kOutputOperandAlias:
       return readOutputOperandAliasV1Attr(reader);
     case vhlo_encoding::kPrecisionAttr:
@@ -534,8 +464,6 @@ Attribute VhloBytecodeInterface::readAttribute(
       return readRngAlgorithmV1Attr(reader);
     case vhlo_encoding::kRngDistributionAttr:
       return readRngDistributionV1Attr(reader);
-    case vhlo_encoding::kScatterDimensionNumbersAttr:
-      return readScatterDimensionNumbersV1Attr(reader);
     case vhlo_encoding::kTransposeAttr:
       return readTransposeV1Attr(reader);
     case vhlo_encoding::kTypeExtensionsAttr:
@@ -569,13 +497,10 @@ Attribute VhloBytecodeInterface::readAttribute(
 LogicalResult VhloBytecodeInterface::writeAttribute(
     Attribute attr, DialectBytecodeWriter &writer) const {
   return TypeSwitch<Attribute, LogicalResult>(attr)
-      .Case<
-          ArgResultAliasV1Attr, ChannelHandleV1Attr, ComparisonDirectionV1Attr,
-          ComparisonTypeV1Attr, ConvDimensionNumbersV1Attr,
-          CustomCallApiVersionV1Attr, DotDimensionNumbersV1Attr, FftTypeV1Attr,
-          GatherDimensionNumbersV1Attr, OutputOperandAliasV1Attr,
-          PrecisionV1Attr, RngAlgorithmV1Attr, RngDistributionV1Attr,
-          ScatterDimensionNumbersV1Attr, TransposeV1Attr, TypeExtensionsV1Attr>(
+      .Case<ArgResultAliasV1Attr, ComparisonDirectionV1Attr,
+            ComparisonTypeV1Attr, CustomCallApiVersionV1Attr, FftTypeV1Attr,
+            OutputOperandAliasV1Attr, PrecisionV1Attr, RngAlgorithmV1Attr,
+            RngDistributionV1Attr, TransposeV1Attr, TypeExtensionsV1Attr>(
           [&](auto attr) {
             LOG_WRITE_CALL;
             write(attr, writer);
@@ -626,26 +551,6 @@ void VhloBytecodeInterface::write(ArgResultAliasV1Attr attr,
 }
 
 //===----------------------------------------------------------------------===//
-// ChannelHandleAttr
-
-ChannelHandleV1Attr VhloBytecodeInterface::readChannelHandleV1Attr(
-    DialectBytecodeReader &reader) const {
-  LOG_READ_CALL;
-  int64_t handle, type;
-  if (failed(reader.readSignedVarInt(handle)) ||
-      failed(reader.readSignedVarInt(type)))
-    return ChannelHandleV1Attr();
-  return ChannelHandleV1Attr::get(getContext(), handle, type);
-}
-
-void VhloBytecodeInterface::write(ChannelHandleV1Attr attr,
-                                  DialectBytecodeWriter &writer) const {
-  writer.writeVarInt(vhlo_encoding::kChannelHandleAttr);
-  writer.writeSignedVarInt(attr.getHandle());
-  writer.writeSignedVarInt(attr.getType());
-}
-
-//===----------------------------------------------------------------------===//
 // ComparisonDirectionAttr
 
 ComparisonDirectionV1Attr VhloBytecodeInterface::readComparisonDirectionV1Attr(
@@ -680,54 +585,6 @@ void VhloBytecodeInterface::write(ComparisonTypeV1Attr attr,
 }
 
 //===----------------------------------------------------------------------===//
-// ConvDimensionNumbersAttr
-
-ConvDimensionNumbersV1Attr
-VhloBytecodeInterface::readConvDimensionNumbersV1Attr(
-    DialectBytecodeReader &reader) const {
-  LOG_READ_CALL;
-  int64_t inputBatchDimension, inputFeatureDimension;
-  llvm::SmallVector<int64_t> inputSpatialDimensions;
-
-  int64_t kernelInputFeatureDimension, kernelOutputFeatureDimension;
-  llvm::SmallVector<int64_t> kernelSpatialDimensions;
-
-  int64_t outputBatchDimension, outputFeatureDimension;
-  llvm::SmallVector<int64_t> outputSpatialDimensions;
-
-  if (failed(reader.readSignedVarInt(inputBatchDimension)) ||
-      failed(reader.readSignedVarInt(inputFeatureDimension)) ||
-      failed(reader.readSignedVarInts(inputSpatialDimensions)) ||
-      failed(reader.readSignedVarInt(kernelInputFeatureDimension)) ||
-      failed(reader.readSignedVarInt(kernelOutputFeatureDimension)) ||
-      failed(reader.readSignedVarInts(kernelSpatialDimensions)) ||
-      failed(reader.readSignedVarInt(outputBatchDimension)) ||
-      failed(reader.readSignedVarInt(outputFeatureDimension)) ||
-      failed(reader.readSignedVarInts(outputSpatialDimensions)))
-    return ConvDimensionNumbersV1Attr();
-
-  return ConvDimensionNumbersV1Attr::get(
-      getContext(), inputBatchDimension, inputFeatureDimension,
-      inputSpatialDimensions, kernelInputFeatureDimension,
-      kernelOutputFeatureDimension, kernelSpatialDimensions,
-      outputBatchDimension, outputFeatureDimension, outputSpatialDimensions);
-}
-
-void VhloBytecodeInterface::write(ConvDimensionNumbersV1Attr attr,
-                                  DialectBytecodeWriter &writer) const {
-  writer.writeVarInt(vhlo_encoding::kConvDimensionNumbersAttr);
-  writer.writeSignedVarInt(attr.getInputBatchDimension());
-  writer.writeSignedVarInt(attr.getInputFeatureDimension());
-  writer.writeSignedVarInts(attr.getInputSpatialDimensions());
-  writer.writeSignedVarInt(attr.getKernelInputFeatureDimension());
-  writer.writeSignedVarInt(attr.getKernelOutputFeatureDimension());
-  writer.writeSignedVarInts(attr.getKernelSpatialDimensions());
-  writer.writeSignedVarInt(attr.getOutputBatchDimension());
-  writer.writeSignedVarInt(attr.getOutputFeatureDimension());
-  writer.writeSignedVarInts(attr.getOutputSpatialDimensions());
-}
-
-//===----------------------------------------------------------------------===//
 // CustomCallApiVersionAttr
 
 CustomCallApiVersionV1Attr
@@ -746,35 +603,6 @@ void VhloBytecodeInterface::write(CustomCallApiVersionV1Attr attr,
 }
 
 //===----------------------------------------------------------------------===//
-// DotDimensionNumbersAttr
-
-DotDimensionNumbersV1Attr VhloBytecodeInterface::readDotDimensionNumbersV1Attr(
-    DialectBytecodeReader &reader) const {
-  LOG_READ_CALL;
-  llvm::SmallVector<int64_t> lhsBatchingDimensions, rhsBatchingDimensions,
-      lhsContractingDimensions, rhsContractingDimensions;
-
-  if (failed(reader.readSignedVarInts(lhsBatchingDimensions)) ||
-      failed(reader.readSignedVarInts(rhsBatchingDimensions)) ||
-      failed(reader.readSignedVarInts(lhsContractingDimensions)) ||
-      failed(reader.readSignedVarInts(rhsContractingDimensions)))
-    return DotDimensionNumbersV1Attr();
-
-  return DotDimensionNumbersV1Attr::get(
-      getContext(), lhsBatchingDimensions, rhsBatchingDimensions,
-      lhsContractingDimensions, rhsContractingDimensions);
-}
-
-void VhloBytecodeInterface::write(DotDimensionNumbersV1Attr attr,
-                                  DialectBytecodeWriter &writer) const {
-  writer.writeVarInt(vhlo_encoding::kDotDimensionNumbers);
-  writer.writeSignedVarInts(attr.getLhsBatchingDimensions());
-  writer.writeSignedVarInts(attr.getRhsBatchingDimensions());
-  writer.writeSignedVarInts(attr.getLhsContractingDimensions());
-  writer.writeSignedVarInts(attr.getRhsContractingDimensions());
-}
-
-//===----------------------------------------------------------------------===//
 // FftTypeAttr
 
 FftTypeV1Attr VhloBytecodeInterface::readFftTypeV1Attr(
@@ -788,36 +616,6 @@ void VhloBytecodeInterface::write(FftTypeV1Attr attr,
                                   DialectBytecodeWriter &writer) const {
   writer.writeVarInt(vhlo_encoding::kFftTypeAttr);
   hlo::bytecode::writeEnumAttribute<FftTypeV1>(attr, writer);
-}
-
-//===----------------------------------------------------------------------===//
-// GatherDimensionNumbersAttr
-
-GatherDimensionNumbersV1Attr
-VhloBytecodeInterface::readGatherDimensionNumbersV1Attr(
-    DialectBytecodeReader &reader) const {
-  LOG_READ_CALL;
-  llvm::SmallVector<int64_t> offsetDims, collapsedSliceDims, startIndexMap;
-  int64_t indexVectorDim;
-
-  if (failed(reader.readSignedVarInts(offsetDims)) ||
-      failed(reader.readSignedVarInts(collapsedSliceDims)) ||
-      failed(reader.readSignedVarInts(startIndexMap)) ||
-      failed(reader.readSignedVarInt(indexVectorDim)))
-    return GatherDimensionNumbersV1Attr();
-
-  return GatherDimensionNumbersV1Attr::get(getContext(), offsetDims,
-                                           collapsedSliceDims, startIndexMap,
-                                           indexVectorDim);
-}
-
-void VhloBytecodeInterface::write(GatherDimensionNumbersV1Attr attr,
-                                  DialectBytecodeWriter &writer) const {
-  writer.writeVarInt(vhlo_encoding::kGatherDimensionNumbers);
-  writer.writeSignedVarInts(attr.getOffsetDims());
-  writer.writeSignedVarInts(attr.getCollapsedSliceDims());
-  writer.writeSignedVarInts(attr.getStartIndexMap());
-  writer.writeSignedVarInt(attr.getIndexVectorDim());
 }
 
 //===----------------------------------------------------------------------===//
@@ -895,37 +693,6 @@ void VhloBytecodeInterface::write(RngDistributionV1Attr attr,
                                   DialectBytecodeWriter &writer) const {
   writer.writeVarInt(vhlo_encoding::kRngDistributionAttr);
   hlo::bytecode::writeEnumAttribute<RngDistributionV1>(attr, writer);
-}
-
-//===----------------------------------------------------------------------===//
-// ScatterDimensionNumbersAttr
-
-ScatterDimensionNumbersV1Attr
-VhloBytecodeInterface::readScatterDimensionNumbersV1Attr(
-    DialectBytecodeReader &reader) const {
-  LOG_READ_CALL;
-  llvm::SmallVector<int64_t> updateWindowDims, insertedWindowDims,
-      scatterDimsToOperandDims;
-  int64_t indexVectorDim;
-
-  if (failed(reader.readSignedVarInts(updateWindowDims)) ||
-      failed(reader.readSignedVarInts(insertedWindowDims)) ||
-      failed(reader.readSignedVarInts(scatterDimsToOperandDims)) ||
-      failed(reader.readSignedVarInt(indexVectorDim)))
-    return ScatterDimensionNumbersV1Attr();
-
-  return ScatterDimensionNumbersV1Attr::get(
-      getContext(), updateWindowDims, insertedWindowDims,
-      scatterDimsToOperandDims, indexVectorDim);
-}
-
-void VhloBytecodeInterface::write(ScatterDimensionNumbersV1Attr attr,
-                                  DialectBytecodeWriter &writer) const {
-  writer.writeVarInt(vhlo_encoding::kScatterDimensionNumbersAttr);
-  writer.writeSignedVarInts(attr.getUpdateWindowDims());
-  writer.writeSignedVarInts(attr.getInsertedWindowDims());
-  writer.writeSignedVarInts(attr.getScatterDimsToOperandDims());
-  writer.writeSignedVarInt(attr.getIndexVectorDim());
 }
 
 //===----------------------------------------------------------------------===//

--- a/stablehlo/dialect/VhloOps.td
+++ b/stablehlo/dialect/VhloOps.td
@@ -87,7 +87,7 @@ def VHLO_AllGatherOpV1 : VHLO_Op<"all_gather", "0.3.0", "0.3.0"> {
     VHLO_AnyType:$operand,
     VHLO_AnyAttr:$all_gather_dim,
     VHLO_AnyAttr:$replica_groups,
-    OptionalAttr<VHLO_AnyAttr>:$channel_handle
+    OptionalAttr<VHLO_AnyAttr>:$channel_id
   );
   let results = (outs VHLO_AnyType:$result);
 }
@@ -97,7 +97,7 @@ def VHLO_AllGatherOpV2 : VHLO_Op<"all_gather_v2", "0.4.0", "current"> {
     VHLO_AnyType:$operand,
     VHLO_AnyAttr:$all_gather_dim,
     VHLO_AnyAttr:$replica_groups,
-    OptionalAttr<VHLO_AnyAttr>:$channel_handle,
+    OptionalAttr<VHLO_AnyAttr>:$channel_id,
     OptionalAttr<VHLO_AnyAttr>:$use_global_device_ids
   );
   let results = (outs VHLO_AnyType:$result);
@@ -107,7 +107,7 @@ def VHLO_AllReduceOpV1 : VHLO_Op<"all_reduce", "0.3.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$operand,
     VHLO_AnyAttr:$replica_groups,
-    OptionalAttr<VHLO_AnyAttr>:$channel_handle,
+    OptionalAttr<VHLO_AnyAttr>:$channel_id,
     OptionalAttr<VHLO_AnyAttr>:$use_global_device_ids
   );
   let regions = (region VHLO_AnyRegion:$computation);
@@ -132,7 +132,7 @@ def VHLO_AllToAllOpV2 : VHLO_Op<"all_to_all_v2", "0.4.0", "current"> {
     VHLO_AnyAttr:$concat_dimension,
     VHLO_AnyAttr:$split_count,
     VHLO_AnyAttr:$replica_groups,
-    OptionalAttr<VHLO_AnyAttr>:$channel_handle
+    OptionalAttr<VHLO_AnyAttr>:$channel_id
   );
   let results = (outs VHLO_AnyType:$result);
 }
@@ -274,7 +274,7 @@ def VHLO_CollectivePermuteOpV2 : VHLO_Op<"collective_permute_v2", "0.4.0", "curr
   let arguments = (ins
     VHLO_AnyType:$operand,
     VHLO_AnyAttr:$source_target_pairs,
-    OptionalAttr<VHLO_AnyAttr>:$channel_handle
+    OptionalAttr<VHLO_AnyAttr>:$channel_id
   );
   let results = (outs VHLO_AnyType:$result);
 }
@@ -321,11 +321,27 @@ def VHLO_ConvertOpV1 : VHLO_Op<"convert", "0.3.0", "current"> {
 }
 
 def VHLO_ConvolutionOpV1 : VHLO_Op<"convolution", "0.3.0", "current"> {
-  let arguments = !con(
-    (ins
-       VHLO_AnyType:$lhs,
-       VHLO_AnyType:$rhs),
-    VHLO_ConvolutionAttributesV1.attributes);
+  let arguments = (ins
+    VHLO_AnyType:$lhs,
+    VHLO_AnyType:$rhs,
+    OptionalAttr<VHLO_AnyAttr>:$window_strides,
+    OptionalAttr<VHLO_AnyAttr>:$padding,
+    OptionalAttr<VHLO_AnyAttr>:$lhs_dilation,
+    OptionalAttr<VHLO_AnyAttr>:$rhs_dilation,
+    OptionalAttr<VHLO_AnyAttr>:$window_reversal,
+    VHLO_AnyAttr:$input_batch_dimension,
+    VHLO_AnyAttr:$input_feature_dimension,
+    VHLO_AnyAttr:$input_spatial_dimensions,
+    VHLO_AnyAttr:$kernel_input_feature_dimension,
+    VHLO_AnyAttr:$kernel_output_feature_dimension,
+    VHLO_AnyAttr:$kernel_spatial_dimensions,
+    VHLO_AnyAttr:$output_batch_dimension,
+    VHLO_AnyAttr:$output_feature_dimension,
+    VHLO_AnyAttr:$output_spatial_dimensions,
+    VHLO_AnyAttr:$feature_group_count,
+    VHLO_AnyAttr:$batch_group_count,
+    OptionalAttr<VHLO_AnyAttr>:$precision_config
+  );
   let results = (outs VHLO_AnyType:$result);
 }
 
@@ -404,7 +420,10 @@ def VHLO_DotGeneralOpV1 : VHLO_Op<"dot_general", "0.3.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$lhs,
     VHLO_AnyType:$rhs,
-    VHLO_AnyAttr:$dot_dimension_numbers,
+    VHLO_AnyAttr:$lhs_batching_dimensions,
+    VHLO_AnyAttr:$rhs_batching_dimensions,
+    VHLO_AnyAttr:$lhs_contracting_dimensions,
+    VHLO_AnyAttr:$rhs_contracting_dimensions,
     OptionalAttr<VHLO_AnyAttr>:$precision_config
   );
   let results = (outs VHLO_AnyType:$result);
@@ -440,12 +459,28 @@ def VHLO_DynamicBroadcastInDimOpV1 : VHLO_Op<"dynamic_broadcast_in_dim", "0.3.0"
 // This operation is a work in progress, so it is not yet included in
 // the StableHLO specification.
 def VHLO_DynamicConvOpV1 : VHLO_Op<"dynamic_conv", "0.3.0", "current"> {
-  let arguments = !con(
-    (ins
-       VHLO_AnyType:$lhs,
-       VHLO_AnyType:$rhs,
-       VHLO_AnyType:$d_padding),
-    VHLO_ConvolutionAttributesV1.attributes);
+  let arguments = (ins
+    VHLO_AnyType:$lhs,
+    VHLO_AnyType:$rhs,
+    VHLO_AnyType:$d_padding,
+    OptionalAttr<VHLO_AnyAttr>:$window_strides,
+    OptionalAttr<VHLO_AnyAttr>:$padding,
+    OptionalAttr<VHLO_AnyAttr>:$lhs_dilation,
+    OptionalAttr<VHLO_AnyAttr>:$rhs_dilation,
+    OptionalAttr<VHLO_AnyAttr>:$window_reversal,
+    VHLO_AnyAttr:$input_batch_dimension,
+    VHLO_AnyAttr:$input_feature_dimension,
+    VHLO_AnyAttr:$input_spatial_dimensions,
+    VHLO_AnyAttr:$kernel_input_feature_dimension,
+    VHLO_AnyAttr:$kernel_output_feature_dimension,
+    VHLO_AnyAttr:$kernel_spatial_dimensions,
+    VHLO_AnyAttr:$output_batch_dimension,
+    VHLO_AnyAttr:$output_feature_dimension,
+    VHLO_AnyAttr:$output_spatial_dimensions,
+    VHLO_AnyAttr:$feature_group_count,
+    VHLO_AnyAttr:$batch_group_count,
+    OptionalAttr<VHLO_AnyAttr>:$precision_config
+  );
   let results = (outs VHLO_AnyType:$result);
 }
 
@@ -457,7 +492,10 @@ def VHLO_DynamicGatherOpV1 : VHLO_Op<"dynamic_gather", "0.3.0", "current"> {
     VHLO_AnyType:$operand,
     VHLO_AnyType:$start_indices,
     VHLO_AnyType:$slice_sizes,
-    VHLO_AnyAttr:$dimension_numbers,
+    VHLO_AnyAttr:$offset_dims,
+    VHLO_AnyAttr:$collapsed_slice_dims,
+    VHLO_AnyAttr:$start_index_map,
+    VHLO_AnyAttr:$index_vector_dim,
     OptionalAttr<VHLO_AnyAttr>:$indices_are_sorted
   );
   let results = (outs VHLO_AnyType:$result);
@@ -565,7 +603,10 @@ def VHLO_GatherOpV1 : VHLO_Op<"gather", "0.3.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$operand,
     VHLO_AnyType:$start_indices,
-    VHLO_AnyAttr:$dimension_numbers,
+    VHLO_AnyAttr:$offset_dims,
+    VHLO_AnyAttr:$collapsed_slice_dims,
+    VHLO_AnyAttr:$start_index_map,
+    VHLO_AnyAttr:$index_vector_dim,
     VHLO_AnyAttr:$slice_sizes,
     OptionalAttr<VHLO_AnyAttr>:$indices_are_sorted
   );
@@ -741,7 +782,8 @@ def VHLO_RealOpV1 : VHLO_Op<"real", "0.3.0", "current"> {
 def VHLO_RecvOpV1 : VHLO_Op<"recv", "0.3.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$token,
-    VHLO_AnyAttr:$channel_handle,
+    VHLO_AnyAttr:$channel_id,
+    VHLO_AnyAttr:$channel_type,
     OptionalAttr<VHLO_AnyAttr>:$is_host_transfer
   );
   let results = (outs Variadic<VHLO_AnyType>:$results);
@@ -771,7 +813,7 @@ def VHLO_ReduceScatterOpV1 : VHLO_Op<"reduce_scatter", "0.3.0", "current"> {
     VHLO_AnyType:$operand,
     VHLO_AnyAttr:$scatter_dimension,
     VHLO_AnyAttr:$replica_groups,
-    OptionalAttr<VHLO_AnyAttr>:$channel_handle,
+    OptionalAttr<VHLO_AnyAttr>:$channel_id,
     OptionalAttr<VHLO_AnyAttr>:$use_global_device_ids
   );
   let regions = (region VHLO_AnyRegion:$computation);
@@ -862,7 +904,10 @@ def VHLO_ScatterOpV1 : VHLO_Op<"scatter", "0.3.0", "current", [SameVariadicOpera
     Variadic<VHLO_AnyType>:$inputs,
     VHLO_AnyType:$scatter_indices,
     Variadic<VHLO_AnyType>:$updates,
-    VHLO_AnyAttr:$scatter_dimension_numbers,
+    VHLO_AnyAttr:$update_window_dims,
+    VHLO_AnyAttr:$inserted_window_dims,
+    VHLO_AnyAttr:$scatter_dims_to_operand_dims,
+    VHLO_AnyAttr:$index_vector_dim,
     OptionalAttr<VHLO_AnyAttr>:$indices_are_sorted,
     OptionalAttr<VHLO_AnyAttr>:$unique_indices
   );
@@ -896,7 +941,8 @@ def VHLO_SendOpV1 : VHLO_Op<"send", "0.3.0", "current"> {
   let arguments = (ins
     Variadic<VHLO_AnyType>:$inputs,
     VHLO_AnyType:$token,
-    VHLO_AnyAttr:$channel_handle,
+    VHLO_AnyAttr:$channel_id,
+    VHLO_AnyAttr:$channel_type,
     OptionalAttr<VHLO_AnyAttr>:$is_host_transfer
   );
   let results = (outs VHLO_AnyType:$result);

--- a/stablehlo/tests/vhlo_to_version_downgrade_invalid.mlir
+++ b/stablehlo/tests/vhlo_to_version_downgrade_invalid.mlir
@@ -38,7 +38,7 @@ func.func @custom_call_v2_with_output_operand_aliases_unregistered(%arg0 : tenso
 // -----
 
 func.func @op_collective_permute(%arg0: tensor<16x8xf32>) -> tensor<16x8xf32> {
-  // expected-error @+2 {{failed to downgrade vhlo.collective_permute_v2, op has a non-empty channel_handle attribute}}
+  // expected-error @+2 {{failed to downgrade vhlo.collective_permute_v2, op has a non-empty channel_id attribute}}
   // expected-error @+1 {{failed to legalize operation 'vhlo.collective_permute_v2' that was explicitly marked illegal}}
   %0 = "stablehlo.collective_permute"(%arg0) {
     source_target_pairs = dense<[[0, 1], [1, 2], [2, 3]]> : tensor<3x2xi64>,
@@ -84,7 +84,7 @@ func.func @invalid_program_unknown_op(%arg0 : tensor<f32>) -> (tensor<f32>) {
 // -----
 
 func.func @all_to_all_to_v1(%arg0: tensor<4x16xf32>) -> tensor<16x4xf32> {
-  // expected-error @+2 {{failed to downgrade vhlo.all_to_all_v2, op has a non-empty channel_handle attribute}}
+  // expected-error @+2 {{failed to downgrade vhlo.all_to_all_v2, op has a non-empty channel_id attribute}}
   // expected-error @+1 {{failed to legalize operation 'vhlo.all_to_all_v2' that was explicitly marked illegal}}
   %0 = "stablehlo.all_to_all"(%arg0) {
     split_dimension = 1 : i64,

--- a/stablehlo/tests/vhlo_to_version_upgrade.mlir
+++ b/stablehlo/tests/vhlo_to_version_upgrade.mlir
@@ -18,7 +18,7 @@ vhlo.func @all_gather_to_v2(%arg0: !vhlo.tensor<16x8x!vhlo.f32>) -> !vhlo.tensor
   // CHECK-NEXT: %0 = "vhlo.all_gather_v2"(%arg0)
   %0 = "vhlo.all_gather"(%arg0) {
     all_gather_dim = #vhlo.integer<1 : i64>,
-    channel_handle = #vhlo.channel_handle<handle = 0, type = 0>,
+    channel_id = #vhlo.integer<0 : i64>,
     replica_groups = #vhlo.tensor<dense<[[0], [1]]> : tensor<2x1xi64>>
   } : (!vhlo.tensor<16x8x!vhlo.f32>) -> !vhlo.tensor<16x16x!vhlo.f32>
   "vhlo.return"(%0) : (!vhlo.tensor<16x16x!vhlo.f32>) -> ()

--- a/stablehlo/transforms/VhloToVersion.cpp
+++ b/stablehlo/transforms/VhloToVersion.cpp
@@ -335,9 +335,8 @@ struct CollectivePermuteOpV2ToV1
                                       CollectivePermuteOpV1> {
   using VersionConversionPattern::VersionConversionPattern;
   LogicalResult prepareOpForConversion(CollectivePermuteOpV2 op) const final {
-    if (op.getChannelHandle().has_value())
-      return emitDowngradeError(op,
-                                "op has a non-empty channel_handle attribute");
+    if (op.getChannelId().has_value())
+      return emitDowngradeError(op, "op has a non-empty channel_id attribute");
     return success();
   }
 };
@@ -377,9 +376,8 @@ struct AllToAllOpV2ToV1
     : public VersionConversionPattern<AllToAllOpV2, AllToAllOpV1> {
   using VersionConversionPattern::VersionConversionPattern;
   LogicalResult prepareOpForConversion(AllToAllOpV2 op) const final {
-    if (op.getChannelHandle().has_value())
-      return emitDowngradeError(op,
-                                "op has a non-empty channel_handle attribute");
+    if (op.getChannelId().has_value())
+      return emitDowngradeError(op, "op has a non-empty channel_id attribute");
     return success();
   }
 };


### PR DESCRIPTION
I think that grouping of the elementary attrs into bigger attrs is
pretty incidental as far as serialization format goes, so I would
propose to break all of them down, just like the spec does.

This is a breaking change for VHLO, and I was hesitating whether to
provide proper versioning for it or not. Ultimately, I decided that
I won't be doing that, similarly to how the work on forking attributes
and types (also a breaking change) didn't do that. We haven't yet
officially released VHLO, so I think that it's fine. See #1047.