### PR TITLE
Reformat BUILD.bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -53,6 +53,7 @@ cc_library(
 
 gentbl_cc_library(
     name = "base_attr_interfaces_inc_gen",
+    strip_include_prefix = ".",
     tbl_outs = [
         (
             ["-gen-attr-interface-decls"],
@@ -65,7 +66,6 @@ gentbl_cc_library(
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "stablehlo/dialect/Base.td",
-    strip_include_prefix = ".",
     deps = [":stablehlo_ops_td_files"],
 )
 
@@ -100,6 +100,7 @@ cc_library(
 
 gentbl_cc_library(
     name = "chlo_attrs_inc_gen",
+    strip_include_prefix = ".",
     tbl_outs = [
         (
             ["-gen-attrdef-decls"],
@@ -112,7 +113,6 @@ gentbl_cc_library(
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "stablehlo/dialect/ChloOps.td",
-    strip_include_prefix = ".",
     deps = [
         ":chlo_ops_td_files",
     ],
@@ -164,6 +164,7 @@ cc_library(
 
 gentbl_cc_library(
     name = "chlo_enums_inc_gen",
+    strip_include_prefix = ".",
     tbl_outs = [
         (
             ["-gen-enum-decls"],
@@ -176,7 +177,6 @@ gentbl_cc_library(
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "stablehlo/dialect/ChloOps.td",
-    strip_include_prefix = ".",
     deps = [
         ":chlo_ops_td_files",
     ],
@@ -184,6 +184,7 @@ gentbl_cc_library(
 
 gentbl_cc_library(
     name = "chlo_ops_inc_gen",
+    strip_include_prefix = ".",
     tbl_outs = [
         (
             ["-gen-op-decls"],
@@ -196,7 +197,6 @@ gentbl_cc_library(
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "stablehlo/dialect/ChloOps.td",
-    strip_include_prefix = ".",
     deps = [
         ":chlo_ops_td_files",
     ],
@@ -233,7 +233,10 @@ td_library(
     srcs = [
         "@llvm-project//mlir:include/mlir/Bindings/Python/Attributes.td",
     ],
-    includes = ["include", "."],
+    includes = [
+        ".",
+        "include",
+    ],
     deps = [
         ":chlo_ops_td_files",
         "@llvm-project//mlir:OpBaseTdFiles",
@@ -358,9 +361,9 @@ cc_library(
     deps = [
         ":reference_axes",
         ":reference_element",
-        ":reference_sizes",
         ":reference_errors",
         ":reference_scope",
+        ":reference_sizes",
         ":reference_tensor",
         ":reference_types",
         ":stablehlo_ops",
@@ -473,6 +476,7 @@ cc_library(
 
 gentbl_cc_library(
     name = "stablehlo_attrs_inc_gen",
+    strip_include_prefix = ".",
     tbl_outs = [
         (
             ["-gen-attrdef-decls"],
@@ -485,7 +489,6 @@ gentbl_cc_library(
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "stablehlo/dialect/StablehloOps.td",
-    strip_include_prefix = ".",
     deps = [
         ":stablehlo_ops_td_files",
     ],
@@ -539,6 +542,7 @@ cc_library(
 
 gentbl_cc_library(
     name = "stablehlo_enums_inc_gen",
+    strip_include_prefix = ".",
     tbl_outs = [
         (
             ["-gen-enum-decls"],
@@ -551,7 +555,6 @@ gentbl_cc_library(
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "stablehlo/dialect/StablehloOps.td",
-    strip_include_prefix = ".",
     deps = [
         ":stablehlo_ops_td_files",
     ],
@@ -559,6 +562,7 @@ gentbl_cc_library(
 
 gentbl_cc_library(
     name = "stablehlo_ops_inc_gen",
+    strip_include_prefix = ".",
     tbl_outs = [
         (
             ["-gen-op-decls"],
@@ -571,7 +575,6 @@ gentbl_cc_library(
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "stablehlo/dialect/StablehloOps.td",
-    strip_include_prefix = ".",
     deps = [
         ":stablehlo_ops_td_files",
     ],
@@ -634,6 +637,7 @@ td_library(
 
 gentbl_cc_library(
     name = "stablehlo_pass_inc_gen",
+    strip_include_prefix = ".",
     tbl_outs = [
         (
             [
@@ -644,7 +648,6 @@ gentbl_cc_library(
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "stablehlo/transforms/Passes.td",
-    strip_include_prefix = ".",
     deps = ["@llvm-project//mlir:PassBaseTdFiles"],
 )
 
@@ -672,13 +675,13 @@ cc_library(
         ":vhlo_types",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:FuncDialect",
-        "@llvm-project//mlir:InferTypeOpInterface",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:InferTypeOpInterface",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TensorDialect",
-        "@llvm-project//mlir:Transforms",
         "@llvm-project//mlir:TransformUtils",
+        "@llvm-project//mlir:Transforms",
     ],
 )
 
@@ -775,6 +778,7 @@ filegroup(
 
 gentbl_cc_library(
     name = "test_utils_inc_gen",
+    strip_include_prefix = ".",
     tbl_outs = [
         (
             [
@@ -786,7 +790,6 @@ gentbl_cc_library(
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "stablehlo/tests/TestUtils.td",
-    strip_include_prefix = ".",
     deps = [
         ":test_utils_td_files",
     ],
@@ -915,7 +918,10 @@ td_library(
     srcs = [
         "@llvm-project//mlir:include/mlir/Bindings/Python/Attributes.td",
     ],
-    includes = ["include", "."],
+    includes = [
+        ".",
+        "include",
+    ],
     deps = [
         ":vhlo_ops_td_files",
         "@llvm-project//mlir:OpBaseTdFiles",
@@ -924,6 +930,7 @@ td_library(
 
 gentbl_cc_library(
     name = "vhlo_attr_interfaces_inc_gen",
+    strip_include_prefix = ".",
     tbl_outs = [
         (
             ["-gen-attr-interface-decls"],
@@ -936,7 +943,6 @@ gentbl_cc_library(
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "stablehlo/dialect/VhloAttrs.td",
-    strip_include_prefix = ".",
     deps = [
         ":vhlo_ops_td_files",
     ],
@@ -944,6 +950,7 @@ gentbl_cc_library(
 
 gentbl_cc_library(
     name = "vhlo_attrs_inc_gen",
+    strip_include_prefix = ".",
     tbl_outs = [
         (
             ["-gen-attrdef-decls"],
@@ -956,7 +963,6 @@ gentbl_cc_library(
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "stablehlo/dialect/VhloOps.td",
-    strip_include_prefix = ".",
     deps = [
         ":vhlo_ops_td_files",
     ],
@@ -964,6 +970,7 @@ gentbl_cc_library(
 
 gentbl_cc_library(
     name = "vhlo_enums_inc_gen",
+    strip_include_prefix = ".",
     tbl_outs = [
         (
             ["-gen-enum-decls"],
@@ -976,7 +983,6 @@ gentbl_cc_library(
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "stablehlo/dialect/VhloEnums.td",
-    strip_include_prefix = ".",
     deps = [
         ":vhlo_ops_td_files",
     ],
@@ -984,6 +990,7 @@ gentbl_cc_library(
 
 gentbl_cc_library(
     name = "vhlo_op_interfaces_inc_gen",
+    strip_include_prefix = ".",
     tbl_outs = [
         (
             ["-gen-op-interface-decls"],
@@ -996,7 +1003,6 @@ gentbl_cc_library(
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "stablehlo/dialect/VhloOps.td",
-    strip_include_prefix = ".",
     deps = [
         ":vhlo_ops_td_files",
     ],
@@ -1033,6 +1039,7 @@ cc_library(
 
 gentbl_cc_library(
     name = "vhlo_ops_inc_gen",
+    strip_include_prefix = ".",
     tbl_outs = [
         (
             ["-gen-op-decls"],
@@ -1045,7 +1052,6 @@ gentbl_cc_library(
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "stablehlo/dialect/VhloOps.td",
-    strip_include_prefix = ".",
     deps = [
         ":vhlo_ops_td_files",
     ],
@@ -1094,6 +1100,7 @@ cc_library(
 
 gentbl_cc_library(
     name = "vhlo_type_interfaces_inc_gen",
+    strip_include_prefix = ".",
     tbl_outs = [
         (
             ["-gen-type-interface-decls"],
@@ -1106,7 +1113,6 @@ gentbl_cc_library(
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "stablehlo/dialect/VhloTypes.td",
-    strip_include_prefix = ".",
     deps = [
         ":vhlo_ops_td_files",
     ],
@@ -1114,6 +1120,7 @@ gentbl_cc_library(
 
 gentbl_cc_library(
     name = "vhlo_types_inc_gen",
+    strip_include_prefix = ".",
     tbl_outs = [
         (
             ["-gen-typedef-decls"],
@@ -1126,7 +1133,6 @@ gentbl_cc_library(
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "stablehlo/dialect/VhloOps.td",
-    strip_include_prefix = ".",
     deps = [
         ":vhlo_ops_td_files",
     ],


### PR DESCRIPTION
A downstream linter noticed a change in BUILD.bazel and decide to opine on overall formatting in the file, even beyond the changed lines.

I think it's a reasonable idea to humor it and apply the formatting changes here as well.