### PR TITLE
Add index info in interpreter-mismatch error message

### DIFF
--- a/stablehlo/tests/CheckOps.cpp
+++ b/stablehlo/tests/CheckOps.cpp
@@ -57,9 +57,10 @@ llvm::Error evalEqOp(const Tensor &lhs, ElementsAttr value) {
        lhsIt != lhs.index_end(); ++lhsIt, ++rhsIt)
     if (lhs.get(*lhsIt) != rhs.get(*rhsIt))
       return invalidArgument(
-          "Element values don't match: %s (actual) vs %s (expected)\n",
+          "Element values don't match: %s (actual) vs %s (expected) at index %s\n",
           debugString(lhs.get(*lhsIt)).c_str(),
-          debugString(rhs.get(*rhsIt)).c_str());
+          debugString(rhs.get(*rhsIt)).c_str(),
+          debugString((*lhsIt)).c_str());
 
   return llvm::Error::success();
 }

--- a/stablehlo/tests/CheckOps.cpp
+++ b/stablehlo/tests/CheckOps.cpp
@@ -44,9 +44,10 @@ llvm::Error evalAlmostEqOp(const Tensor &lhs, ElementsAttr value) {
        lhsIt != lhs.index_end(); ++lhsIt, ++rhsIt)
     if (!areApproximatelyEqual(lhs.get(*lhsIt), rhs.get(*rhsIt)))
       return invalidArgument(
-          "Element values don't match: %s (actual) vs %s (expected)\n",
+          "Element values don't match: %s (actual) vs %s (expected) at index "
+          "%s\n",
           debugString(lhs.get(*lhsIt)).c_str(),
-          debugString(rhs.get(*rhsIt)).c_str());
+          debugString(rhs.get(*rhsIt)).c_str(), debugString((*lhsIt)).c_str());
 
   return llvm::Error::success();
 }
@@ -57,10 +58,10 @@ llvm::Error evalEqOp(const Tensor &lhs, ElementsAttr value) {
        lhsIt != lhs.index_end(); ++lhsIt, ++rhsIt)
     if (lhs.get(*lhsIt) != rhs.get(*rhsIt))
       return invalidArgument(
-          "Element values don't match: %s (actual) vs %s (expected) at index %s\n",
+          "Element values don't match: %s (actual) vs %s (expected) at index "
+          "%s\n",
           debugString(lhs.get(*lhsIt)).c_str(),
-          debugString(rhs.get(*rhsIt)).c_str(),
-          debugString((*lhsIt)).c_str());
+          debugString(rhs.get(*rhsIt)).c_str(), debugString((*lhsIt)).c_str());
 
   return llvm::Error::success();
 }


### PR DESCRIPTION
Even though we have a dedicated issue https://github.com/openxla/stablehlo/issues/1196 to help improving such cases, this change will have some immediate benefits during debugging.  