### PR TITLE
Refactor StableHLO <=> VHLO

### DIFF
--- a/stablehlo/transforms/StablehloLegalizeToVhlo.cpp
+++ b/stablehlo/transforms/StablehloLegalizeToVhlo.cpp
@@ -500,55 +500,45 @@ SpecialResult convertSpecial(const OpConversionPattern<StablehloOpTy>& pattern,
                              stablehlo::CollectivePermuteOp>::value ||
                 std::is_same<StablehloOpTy,
                              stablehlo::ReduceScatterOp>::value) {
-    if (stablehloName == "channel_handle") {
+    if (stablehloName == "channel_handle")
       return convertChannelId(pattern, stablehloAttr, vhloAttrs);
-    }
-    if (stablehloName == "use_global_device_ids") {
+    if (stablehloName == "use_global_device_ids")
       return convertUseGlobalDeviceIds(pattern, stablehloAttr, vhloAttrs);
-    }
   }
   if constexpr (std::is_same<StablehloOpTy, stablehlo::ConvolutionOp>::value ||
                 std::is_same<StablehloOpTy, stablehlo::DynamicConvOp>::value) {
-    if (stablehloName == "dimension_numbers") {
+    if (stablehloName == "dimension_numbers")
       return convertConvDimensionNumbers(pattern, stablehloAttr, vhloAttrs);
-    }
   }
   if constexpr (std::is_same<StablehloOpTy, stablehlo::CustomCallOp>::value) {
-    if (stablehloName == "api_version") {
+    if (stablehloName == "api_version")
       return convertCustomCallApiVersion(pattern, stablehloAttr, vhloAttrs);
-    }
-    if (stablehloName == "called_computations") {
+    if (stablehloName == "called_computations")
       return convertCustomCallCalledComputations(pattern, stablehloAttr,
                                                  vhloAttrs);
-    }
   }
   if constexpr (std::is_same<StablehloOpTy, stablehlo::DotGeneralOp>::value) {
-    if (stablehloName == "dot_dimension_numbers") {
+    if (stablehloName == "dot_dimension_numbers")
       return convertDotDimensionNumbers(pattern, stablehloAttr, vhloAttrs);
-    }
   }
   if constexpr (std::is_same<StablehloOpTy,
                              stablehlo::DynamicGatherOp>::value ||
                 std::is_same<StablehloOpTy, stablehlo::GatherOp>::value) {
-    if (stablehloName == "dimension_numbers") {
+    if (stablehloName == "dimension_numbers")
       return convertGatherDimensionNumbers(pattern, stablehloAttr, vhloAttrs);
-    }
   }
   if constexpr (std::is_same<StablehloOpTy, stablehlo::RecvOp>::value ||
                 std::is_same<StablehloOpTy, stablehlo::SendOp>::value) {
-    if (stablehloName == "channel_handle") {
+    if (stablehloName == "channel_handle")
       return convertChannelHandle(pattern, stablehloAttr, vhloAttrs);
-    }
   }
   if constexpr (std::is_same<StablehloOpTy, stablehlo::ScatterOp>::value) {
-    if (stablehloName == "scatter_dimension_numbers") {
+    if (stablehloName == "scatter_dimension_numbers")
       return convertScatterDimensionNumbers(pattern, stablehloAttr, vhloAttrs);
-    }
   }
   if constexpr (std::is_same<StablehloOpTy, func::CallOp>::value) {
-    if (stablehloName == "callee") {
+    if (stablehloName == "callee")
       return convertFuncCallee(pattern, stablehloAttr, vhloAttrs);
-    }
   }
   return notSpecial();
 }

