### PR TITLE
Add interpreter for PowOp

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3688,9 +3688,11 @@ produces a `result` tensor. Depending on the element type, does the following:
 ```mlir
 // %lhs: [-2.0, -0.0, -36.0, 5.0, 3.0, 10000.0]
 // %rhs: [2.0, 2.0, 1.1, 2.0, -1.0, 10.0]
-%result = "stablehlo.power"(%lhs, %rhs) : (tensor<6xf32>, tensor<6xf32>) -> tensor<6xf32>
+%result = "stablehlo.power"(%lhs, %rhs) : (tensor<6xf64>, tensor<6xf64>) -> tensor<6xf64>
 // %result: [4.0, 0.0, -nan, 25.0, 0.333333343, inf]
 ```
+
+&nbsp;[More Examples](../stablehlo/tests/interpret_power.mlir)
 
 ### real
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -114,7 +114,7 @@ one of the following tracking labels.
 | pad                      | yes           | yes          | yes            | yes             | yes         |
 | partition_id             | yes           | yes          | yes            | yes             | no          |
 | popcnt                   | yes           | yes          | yes            | yes             | no          |
-| power                    | yes           | yes          | yes            | yes             | no          |
+| power                    | yes           | yes          | yes            | yes             | yes         |
 | real                     | yes           | yes          | yes            | yes             | yes         |
 | real_dynamic_slice       | no            | revisit      | no             | yes             | no          |
 | recv                     | yes           | revisit      | infeasible     | no              | no          |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -805,8 +805,9 @@ def StableHLO_MulOp : StableHLO_BinaryElementwiseOp<"multiply",
 }
 
 def StableHLO_PowOp : StableHLO_BinaryElementwiseOp<"power",
