### PR TITLE
Fix a typo in the spec of IfOp

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2850,11 +2850,11 @@ output of `true_branch` is returned, else if pred is `false`, output of
 
 #### Inputs
 
-| Label | Name           | Type                                       | Constraints |
-|-------|----------------|--------------------------------------------|-------------|
-| (I1)  | `pred`         | 0-dimensional tensor constant of type `i1` |             |
-| (I2)  | `true_branch`  | function                                   | (C1-C3)     |
-| (I3)  | `false_branch` | function                                   | (C1), (C2)  |
+| Label | Name           | Type                              | Constraints |
+|-------|----------------|-----------------------------------|-------------|
+| (I1)  | `pred`         | 0-dimensional tensor of type `i1` |             |
+| (I2)  | `true_branch`  | function                          | (C1-C3)     |
+| (I3)  | `false_branch` | function                          | (C1), (C2)  |
 
 #### Outputs
 


### PR DESCRIPTION
PR #1164 updated the spec of IfOp to say that pred is a 0-dimensional tensor, fixing an oversight from the PR that introduced this spec.

However, this PR also said that pred is a constant, which it is not. I missed that during review, and this PR fixes this.