--- a/stablehlo/transforms/StablehloLegalizeToVhlo.cpp
+++ b/stablehlo/transforms/StablehloLegalizeToVhlo.cpp
@@ -34,9 +34,9 @@ namespace stablehlo {
 
 namespace {
 
-///////////////////////////////////////////////
-/// StableHLO --> VHLO Types and Attributes ///
-///////////////////////////////////////////////
+//===----------------------------------------------------------------------===//
+// StableHLO --> VHLO types
+//===----------------------------------------------------------------------===//
 
 class StablehloToVhloTypeConverter : public vhlo::VhloTypeConverter {
  public:
@@ -73,14 +73,20 @@ class StablehloToVhloTypeConverter : public vhlo::VhloTypeConverter {
   }
 };
 
+//===----------------------------------------------------------------------===//
+// StableHLO --> VHLO attributes: 1) Generic case.
+// Applicable in areas where there is 1:1 mapping from StableHLO to VHLO.
+// This is the predominant case.
+//===----------------------------------------------------------------------===//
+
 #define RETURN_CONVERTED_ENUM_ATTR(Name, Version)                    \
   auto stablehloValue = stablehlo::stringify##Name(attr.getValue()); \
   auto vhloValue = vhlo::symbolize##Name##Version(stablehloValue);   \
   if (!vhloValue.has_value()) return {};                             \
   return vhlo::Name##Version##Attr::get(attr.getContext(), vhloValue.value())
 
-Attribute convertAttrToVhlo(Attribute stablehloAttr,
-                            TypeConverter* typeConverter) {
+Attribute convertGeneric(Attribute stablehloAttr,
+                         TypeConverter* typeConverter) {
   // Handle StableHLO attributes.
   // The logic that handles attributes from other dialects (e.g. builtin
   // attributes) lives below.
@@ -123,7 +129,7 @@ Attribute convertAttrToVhlo(Attribute stablehloAttr,
   if (auto stablehloAttrs = stablehloAttr.dyn_cast<ArrayAttr>()) {
     SmallVector<Attribute> vhloAttrs;
     for (auto stablehloAttr : stablehloAttrs) {
-      auto vhloAttr = convertAttrToVhlo(stablehloAttr, typeConverter);
+      auto vhloAttr = convertGeneric(stablehloAttr, typeConverter);
       if (!vhloAttr) return {};
       vhloAttrs.push_back(vhloAttr);
     }
@@ -139,8 +145,8 @@ Attribute convertAttrToVhlo(Attribute stablehloAttr,
   if (auto attr = stablehloAttr.dyn_cast<DictionaryAttr>()) {
     SmallVector<std::pair<Attribute, Attribute>> vhloAttrs;
     for (auto namedAttr : attr.getValue()) {
-      auto vhloName = convertAttrToVhlo(namedAttr.getName(), typeConverter);
-      auto vhloValue = convertAttrToVhlo(namedAttr.getValue(), typeConverter);
+      auto vhloName = convertGeneric(namedAttr.getName(), typeConverter);
+      auto vhloValue = convertGeneric(namedAttr.getValue(), typeConverter);
       if (!vhloName || !vhloValue) return {};
       vhloAttrs.push_back({vhloName, vhloValue});
     }
@@ -182,10 +188,30 @@ Attribute convertAttrToVhlo(Attribute stablehloAttr,
   return {};  // Failed to convert attribute.
 }
 
+//===----------------------------------------------------------------------===//
+// StableHLO --> VHLO attributes: 2) Special cases.
+// Applicable in areas where there is no 1:1 mapping from StableHLO to VHLO.
+// This is pretty infrequent.
+//===----------------------------------------------------------------------===//
+
+// Indicates the outcome of converting a potentially special case.
+// NOT_SPECIAL means that this wasn't actually a special case.
+// SPECIAL_FAILURE means that this was a special case and conversion failed.
+// SPECIAL_SUCCESS means that this was a special case and conversion succeeded.
+enum class SpecialResult {
+  SPECIAL_SUCCESS = 0,
+  SPECIAL_FAILURE = 1,
+  NOT_SPECIAL = 2,
+};
+
+SpecialResult specialSuccess() { return SpecialResult::SPECIAL_SUCCESS; }
+SpecialResult specialFailure() { return SpecialResult::SPECIAL_FAILURE; }
+SpecialResult notSpecial() { return SpecialResult::NOT_SPECIAL; }
+
 Attribute convertInt(const ConversionPattern& pattern, int64_t stablehloDim) {
   auto stablehloType = IntegerType::get(pattern.getContext(), 64);
   auto stablehloAttr = IntegerAttr::get(stablehloType, stablehloDim);
-  return convertAttrToVhlo(stablehloAttr, pattern.getTypeConverter());
+  return convertGeneric(stablehloAttr, pattern.getTypeConverter());
 }
 
 Attribute convertInts(const ConversionPattern& pattern,
@@ -193,249 +219,345 @@ Attribute convertInts(const ConversionPattern& pattern,
   auto stablehloType = RankedTensorType::get(
       stablehloDims.size(), IntegerType::get(pattern.getContext(), 64));
   auto stablehloAttr = DenseIntElementsAttr::get(stablehloType, stablehloDims);
-  return convertAttrToVhlo(stablehloAttr, pattern.getTypeConverter());
+  return convertGeneric(stablehloAttr, pattern.getTypeConverter());
 }
 
 Attribute convertSymbol(const ConversionPattern& pattern,
                         Attribute stablehloAttr) {
   auto stablehloSymbolAttr = stablehloAttr.dyn_cast<FlatSymbolRefAttr>();
   if (!stablehloSymbolAttr) return {};
-  return convertAttrToVhlo(stablehloSymbolAttr.getAttr(),
-                           pattern.getTypeConverter());
+  return convertGeneric(stablehloSymbolAttr.getAttr(),
+                        pattern.getTypeConverter());
 }
 
-Attribute convertCustomCallApiVersion(Attribute stablehloAttr) {
-  if (auto attr = stablehloAttr.dyn_cast<CustomCallApiVersionAttr>()) {
-    RETURN_CONVERTED_ENUM_ATTR(CustomCallApiVersion, V1);
-  }
-  return {};
-}
-
-LogicalResult convertChannelHandle(const ConversionPattern& pattern,
+SpecialResult convertChannelHandle(const ConversionPattern& pattern,
                                    Attribute stablehloAttr,
                                    SmallVector<NamedAttribute>& vhloAttrs) {
   auto attr = stablehloAttr.dyn_cast<stablehlo::ChannelHandleAttr>();
-  if (!attr) return failure();
+  if (!attr) return specialFailure();
 
   auto vhloChannelId = convertInt(pattern, attr.getHandle());
-  if (!vhloChannelId) return failure();
+  if (!vhloChannelId) return specialFailure();
   vhloAttrs.emplace_back(StringAttr::get(pattern.getContext(), "channel_id"),
                          vhloChannelId);
 
   auto vhloChannelType = convertInt(pattern, attr.getType());
-  if (!vhloChannelType) return failure();
+  if (!vhloChannelType) return specialFailure();
   vhloAttrs.emplace_back(StringAttr::get(pattern.getContext(), "channel_type"),
                          vhloChannelType);
-  return success();
+  return specialSuccess();
 }
 
-LogicalResult convertChannelId(const ConversionPattern& pattern,
+SpecialResult convertChannelId(const ConversionPattern& pattern,
                                Attribute stablehloAttr,
                                SmallVector<NamedAttribute>& vhloAttrs) {
   auto attr = stablehloAttr.dyn_cast<stablehlo::ChannelHandleAttr>();
-  if (!attr) return failure();
+  if (!attr) return specialFailure();
 
   auto vhloChannelId = convertInt(pattern, attr.getHandle());
-  if (!vhloChannelId) return failure();
+  if (!vhloChannelId) return specialFailure();
   vhloAttrs.emplace_back(StringAttr::get(pattern.getContext(), "channel_id"),
                          vhloChannelId);
-  return success();
+  return specialSuccess();
 }
 
-LogicalResult convertConvDimensionNumbers(
+SpecialResult convertConvDimensionNumbers(
     const ConversionPattern& pattern, Attribute stablehloAttr,
     SmallVector<NamedAttribute>& vhloAttrs) {
   auto attr = stablehloAttr.dyn_cast<stablehlo::ConvDimensionNumbersAttr>();
-  if (!attr) return failure();
+  if (!attr) return specialFailure();
 
   auto vhloInputBatchDimension =
       convertInt(pattern, attr.getInputBatchDimension());
-  if (!vhloInputBatchDimension) return failure();
+  if (!vhloInputBatchDimension) return specialFailure();
   vhloAttrs.emplace_back(
       StringAttr::get(pattern.getContext(), "input_batch_dimension"),
       vhloInputBatchDimension);
 
   auto vhloInputFeatureDimension =
       convertInt(pattern, attr.getInputFeatureDimension());
-  if (!vhloInputFeatureDimension) return failure();
+  if (!vhloInputFeatureDimension) return specialFailure();
   vhloAttrs.emplace_back(
       StringAttr::get(pattern.getContext(), "input_feature_dimension"),
       vhloInputFeatureDimension);
 
   auto vhloInputSpatialDimensions =
       convertInts(pattern, attr.getInputSpatialDimensions());
-  if (!vhloInputSpatialDimensions) return failure();
+  if (!vhloInputSpatialDimensions) return specialFailure();
   vhloAttrs.emplace_back(
       StringAttr::get(pattern.getContext(), "input_spatial_dimensions"),
       vhloInputSpatialDimensions);
 
   auto vhloKernelInputFeatureDimension =
       convertInt(pattern, attr.getKernelInputFeatureDimension());
-  if (!vhloKernelInputFeatureDimension) return failure();
+  if (!vhloKernelInputFeatureDimension) return specialFailure();
   vhloAttrs.emplace_back(
       StringAttr::get(pattern.getContext(), "kernel_input_feature_dimension"),
       vhloKernelInputFeatureDimension);
 
   auto vhloKernelOutputFeatureDimension =
       convertInt(pattern, attr.getKernelOutputFeatureDimension());
-  if (!vhloKernelOutputFeatureDimension) return failure();
+  if (!vhloKernelOutputFeatureDimension) return specialFailure();
   vhloAttrs.emplace_back(
       StringAttr::get(pattern.getContext(), "kernel_output_feature_dimension"),
       vhloKernelOutputFeatureDimension);
 
   auto vhloKernelSpatialDimensions =
       convertInts(pattern, attr.getKernelSpatialDimensions());
-  if (!vhloKernelSpatialDimensions) return failure();
+  if (!vhloKernelSpatialDimensions) return specialFailure();
   vhloAttrs.emplace_back(
       StringAttr::get(pattern.getContext(), "kernel_spatial_dimensions"),
       vhloKernelSpatialDimensions);
 
   auto vhloOutputBatchDimension =
       convertInt(pattern, attr.getOutputBatchDimension());
-  if (!vhloOutputBatchDimension) return failure();
+  if (!vhloOutputBatchDimension) return specialFailure();
   vhloAttrs.emplace_back(
       StringAttr::get(pattern.getContext(), "output_batch_dimension"),
       vhloOutputBatchDimension);
 
   auto vhloOutputFeatureDimension =
       convertInt(pattern, attr.getOutputFeatureDimension());
-  if (!vhloOutputFeatureDimension) return failure();
+  if (!vhloOutputFeatureDimension) return specialFailure();
   vhloAttrs.emplace_back(
       StringAttr::get(pattern.getContext(), "output_feature_dimension"),
       vhloOutputFeatureDimension);
 
   auto vhloOutputSpatialDimensions =
       convertInts(pattern, attr.getOutputSpatialDimensions());
-  if (!vhloOutputSpatialDimensions) return failure();
+  if (!vhloOutputSpatialDimensions) return specialFailure();
   vhloAttrs.emplace_back(
       StringAttr::get(pattern.getContext(), "output_spatial_dimensions"),
       vhloOutputSpatialDimensions);
-
-  return success();
+  return specialSuccess();
 }
 
-Attribute convertCustomCallCalledComputations(const ConversionPattern& pattern,
-                                              Attribute stablehloAttr) {
-  if (auto stablehloArrayAttr = stablehloAttr.dyn_cast<ArrayAttr>()) {
-    SmallVector<Attribute> vhloAttrs;
-    for (auto stablehloAttr : stablehloArrayAttr) {
-      auto vhloAttr = convertSymbol(pattern, stablehloAttr);
-      if (!vhloAttr) return {};
-      vhloAttrs.push_back(vhloAttr);
-    }
-    return vhlo::ArrayV1Attr::get(pattern.getContext(), vhloAttrs);
+SpecialResult convertCustomCallApiVersion(
+    const ConversionPattern& pattern, Attribute stablehloAttr,
+    SmallVector<NamedAttribute>& vhloAttrs) {
+  auto attr = stablehloAttr.dyn_cast<CustomCallApiVersionAttr>();
+  if (!attr) return specialFailure();
+
+  auto convert = [&]() -> Attribute {
+    RETURN_CONVERTED_ENUM_ATTR(CustomCallApiVersion, V1);
+  };
+  auto vhloAttr = convert();
+  if (!vhloAttr) return specialFailure();
+  vhloAttrs.emplace_back(StringAttr::get(pattern.getContext(), "api_version"),
+                         vhloAttr);
+  return specialSuccess();
+}
+
+SpecialResult convertCustomCallCalledComputations(
+    const ConversionPattern& pattern, Attribute stablehloAttr,
+    SmallVector<NamedAttribute>& vhloAttrs) {
+  auto attr = stablehloAttr.dyn_cast<ArrayAttr>();
+  if (!attr) return specialFailure();
+
+  SmallVector<Attribute> vhloElementAttrs;
+  for (auto stablehloElementAttr : attr) {
+    auto vhloElementAttr = convertSymbol(pattern, stablehloElementAttr);
+    if (!vhloElementAttr) return specialFailure();
+    vhloElementAttrs.push_back(vhloElementAttr);
   }
-  return {};
+
+  vhloAttrs.emplace_back(
+      StringAttr::get(pattern.getContext(), "called_computations"),
+      vhlo::ArrayV1Attr::get(pattern.getContext(), vhloElementAttrs));
+  return specialSuccess();
 }
 
-LogicalResult convertDotDimensionNumbers(
+SpecialResult convertDotDimensionNumbers(
     const ConversionPattern& pattern, Attribute stablehloAttr,
     SmallVector<NamedAttribute>& vhloAttrs) {
   auto attr = stablehloAttr.dyn_cast<stablehlo::DotDimensionNumbersAttr>();
-  if (!attr) return failure();
+  if (!attr) return specialFailure();
 
   auto vhloLhsBatchingDimensions =
       convertInts(pattern, attr.getLhsBatchingDimensions());
-  if (!vhloLhsBatchingDimensions) return failure();
+  if (!vhloLhsBatchingDimensions) return specialFailure();
   vhloAttrs.emplace_back(
       StringAttr::get(pattern.getContext(), "lhs_batching_dimensions"),
       vhloLhsBatchingDimensions);
 
   auto vhloRhsBatchingDimensions =
       convertInts(pattern, attr.getRhsBatchingDimensions());
-  if (!vhloRhsBatchingDimensions) return failure();
+  if (!vhloRhsBatchingDimensions) return specialFailure();
   vhloAttrs.emplace_back(
       StringAttr::get(pattern.getContext(), "rhs_batching_dimensions"),
       vhloRhsBatchingDimensions);
 
   auto vhloLhsContractingDimensions =
       convertInts(pattern, attr.getLhsContractingDimensions());
-  if (!vhloLhsContractingDimensions) return failure();
+  if (!vhloLhsContractingDimensions) return specialFailure();
   vhloAttrs.emplace_back(
       StringAttr::get(pattern.getContext(), "lhs_contracting_dimensions"),
       vhloLhsContractingDimensions);
 
   auto vhloRhsContractingDimensions =
       convertInts(pattern, attr.getRhsContractingDimensions());
-  if (!vhloRhsContractingDimensions) return failure();
+  if (!vhloRhsContractingDimensions) return specialFailure();
   vhloAttrs.emplace_back(
       StringAttr::get(pattern.getContext(), "rhs_contracting_dimensions"),
       vhloRhsContractingDimensions);
-  return success();
+  return specialSuccess();
 }
 
-Attribute convertFuncCallee(const ConversionPattern& pattern,
-                            Attribute stablehloAttr) {
-  return convertSymbol(pattern, stablehloAttr);
+SpecialResult convertFuncCallee(const ConversionPattern& pattern,
+                                Attribute stablehloAttr,
+                                SmallVector<NamedAttribute>& vhloAttrs) {
+  auto vhloAttr = convertSymbol(pattern, stablehloAttr);
+  if (!vhloAttr) return specialFailure();
+  vhloAttrs.emplace_back(StringAttr::get(pattern.getContext(), "callee"),
+                         vhloAttr);
+  return specialSuccess();
 }
 
-LogicalResult convertGatherDimensionNumbers(
+SpecialResult convertGatherDimensionNumbers(
     const ConversionPattern& pattern, Attribute stablehloAttr,
     SmallVector<NamedAttribute>& vhloAttrs) {
   auto attr = stablehloAttr.dyn_cast<stablehlo::GatherDimensionNumbersAttr>();
-  if (!attr) return failure();
+  if (!attr) return specialFailure();
 
   auto vhloOffsetDims = convertInts(pattern, attr.getOffsetDims());
-  if (!vhloOffsetDims) return failure();
+  if (!vhloOffsetDims) return specialFailure();
   vhloAttrs.emplace_back(StringAttr::get(pattern.getContext(), "offset_dims"),
                          vhloOffsetDims);
 
   auto vhloCollapsedSliceDims =
       convertInts(pattern, attr.getCollapsedSliceDims());
-  if (!vhloCollapsedSliceDims) return failure();
+  if (!vhloCollapsedSliceDims) return specialFailure();
   vhloAttrs.emplace_back(
       StringAttr::get(pattern.getContext(), "collapsed_slice_dims"),
       vhloCollapsedSliceDims);
 
   auto vhloStartIndexMap = convertInts(pattern, attr.getStartIndexMap());
-  if (!vhloStartIndexMap) return failure();
+  if (!vhloStartIndexMap) return specialFailure();
   vhloAttrs.emplace_back(
       StringAttr::get(pattern.getContext(), "start_index_map"),
       vhloStartIndexMap);
 
   auto vhloIndexVectorDim = convertInt(pattern, attr.getIndexVectorDim());
-  if (!vhloIndexVectorDim) return failure();
+  if (!vhloIndexVectorDim) return specialFailure();
   vhloAttrs.emplace_back(
       StringAttr::get(pattern.getContext(), "index_vector_dim"),
       vhloIndexVectorDim);
-  return success();
+  return specialSuccess();
 }
 
-LogicalResult convertScatterDimensionNumbers(
+SpecialResult convertScatterDimensionNumbers(
     const ConversionPattern& pattern, Attribute stablehloAttr,
     SmallVector<NamedAttribute>& vhloAttrs) {
   auto attr = stablehloAttr.dyn_cast<stablehlo::ScatterDimensionNumbersAttr>();
-  if (!attr) return failure();
+  if (!attr) return specialFailure();
 
   auto vhloUpdateWindowDims = convertInts(pattern, attr.getUpdateWindowDims());
-  if (!vhloUpdateWindowDims) return failure();
+  if (!vhloUpdateWindowDims) return specialFailure();
   vhloAttrs.emplace_back(
       StringAttr::get(pattern.getContext(), "update_window_dims"),
       vhloUpdateWindowDims);
 
   auto vhloInsertedWindowDims =
       convertInts(pattern, attr.getInsertedWindowDims());
-  if (!vhloInsertedWindowDims) return failure();
+  if (!vhloInsertedWindowDims) return specialFailure();
   vhloAttrs.emplace_back(
       StringAttr::get(pattern.getContext(), "inserted_window_dims"),
       vhloInsertedWindowDims);
 
   auto vhloScatterDimsToOperandDims =
       convertInts(pattern, attr.getScatterDimsToOperandDims());
-  if (!vhloScatterDimsToOperandDims) return failure();
+  if (!vhloScatterDimsToOperandDims) return specialFailure();
   vhloAttrs.emplace_back(
       StringAttr::get(pattern.getContext(), "scatter_dims_to_operand_dims"),
       vhloScatterDimsToOperandDims);
 
   auto vhloIndexVectorDim = convertInt(pattern, attr.getIndexVectorDim());
-  if (!vhloIndexVectorDim) return failure();
+  if (!vhloIndexVectorDim) return specialFailure();
   vhloAttrs.emplace_back(
       StringAttr::get(pattern.getContext(), "index_vector_dim"),
       vhloIndexVectorDim);
-  return success();
+  return specialSuccess();
+}
+
+SpecialResult convertUseGlobalDeviceIds(
+    const ConversionPattern& pattern, Attribute stablehloAttr,
+    SmallVector<NamedAttribute>& vhloAttrs) {
+  if (!stablehloAttr.isa<UnitAttr>()) return specialFailure();
+  vhloAttrs.emplace_back(
+      StringAttr::get(pattern.getContext(), "use_global_device_ids"),
+      vhlo::BooleanV1Attr::get(pattern.getContext(), true));
+  return specialSuccess();
+}
+
+template <typename StablehloOpTy>
+SpecialResult convertSpecial(const OpConversionPattern<StablehloOpTy>& pattern,
+                             StringRef stablehloName, Attribute stablehloAttr,
+                             SmallVector<NamedAttribute>& vhloAttrs) {
+  if constexpr (std::is_same<StablehloOpTy, stablehlo::AllGatherOp>::value ||
+                std::is_same<StablehloOpTy, stablehlo::AllReduceOp>::value ||
+                std::is_same<StablehloOpTy, stablehlo::AllToAllOp>::value ||
+                std::is_same<StablehloOpTy,
+                             stablehlo::CollectivePermuteOp>::value ||
+                std::is_same<StablehloOpTy,
+                             stablehlo::ReduceScatterOp>::value) {
+    if (stablehloName == "channel_handle") {
+      return convertChannelId(pattern, stablehloAttr, vhloAttrs);
+    }
+    if (stablehloName == "use_global_device_ids") {
+      return convertUseGlobalDeviceIds(pattern, stablehloAttr, vhloAttrs);
+    }
+  }
+  if constexpr (std::is_same<StablehloOpTy, stablehlo::ConvolutionOp>::value ||
+                std::is_same<StablehloOpTy, stablehlo::DynamicConvOp>::value) {
+    if (stablehloName == "dimension_numbers") {
+      return convertConvDimensionNumbers(pattern, stablehloAttr, vhloAttrs);
+    }
+  }
+  if constexpr (std::is_same<StablehloOpTy, stablehlo::CustomCallOp>::value) {
+    if (stablehloName == "api_version") {
+      return convertCustomCallApiVersion(pattern, stablehloAttr, vhloAttrs);
+    }
+    if (stablehloName == "called_computations") {
+      return convertCustomCallCalledComputations(pattern, stablehloAttr,
+                                                 vhloAttrs);
+    }
+  }
+  if constexpr (std::is_same<StablehloOpTy, stablehlo::DotGeneralOp>::value) {
+    if (stablehloName == "dot_dimension_numbers") {
+      return convertDotDimensionNumbers(pattern, stablehloAttr, vhloAttrs);
+    }
+  }
+  if constexpr (std::is_same<StablehloOpTy,
+                             stablehlo::DynamicGatherOp>::value ||
+                std::is_same<StablehloOpTy, stablehlo::GatherOp>::value) {
+    if (stablehloName == "dimension_numbers") {
+      return convertGatherDimensionNumbers(pattern, stablehloAttr, vhloAttrs);
+    }
+  }
+  if constexpr (std::is_same<StablehloOpTy, stablehlo::RecvOp>::value ||
+                std::is_same<StablehloOpTy, stablehlo::SendOp>::value) {
+    if (stablehloName == "channel_handle") {
+      return convertChannelHandle(pattern, stablehloAttr, vhloAttrs);
+    }
+  }
+  if constexpr (std::is_same<StablehloOpTy, stablehlo::ScatterOp>::value) {
+    if (stablehloName == "scatter_dimension_numbers") {
+      return convertScatterDimensionNumbers(pattern, stablehloAttr, vhloAttrs);
+    }
+  }
+  if constexpr (std::is_same<StablehloOpTy, func::CallOp>::value) {
+    if (stablehloName == "callee") {
+      return convertFuncCallee(pattern, stablehloAttr, vhloAttrs);
+    }
+  }
+  return notSpecial();
 }
 
 #undef RETURN_CONVERTED_ENUM_ATTR
+
+//===----------------------------------------------------------------------===//
+// StableHLO --> VHLO operations
+//===----------------------------------------------------------------------===//
 
 template <typename StablehloOpTy>
 class StablehloToVhloOpConverter : public OpConversionPattern<StablehloOpTy> {
@@ -455,98 +577,33 @@ class StablehloToVhloOpConverter : public OpConversionPattern<StablehloOpTy> {
     // the dialect conversion infrastructure.
     ValueRange vhloOperands = adaptor.getOperands();
 
+    // Convert StableHLO attributes to VHLO equivalents.
+    // There are two paths:
+    //   1) Generic path where default logic applies, and there is a 1:1
+    //      mapping from StableHLO to VHLO.
+    //   2) Special cases (currently, about a dozen) where there is not 1:1
+    //      mapping from StableHLO to VHLO.
     SmallVector<NamedAttribute> vhloAttrs;
     for (NamedAttribute stablehloAttr : stablehloOp->getAttrs()) {
-      Attribute vhloAttr;
-      if (stablehloAttr.getName() == "use_global_device_ids") {
-        if (!stablehloAttr.getValue().isa<UnitAttr>()) return failure();
-        vhloAttr = vhlo::BooleanV1Attr::get(this->getContext(), true);
-      } else if constexpr (
-          std::is_same<StablehloOpTy, stablehlo::AllGatherOp>::value ||
-          std::is_same<StablehloOpTy, stablehlo::AllReduceOp>::value ||
-          std::is_same<StablehloOpTy, stablehlo::AllToAllOp>::value ||
-          std::is_same<StablehloOpTy, stablehlo::CollectivePermuteOp>::value ||
-          std::is_same<StablehloOpTy, stablehlo::ReduceScatterOp>::value) {
-        if (stablehloAttr.getName() == "channel_handle") {
-          auto result =
-              convertChannelId(*this, stablehloAttr.getValue(), vhloAttrs);
-          if (failed(result)) return failure();
-          continue;
-        }
-      } else if constexpr (std::is_same<StablehloOpTy,
-                                        stablehlo::CustomCallOp>::value) {
-        if (stablehloAttr.getName() == "api_version") {
-          vhloAttr = convertCustomCallApiVersion(stablehloAttr.getValue());
+      auto result = convertSpecial(*this, stablehloAttr.getName(),
+                                   stablehloAttr.getValue(), vhloAttrs);
+      switch (result) {
+        case SpecialResult::SPECIAL_SUCCESS:
+          break;
+        case SpecialResult::SPECIAL_FAILURE:
+          return failure();
+        case SpecialResult::NOT_SPECIAL:
+          auto vhloAttr = convertGeneric(stablehloAttr.getValue(),
+                                         this->getTypeConverter());
           if (!vhloAttr) return failure();
-        }
-        if (stablehloAttr.getName() == "called_computations") {
-          vhloAttr = convertCustomCallCalledComputations(
-              *this, stablehloAttr.getValue());
-          if (!vhloAttr) return failure();
-        }
-      } else if constexpr (std::is_same<StablehloOpTy,
-                                        stablehlo::DotGeneralOp>::value) {
-        if (stablehloAttr.getName() == "dot_dimension_numbers") {
-          auto result = convertDotDimensionNumbers(
-              *this, stablehloAttr.getValue(), vhloAttrs);
-          if (failed(result)) return failure();
-          continue;
-        }
-      } else if constexpr (std::is_same<StablehloOpTy,
-                                        stablehlo::DynamicConvOp>::value ||
-                           std::is_same<StablehloOpTy,
-                                        stablehlo::ConvolutionOp>::value) {
-        if (stablehloAttr.getName() == "dimension_numbers") {
-          auto result = convertConvDimensionNumbers(
-              *this, stablehloAttr.getValue(), vhloAttrs);
-          if (failed(result)) return failure();
-          continue;
-        }
-      } else if constexpr (std::is_same<StablehloOpTy,
-                                        stablehlo::DynamicGatherOp>::value ||
-                           std::is_same<StablehloOpTy,
-                                        stablehlo::GatherOp>::value) {
-        if (stablehloAttr.getName() == "dimension_numbers") {
-          auto result = convertGatherDimensionNumbers(
-              *this, stablehloAttr.getValue(), vhloAttrs);
-          if (failed(result)) return failure();
-          continue;
-        }
-      } else if constexpr (std::is_same<StablehloOpTy,
-                                        stablehlo::RecvOp>::value ||
-                           std::is_same<StablehloOpTy,
-                                        stablehlo::SendOp>::value) {
-        if (stablehloAttr.getName() == "channel_handle") {
-          auto result =
-              convertChannelHandle(*this, stablehloAttr.getValue(), vhloAttrs);
-          if (failed(result)) return failure();
-          continue;
-        }
-      } else if constexpr (std::is_same<StablehloOpTy,
-                                        stablehlo::ScatterOp>::value) {
-        if (stablehloAttr.getName() == "scatter_dimension_numbers") {
-          auto result = convertScatterDimensionNumbers(
-              *this, stablehloAttr.getValue(), vhloAttrs);
-          if (failed(result)) return failure();
-          continue;
-        }
-      } else if constexpr (std::is_same<StablehloOpTy, func::CallOp>::value) {
-        if (stablehloAttr.getName() == "callee") {
-          vhloAttr = convertFuncCallee(*this, stablehloAttr.getValue());
-          if (!vhloAttr) return failure();
-        }
+          vhloAttrs.push_back({stablehloAttr.getName(), vhloAttr});
+          break;
       }
-      if (!vhloAttr) {
-        vhloAttr = convertAttrToVhlo(stablehloAttr.getValue(),
-                                     this->getTypeConverter());
-        if (!vhloAttr) return failure();
-      }
-      vhloAttrs.push_back({stablehloAttr.getName(), vhloAttr});
     }
 
-    // Convert the vhlo operation to a StableHLO equivalent.
+    // Convert the StableHLO operation to a VHLO equivalent.
     // This can almost be done in a generic fashion, except for
-    // vhlo.case that uses a variadic number of regions which means an
+    // stablehlo.case that uses a variadic number of regions which means an
     // additional argument for the generic builder.
     StablehloToVhloOp<StablehloOpTy> vhloOp;
     if constexpr (std::is_same<StablehloOpTy, stablehlo::CaseOp>::value) {
@@ -581,10 +638,6 @@ void populateStablehloToVhloPatterns(RewritePatternSet* patterns,
 
 }  // namespace
 
-/////////////////////////////////////
-/// StableHLO --> VHLO Operations ///
-/////////////////////////////////////
-
 struct StablehloLegalizeToVhloPass
     : public impl::StablehloLegalizeToVhloPassBase<
           StablehloLegalizeToVhloPass> {
@@ -599,7 +652,7 @@ struct StablehloLegalizeToVhloPass
     stablehlo::populateStablehloToVhloPatterns(&patterns, &converter,
                                                &getContext());
 
-    // StableHLO is a subset of VHLO.
+    // StableHLO should always be convertible to VHLO.
     if (failed(applyPartialConversion(getOperation(), target,
                                       std::move(patterns)))) {
       LLVM_DEBUG(llvm::dbgs() << "Failed partial conversion\n");

--- a/stablehlo/transforms/VhloLegalizeToStablehlo.cpp
+++ b/stablehlo/transforms/VhloLegalizeToStablehlo.cpp
@@ -12,6 +12,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringSet.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -35,9 +38,9 @@ namespace stablehlo {
 
 namespace {
 
-///////////////////////////////////////////////
-/// VHLO --> StableHLO Types and Attributes ///
-///////////////////////////////////////////////
+//===----------------------------------------------------------------------===//
+// VHLO --> StableHLO types
+//===----------------------------------------------------------------------===//
 
 class VhloToStablehloTypeConverter : public vhlo::VhloTypeConverter {
  public:
@@ -60,20 +63,25 @@ class VhloToStablehloTypeConverter : public vhlo::VhloTypeConverter {
   }
 };
 
+//===----------------------------------------------------------------------===//
+// VHLO --> StableHLO attributes: 1) Generic case.
+// Applicable in areas where there is 1:1 mapping from VHLO to StableHLO.
+// This is the predominant case.
+//===----------------------------------------------------------------------===//
+
 #define RETURN_CONVERTED_ENUM_ATTR(Name, Version)                   \
   auto vhloValue = vhlo::stringify##Name##Version(attr.getValue()); \
   auto stablehloValue = stablehlo::symbolize##Name(vhloValue);      \
   if (!stablehloValue.has_value()) return {};                       \
   return stablehlo::Name##Attr::get(attr.getContext(), stablehloValue.value())
 
-Attribute convertAttrToStablehlo(Attribute vhloAttr,
-                                 TypeConverter* typeConverter) {
+Attribute convertGeneric(Attribute vhloAttr, TypeConverter* typeConverter) {
   LLVM_DEBUG(llvm::dbgs() << "Converting attr " << vhloAttr);
   // TODO: ArgResultAliasV1Attr isn't handled yet.
   if (auto vhloAttrs = vhloAttr.dyn_cast<vhlo::ArrayV1Attr>()) {
     SmallVector<Attribute> stablehloAttrs;
     for (auto vhloAttr : vhloAttrs.getValue()) {
-      auto stablehloAttr = convertAttrToStablehlo(vhloAttr, typeConverter);
+      auto stablehloAttr = convertGeneric(vhloAttr, typeConverter);
       if (!stablehloAttr) return {};
       stablehloAttrs.push_back(stablehloAttr);
     }
@@ -94,10 +102,9 @@ Attribute convertAttrToStablehlo(Attribute vhloAttr,
   if (auto attr = vhloAttr.dyn_cast<vhlo::DictionaryV1Attr>()) {
     SmallVector<NamedAttribute> vhloAttrs;
     for (auto namedAttr : attr.getValue()) {
-      auto builtinName = convertAttrToStablehlo(namedAttr.first, typeConverter)
+      auto builtinName = convertGeneric(namedAttr.first, typeConverter)
                              .dyn_cast_or_null<StringAttr>();
-      auto builtinValue =
-          convertAttrToStablehlo(namedAttr.second, typeConverter);
+      auto builtinValue = convertGeneric(namedAttr.second, typeConverter);
       if (!builtinName || !builtinValue) return {};
       vhloAttrs.push_back({builtinName, builtinValue});
     }
@@ -163,6 +170,26 @@ Attribute convertAttrToStablehlo(Attribute vhloAttr,
   return {};
 }
 
+//===----------------------------------------------------------------------===//
+// VHLO --> StableHLO attributes: 2) Special cases.
+// Applicable in areas where there is no 1:1 mapping from VHLO to StableHLO.
+// This is pretty infrequent.
+//===----------------------------------------------------------------------===//
+
+// Indicates the outcome of converting a potentially special case.
+// NOT_SPECIAL means that this wasn't actually a special case.
+// SPECIAL_FAILURE means that this was a special case and conversion failed.
+// SPECIAL_SUCCESS means that this was a special case and conversion succeeded.
+enum class SpecialResult {
+  SPECIAL_SUCCESS = 0,
+  SPECIAL_FAILURE = 1,
+  NOT_SPECIAL = 2,
+};
+
+SpecialResult specialSuccess() { return SpecialResult::SPECIAL_SUCCESS; }
+SpecialResult specialFailure() { return SpecialResult::SPECIAL_FAILURE; }
+SpecialResult notSpecial() { return SpecialResult::NOT_SPECIAL; }
+
 LogicalResult convertInt(Attribute vhloAttr, int64_t& result) {
   auto vhloIntegerAttr = vhloAttr.dyn_cast<vhlo::IntegerV1Attr>();
   if (!vhloIntegerAttr) return failure();
@@ -174,7 +201,7 @@ LogicalResult convertInts(Attribute vhloAttr, TypeConverter* typeConverter,
                           SmallVector<int64_t>& result) {
   auto vhloTensorAttr = vhloAttr.dyn_cast<vhlo::TensorV1Attr>();
   if (!vhloTensorAttr) return failure();
-  auto stablehloAttr = convertAttrToStablehlo(vhloAttr, typeConverter)
+  auto stablehloAttr = convertGeneric(vhloAttr, typeConverter)
                            .dyn_cast_or_null<DenseIntElementsAttr>();
   if (!stablehloAttr) return failure();
   llvm::append_range(result, stablehloAttr.getValues<int64_t>());
@@ -184,9 +211,8 @@ LogicalResult convertInts(Attribute vhloAttr, TypeConverter* typeConverter,
 Attribute convertSymbol(Attribute vhloAttr, TypeConverter* typeConverter) {
   auto vhloStringAttr = vhloAttr.dyn_cast<vhlo::StringV1Attr>();
   if (!vhloStringAttr) return {};
-  auto stablehloStringAttr =
-      convertAttrToStablehlo(vhloStringAttr, typeConverter)
-          .dyn_cast_or_null<StringAttr>();
+  auto stablehloStringAttr = convertGeneric(vhloStringAttr, typeConverter)
+                                 .dyn_cast_or_null<StringAttr>();
   if (!stablehloStringAttr) return {};
   return FlatSymbolRefAttr::get(stablehloStringAttr);
 }
@@ -324,31 +350,123 @@ Attribute convertScatterDimensionNumbers(vhlo::ScatterOpV1 vhloOp,
 
 #undef RETURN_CONVERTED_ENUM_ATTR
 
-/////////////////////////////////////
-/// VHLO --> StableHLO Operations ///
-/////////////////////////////////////
+template <typename... StringTy>
+void eraseAttrs(SmallVector<NamedAttribute>& attrs, StringTy... names) {
+  StringSet<llvm::MallocAllocator> nameSet({names...});
+  llvm::erase_if(attrs, [&](NamedAttribute attr) {
+    return nameSet.contains(attr.getName());
+  });
+}
 
-struct VhloLegalizeToStablehloPass
-    : public impl::VhloLegalizeToStablehloPassBase<
-          VhloLegalizeToStablehloPass> {
-  void runOnOperation() override {
-    ConversionTarget target(getContext());
-    target.addIllegalDialect<vhlo::VhloDialect>();
-    target.addLegalDialect<stablehlo::StablehloDialect>();
-    target.addLegalDialect<func::FuncDialect>();
+template <typename VhloOpTy>
+LogicalResult implodeSpecial(const OpConversionPattern<VhloOpTy>& pattern,
+                             VhloOpTy vhloOp,
+                             SmallVector<NamedAttribute>& vhloAttrs,
+                             SmallVector<NamedAttribute>& stablehloAttrs) {
+  if constexpr (std::is_same<VhloOpTy, vhlo::ConvolutionOpV1>::value ||
+                std::is_same<VhloOpTy, vhlo::DynamicConvOpV1>::value) {
+    auto stablehloAttr =
+        convertConvDimensionNumbers(vhloOp, pattern.getTypeConverter());
+    if (!stablehloAttr) return failure();
+    stablehloAttrs.emplace_back(
+        StringAttr::get(pattern.getContext(), "dimension_numbers"),
+        stablehloAttr);
+    eraseAttrs(vhloAttrs, "input_batch_dimension", "input_feature_dimension",
+               "input_spatial_dimensions", "kernel_input_feature_dimension",
+               "kernel_output_feature_dimension", "kernel_spatial_dimensions",
+               "output_batch_dimension", "output_feature_dimension",
+               "output_spatial_dimensions");
+  }
+  if constexpr (std::is_same<VhloOpTy, vhlo::DotGeneralOpV1>::value) {
+    auto stablehloAttr =
+        convertDotDimensionNumbers(vhloOp, pattern.getTypeConverter());
+    if (!stablehloAttr) return failure();
+    stablehloAttrs.emplace_back(
+        StringAttr::get(pattern.getContext(), "dot_dimension_numbers"),
+        stablehloAttr);
+    eraseAttrs(vhloAttrs, "lhs_batching_dimensions", "rhs_batching_dimensions",
+               "lhs_contracting_dimensions", "rhs_contracting_dimensions");
+  }
+  if constexpr (std::is_same<VhloOpTy, vhlo::DynamicGatherOpV1>::value ||
+                std::is_same<VhloOpTy, vhlo::GatherOpV1>::value) {
+    auto stablehloAttr =
+        convertGatherDimensionNumbers(vhloOp, pattern.getTypeConverter());
+    if (!stablehloAttr) return failure();
+    stablehloAttrs.emplace_back(
+        StringAttr::get(pattern.getContext(), "dimension_numbers"),
+        stablehloAttr);
+    eraseAttrs(vhloAttrs, "offset_dims", "collapsed_slice_dims",
+               "start_index_map", "index_vector_dim");
+  }
+  if constexpr (std::is_same<VhloOpTy, vhlo::ScatterOpV1>::value) {
+    auto stablehloAttr =
+        convertScatterDimensionNumbers(vhloOp, pattern.getTypeConverter());
+    if (!stablehloAttr) return failure();
+    stablehloAttrs.emplace_back(
+        StringAttr::get(pattern.getContext(), "scatter_dimension_numbers"),
+        stablehloAttr);
+    eraseAttrs(vhloAttrs, "update_window_dims", "inserted_window_dims",
+               "scatter_dims_to_operand_dims", "index_vector_dim");
+  }
+  if constexpr (std::is_same<VhloOpTy, vhlo::RecvOpV1>::value ||
+                std::is_same<VhloOpTy, vhlo::SendOpV1>::value) {
+    auto stablehloAttr =
+        convertChannelHandle(vhloOp, pattern.getTypeConverter());
+    if (!stablehloAttr) return failure();
+    stablehloAttrs.emplace_back(
+        StringAttr::get(pattern.getContext(), "channel_handle"), stablehloAttr);
+    eraseAttrs(vhloAttrs, "channel_id", "channel_type");
+  }
+  return success();
+}
 
-    VhloToStablehloTypeConverter converter;
-    RewritePatternSet patterns(&getContext());
-    stablehlo::populateVhloToStablehloPatterns(&patterns, &converter,
-                                               &getContext());
-
-    // VHLO should always be convertible to StableHLO if upgraded.
-    if (failed(applyPartialConversion(getOperation(), target,
-                                      std::move(patterns)))) {
-      return signalPassFailure();
+template <typename VhloOpTy>
+SpecialResult convertSpecial(const OpConversionPattern<VhloOpTy>& pattern,
+                             StringRef vhloName, Attribute vhloAttr,
+                             SmallVector<NamedAttribute>& stablehloAttrs) {
+  StringRef stablehloName = vhloName;
+  Attribute stablehloAttr;
+  if constexpr (std::is_same<VhloOpTy, vhlo::AllGatherOpV1>::value ||
+                std::is_same<VhloOpTy, vhlo::AllReduceOpV1>::value ||
+                std::is_same<VhloOpTy, vhlo::AllToAllOpV1>::value ||
+                std::is_same<VhloOpTy, vhlo::CollectivePermuteOpV1>::value ||
+                std::is_same<VhloOpTy, vhlo::ReduceScatterOpV1>::value) {
+    if (vhloName == "channel_id") {
+      stablehloName = StringAttr::get(pattern.getContext(), "channel_handle");
+      stablehloAttr = convertChannelId(vhloAttr, pattern.getTypeConverter());
+      if (!stablehloAttr) return specialFailure();
+    }
+    if (vhloName == "use_global_device_ids") {
+      auto vhloBooleanAttr = vhloAttr.dyn_cast<vhlo::BooleanV1Attr>();
+      if (!vhloBooleanAttr) return specialFailure();
+      if (!vhloBooleanAttr.getValue()) return specialSuccess();
+      stablehloAttr = UnitAttr::get(pattern.getContext());
     }
   }
-};
+  if constexpr (std::is_same<VhloOpTy, vhlo::CustomCallOpV1>::value) {
+    if (vhloName == "called_computations") {
+      stablehloAttr = convertCustomCallCalledComputations(
+          vhloAttr, pattern.getTypeConverter());
+      if (!stablehloAttr) return specialFailure();
+    }
+  }
+  if constexpr (std::is_same<VhloOpTy, vhlo::CallOpV1>::value) {
+    if (vhloName == "callee") {
+      stablehloAttr = convertFuncCallee(vhloAttr, pattern.getTypeConverter());
+      if (!stablehloAttr) return specialFailure();
+    }
+  }
+  if (stablehloAttr) {
+    stablehloAttrs.emplace_back(
+        StringAttr::get(pattern.getContext(), stablehloName), stablehloAttr);
+    return specialSuccess();
+  }
+  return notSpecial();
+}
+
+//===----------------------------------------------------------------------===//
+// VHLO --> StableHLO operations
+//===----------------------------------------------------------------------===//
 
 template <typename VhloOpTy>
 class VhloToStablehloOpConverter : public OpConversionPattern<VhloOpTy> {
@@ -366,134 +484,31 @@ class VhloToStablehloOpConverter : public OpConversionPattern<VhloOpTy> {
     // the dialect conversion infrastructure.
     ValueRange stablehloOperands = adaptor.getOperands();
 
+    // Convert VHLO attributes to StableHLO equivalents.
+    // There are two paths:
+    //   1) Generic path where default logic applies, and there is a 1:1
+    //      mapping from VHLO to StableHLO.
+    //   2) Special cases (currently, about a dozen) where there is not 1:1
+    //      mapping from VHLO to StableHLO.
+    SmallVector<NamedAttribute> vhloAttrs = to_vector(vhloOp->getAttrs());
     SmallVector<NamedAttribute> stablehloAttrs;
-    if constexpr (std::is_same<VhloOpTy, vhlo::DotGeneralOpV1>::value) {
-      auto stablehloAttr =
-          convertDotDimensionNumbers(vhloOp, this->getTypeConverter());
-      if (!stablehloAttr) return failure();
-      stablehloAttrs.emplace_back(
-          StringAttr::get(this->getContext(), "dot_dimension_numbers"),
-          stablehloAttr);
-    } else if constexpr (std::is_same<VhloOpTy, vhlo::DynamicConvOpV1>::value ||
-                         std::is_same<VhloOpTy, vhlo::ConvolutionOpV1>::value) {
-      auto stablehloAttr =
-          convertConvDimensionNumbers(vhloOp, this->getTypeConverter());
-      if (!stablehloAttr) return failure();
-      stablehloAttrs.emplace_back(
-          StringAttr::get(this->getContext(), "dimension_numbers"),
-          stablehloAttr);
-    } else if constexpr (std::is_same<VhloOpTy,
-                                      vhlo::DynamicGatherOpV1>::value ||
-                         std::is_same<VhloOpTy, vhlo::GatherOpV1>::value) {
-      auto stablehloAttr =
-          convertGatherDimensionNumbers(vhloOp, this->getTypeConverter());
-      if (!stablehloAttr) return failure();
-      stablehloAttrs.emplace_back(
-          StringAttr::get(this->getContext(), "dimension_numbers"),
-          stablehloAttr);
-    } else if constexpr (std::is_same<VhloOpTy, vhlo::ScatterOpV1>::value) {
-      auto stablehloAttr =
-          convertScatterDimensionNumbers(vhloOp, this->getTypeConverter());
-      if (!stablehloAttr) return failure();
-      stablehloAttrs.emplace_back(
-          StringAttr::get(this->getContext(), "scatter_dimension_numbers"),
-          stablehloAttr);
-    } else if constexpr (std::is_same<VhloOpTy, vhlo::RecvOpV1>::value ||
-                         std::is_same<VhloOpTy, vhlo::SendOpV1>::value) {
-      auto stablehloAttr =
-          convertChannelHandle(vhloOp, this->getTypeConverter());
-      if (!stablehloAttr) return failure();
-      stablehloAttrs.emplace_back(
-          StringAttr::get(this->getContext(), "channel_handle"), stablehloAttr);
-    }
-
-    for (NamedAttribute vhloAttr : vhloOp->getAttrs()) {
-      StringAttr stablehloName = vhloAttr.getName();
-      Attribute stablehloAttr;
-      if (vhloAttr.getName() == "use_global_device_ids") {
-        auto vhloBooleanAttr =
-            vhloAttr.getValue().dyn_cast<vhlo::BooleanV1Attr>();
-        if (!vhloBooleanAttr) return failure();
-        if (!vhloBooleanAttr.getValue()) continue;
-        stablehloAttr = UnitAttr::get(this->getContext());
-      } else if constexpr (std::is_same<VhloOpTy, vhlo::AllGatherOpV1>::value ||
-                           std::is_same<VhloOpTy, vhlo::AllReduceOpV1>::value ||
-                           std::is_same<VhloOpTy, vhlo::AllToAllOpV1>::value ||
-                           std::is_same<VhloOpTy,
-                                        vhlo::CollectivePermuteOpV1>::value ||
-                           std::is_same<VhloOpTy,
-                                        vhlo::ReduceScatterOpV1>::value) {
-        if (vhloAttr.getName() == "channel_id") {
-          stablehloName = StringAttr::get(this->getContext(), "channel_handle");
-          stablehloAttr =
-              convertChannelId(vhloAttr.getValue(), this->getTypeConverter());
+    if (failed(implodeSpecial(*this, vhloOp, vhloAttrs, stablehloAttrs)))
+      return failure();
+    for (NamedAttribute vhloAttr : vhloAttrs) {
+      auto result = convertSpecial(*this, vhloAttr.getName(),
+                                   vhloAttr.getValue(), stablehloAttrs);
+      switch (result) {
+        case SpecialResult::SPECIAL_SUCCESS:
+          break;
+        case SpecialResult::SPECIAL_FAILURE:
+          return failure();
+        case SpecialResult::NOT_SPECIAL:
+          auto stablehloAttr =
+              convertGeneric(vhloAttr.getValue(), this->getTypeConverter());
           if (!stablehloAttr) return failure();
-        }
-      } else if constexpr (std::is_same<VhloOpTy,
-                                        vhlo::CustomCallOpV1>::value) {
-        if (vhloAttr.getName() == "called_computations") {
-          stablehloAttr = convertCustomCallCalledComputations(
-              vhloAttr.getValue(), this->getTypeConverter());
-          if (!stablehloAttr) return failure();
-        }
-      } else if constexpr (std::is_same<VhloOpTy,
-                                        vhlo::DotGeneralOpV1>::value) {
-        if (vhloAttr.getName() == "lhs_batching_dimensions" ||
-            vhloAttr.getName() == "rhs_batching_dimensions" ||
-            vhloAttr.getName() == "lhs_contracting_dimensions" ||
-            vhloAttr.getName() == "rhs_contracting_dimensions") {
-          continue;
-        }
-      } else if constexpr (std::is_same<VhloOpTy,
-                                        vhlo::DynamicConvOpV1>::value ||
-                           std::is_same<VhloOpTy,
-                                        vhlo::ConvolutionOpV1>::value) {
-        if (vhloAttr.getName() == "input_batch_dimension" ||
-            vhloAttr.getName() == "input_feature_dimension" ||
-            vhloAttr.getName() == "input_spatial_dimensions" ||
-            vhloAttr.getName() == "kernel_input_feature_dimension" ||
-            vhloAttr.getName() == "kernel_output_feature_dimension" ||
-            vhloAttr.getName() == "kernel_spatial_dimensions" ||
-            vhloAttr.getName() == "output_batch_dimension" ||
-            vhloAttr.getName() == "output_feature_dimension" ||
-            vhloAttr.getName() == "output_spatial_dimensions") {
-          continue;
-        }
-      } else if constexpr (std::is_same<VhloOpTy,
-                                        vhlo::DynamicGatherOpV1>::value ||
-                           std::is_same<VhloOpTy, vhlo::GatherOpV1>::value) {
-        if (vhloAttr.getName() == "offset_dims" ||
-            vhloAttr.getName() == "collapsed_slice_dims" ||
-            vhloAttr.getName() == "start_index_map" ||
-            vhloAttr.getName() == "index_vector_dim") {
-          continue;
-        }
-      } else if constexpr (std::is_same<VhloOpTy, vhlo::ScatterOpV1>::value) {
-        if (vhloAttr.getName() == "update_window_dims" ||
-            vhloAttr.getName() == "inserted_window_dims" ||
-            vhloAttr.getName() == "scatter_dims_to_operand_dims" ||
-            vhloAttr.getName() == "index_vector_dim") {
-          continue;
-        }
-      } else if constexpr (std::is_same<VhloOpTy, vhlo::RecvOpV1>::value ||
-                           std::is_same<VhloOpTy, vhlo::SendOpV1>::value) {
-        if (vhloAttr.getName() == "channel_id" ||
-            vhloAttr.getName() == "channel_type") {
-          continue;
-        }
-      } else if constexpr (std::is_same<VhloOpTy, vhlo::CallOpV1>::value) {
-        if (vhloAttr.getName() == "callee") {
-          stablehloAttr =
-              convertFuncCallee(vhloAttr.getValue(), this->getTypeConverter());
-          if (!stablehloAttr) return failure();
-        }
+          stablehloAttrs.push_back({vhloAttr.getName(), stablehloAttr});
+          break;
       }
-      if (!stablehloAttr) {
-        stablehloAttr = convertAttrToStablehlo(vhloAttr.getValue(),
-                                               this->getTypeConverter());
-        if (!stablehloAttr) return failure();
-      }
-      stablehloAttrs.push_back({stablehloName, stablehloAttr});
     }
 
     // Replace vhlo.return --> func.return if direct parent is a func op.
@@ -505,7 +520,7 @@ class VhloToStablehloOpConverter : public OpConversionPattern<VhloOpTy> {
       }
     }
 
-    // Convert the vhlo operation to a StableHLO equivalent.
+    // Convert the VHLO operation to a StableHLO equivalent.
     // This can almost be done in a generic fashion, except for
     // vhlo.case that uses a variadic number of regions which means an
     // additional argument for the generic builder.
@@ -542,6 +557,30 @@ void populateVhloToStablehloPatterns(RewritePatternSet* patterns,
 }
 
 }  // namespace
+
+struct VhloLegalizeToStablehloPass
+    : public impl::VhloLegalizeToStablehloPassBase<
+          VhloLegalizeToStablehloPass> {
+  void runOnOperation() override {
+    ConversionTarget target(getContext());
+    target.addIllegalDialect<vhlo::VhloDialect>();
+    target.addLegalDialect<stablehlo::StablehloDialect>();
+    target.addLegalDialect<func::FuncDialect>();
+
+    VhloToStablehloTypeConverter converter;
+    RewritePatternSet patterns(&getContext());
+    stablehlo::populateVhloToStablehloPatterns(&patterns, &converter,
+                                               &getContext());
+
+    // Upgraded VHLO should always be convertible to StableHLO.
+    // Arbitrary VHLO might not be convertible if it uses deprecated features
+    // which are no longer available in StableHLO.
+    if (failed(applyPartialConversion(getOperation(), target,
+                                      std::move(patterns)))) {
+      return signalPassFailure();
+    }
+  }
+};
 
 void populateVhloToStablehloPatterns(RewritePatternSet* patterns,
                                      TypeConverter* converter,


### PR DESCRIPTION
In the last few pull requests, I crammed a lot of adhoc logic into
the corresponding conversion patterns.

When working on removing optional attrs from VHLO, I needed to further
update the conversion patterns, and I found it to be unnecessarily
complicated with all the stuff in there.

This PR refactors the conversion patterns to encapsulate the logic
that bridges the gaps between StableHLO and VHLO. I think that modifying
the conversion patterns will become considerably easier now.