-      [Pure, HLO_CompatibleOperandsAndResultType], HLO_IntFpOrComplexTensor> {
-  let summary = "Pow operation";
+      [Pure, HLO_CompatibleOperandsAndResultType /* pow_c1 */],
+      HLO_IntFpOrComplexTensor /* pow_i1, pow_i2 */> {
+  let summary = "Power operation";
   let description = [{
     Performs element-wise exponentiation of `lhs` tensor by `rhs` tensor and
     produces a `result` tensor.
@@ -816,7 +817,7 @@ def StableHLO_PowOp : StableHLO_BinaryElementwiseOp<"power",
 
     Example:
     ```mlir
-    %result = stablehlo.power %lhs, %rhs : tensor<6xf32>
+    %result = stablehlo.power %lhs, %rhs : tensor<6xf64>
     ```
   }];
 }

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -581,10 +581,6 @@ Element min(const Element &e1, const Element &e2) {
 
 Element power(const Element &e1, const Element &e2) {
   Type type = e1.getType();
-  if (e1.getType() != e2.getType())
-    report_fatal_error(invalidArgument("Element types don't match: %s vs %s",
-                                       debugString(e1.getType()).c_str(),
-                                       debugString(e2.getType()).c_str()));
 
   if (isSupportedIntegerType(type)) {
     APInt x = e1.getIntegerValue();

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -594,10 +594,10 @@ Element power(const Element &e1, const Element &e2) {
       else
         return Element(type, APInt(x.getBitWidth(), 0, isSigned));
     }
-    APInt constant1(x.getBitWidth(), 1, isSigned);
-    APInt result(constant1);
+    const APInt kOne(x.getBitWidth(), 1, isSigned);
+    APInt result(kOne);
     while (!y.isZero()) {
-      if ((y & constant1).getBoolValue()) result *= x;
+      if ((y & kOne).getBoolValue()) result *= x;
       x *= x;
       y = y.lshr(1);
     }

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -577,14 +577,13 @@ Element power(const Element &e1, const Element &e2) {
       if (base.abs().isOne())
         exponent = exponent.abs();
       else
-        return Element(type, (int64_t)0);
+        return Element(type, 0l);
     }
     APInt result(base.getBitWidth(), 1, isSigned);
     while (!exponent.isZero()) {
       if (!(exponent & 1).isZero()) result *= base;
       base *= base;
-      exponent = isSupportedSignedIntegerType(type) ? exponent.ashr(1)
-                                                    : exponent.lshr(1);
+      exponent = exponent.lshr(1);
     }
     return Element(type, result);
   }

--- a/stablehlo/reference/Element.h
+++ b/stablehlo/reference/Element.h
@@ -149,6 +149,9 @@ Element max(const Element &e1, const Element &e2);
 /// Returns the minimum between two Element objects.
 Element min(const Element &e1, const Element &e2);
 
+/// Returns the exponentiation of first element to the power of second element.
+Element power(const Element &e1, const Element &e2);
+
 /// Returns the real part extracted from the Element object with floating-point
 /// or complex type.
 Element real(const Element &e);

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -292,6 +292,14 @@ Tensor evalPadOp(const Tensor &operand, const Tensor &paddingValue,
   return result;
 }
 
+Tensor evalPowerOp(const Tensor &lhs, const Tensor &rhs,
+                   TensorType resultType) {
+  Tensor result(resultType);
+  for (auto it = result.index_begin(); it != result.index_end(); ++it)
+    result.set(*it, power(lhs.get(*it), rhs.get(*it)));
+  return result;
+}
+
 Tensor evalRealOp(const Tensor &operand, TensorType resultType) {
   Tensor result(resultType);
   for (auto it = operand.index_begin(); it != operand.index_end(); ++it)
@@ -575,6 +583,12 @@ SmallVector<Tensor> eval(
       Tensor runtimeResult =
           evalPadOp(runtimeOperand, runtimePaddingValue, edgePaddingLow,
                     interiorPadding, padOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto powerOp = dyn_cast<PowOp>(op)) {
+      Tensor runtimeLhs = scope.find(powerOp.getLhs());
+      Tensor runtimeRhs = scope.find(powerOp.getRhs());
+      Tensor runtimeResult =
+          evalPowerOp(runtimeLhs, runtimeRhs, powerOp.getType());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto remOp = dyn_cast<RemOp>(op)) {
       Tensor runtimeLhs = scope.find(remOp.getLhs());

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -66,6 +66,7 @@ Tensor evalOrOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType);
 Tensor evalPadOp(const Tensor &operand, const Tensor &paddingValue,
                  Sizes edgePaddingLow, Sizes interiorPadding,
                  TensorType resultType);
+Tensor evalPowerOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType);
 Tensor evalRealOp(const Tensor &operand, TensorType resultType);
 Tensor evalRemOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType);
 Tensor evalReshapeOp(const Tensor &operand, TensorType resultType);

--- a/stablehlo/tests/interpret_power.mlir
+++ b/stablehlo/tests/interpret_power.mlir
@@ -1,17 +1,5 @@
 // RUN: stablehlo-interpreter --interpret -split-input-file %s
 
-// CHECK-LABEL: Evaluated results of function: power_op_test_ui64
-func.func @power_op_test_ui64() {
-  %lhs = stablehlo.constant dense<[0, 0, 1, 1, 5]> : tensor<5xui64>
-  %rhs = stablehlo.constant dense<[0, 1, 0, 2, 5]> : tensor<5xui64>
-  %result = stablehlo.power %lhs, %rhs : tensor<5xui64>
-  check.eq %result, dense<[1, 0, 1, 1, 3125]> : tensor<5xui64>
-  func.return
-}
-
-// -----
-
-// CHECK-LABEL: Evaluated results of function: power_op_test_si64
 func.func @power_op_test_si64() {
   %lhs = stablehlo.constant dense<[-1, -1, -3, -3, 0]> : tensor<5xi64>
   %rhs = stablehlo.constant dense<[1, 0, -3, 3, 2]> : tensor<5xi64>
@@ -22,7 +10,16 @@ func.func @power_op_test_si64() {
 
 // -----
 
-// CHECK-LABEL: Evaluated results of function: power_op_test_f64
+func.func @power_op_test_ui64() {
+  %lhs = stablehlo.constant dense<[0, 0, 1, 1, 5]> : tensor<5xui64>
+  %rhs = stablehlo.constant dense<[0, 1, 0, 2, 5]> : tensor<5xui64>
+  %result = stablehlo.power %lhs, %rhs : tensor<5xui64>
+  check.eq %result, dense<[1, 0, 1, 1, 3125]> : tensor<5xui64>
+  func.return
+}
+
+// -----
+
 func.func @power_op_test_f64() {
   %lhs = stablehlo.constant dense<[-2.0, -0.0, -36.0, 5.0, 3.0, 10000.0]> : tensor<6xf64>
   %rhs = stablehlo.constant dense<[2.0, 2.0, 1.1, 2.0, -1.0, 10.0]> : tensor<6xf64>
@@ -34,8 +31,7 @@ func.func @power_op_test_f64() {
 
 // -----
 
-// CHECK-LABEL: Evaluated results of function: power_op_test_c64
-func.func @power_op_test_c64() {
+func.func @power_op_test_c128() {
   %lhs = stablehlo.constant dense<[(1.5, 2.5), (7.5, 5.5)]> : tensor<2xcomplex<f64>>
   %rhs = stablehlo.constant dense<[(2.5, 1.5), (5.5, 7.5)]> : tensor<2xcomplex<f64>>
   %result = stablehlo.power %lhs, %rhs : tensor<2xcomplex<f64>>

--- a/stablehlo/tests/interpret_power.mlir
+++ b/stablehlo/tests/interpret_power.mlir
@@ -4,7 +4,7 @@ func.func @power_op_test_si64() {
   %lhs = stablehlo.constant dense<[-1, -1, -3, -3, 0]> : tensor<5xi64>
   %rhs = stablehlo.constant dense<[1, 0, -3, 3, 2]> : tensor<5xi64>
   %result = stablehlo.power %lhs, %rhs : tensor<5xi64>
-  check.eq %result, dense<[-1, 1, 0, -27, 0]> : tensor<5xi64>
+  check.expect_eq_const %result, dense<[-1, 1, 0, -27, 0]> : tensor<5xi64>
   func.return
 }
 
@@ -14,7 +14,7 @@ func.func @power_op_test_ui64() {
   %lhs = stablehlo.constant dense<[0, 0, 1, 1, 5]> : tensor<5xui64>
   %rhs = stablehlo.constant dense<[0, 1, 0, 2, 5]> : tensor<5xui64>
   %result = stablehlo.power %lhs, %rhs : tensor<5xui64>
-  check.eq %result, dense<[1, 0, 1, 1, 3125]> : tensor<5xui64>
+  check.expect_eq_const %result, dense<[1, 0, 1, 1, 3125]> : tensor<5xui64>
   func.return
 }
 
@@ -24,8 +24,8 @@ func.func @power_op_test_f64() {
   %lhs = stablehlo.constant dense<[-2.0, -0.0, -36.0, 5.0, 3.0, 10000.0]> : tensor<6xf64>
   %rhs = stablehlo.constant dense<[2.0, 2.0, 1.1, 2.0, -1.0, 10.0]> : tensor<6xf64>
   %result = stablehlo.power %lhs, %rhs : tensor<6xf64>
-  check.almost_eq %result, dense<[4.000000e+00, 0.000000e+00, 0xFFF8000000000000,
-                                  2.500000e+01, 0.33333333333333331, 1.000000e+40]> : tensor<6xf64>
+  check.expect_almost_eq_const %result, dense<[4.000000e+00, 0.000000e+00, 0xFFF8000000000000,
+                                               2.500000e+01, 0.33333333333333331, 1.000000e+40]> : tensor<6xf64>
   func.return
 }
 
@@ -35,7 +35,7 @@ func.func @power_op_test_c128() {
   %lhs = stablehlo.constant dense<[(1.5, 2.5), (7.5, 5.5)]> : tensor<2xcomplex<f64>>
   %rhs = stablehlo.constant dense<[(2.5, 1.5), (5.5, 7.5)]> : tensor<2xcomplex<f64>>
   %result = stablehlo.power %lhs, %rhs : tensor<2xcomplex<f64>>
-  check.almost_eq %result, dense<[(-1.5679313814305016, -2.6674775446623613),
-                                  (392.89270835580857, 1801.8249193362644)]> : tensor<2xcomplex<f64>>
+  check.expect_almost_eq_const %result, dense<[(-1.5679313814305016, -2.6674775446623613),
+                                               (392.89270835580857, 1801.8249193362644)]> : tensor<2xcomplex<f64>>
   func.return
 }

--- a/stablehlo/tests/interpret_power.mlir
+++ b/stablehlo/tests/interpret_power.mlir
@@ -1,0 +1,45 @@
+// RUN: stablehlo-interpreter --interpret -split-input-file %s
+
+// CHECK-LABEL: Evaluated results of function: power_op_test_ui64
+func.func @power_op_test_ui64() {
+  %lhs = stablehlo.constant dense<[0, 0, 1, 1, 5]> : tensor<5xui64>
+  %rhs = stablehlo.constant dense<[0, 1, 0, 2, 5]> : tensor<5xui64>
+  %result = stablehlo.power %lhs, %rhs : tensor<5xui64>
+  check.eq %result, dense<[1, 0, 1, 1, 3125]> : tensor<5xui64>
+  func.return
+}
+
+// -----
+
+// CHECK-LABEL: Evaluated results of function: power_op_test_si64
+func.func @power_op_test_si64() {
+  %lhs = stablehlo.constant dense<[-1, -1, -3, -3, 0]> : tensor<5xi64>
+  %rhs = stablehlo.constant dense<[1, 0, -3, 3, 2]> : tensor<5xi64>
+  %result = stablehlo.power %lhs, %rhs : tensor<5xi64>
+  check.eq %result, dense<[-1, 1, 0, -27, 0]> : tensor<5xi64>
+  func.return
+}
+
+// -----
+
+// CHECK-LABEL: Evaluated results of function: power_op_test_f64
+func.func @power_op_test_f64() {
+  %lhs = stablehlo.constant dense<[-2.0, -0.0, -36.0, 5.0, 3.0, 10000.0]> : tensor<6xf64>
+  %rhs = stablehlo.constant dense<[2.0, 2.0, 1.1, 2.0, -1.0, 10.0]> : tensor<6xf64>
+  %result = stablehlo.power %lhs, %rhs : tensor<6xf64>
+  check.almost_eq %result, dense<[4.000000e+00, 0.000000e+00, 0xFFF8000000000000,
+                                  2.500000e+01, 0.33333333333333331, 1.000000e+40]> : tensor<6xf64>
+  func.return
+}
+
+// -----
+
+// CHECK-LABEL: Evaluated results of function: power_op_test_c64
+func.func @power_op_test_c64() {
+  %lhs = stablehlo.constant dense<[(1.5, 2.5), (7.5, 5.5)]> : tensor<2xcomplex<f64>>
+  %rhs = stablehlo.constant dense<[(2.5, 1.5), (5.5, 7.5)]> : tensor<2xcomplex<f64>>
+  %result = stablehlo.power %lhs, %rhs : tensor<2xcomplex<f64>>
+  check.almost_eq %result, dense<[(-1.5679313814305016, -2.6674775446623613),
+                                  (392.89270835580857, 1801.8249193362644)]> : tensor<2xcomplex<f64>>
+  func.return
+}


### PR DESCRIPTION
closes #981 

We have the following constraints in the spec:

```
(I1) lhs is a tensor of integer, floating-point, or complex type.
(I2) rhs is a tensor of integer, floating-point, or complex type.
(C1) lhs, rhs, and result have the same type.
```

These constraints are covered by the following tests

```
(I1) lhs is not a tensor of integer, floating-point, or complex type. (covered by ODS)
(I2) rhs is not a tensor of integer, floating-point, or complex type. (covered by ODS)
(C1) lhs, rhs, and result do not have the same type. (covered by ODS)
```