### PR TITLE
Sync check ops with IREE check ops

### DIFF
--- a/stablehlo/tests/CheckOps.cpp
+++ b/stablehlo/tests/CheckOps.cpp
@@ -38,49 +38,6 @@ CheckDialect::CheckDialect(MLIRContext *context)
       >();
 }
 
-void ExpectAlmostEqOp::print(OpAsmPrinter &p) {
-  p.printOptionalAttrDict(getOperation()->getAttrs());
-  p << " : ";
-  p.printType(getLhs().getType());
-}
-
-ParseResult ExpectAlmostEqOp::parse(OpAsmParser &parser,
-                                    OperationState &result) {
-  llvm::SMLoc loc = parser.getCurrentLocation();
-  OpAsmParser::UnresolvedOperand lhs, rhs;
-  Type type;
-  if (parser.parseOptionalAttrDict(result.attributes) ||
-      parser.parseOperand(lhs) || parser.parseComma() ||
-      parser.parseOperand(rhs) || parser.parseColon() ||
-      parser.parseType(type) ||
-      parser.resolveOperands({lhs, rhs}, {type, type}, loc, result.operands))
-    return failure();
-
-  result.addTypes({});
-  return success();
-}
-
-void ExpectEqOp::print(OpAsmPrinter &p) {
-  p.printOptionalAttrDict(getOperation()->getAttrs());
-  p << " : ";
-  p.printType(getLhs().getType());
-}
-
-ParseResult ExpectEqOp::parse(OpAsmParser &parser, OperationState &result) {
-  llvm::SMLoc loc = parser.getCurrentLocation();
-  OpAsmParser::UnresolvedOperand lhs, rhs;
-  Type type;
-  if (parser.parseOptionalAttrDict(result.attributes) ||
-      parser.parseOperand(lhs) || parser.parseComma() ||
-      parser.parseOperand(rhs) || parser.parseColon() ||
-      parser.parseType(type) ||
-      parser.resolveOperands({lhs, rhs}, {type, type}, loc, result.operands))
-    return failure();
-
-  result.addTypes({});
-  return success();
-}
-
 llvm::Error evalExpectAlmostEqConstOp(const Tensor &lhs, ElementsAttr value) {
   auto rhs = makeTensor(value.cast<DenseElementsAttr>());
   return evalExpectAlmostEqOp(lhs, rhs);

--- a/stablehlo/tests/CheckOps.h
+++ b/stablehlo/tests/CheckOps.h
@@ -37,8 +37,10 @@ class CheckDialect : public Dialect {
 };
 
 // The eval functions for the following ops are used only for test harness.
-llvm::Error evalAlmostEqOp(const Tensor &lhs, ElementsAttr value);
-llvm::Error evalEqOp(const Tensor &lhs, ElementsAttr value);
+llvm::Error evalExpectAlmostEqConstOp(const Tensor &lhs, ElementsAttr value);
+llvm::Error evalExpectAlmostEqOp(const Tensor &lhs, const Tensor &rhs);
+llvm::Error evalExpectEqConstOp(const Tensor &lhs, ElementsAttr value);
+llvm::Error evalExpectEqOp(const Tensor &lhs, const Tensor &rhs);
 
 }  // namespace check
 }  // namespace stablehlo

--- a/stablehlo/tests/CheckOps.td
+++ b/stablehlo/tests/CheckOps.td
@@ -77,7 +77,7 @@ def CHECK_ExpectAlmostEqOp :
       TensorOf<[AnyFloat, AnyComplex]>:$rhs
   );
 
-  let hasCustomAssemblyFormat = 1;
+  let assemblyFormat = "$lhs `,` $rhs attr-dict `:` type($lhs)";
 }
 
 def CHECK_ExpectEqConstOp :
@@ -114,7 +114,7 @@ def CHECK_ExpectEqOp : Op<CHECK_Dialect, "expect_eq", [SameTypeOperands]> {
       HLO_Tensor:$rhs
   );
 
-  let hasCustomAssemblyFormat = 1;
+  let assemblyFormat = "$lhs `,` $rhs attr-dict `:` type($lhs)";
 }
 
 #endif  // STABLEHLO_DIALECT_CHECK_OPS

--- a/stablehlo/tests/CheckOps.td
+++ b/stablehlo/tests/CheckOps.td
@@ -38,9 +38,9 @@ def CHECK_Dialect : Dialect {
 // CHECK op definitions.
 //===----------------------------------------------------------------------===//
 
-def CHECK_AlmostEqOp :
+def CHECK_ExpectAlmostEqConstOp :
     Op<CHECK_Dialect,
-       "almost_eq", [AllTypesMatch<["lhs", "value"]>]> {
+       "expect_almost_eq_const", [AllTypesMatch<["lhs", "value"]>]> {
   let summary = [{Checks the tensor operand is almost equal to some constant}];
   let description =  [{
     Verifies that the tensor operand with floating-point or complex element
@@ -48,7 +48,7 @@ def CHECK_AlmostEqOp :
     implementation-defined tolerance.
 
     ```mlir
-    check.almost_eq %arg0, dense<[0.999999, 2.0]> : tensor<2xf32>
+    check.expect_almost_eq_const %arg0, dense<[0.999999, 2.0]> : tensor<2xf32>
     ```
   }];
 
@@ -60,14 +60,34 @@ def CHECK_AlmostEqOp :
   let assemblyFormat = "$lhs `,` $value attr-dict";
 }
 
-def CHECK_EqOp :
-    Op<CHECK_Dialect, "eq", [AllTypesMatch<["lhs", "value"]>]> {
+def CHECK_ExpectAlmostEqOp :
+    Op<CHECK_Dialect, "expect_almost_eq", [SameTypeOperands]> {
+  let summary = [{Checks that the tensor operands are almost equal}];
+  let description = [{
+    Verifies that the tensor operands with floating-point or complex element
+    types are almost equal within an implementation-defined tolerance.
+
+    ```mlir
+    check.expect_almost_eq %arg0, %arg1 : tensor<2xf32>
+    ```
+  }];
+
+  let arguments = (ins
+      TensorOf<[AnyFloat, AnyComplex]>:$lhs,
+      TensorOf<[AnyFloat, AnyComplex]>:$rhs
+  );
+
+  let hasCustomAssemblyFormat = 1;
+}
+
+def CHECK_ExpectEqConstOp :
+    Op<CHECK_Dialect, "expect_eq_const", [AllTypesMatch<["lhs", "value"]>]> {
   let summary = [{Checks the tensor operand is equal to some constant}];
   let description =  [{
     Verifies that the tensor operand is exactly equal to a constant attribute.
 
     ```mlir
-    check.eq %arg0, dense<[1, 2]> : tensor<2xi32>
+    check.expect_eq_const %arg0, dense<[1, 2]> : tensor<2xi32>
     ```
   }];
 
@@ -77,6 +97,24 @@ def CHECK_EqOp :
   );
 
   let assemblyFormat = "$lhs `,` $value attr-dict";
+}
+
+def CHECK_ExpectEqOp : Op<CHECK_Dialect, "expect_eq", [SameTypeOperands]> {
+  let summary = [{Checks that the tensor operands are equal}];
+  let description = [{
+    Verifies that the operands are exactly equal.
+
+    ```mlir
+    check.expect_eq %arg0, %arg1 : tensor<2xi32>
+    ```
+  }];
+
+  let arguments = (ins
+      HLO_Tensor:$lhs,
+      HLO_Tensor:$rhs
+  );
+
+  let hasCustomAssemblyFormat = 1;
 }
 
 #endif  // STABLEHLO_DIALECT_CHECK_OPS

--- a/stablehlo/tests/interpret_abs.mlir
+++ b/stablehlo/tests/interpret_abs.mlir
@@ -3,7 +3,7 @@
 func.func @abs_op_test_si64() {
   %operand = stablehlo.constant dense<[-2, 0, 2]> : tensor<3xi64>
   %result = stablehlo.abs %operand : tensor<3xi64>
-  check.eq %result, dense<[2, 0, 2]> : tensor<3xi64>
+  check.expect_eq_const %result, dense<[2, 0, 2]> : tensor<3xi64>
   func.return
 }
 
@@ -12,7 +12,7 @@ func.func @abs_op_test_si64() {
 func.func @abs_op_test_f64() {
   %operand = stablehlo.constant dense<[23.1, -23.1, -0.0]> : tensor<3xf64>
   %result = stablehlo.abs %operand : tensor<3xf64>
-  check.almost_eq %result, dense<[2.310000e+01, 2.310000e+01, 0.000000e+00]> : tensor<3xf64>
+  check.expect_almost_eq_const %result, dense<[2.310000e+01, 2.310000e+01, 0.000000e+00]> : tensor<3xf64>
   func.return
 }
 
@@ -21,6 +21,6 @@ func.func @abs_op_test_f64() {
 func.func @abs_op_test_c64() {
   %operand = stablehlo.constant dense<(3.0, 4.0)> : tensor<complex<f64>>
   %result = "stablehlo.abs"(%operand) : (tensor<complex<f64>>) -> tensor<f64>
-  check.almost_eq %result, dense<5.000000e+00> : tensor<f64>
+  check.expect_almost_eq_const %result, dense<5.000000e+00> : tensor<f64>
   func.return
 }

--- a/stablehlo/tests/interpret_add.mlir
+++ b/stablehlo/tests/interpret_add.mlir
@@ -4,7 +4,7 @@ func.func @add_op_test_si4() {
   %0 = stablehlo.constant dense<[0, 1, 2, -3, 0]> : tensor<5xi4>
   %1 = stablehlo.constant dense<[-8, -1, 2, -3, 7]> : tensor<5xi4>
   %2 = stablehlo.add %0, %1 : tensor<5xi4>
-  check.eq %2, dense<[-8, 0, 4, -6, 7]> : tensor<5xi4>
+  check.expect_eq_const %2, dense<[-8, 0, 4, -6, 7]> : tensor<5xi4>
   func.return
 }
 
@@ -14,7 +14,7 @@ func.func @add_op_test_ui4() {
   %0 = stablehlo.constant dense<[0, 2]> : tensor<2xui4>
   %1 = stablehlo.constant dense<[15, 3]> : tensor<2xui4>
   %2 = stablehlo.add %0, %1 : tensor<2xui4>
-  check.eq %2, dense<[15, 5]> : tensor<2xui4>
+  check.expect_eq_const %2, dense<[15, 5]> : tensor<2xui4>
   func.return
 }
 
@@ -24,7 +24,7 @@ func.func @add_op_test_si8() {
   %0 = stablehlo.constant dense<[0, 1, 8, -9, 0]> : tensor<5xi8>
   %1 = stablehlo.constant dense<[-128, -1, 8, -9, 127]> : tensor<5xi8>
   %2 = stablehlo.add %0, %1 : tensor<5xi8>
-  check.eq %2, dense<[-128, 0, 16, -18, 127]> : tensor<5xi8>
+  check.expect_eq_const %2, dense<[-128, 0, 16, -18, 127]> : tensor<5xi8>
   func.return
 }
 
@@ -34,7 +34,7 @@ func.func @add_op_test_ui8() {
   %0 = stablehlo.constant dense<[0, 16]> : tensor<2xui8>
   %1 = stablehlo.constant dense<[255, 16]> : tensor<2xui8>
   %2 = stablehlo.add %0, %1 : tensor<2xui8>
-  check.eq %2, dense<[255, 32]> : tensor<2xui8>
+  check.expect_eq_const %2, dense<[255, 32]> : tensor<2xui8>
   func.return
 }
 
@@ -44,7 +44,7 @@ func.func @add_op_test_si16() {
   %0 = stablehlo.constant dense<[0, 1, 128, -129, 0]> : tensor<5xi16>
   %1 = stablehlo.constant dense<[-32768, -1, 128, -129, 32767]> : tensor<5xi16>
   %2 = stablehlo.add %0, %1 : tensor<5xi16>
-  check.eq %2, dense<[-32768, 0, 256, -258, 32767]> : tensor<5xi16>
+  check.expect_eq_const %2, dense<[-32768, 0, 256, -258, 32767]> : tensor<5xi16>
   func.return
 }
 
@@ -54,7 +54,7 @@ func.func @add_op_test_ui16() {
   %0 = stablehlo.constant dense<[0, 256]> : tensor<2xui16>
   %1 = stablehlo.constant dense<[65535, 256]> : tensor<2xui16>
   %2 = stablehlo.add %0, %1 : tensor<2xui16>
-  check.eq %2, dense<[65535, 512]> : tensor<2xui16>
+  check.expect_eq_const %2, dense<[65535, 512]> : tensor<2xui16>
   func.return
 }
 
@@ -64,7 +64,7 @@ func.func @add_op_test_si32() {
   %0 = stablehlo.constant dense<[0, 1, 32768, -32769, 0]> : tensor<5xi32>
   %1 = stablehlo.constant dense<[-2147483648, -1, 32768, -32769, 2147483647]> : tensor<5xi32>
   %2 = stablehlo.add %0, %1 : tensor<5xi32>
-  check.eq %2, dense<[-2147483648, 0, 65536, -65538, 2147483647]> : tensor<5xi32>
+  check.expect_eq_const %2, dense<[-2147483648, 0, 65536, -65538, 2147483647]> : tensor<5xi32>
   func.return
 }
 
@@ -74,7 +74,7 @@ func.func @add_op_test_ui32() {
   %0 = stablehlo.constant dense<[0, 65536]> : tensor<2xui32>
   %1 = stablehlo.constant dense<[4294967295, 65536]> : tensor<2xui32>
   %2 = stablehlo.add %0, %1 : tensor<2xui32>
-  check.eq %2, dense<[4294967295, 131072]> : tensor<2xui32>
+  check.expect_eq_const %2, dense<[4294967295, 131072]> : tensor<2xui32>
   func.return
 }
 
@@ -84,7 +84,7 @@ func.func @add_op_test_si64() {
   %0 = stablehlo.constant dense<[0, 1, 2147483648, -2147483649, 0]> : tensor<5xi64>
   %1 = stablehlo.constant dense<[-9223372036854775808, -1, 2147483648, -2147483649, 9223372036854775807]> : tensor<5xi64>
   %2 = stablehlo.add %0, %1 : tensor<5xi64>
-  check.eq %2, dense<[-9223372036854775808, 0, 4294967296, -4294967298, 9223372036854775807]> : tensor<5xi64>
+  check.expect_eq_const %2, dense<[-9223372036854775808, 0, 4294967296, -4294967298, 9223372036854775807]> : tensor<5xi64>
   func.return
 }
 
@@ -94,7 +94,7 @@ func.func @add_op_test_ui64() {
   %0 = stablehlo.constant dense<[0, 4294967296]> : tensor<2xui64>
   %1 = stablehlo.constant dense<[18446744073709551615, 4294967296]> : tensor<2xui64>
   %2 = stablehlo.add %0, %1 : tensor<2xui64>
-  check.eq %2, dense<[18446744073709551615, 8589934592]> : tensor<2xui64>
+  check.expect_eq_const %2, dense<[18446744073709551615, 8589934592]> : tensor<2xui64>
   func.return
 }
 
@@ -104,7 +104,7 @@ func.func @add_op_test_i1() {
   %0 = stablehlo.constant dense<[false, false, true, true]> : tensor<4xi1>
   %1 = stablehlo.constant dense<[false, true, false, true]> : tensor<4xi1>
   %2 = stablehlo.add %0, %1 : tensor<4xi1>
-  check.eq %2, dense<[false, true, true, true]> : tensor<4xi1>
+  check.expect_eq_const %2, dense<[false, true, true, true]> : tensor<4xi1>
   func.return
 }
 
@@ -114,7 +114,7 @@ func.func @add_op_test_bf16() {
   %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.140625, 0x7F80, 0x7F80, 0xFF80, 0x7F80, 0x0001]> : tensor<11xbf16>
   %1 = stablehlo.constant dense<[0.0, -0.0, 7.0, 0.75, 0.3, 3.140625, 0.0, 0x7F80, 0xFF80, 0xFF80, 0x8001]> : tensor<11xbf16>
   %2 = stablehlo.add %0, %1 : tensor<11xbf16>
-  check.almost_eq %2, dense<[0.000000e+00, -0.000000e+00, 8.000000e+00, 8.750000e-01, 4.003910e-01, 6.281250e+00, 0x7F80, 0x7F80, 0xFF80, 0x7FC0, 0.000000e+00]> : tensor<11xbf16>
+  check.expect_almost_eq_const %2, dense<[0.000000e+00, -0.000000e+00, 8.000000e+00, 8.750000e-01, 4.003910e-01, 6.281250e+00, 0x7F80, 0x7F80, 0xFF80, 0x7FC0, 0.000000e+00]> : tensor<11xbf16>
   func.return
 }
 
@@ -124,7 +124,7 @@ func.func @add_op_test_f16() {
   %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.141, 0x7C00, 0x7C00, 0xFC00, 0x7C00, 0x0001]> : tensor<11xf16>
   %1 = stablehlo.constant dense<[0.0, -0.0, 7.0, 0.75, 0.3, 3.141, 0.0, 0x7C00, 0xFC00, 0xFC00, 0x8001]> : tensor<11xf16>
   %2 = stablehlo.add %0, %1 : tensor<11xf16>
-  check.almost_eq %2, dense<[0.000000e+00, -0.000000e+00, 8.000000e+00, 8.750000e-01, 3.999020e-01, 6.281250e+00, 0x7C00, 0x7C00, 0xFC00, 0x7E00, 0.000000e+00]> : tensor<11xf16>
+  check.expect_almost_eq_const %2, dense<[0.000000e+00, -0.000000e+00, 8.000000e+00, 8.750000e-01, 3.999020e-01, 6.281250e+00, 0x7C00, 0x7C00, 0xFC00, 0x7E00, 0.000000e+00]> : tensor<11xf16>
   func.return
 
 }
@@ -135,7 +135,7 @@ func.func @add_op_test_f32() {
   %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.14159265, 0x7F800000, 0x7F800000, 0xFF800000, 0x7F800000, 0x00000001]> : tensor<11xf32>
   %1 = stablehlo.constant dense<[0.0, -0.0, 7.0, 0.75, 0.3, 3.14159265, 0.0, 0x7F800000, 0xFF800000, 0xFF800000, 0x80000001]> : tensor<11xf32>
   %2 = stablehlo.add %0, %1 : tensor<11xf32>
-  check.almost_eq %2, dense<[0.000000e+00, -0.000000e+00, 8.000000e+00, 8.750000e-01, 4.000000e-01, 6.28318548, 0x7F800000, 0x7F800000, 0xFF800000, 0x7FC00000, 0.000000e+00]> : tensor<11xf32>
+  check.expect_almost_eq_const %2, dense<[0.000000e+00, -0.000000e+00, 8.000000e+00, 8.750000e-01, 4.000000e-01, 6.28318548, 0x7F800000, 0x7F800000, 0xFF800000, 0x7FC00000, 0.000000e+00]> : tensor<11xf32>
   func.return
 
 }
@@ -146,7 +146,7 @@ func.func @add_op_test_f64() {
   %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.14159265358979323846, 0x7FF0000000000000, 0x7FF0000000000000, 0xFFF0000000000000, 0x7FF0000000000000, 0x0000000000000001]> : tensor<11xf64>
   %1 = stablehlo.constant dense<[0.0, -0.0, 7.0, 0.75, 0.3, 3.14159265358979323846, 0.0, 0x7FF0000000000000, 0xFFF0000000000000, 0xFFF0000000000000, 0x8000000000000001]> : tensor<11xf64>
   %2 = stablehlo.add %0, %1 : tensor<11xf64>
-  check.almost_eq %2, dense<[0.000000e+00, -0.000000e+00, 8.000000e+00, 8.750000e-01, 4.000000e-01, 6.2831853071795862, 0x7FF0000000000000, 0x7FF0000000000000, 0xFFF0000000000000, 0x7FF8000000000000, 0.000000e+00]> : tensor<11xf64>
+  check.expect_almost_eq_const %2, dense<[0.000000e+00, -0.000000e+00, 8.000000e+00, 8.750000e-01, 4.000000e-01, 6.2831853071795862, 0x7FF0000000000000, 0x7FF0000000000000, 0xFFF0000000000000, 0x7FF8000000000000, 0.000000e+00]> : tensor<11xf64>
   func.return
 }
 
@@ -156,7 +156,7 @@ func.func @add_op_test_c64() {
   %0 = stablehlo.constant dense<[(1.5, 2.5), (7.5, 5.5)]> : tensor<2xcomplex<f32>>
   %1 = stablehlo.constant dense<[(1.5, 2.5), (7.5, 5.5)]> : tensor<2xcomplex<f32>>
   %2 = stablehlo.add %0, %1 : tensor<2xcomplex<f32>>
-  check.almost_eq %2, dense<[(3.000000e+00, 5.000000e+00), (1.500000e+01, 1.100000e+01)]> : tensor<2xcomplex<f32>>
+  check.expect_almost_eq_const %2, dense<[(3.000000e+00, 5.000000e+00), (1.500000e+01, 1.100000e+01)]> : tensor<2xcomplex<f32>>
   func.return
 }
 
@@ -166,7 +166,7 @@ func.func @add_op_test_c128() {
   %0 = stablehlo.constant dense<[(1.5, 2.5), (7.5, 5.5)]> : tensor<2xcomplex<f64>>
   %1 = stablehlo.constant dense<[(1.5, 2.5), (7.5, 5.5)]> : tensor<2xcomplex<f64>>
   %2 = stablehlo.add %0, %1 : tensor<2xcomplex<f64>>
-  check.almost_eq %2, dense<[(3.000000e+00, 5.000000e+00), (1.500000e+01, 1.100000e+01)]> : tensor<2xcomplex<f64>>
+  check.expect_almost_eq_const %2, dense<[(3.000000e+00, 5.000000e+00), (1.500000e+01, 1.100000e+01)]> : tensor<2xcomplex<f64>>
   func.return
 }
 
@@ -176,7 +176,7 @@ func.func @add_op_scalar() {
   %0 = stablehlo.constant dense<2> : tensor<i4>
   %1 = stablehlo.constant dense<3> : tensor<i4>
   %2 = stablehlo.add %0, %1 : tensor<i4>
-  check.eq %2, dense<5> : tensor<i4>
+  check.expect_eq_const %2, dense<5> : tensor<i4>
   func.return
 }
 
@@ -186,6 +186,6 @@ func.func @add_op_tensor_shape_with_zero_dim_size() {
   %0 = stablehlo.constant dense<2> : tensor<2x0x3xi4>
   %1 = stablehlo.constant dense<3> : tensor<2x0x3xi4>
   %2 = stablehlo.add %0, %1 : tensor<2x0x3xi4>
-  check.eq %2, dense<> : tensor<2x0x3xi4>
+  check.expect_eq_const %2, dense<> : tensor<2x0x3xi4>
   func.return
 }

--- a/stablehlo/tests/interpret_and.mlir
+++ b/stablehlo/tests/interpret_and.mlir
@@ -4,7 +4,7 @@ func.func @and_op_test_si4() {
   %0 = stablehlo.constant dense<[7, -8, -8]> : tensor<3xi4>
   %1 = stablehlo.constant dense<[0, 7, -8]> : tensor<3xi4>
   %2 = stablehlo.and %0, %1 : tensor<3xi4>
-  check.eq %2, dense<[0, 0, -8]> : tensor<3xi4>
+  check.expect_eq_const %2, dense<[0, 0, -8]> : tensor<3xi4>
   func.return
 }
 
@@ -14,7 +14,7 @@ func.func @and_op_test_ui4() {
   %0 = stablehlo.constant dense<[0, 7, 15]> : tensor<3xui4>
   %1 = stablehlo.constant dense<15> : tensor<3xui4>
   %2 = stablehlo.and %0, %1 : tensor<3xui4>
-  check.eq %2, dense<[0, 7, 15]> : tensor<3xui4>
+  check.expect_eq_const %2, dense<[0, 7, 15]> : tensor<3xui4>
   func.return
 }
 
@@ -24,7 +24,7 @@ func.func @and_op_test_si8() {
   %0 = stablehlo.constant dense<[127, -128, -128]> : tensor<3xi8>
   %1 = stablehlo.constant dense<[0, 127, -128]> : tensor<3xi8>
   %2 = stablehlo.and %0, %1 : tensor<3xi8>
-  check.eq %2, dense<[0, 0, -128]> : tensor<3xi8>
+  check.expect_eq_const %2, dense<[0, 0, -128]> : tensor<3xi8>
   func.return
 }
 
@@ -34,7 +34,7 @@ func.func @and_op_test_ui8() {
   %0 = stablehlo.constant dense<[0, 127, 255]> : tensor<3xui8>
   %1 = stablehlo.constant dense<255> : tensor<3xui8>
   %2 = stablehlo.and %0, %1 : tensor<3xui8>
-  check.eq %2, dense<[0, 127, 255]> : tensor<3xui8>
+  check.expect_eq_const %2, dense<[0, 127, 255]> : tensor<3xui8>
   func.return
 }
 
@@ -44,7 +44,7 @@ func.func @and_op_test_si16() {
   %0 = stablehlo.constant dense<[32767, -32768, -32768]> : tensor<3xi16>
   %1 = stablehlo.constant dense<[0, 32767, -32768]> : tensor<3xi16>
   %2 = stablehlo.and %0, %1 : tensor<3xi16>
-  check.eq %2, dense<[0, 0, -32768]> : tensor<3xi16>
+  check.expect_eq_const %2, dense<[0, 0, -32768]> : tensor<3xi16>
   func.return
 }
 
@@ -54,7 +54,7 @@ func.func @and_op_test_ui16() {
   %0 = stablehlo.constant dense<[0, 32767, 65535]> : tensor<3xui16>
   %1 = stablehlo.constant dense<65535> : tensor<3xui16>
   %2 = stablehlo.and %0, %1 : tensor<3xui16>
-  check.eq %2, dense<[0, 32767, 65535]> : tensor<3xui16>
+  check.expect_eq_const %2, dense<[0, 32767, 65535]> : tensor<3xui16>
   func.return
 }
 
@@ -64,7 +64,7 @@ func.func @and_op_test_si32() {
   %0 = stablehlo.constant dense<[2147483647, -2147483648, -2147483648]> : tensor<3xi32>
   %1 = stablehlo.constant dense<[0, 2147483647, -2147483648]> : tensor<3xi32>
   %2 = stablehlo.and %0, %1 : tensor<3xi32>
-  check.eq %2, dense<[0, 0, -2147483648]> : tensor<3xi32>
+  check.expect_eq_const %2, dense<[0, 0, -2147483648]> : tensor<3xi32>
   func.return
 }
 
@@ -74,7 +74,7 @@ func.func @and_op_test_ui32() {
   %0 = stablehlo.constant dense<[0, 2147483647, 4294967295]> : tensor<3xui32>
   %1 = stablehlo.constant dense<4294967295> : tensor<3xui32>
   %2 = stablehlo.and %0, %1 : tensor<3xui32>
-  check.eq %2, dense<[0, 2147483647, 4294967295]> : tensor<3xui32>
+  check.expect_eq_const %2, dense<[0, 2147483647, 4294967295]> : tensor<3xui32>
   func.return
 }
 
@@ -84,7 +84,7 @@ func.func @and_op_test_si64() {
   %0 = stablehlo.constant dense<[9223372036854775807, -9223372036854775808, -9223372036854775808]> : tensor<3xi64>
   %1 = stablehlo.constant dense<[0, 9223372036854775807, -9223372036854775808]> : tensor<3xi64>
   %2 = stablehlo.and %0, %1 : tensor<3xi64>
-  check.eq %2, dense<[0, 0, -9223372036854775808]> : tensor<3xi64>
+  check.expect_eq_const %2, dense<[0, 0, -9223372036854775808]> : tensor<3xi64>
   func.return
 }
 
@@ -94,7 +94,7 @@ func.func @and_op_test_ui64() {
   %0 = stablehlo.constant dense<[0, 9223372036854775807, 18446744073709551615]> : tensor<3xui64>
   %1 = stablehlo.constant dense<18446744073709551615> : tensor<3xui64>
   %2 = stablehlo.and %0, %1 : tensor<3xui64>
-  check.eq %2, dense<[0, 9223372036854775807, 18446744073709551615]> : tensor<3xui64>
+  check.expect_eq_const %2, dense<[0, 9223372036854775807, 18446744073709551615]> : tensor<3xui64>
   func.return
 }
 
@@ -104,7 +104,7 @@ func.func @and_op_test_i1() {
   %0 = stablehlo.constant dense<[false, false, true, true]> : tensor<4xi1>
   %1 = stablehlo.constant dense<[false, true, false, true]> : tensor<4xi1>
   %2 = stablehlo.and %0, %1 : tensor<4xi1>
-  check.eq %2, dense<[false, false, false, true]> : tensor<4xi1>
+  check.expect_eq_const %2, dense<[false, false, false, true]> : tensor<4xi1>
   func.return
 }
 
@@ -114,7 +114,7 @@ func.func @and_op_test_i1_splat_false() {
   %0 = stablehlo.constant dense<false> : tensor<2xi1>
   %1 = stablehlo.constant dense<[false, true]> : tensor<2xi1>
   %2 = stablehlo.and %0, %1 : tensor<2xi1>
-  check.eq %2, dense<[false, false]> : tensor<2xi1>
+  check.expect_eq_const %2, dense<[false, false]> : tensor<2xi1>
   func.return
 }
 
@@ -124,6 +124,6 @@ func.func @and_op_test_i1_splat_true() {
   %0 = stablehlo.constant dense<true> : tensor<2xi1>
   %1 = stablehlo.constant dense<[false, true]> : tensor<2xi1>
   %2 = stablehlo.and %0, %1 : tensor<2xi1>
-  check.eq %2, dense<[false, true]> : tensor<2xi1>
+  check.expect_eq_const %2, dense<[false, true]> : tensor<2xi1>
   func.return
 }

--- a/stablehlo/tests/interpret_broadcast_in_dim.mlir
+++ b/stablehlo/tests/interpret_broadcast_in_dim.mlir
@@ -5,6 +5,6 @@ func.func @broadcast_in_dim() {
   %result = "stablehlo.broadcast_in_dim"(%operand) {
     broadcast_dimensions = dense<[0, 2]>: tensor<2xi64>
   } : (tensor<3x1xi64>) -> tensor<3x2x2xi64>
-  check.eq %result, dense<[[[1, 1], [1, 1]], [[2, 2], [2, 2]], [[3, 3], [3, 3]]]> : tensor<3x2x2xi64>
+  check.expect_eq_const %result, dense<[[[1, 1], [1, 1]], [[2, 2], [2, 2]], [[3, 3], [3, 3]]]> : tensor<3x2x2xi64>
   func.return
 }

--- a/stablehlo/tests/interpret_case.mlir
+++ b/stablehlo/tests/interpret_case.mlir
@@ -9,8 +9,8 @@ func.func @case_negative_index_default() {
   }, {
     stablehlo.return %result_branch1, %result_branch1 : tensor<2xi64>, tensor<2xi64>
   }) : (tensor<i32>) -> (tensor<2xi64>, tensor<2xi64>)
-  check.eq %result0, dense<[1, 1]> : tensor<2xi64>
-  check.eq %result1, dense<[1, 1]> : tensor<2xi64>
+  check.expect_eq_const %result0, dense<[1, 1]> : tensor<2xi64>
+  check.expect_eq_const %result1, dense<[1, 1]> : tensor<2xi64>
   func.return
 }
 
@@ -25,8 +25,8 @@ func.func @case_in_bound_index() {
   }, {
     stablehlo.return %result_branch1, %result_branch1 : tensor<2xi64>, tensor<2xi64>
   }) : (tensor<i32>) -> (tensor<2xi64>, tensor<2xi64>)
-  check.eq %result0, dense<[0, 0]> : tensor<2xi64>
-  check.eq %result1, dense<[0, 0]> : tensor<2xi64>
+  check.expect_eq_const %result0, dense<[0, 0]> : tensor<2xi64>
+  check.expect_eq_const %result1, dense<[0, 0]> : tensor<2xi64>
   func.return
 }
 
@@ -41,7 +41,7 @@ func.func @case_out_of_bound_index_default() {
   }, {
     stablehlo.return %result_branch1, %result_branch1 : tensor<2xi64>, tensor<2xi64>
   }) : (tensor<i32>) -> (tensor<2xi64>, tensor<2xi64>)
-  check.eq %result0, dense<[1, 1]> : tensor<2xi64>
-  check.eq %result1, dense<[1, 1]> : tensor<2xi64>
+  check.expect_eq_const %result0, dense<[1, 1]> : tensor<2xi64>
+  check.expect_eq_const %result1, dense<[1, 1]> : tensor<2xi64>
   func.return
 }

--- a/stablehlo/tests/interpret_ceil.mlir
+++ b/stablehlo/tests/interpret_ceil.mlir
@@ -3,7 +3,7 @@
 func.func @ceil_op_test_bf16() {
   %0 = stablehlo.constant dense<[0xFF80, -2.5, 0x8001, -0.0, 0.0, 0x0001, 2.5, 0x7F80, 0x7FC0]> : tensor<9xbf16>
   %1 = stablehlo.ceil %0 : tensor<9xbf16>
-  check.almost_eq %1, dense<[0xFF80, -2.000000e+00, -0.000000e+00, -0.000000e+00, 0.000000e+00, 1.000000e+00, 3.000000e+00, 0x7F80, 0x7FC0]> : tensor<9xbf16>
+  check.expect_almost_eq_const %1, dense<[0xFF80, -2.000000e+00, -0.000000e+00, -0.000000e+00, 0.000000e+00, 1.000000e+00, 3.000000e+00, 0x7F80, 0x7FC0]> : tensor<9xbf16>
   func.return
 }
 
@@ -12,7 +12,7 @@ func.func @ceil_op_test_bf16() {
 func.func @ceil_op_test_f16() {
   %0 = stablehlo.constant dense<[0xFC00, -2.5, 0x8001, -0.0, 0.0, 0x0001, 2.5, 0x7C00, 0x7E00]> : tensor<9xf16>
   %1 = stablehlo.ceil %0 : tensor<9xf16>
-  check.almost_eq %1, dense<[0xFC00, -2.000000e+00, -0.000000e+00, -0.000000e+00, 0.000000e+00, 1.000000e+00, 3.000000e+00, 0x7C00, 0x7E00]> : tensor<9xf16>
+  check.expect_almost_eq_const %1, dense<[0xFC00, -2.000000e+00, -0.000000e+00, -0.000000e+00, 0.000000e+00, 1.000000e+00, 3.000000e+00, 0x7C00, 0x7E00]> : tensor<9xf16>
   func.return
 }
 
@@ -21,7 +21,7 @@ func.func @ceil_op_test_f16() {
 func.func @ceil_op_test_f32() {
   %0 = stablehlo.constant dense<[0xFF800000, -2.5, 0x80000001, -0.0, 0.0, 0x00000001, 2.5, 0x7F800000, 0x7FC00000]> : tensor<9xf32>
   %1 = stablehlo.ceil %0 : tensor<9xf32>
-  check.almost_eq %1, dense<[0xFF800000, -2.000000e+00, -0.000000e+00, -0.000000e+00, 0.000000e+00, 1.000000e+00, 3.000000e+00, 0x7F800000, 0x7FC00000]> : tensor<9xf32>
+  check.expect_almost_eq_const %1, dense<[0xFF800000, -2.000000e+00, -0.000000e+00, -0.000000e+00, 0.000000e+00, 1.000000e+00, 3.000000e+00, 0x7F800000, 0x7FC00000]> : tensor<9xf32>
   func.return
 }
 
@@ -30,6 +30,6 @@ func.func @ceil_op_test_f32() {
 func.func @ceil_op_test_f64() {
   %0 = stablehlo.constant dense<[0xFFF0000000000000, -2.5, 0x8000000000000001, -0.0, 0.0, 0x0000000000000001, 2.5, 0x7FF0000000000000, 0x7FF8000000000000]> : tensor<9xf64>
   %1 = stablehlo.ceil %0 : tensor<9xf64>
-  check.almost_eq %1, dense<[0xFFF0000000000000, -2.000000e+00, -0.000000e+00, -0.000000e+00, 0.000000e+00, 1.000000e+00, 3.000000e+00, 0x7FF0000000000000, 0x7FF8000000000000]> : tensor<9xf64>
+  check.expect_almost_eq_const %1, dense<[0xFFF0000000000000, -2.000000e+00, -0.000000e+00, -0.000000e+00, 0.000000e+00, 1.000000e+00, 3.000000e+00, 0x7FF0000000000000, 0x7FF8000000000000]> : tensor<9xf64>
   func.return
 }

--- a/stablehlo/tests/interpret_clamp.mlir
+++ b/stablehlo/tests/interpret_clamp.mlir
@@ -5,7 +5,7 @@ func.func @clamp_op_test_si64() {
   %operand = stablehlo.constant dense<[2, 3, -1]> : tensor<3xi64>
   %max = stablehlo.constant dense<[3, 7, -3]> : tensor<3xi64>
   %result = stablehlo.clamp %min, %operand, %max : (tensor<3xi64>, tensor<3xi64>, tensor<3xi64>) -> tensor<3xi64>
-  check.eq %result, dense<[2, 5, -3]> : tensor<3xi64>
+  check.expect_eq_const %result, dense<[2, 5, -3]> : tensor<3xi64>
   func.return
 }
 
@@ -16,7 +16,7 @@ func.func @clamp_op_test_si64_min_scalar() {
   %operand = stablehlo.constant dense<[2, 3, -1]> : tensor<3xi64>
   %max = stablehlo.constant dense<1> : tensor<i64>
   %result = stablehlo.clamp %min, %operand, %max : (tensor<3xi64>, tensor<3xi64>, tensor<i64>) -> tensor<3xi64>
-  check.eq %result, dense<[1, 1, -1]> : tensor<3xi64>
+  check.expect_eq_const %result, dense<[1, 1, -1]> : tensor<3xi64>
   func.return
 }
 
@@ -27,7 +27,7 @@ func.func @clamp_op_test_si64_max_scalar() {
   %operand = stablehlo.constant dense<[2, 3, -1]> : tensor<3xi64>
   %max = stablehlo.constant dense<[1, 1, 4]> : tensor<3xi64>
   %result = stablehlo.clamp %min, %operand, %max : (tensor<i64>, tensor<3xi64>, tensor<3xi64>) -> tensor<3xi64>
-  check.eq %result, dense<[1, 1, 0]> : tensor<3xi64>
+  check.expect_eq_const %result, dense<[1, 1, 0]> : tensor<3xi64>
   func.return
 }
 
@@ -38,6 +38,6 @@ func.func @clamp_op_test_si64_min_max_both_scalar() {
   %operand = stablehlo.constant dense<[2, 3, -1]> : tensor<3xi64>
   %max = stablehlo.constant dense<1> : tensor<i64>
   %result = stablehlo.clamp %min, %operand, %max : (tensor<i64>, tensor<3xi64>, tensor<i64>) -> tensor<3xi64>
-  check.eq %result, dense<[1, 1, 0]> : tensor<3xi64>
+  check.expect_eq_const %result, dense<[1, 1, 0]> : tensor<3xi64>
   func.return
 }

--- a/stablehlo/tests/interpret_concatenate.mlir
+++ b/stablehlo/tests/interpret_concatenate.mlir
@@ -4,6 +4,6 @@ func.func @concatenate() {
   %input0 = stablehlo.constant dense<[[1, 2], [3, 4], [5, 6]]> : tensor<3x2xi64>
   %input1 = stablehlo.constant dense<[[7, 8]]> : tensor<1x2xi64>
   %result = stablehlo.concatenate %input0, %input1, dim = 0 : (tensor<3x2xi64>, tensor<1x2xi64>) -> tensor<4x2xi64>
-  check.eq %result, dense<[[1, 2], [3, 4] , [5, 6], [7, 8]]> : tensor<4x2xi64>
+  check.expect_eq_const %result, dense<[[1, 2], [3, 4] , [5, 6], [7, 8]]> : tensor<4x2xi64>
   func.return
 }

--- a/stablehlo/tests/interpret_constant.mlir
+++ b/stablehlo/tests/interpret_constant.mlir
@@ -2,7 +2,7 @@
 
 func.func @constant_op_test_si4() {
   %0 = stablehlo.constant dense<[-8, -1, 0, 1, 7]> : tensor<5xi4>
-  check.eq %0, dense<[-8, -1, 0, 1, 7]> : tensor<5xi4>
+  check.expect_eq_const %0, dense<[-8, -1, 0, 1, 7]> : tensor<5xi4>
   func.return
 }
 
@@ -10,7 +10,7 @@ func.func @constant_op_test_si4() {
 
 func.func @constant_op_test_ui4() {
   %0 = stablehlo.constant dense<[0, 8, 15]> : tensor<3xui4>
-  check.eq %0, dense<[0, 8, 15]> : tensor<3xui4>
+  check.expect_eq_const %0, dense<[0, 8, 15]> : tensor<3xui4>
   func.return
 }
 
@@ -18,7 +18,7 @@ func.func @constant_op_test_ui4() {
 
 func.func @constant_op_test_si8() {
   %0 = stablehlo.constant dense<[-128, -9, 0, 8, 127]> : tensor<5xi8>
-  check.eq %0, dense<[-128, -9, 0, 8, 127]> : tensor<5xi8>
+  check.expect_eq_const %0, dense<[-128, -9, 0, 8, 127]> : tensor<5xi8>
   func.return
 }
 
@@ -26,7 +26,7 @@ func.func @constant_op_test_si8() {
 
 func.func @constant_op_test_ui8() {
   %0 = stablehlo.constant dense<[0, 16, 255]> : tensor<3xui8>
-  check.eq %0, dense<[0, 16, 255]> : tensor<3xui8>
+  check.expect_eq_const %0, dense<[0, 16, 255]> : tensor<3xui8>
   func.return
 }
 
@@ -34,7 +34,7 @@ func.func @constant_op_test_ui8() {
 
 func.func @constant_op_test_si16() {
   %0 = stablehlo.constant dense<[-32768, -129, 0, 128, 32767]> : tensor<5xi16>
-  check.eq %0, dense<[-32768, -129, 0, 128, 32767]> : tensor<5xi16>
+  check.expect_eq_const %0, dense<[-32768, -129, 0, 128, 32767]> : tensor<5xi16>
   func.return
 }
 
@@ -42,7 +42,7 @@ func.func @constant_op_test_si16() {
 
 func.func @constant_op_test_ui16() {
   %0 = stablehlo.constant dense<[0, 256, 65535]> : tensor<3xui16>
-  check.eq %0, dense<[0, 256, 65535]> : tensor<3xui16>
+  check.expect_eq_const %0, dense<[0, 256, 65535]> : tensor<3xui16>
   func.return
 }
 
@@ -50,7 +50,7 @@ func.func @constant_op_test_ui16() {
 
 func.func @constant_op_test_si32() {
   %0 = stablehlo.constant dense<[-2147483648, -65537, 0, 65536, 2147483647]> : tensor<5xi32>
-  check.eq %0, dense<[-2147483648, -65537, 0, 65536, 2147483647]> : tensor<5xi32>
+  check.expect_eq_const %0, dense<[-2147483648, -65537, 0, 65536, 2147483647]> : tensor<5xi32>
   func.return
 }
 
@@ -58,7 +58,7 @@ func.func @constant_op_test_si32() {
 
 func.func @constant_op_test_ui32() {
   %0 = stablehlo.constant dense<[0, 65536, 4294967295]> : tensor<3xui32>
-  check.eq %0, dense<[0, 65536, 4294967295]> : tensor<3xui32>
+  check.expect_eq_const %0, dense<[0, 65536, 4294967295]> : tensor<3xui32>
   func.return
 }
 
@@ -66,7 +66,7 @@ func.func @constant_op_test_ui32() {
 
 func.func @constant_op_test_si64() {
   %0 = stablehlo.constant dense<[-9223372036854775808, -2147483649, 0, 2147483648, 9223372036854775807]> : tensor<5xi64>
-  check.eq %0, dense<[-9223372036854775808, -2147483649, 0, 2147483648, 9223372036854775807]> : tensor<5xi64>
+  check.expect_eq_const %0, dense<[-9223372036854775808, -2147483649, 0, 2147483648, 9223372036854775807]> : tensor<5xi64>
   func.return
 }
 
@@ -74,7 +74,7 @@ func.func @constant_op_test_si64() {
 
 func.func @constant_op_test_ui64() {
   %0 = stablehlo.constant dense<[0, 4294967296, 18446744073709551615]> : tensor<3xui64>
-  check.eq %0, dense<[0, 4294967296, 18446744073709551615]> : tensor<3xui64>
+  check.expect_eq_const %0, dense<[0, 4294967296, 18446744073709551615]> : tensor<3xui64>
   func.return
 }
 
@@ -82,7 +82,7 @@ func.func @constant_op_test_ui64() {
 
 func.func @constant_op_test_bf16() {
   %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.140630, 0x7F80, 0xFF80, 0x7FFF, 0x0001, 0x8001]> : tensor<11xbf16>
-  check.almost_eq %0, dense<[0.000000e+00, -0.000000e+00, 1.000000e+00, 1.250000e-01, 1.000980e-01, 3.140630e+00, 0x7F80, 0xFF80, 0x7FFF, 9.183550e-41, -9.183550e-41]> : tensor<11xbf16>
+  check.expect_almost_eq_const %0, dense<[0.000000e+00, -0.000000e+00, 1.000000e+00, 1.250000e-01, 1.000980e-01, 3.140630e+00, 0x7F80, 0xFF80, 0x7FFF, 9.183550e-41, -9.183550e-41]> : tensor<11xbf16>
   func.return
 }
 
@@ -90,7 +90,7 @@ func.func @constant_op_test_bf16() {
 
 func.func @constant_op_test_f16() {
   %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.140630, 0x7C00, 0xFC00, 0x7FFF, 0x0001, 0x8001]> : tensor<11xf16>
-  check.almost_eq %0, dense<[0.000000e+00, -0.000000e+00, 1.000000e+00, 1.250000e-01, 9.997550e-02, 3.140630e+00, 0x7C00, 0xFC00, 0x7FFF, 5.960460e-08, -5.960460e-08]> : tensor<11xf16>
+  check.expect_almost_eq_const %0, dense<[0.000000e+00, -0.000000e+00, 1.000000e+00, 1.250000e-01, 9.997550e-02, 3.140630e+00, 0x7C00, 0xFC00, 0x7FFF, 5.960460e-08, -5.960460e-08]> : tensor<11xf16>
   func.return
 }
 
@@ -98,7 +98,7 @@ func.func @constant_op_test_f16() {
 
 func.func @constant_op_test_f32() {
   %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.14159274, 0x7F800000, 0xFF800000, 0x7FFFFFFF, 0x00000001, 0x80000001]> : tensor<11xf32>
-  check.almost_eq %0, dense<[0.000000e+00, -0.000000e+00, 1.000000e+00, 1.250000e-01, 1.000000e-01, 3.14159274, 0x7F800000, 0xFF800000, 0x7FFFFFFF, 1.401300e-45, -1.401300e-45]> : tensor<11xf32>
+  check.expect_almost_eq_const %0, dense<[0.000000e+00, -0.000000e+00, 1.000000e+00, 1.250000e-01, 1.000000e-01, 3.14159274, 0x7F800000, 0xFF800000, 0x7FFFFFFF, 1.401300e-45, -1.401300e-45]> : tensor<11xf32>
   func.return
 }
 
@@ -106,7 +106,7 @@ func.func @constant_op_test_f32() {
 
 func.func @constant_op_test_f64() {
   %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.1415926535897931, 0x7FF0000000000000, 0xFFF0000000000000, 0x7FFFFFFFFFFFFFFF, 0x0000000000000001, 0x8000000000000001]> : tensor<11xf64>
-  check.almost_eq %0, dense<[0.000000e+00, -0.000000e+00, 1.000000e+00, 1.250000e-01, 1.000000e-01, 3.1415926535897931, 0x7FF0000000000000, 0xFFF0000000000000, 0x7FFFFFFFFFFFFFFF, 4.940660e-324, -4.940660e-324]> : tensor<11xf64>
+  check.expect_almost_eq_const %0, dense<[0.000000e+00, -0.000000e+00, 1.000000e+00, 1.250000e-01, 1.000000e-01, 3.1415926535897931, 0x7FF0000000000000, 0xFFF0000000000000, 0x7FFFFFFFFFFFFFFF, 4.940660e-324, -4.940660e-324]> : tensor<11xf64>
   func.return
 }
 
@@ -114,7 +114,7 @@ func.func @constant_op_test_f64() {
 
 func.func @constant_op_test_c64() {
   %0 = stablehlo.constant dense<[(1.5, 2.5), (3.5, 4.5)]> : tensor<2xcomplex<f32>>
-  check.almost_eq %0, dense<[(1.500000e+00, 2.500000e+00), (3.500000e+00, 4.500000e+00)]> : tensor<2xcomplex<f32>>
+  check.expect_almost_eq_const %0, dense<[(1.500000e+00, 2.500000e+00), (3.500000e+00, 4.500000e+00)]> : tensor<2xcomplex<f32>>
   func.return
 }
 
@@ -122,6 +122,6 @@ func.func @constant_op_test_c64() {
 
 func.func @constant_op_test_c128() {
   %0 = stablehlo.constant dense<[(1.5, 2.5), (3.5, 4.5)]> : tensor<2xcomplex<f64>>
-  check.almost_eq %0, dense<[(1.500000e+00, 2.500000e+00), (3.500000e+00, 4.500000e+00)]> : tensor<2xcomplex<f64>>
+  check.expect_almost_eq_const %0, dense<[(1.500000e+00, 2.500000e+00), (3.500000e+00, 4.500000e+00)]> : tensor<2xcomplex<f64>>
   func.return
 }

--- a/stablehlo/tests/interpret_cosine.mlir
+++ b/stablehlo/tests/interpret_cosine.mlir
@@ -3,7 +3,7 @@
 func.func @cosine_op_test_bf16() {
   %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.140630, 0x7F80, 0xFF80, 0x7FFF, 0x0001, 0x8001]> : tensor<11xbf16>
   %1 = stablehlo.cosine %0 : tensor<11xbf16>
-  check.almost_eq %1, dense<[1.000000e+00, 1.000000e+00, 5.390630e-01, 9.921870e-01, 9.960930e-01, -1.000000e+00, 0xFFC0, 0xFFC0, 0x7FFF, 1.000000e+00, 1.000000e+00]> : tensor<11xbf16>
+  check.expect_almost_eq_const %1, dense<[1.000000e+00, 1.000000e+00, 5.390630e-01, 9.921870e-01, 9.960930e-01, -1.000000e+00, 0xFFC0, 0xFFC0, 0x7FFF, 1.000000e+00, 1.000000e+00]> : tensor<11xbf16>
   func.return
 }
 
@@ -12,7 +12,7 @@ func.func @cosine_op_test_bf16() {
 func.func @cosine_op_test_f16() {
   %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.140630, 0x7C00, 0xFC00, 0x7FFF, 0x0001, 0x8001]> : tensor<11xf16>
   %1 = stablehlo.cosine %0 : tensor<11xf16>
-  check.almost_eq %1, dense<[1.000000e+00, 1.000000e+00, 5.405270e-01, 9.921870e-01, 9.951170e-01, -1.000000e+00, 0xFE00, 0xFE00, 0x7FFF, 1.000000e+00, 1.000000e+00]> : tensor<11xf16>
+  check.expect_almost_eq_const %1, dense<[1.000000e+00, 1.000000e+00, 5.405270e-01, 9.921870e-01, 9.951170e-01, -1.000000e+00, 0xFE00, 0xFE00, 0x7FFF, 1.000000e+00, 1.000000e+00]> : tensor<11xf16>
   func.return
 }
 
@@ -21,7 +21,7 @@ func.func @cosine_op_test_f16() {
 func.func @cosine_op_test_f32() {
   %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.14159274, 0x7F800000, 0xFF800000, 0x7FFFFFFF, 0x00000001, 0x80000001]> : tensor<11xf32>
   %1 = stablehlo.cosine %0 : tensor<11xf32>
-  check.almost_eq %1, dense<[1.000000e+00, 1.000000e+00, 0.540302277, 0.992197692, 0.995004177, -1.000000e+00, 0xFFC00000, 0xFFC00000, 0x7FFFFFFF, 1.000000e+00, 1.000000e+00]> : tensor<11xf32>
+  check.expect_almost_eq_const %1, dense<[1.000000e+00, 1.000000e+00, 0.540302277, 0.992197692, 0.995004177, -1.000000e+00, 0xFFC00000, 0xFFC00000, 0x7FFFFFFF, 1.000000e+00, 1.000000e+00]> : tensor<11xf32>
   func.return
 }
 
@@ -30,7 +30,7 @@ func.func @cosine_op_test_f32() {
 func.func @cosine_op_test_f64() {
   %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.1415926535897931, 0x7FF0000000000000, 0xFFF0000000000000, 0x7FFFFFFFFFFFFFFF, 0x0000000000000001, 0x8000000000000001]> : tensor<11xf64>
   %1 = stablehlo.cosine %0 : tensor<11xf64>
-  check.almost_eq %1, dense<[1.000000e+00, 1.000000e+00, 0.54030230586813977, 0.992197667229329, 0.99500416527802582, -1.000000e+00, 0xFFF8000000000000, 0xFFF8000000000000, 0x7FFFFFFFFFFFFFFF, 1.000000e+00, 1.000000e+00]> : tensor<11xf64>
+  check.expect_almost_eq_const %1, dense<[1.000000e+00, 1.000000e+00, 0.54030230586813977, 0.992197667229329, 0.99500416527802582, -1.000000e+00, 0xFFF8000000000000, 0xFFF8000000000000, 0x7FFFFFFFFFFFFFFF, 1.000000e+00, 1.000000e+00]> : tensor<11xf64>
   func.return
 }
 
@@ -39,7 +39,7 @@ func.func @cosine_op_test_f64() {
 func.func @cosine_op_test_c64() {
   %0 = stablehlo.constant dense<[(1.5, 2.5), (3.5, 4.5)]> : tensor<2xcomplex<f32>>
   %1 = stablehlo.cosine %0 : tensor<2xcomplex<f32>>
-  check.almost_eq %1, dense<[(4.337810e-01, -6.03504848), (-42.1537743, 15.7863016)]> : tensor<2xcomplex<f32>>
+  check.expect_almost_eq_const %1, dense<[(4.337810e-01, -6.03504848), (-42.1537743, 15.7863016)]> : tensor<2xcomplex<f32>>
   func.return
 }
 
@@ -48,6 +48,6 @@ func.func @cosine_op_test_c64() {
 func.func @cosine_op_test_c128() {
   %0 = stablehlo.constant dense<[(1.5, 2.5), (3.5, 4.5)]> : tensor<2xcomplex<f64>>
   %1 = stablehlo.cosine %0 : tensor<2xcomplex<f64>>
-  check.almost_eq %1, dense<[(0.43378099760770306, -6.0350486377665726), (-42.153773835602316, 15.786301507647636)]> : tensor<2xcomplex<f64>>
+  check.expect_almost_eq_const %1, dense<[(0.43378099760770306, -6.0350486377665726), (-42.153773835602316, 15.786301507647636)]> : tensor<2xcomplex<f64>>
   func.return
 }

--- a/stablehlo/tests/interpret_divide.mlir
+++ b/stablehlo/tests/interpret_divide.mlir
@@ -4,7 +4,7 @@ func.func @divide_op_test_si64() {
   %lhs = stablehlo.constant dense<[17, -17, 17, -17]> : tensor<4xi64>
   %rhs = stablehlo.constant dense<[3, 3, -3, -3]> : tensor<4xi64>
   %result = stablehlo.divide %lhs, %rhs : tensor<4xi64>
-  check.eq %result, dense<[5, -5, -5, 5]> : tensor<4xi64>
+  check.expect_eq_const %result, dense<[5, -5, -5, 5]> : tensor<4xi64>
   func.return
 }
 
@@ -14,7 +14,7 @@ func.func @divide_op_test_ui64() {
   %lhs = stablehlo.constant dense<[17, 18, 19, 20]> : tensor<4xui64>
   %rhs = stablehlo.constant dense<[3, 4, 5, 7]> : tensor<4xui64>
   %result = stablehlo.divide %lhs, %rhs : tensor<4xui64>
-  check.eq %result, dense<[5, 4, 3, 2]> : tensor<4xui64>
+  check.expect_eq_const %result, dense<[5, 4, 3, 2]> : tensor<4xui64>
   func.return
 }
 
@@ -24,7 +24,7 @@ func.func @divide_op_test_f64() {
   %lhs = stablehlo.constant dense<[17.1, -17.1, 17.1, -17.1]> : tensor<4xf64>
   %rhs = stablehlo.constant dense<[3.0, 3.0, -3.0, -3.0]> : tensor<4xf64>
   %result = stablehlo.divide %lhs, %rhs : tensor<4xf64>
-  check.almost_eq %result, dense<[5.700000e+00, -5.700000e+00, -5.700000e+00, 5.700000e+00]> : tensor<4xf64>
+  check.expect_almost_eq_const %result, dense<[5.700000e+00, -5.700000e+00, -5.700000e+00, 5.700000e+00]> : tensor<4xf64>
   func.return
 }
 
@@ -34,6 +34,6 @@ func.func @divide_op_test_c128() {
   %lhs = stablehlo.constant dense<[(1.5, 2.5), (7.5, 5.5)]> : tensor<2xcomplex<f64>>
   %rhs = stablehlo.constant dense<[(2.5, 1.5), (5.5, 7.5)]> : tensor<2xcomplex<f64>>
   %result = stablehlo.divide %lhs, %rhs : tensor<2xcomplex<f64>>
-  check.almost_eq %result, dense<[(0.88235294117647056, 0.4705882352941177), (0.95375722543352603, -0.30057803468208094)]> : tensor<2xcomplex<f64>>
+  check.expect_almost_eq_const %result, dense<[(0.88235294117647056, 0.4705882352941177), (0.95375722543352603, -0.30057803468208094)]> : tensor<2xcomplex<f64>>
   func.return
 }

--- a/stablehlo/tests/interpret_dynamic_slice.mlir
+++ b/stablehlo/tests/interpret_dynamic_slice.mlir
@@ -9,6 +9,6 @@ func.func @dynamic_slice() {
   %result = "stablehlo.dynamic_slice"(%operand, %start_indices0, %start_indices1) {
     slice_sizes = dense<[3, 3]> : tensor<2xi64>
   } : (tensor<3x3xi64>, tensor<i64>, tensor<i64>) -> tensor<3x3xi64>
-  check.eq %result, dense<[[1, 1, 1], [1, 1, 1], [1, 1, 1]]> : tensor<3x3xi64>
+  check.expect_eq_const %result, dense<[[1, 1, 1], [1, 1, 1], [1, 1, 1]]> : tensor<3x3xi64>
   func.return
 }

--- a/stablehlo/tests/interpret_dynamic_update_slice.mlir
+++ b/stablehlo/tests/interpret_dynamic_update_slice.mlir
@@ -11,6 +11,6 @@ func.func @dynamic_update_slice() {
   %start_indices1 = stablehlo.constant dense<4> : tensor<i64>
   %result = stablehlo.dynamic_update_slice %operand, %update, %start_indices0, %start_indices1 :
       (tensor<4x4xi64>, tensor<2x3xi64>, tensor<i64>, tensor<i64>) -> tensor<4x4xi64>
-  check.eq %result, dense<[[1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1]]> : tensor<4x4xi64>
+  check.expect_eq_const %result, dense<[[1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1]]> : tensor<4x4xi64>
   func.return
 }

--- a/stablehlo/tests/interpret_exponential.mlir
+++ b/stablehlo/tests/interpret_exponential.mlir
@@ -3,7 +3,7 @@
 func.func @exponential_op_test_f64() {
   %operand = stablehlo.constant dense<[[0.0, 1.0], [2.0, 3.0]]> : tensor<2x2xf64>
   %result = stablehlo.exponential %operand : tensor<2x2xf64>
-  check.almost_eq %result, dense<[[1.000000e+00, 2.7182818284590451], [7.3890560989306504, 20.085536923187668]]> : tensor<2x2xf64>
+  check.expect_almost_eq_const %result, dense<[[1.000000e+00, 2.7182818284590451], [7.3890560989306504, 20.085536923187668]]> : tensor<2x2xf64>
   func.return
 }
 
@@ -12,6 +12,6 @@ func.func @exponential_op_test_f64() {
 func.func @exponential_op_test_c128() {
   %operand = stablehlo.constant dense<(1.0, 2.0)> : tensor<complex<f64>>
   %result = stablehlo.exponential %operand : tensor<complex<f64>>
-  check.almost_eq %result, dense<(-1.1312043837568135, 2.4717266720048188)> : tensor<complex<f64>>
+  check.expect_almost_eq_const %result, dense<(-1.1312043837568135, 2.4717266720048188)> : tensor<complex<f64>>
   func.return
 }

--- a/stablehlo/tests/interpret_floor.mlir
+++ b/stablehlo/tests/interpret_floor.mlir
@@ -3,7 +3,7 @@
 func.func @floor_op_test_bf16() {
   %0 = stablehlo.constant dense<[0xFF80, -2.5, 0x8001, -0.0, 0.0, 0x0001, 2.5, 0x7F80, 0x7FC0]>  : tensor<9xbf16>
   %1 = stablehlo.floor %0 : tensor<9xbf16>
-  check.almost_eq %1, dense<[0xFF80, -3.000000e+00, -1.000000e+00, -0.000000e+00, 0.000000e+00, 0.000000e+00, 2.000000e+00, 0x7F80, 0x7FC0]> : tensor<9xbf16>
+  check.expect_almost_eq_const %1, dense<[0xFF80, -3.000000e+00, -1.000000e+00, -0.000000e+00, 0.000000e+00, 0.000000e+00, 2.000000e+00, 0x7F80, 0x7FC0]> : tensor<9xbf16>
   func.return
 }
 
@@ -12,7 +12,7 @@ func.func @floor_op_test_bf16() {
 func.func @floor_op_test_f16() {
   %0 = stablehlo.constant dense<[0xFC00, -2.5, 0x8001, -0.0, 0.0, 0x0001, 2.5, 0x7C00, 0x7E00]>  : tensor<9xf16>
   %1 = stablehlo.floor %0 : tensor<9xf16>
-  check.almost_eq %1, dense<[0xFC00, -3.000000e+00, -1.000000e+00, -0.000000e+00, 0.000000e+00, 0.000000e+00, 2.000000e+00, 0x7C00, 0x7E00]> : tensor<9xf16>
+  check.expect_almost_eq_const %1, dense<[0xFC00, -3.000000e+00, -1.000000e+00, -0.000000e+00, 0.000000e+00, 0.000000e+00, 2.000000e+00, 0x7C00, 0x7E00]> : tensor<9xf16>
   func.return
 }
 
@@ -21,7 +21,7 @@ func.func @floor_op_test_f16() {
 func.func @floor_op_test_f32() {
   %0 = stablehlo.constant dense<[0xFF800000, -2.5, 0x80000001, -0.0, 0.0, 0x00000001, 2.5, 0x7F800000, 0x7FC00000]>  : tensor<9xf32>
   %1 = stablehlo.floor %0 : tensor<9xf32>
-  check.almost_eq %1, dense<[0xFF800000, -3.000000e+00, -1.000000e+00, -0.000000e+00, 0.000000e+00, 0.000000e+00, 2.000000e+00, 0x7F800000, 0x7FC00000]> : tensor<9xf32>
+  check.expect_almost_eq_const %1, dense<[0xFF800000, -3.000000e+00, -1.000000e+00, -0.000000e+00, 0.000000e+00, 0.000000e+00, 2.000000e+00, 0x7F800000, 0x7FC00000]> : tensor<9xf32>
   func.return
 }
 
@@ -30,6 +30,6 @@ func.func @floor_op_test_f32() {
 func.func @floor_op_test_f64() {
   %0 = stablehlo.constant dense<[0xFFF0000000000000, -2.5, 0x8000000000000001, -0.0, 0.0, 0x0000000000000001, 2.5, 0x7FF0000000000000, 0x7FF8000000000000]>  : tensor<9xf64>
   %1 = stablehlo.floor %0 : tensor<9xf64>
-  check.almost_eq %1, dense<[0xFFF0000000000000, -3.000000e+00, -1.000000e+00, -0.000000e+00, 0.000000e+00, 0.000000e+00, 2.000000e+00, 0x7FF0000000000000, 0x7FF8000000000000]> : tensor<9xf64>
+  check.expect_almost_eq_const %1, dense<[0xFFF0000000000000, -3.000000e+00, -1.000000e+00, -0.000000e+00, 0.000000e+00, 0.000000e+00, 2.000000e+00, 0x7FF0000000000000, 0x7FF8000000000000]> : tensor<9xf64>
   func.return
 }

--- a/stablehlo/tests/interpret_if.mlir
+++ b/stablehlo/tests/interpret_if.mlir
@@ -9,8 +9,8 @@ func.func @if_ops_true_branch() {
     %1 = stablehlo.constant dense<1> : tensor<2xi64>
     stablehlo.return %1, %1 : tensor<2xi64>, tensor<2xi64>
   }) : (tensor<i1>) -> (tensor<2xi64>, tensor<2xi64>)
-  check.eq %result0, dense<[0,0]> : tensor<2xi64>
-  check.eq %result1, dense<[0,0]> : tensor<2xi64>
+  check.expect_eq_const %result0, dense<[0,0]> : tensor<2xi64>
+  check.expect_eq_const %result1, dense<[0,0]> : tensor<2xi64>
   func.return
 }
 
@@ -25,7 +25,7 @@ func.func @if_ops_false_branch() {
     %1 = stablehlo.constant dense<1> : tensor<2xi64>
     stablehlo.return %1, %1 : tensor<2xi64>, tensor<2xi64>
   }) : (tensor<i1>) -> (tensor<2xi64>, tensor<2xi64>)
-  check.eq %result0, dense<[1, 1]> : tensor<2xi64>
-  check.eq %result1, dense<[1, 1]> : tensor<2xi64>
+  check.expect_eq_const %result0, dense<[1, 1]> : tensor<2xi64>
+  check.expect_eq_const %result1, dense<[1, 1]> : tensor<2xi64>
   func.return
 }

--- a/stablehlo/tests/interpret_imag.mlir
+++ b/stablehlo/tests/interpret_imag.mlir
@@ -3,7 +3,7 @@
 func.func @imag_op_test_f64() {
   %0 = stablehlo.constant dense<[1.0, 2.0]> : tensor<2xf64>
   %1 = stablehlo.imag %0 : tensor<2xf64>
-  check.almost_eq %1, dense<[0.0, 0.0]> : tensor<2xf64>
+  check.expect_almost_eq_const %1, dense<[0.0, 0.0]> : tensor<2xf64>
   func.return
 }
 
@@ -12,6 +12,6 @@ func.func @imag_op_test_f64() {
 func.func @imag_op_test_c128() {
   %0 = stablehlo.constant dense<[(1.0, 2.0), (3.0, 4.0)]> : tensor<2xcomplex<f64>>
   %1 = stablehlo.imag %0 : (tensor<2xcomplex<f64>>) -> tensor<2xf64>
-  check.almost_eq %1, dense<[2.0, 4.0]> : tensor<2xf64>
+  check.expect_almost_eq_const %1, dense<[2.0, 4.0]> : tensor<2xf64>
   func.return
 }

--- a/stablehlo/tests/interpret_iota.mlir
+++ b/stablehlo/tests/interpret_iota.mlir
@@ -2,7 +2,7 @@
 
 func.func @iota_op_test_si4_dim_0() {
   %0 = stablehlo.iota dim = 0 : tensor<3x4xi4>
-  check.eq %0, dense<[[0, 0, 0, 0], [1, 1, 1, 1], [2, 2, 2, 2]]> : tensor<3x4xi4>
+  check.expect_eq_const %0, dense<[[0, 0, 0, 0], [1, 1, 1, 1], [2, 2, 2, 2]]> : tensor<3x4xi4>
   func.return
 }
 
@@ -10,7 +10,7 @@ func.func @iota_op_test_si4_dim_0() {
 
 func.func @iota_op_test_si4_dim_1() {
   %0 = stablehlo.iota dim = 1 : tensor<3x4xi4>
-  check.eq %0, dense<[[0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]]> : tensor<3x4xi4>
+  check.expect_eq_const %0, dense<[[0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]]> : tensor<3x4xi4>
   func.return
 }
 
@@ -18,7 +18,7 @@ func.func @iota_op_test_si4_dim_1() {
 
 func.func @iota_op_test_si8_dim_0() {
   %0 = stablehlo.iota dim = 0 : tensor<3x4xi8>
-  check.eq %0, dense<[[0, 0, 0, 0], [1, 1, 1, 1], [2, 2, 2, 2]]> : tensor<3x4xi8>
+  check.expect_eq_const %0, dense<[[0, 0, 0, 0], [1, 1, 1, 1], [2, 2, 2, 2]]> : tensor<3x4xi8>
   func.return
 }
 
@@ -26,7 +26,7 @@ func.func @iota_op_test_si8_dim_0() {
 
 func.func @iota_op_test_si8_dim_1() {
   %0 = stablehlo.iota dim = 1 : tensor<3x4xi8>
-  check.eq %0, dense<[[0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]]> : tensor<3x4xi8>
+  check.expect_eq_const %0, dense<[[0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]]> : tensor<3x4xi8>
   func.return
 }
 
@@ -34,7 +34,7 @@ func.func @iota_op_test_si8_dim_1() {
 
 func.func @iota_op_test_si16_dim_0() {
   %0 = stablehlo.iota dim = 0 : tensor<3x4xi16>
-  check.eq %0, dense<[[0, 0, 0, 0], [1, 1, 1, 1], [2, 2, 2, 2]]> : tensor<3x4xi16>
+  check.expect_eq_const %0, dense<[[0, 0, 0, 0], [1, 1, 1, 1], [2, 2, 2, 2]]> : tensor<3x4xi16>
   func.return
 }
 
@@ -42,7 +42,7 @@ func.func @iota_op_test_si16_dim_0() {
 
 func.func @iota_op_test_si16_dim_1() {
   %0 = stablehlo.iota dim = 1 : tensor<3x4xi16>
-  check.eq %0, dense<[[0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]]> : tensor<3x4xi16>
+  check.expect_eq_const %0, dense<[[0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]]> : tensor<3x4xi16>
   func.return
 }
 
@@ -50,7 +50,7 @@ func.func @iota_op_test_si16_dim_1() {
 
 func.func @iota_op_test_si32_dim_0() {
   %0 = stablehlo.iota dim = 0 : tensor<3x4xi32>
-  check.eq %0, dense<[[0, 0, 0, 0], [1, 1, 1, 1], [2, 2, 2, 2]]> : tensor<3x4xi32>
+  check.expect_eq_const %0, dense<[[0, 0, 0, 0], [1, 1, 1, 1], [2, 2, 2, 2]]> : tensor<3x4xi32>
   func.return
 }
 
@@ -58,7 +58,7 @@ func.func @iota_op_test_si32_dim_0() {
 
 func.func @iota_op_test_si32_dim_1() {
   %0 = stablehlo.iota dim = 1 : tensor<3x4xi32>
-  check.eq %0, dense<[[0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]]> : tensor<3x4xi32>
+  check.expect_eq_const %0, dense<[[0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]]> : tensor<3x4xi32>
   func.return
 }
 
@@ -66,7 +66,7 @@ func.func @iota_op_test_si32_dim_1() {
 
 func.func @iota_op_test_si64_dim_0() {
   %0 = stablehlo.iota dim = 0 : tensor<3x4xi64>
-  check.eq %0, dense<[[0, 0, 0, 0], [1, 1, 1, 1], [2, 2, 2, 2]]> : tensor<3x4xi64>
+  check.expect_eq_const %0, dense<[[0, 0, 0, 0], [1, 1, 1, 1], [2, 2, 2, 2]]> : tensor<3x4xi64>
   func.return
 }
 // -----
@@ -74,7 +74,7 @@ func.func @iota_op_test_si64_dim_0() {
 
 func.func @iota_op_test_si64_dim_1() {
   %0 = stablehlo.iota dim = 1 : tensor<3x4xi64>
-  check.eq %0, dense<[[0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]]> : tensor<3x4xi64>
+  check.expect_eq_const %0, dense<[[0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]]> : tensor<3x4xi64>
   func.return
 }
 
@@ -82,7 +82,7 @@ func.func @iota_op_test_si64_dim_1() {
 
 func.func @iota_op_test_ui64_dim_0() {
   %0 = stablehlo.iota dim = 0 : tensor<2x3x2xui64>
-  check.eq %0, dense<[[[0, 0], [0, 0], [0, 0]], [[1, 1], [1, 1], [1, 1]]]> : tensor<2x3x2xui64>
+  check.expect_eq_const %0, dense<[[[0, 0], [0, 0], [0, 0]], [[1, 1], [1, 1], [1, 1]]]> : tensor<2x3x2xui64>
   func.return
 }
 
@@ -90,7 +90,7 @@ func.func @iota_op_test_ui64_dim_0() {
 
 func.func @iota_op_test_ui64_dim_1() {
   %0 = stablehlo.iota dim = 1 : tensor<2x3x2xui64>
-  check.eq %0, dense<[[[0, 0], [1, 1], [2, 2]], [[0, 0], [1, 1], [2, 2]]]> : tensor<2x3x2xui64>
+  check.expect_eq_const %0, dense<[[[0, 0], [1, 1], [2, 2]], [[0, 0], [1, 1], [2, 2]]]> : tensor<2x3x2xui64>
   func.return
 }
 
@@ -98,7 +98,7 @@ func.func @iota_op_test_ui64_dim_1() {
 
 func.func @iota_op_test_ui64_dim_2() {
   %0 = stablehlo.iota dim = 2 : tensor<2x3x2xui64>
-  check.eq %0, dense<[[[0, 1], [0, 1], [0, 1]], [[0, 1], [0, 1], [0, 1]]]> : tensor<2x3x2xui64>
+  check.expect_eq_const %0, dense<[[[0, 1], [0, 1], [0, 1]], [[0, 1], [0, 1], [0, 1]]]> : tensor<2x3x2xui64>
   func.return
 }
 
@@ -106,7 +106,7 @@ func.func @iota_op_test_ui64_dim_2() {
 
 func.func @iota_op_test_bf16_dim_0() {
   %0 = stablehlo.iota dim = 0 : tensor<3x4xbf16>
-  check.almost_eq %0, dense<[[0.000000e+00, 0.000000e+00, 0.000000e+00, 0.000000e+00], [1.000000e+00, 1.000000e+00, 1.000000e+00, 1.000000e+00], [2.000000e+00, 2.000000e+00, 2.000000e+00, 2.000000e+00]]> : tensor<3x4xbf16>
+  check.expect_almost_eq_const %0, dense<[[0.000000e+00, 0.000000e+00, 0.000000e+00, 0.000000e+00], [1.000000e+00, 1.000000e+00, 1.000000e+00, 1.000000e+00], [2.000000e+00, 2.000000e+00, 2.000000e+00, 2.000000e+00]]> : tensor<3x4xbf16>
   func.return
 }
 
@@ -114,7 +114,7 @@ func.func @iota_op_test_bf16_dim_0() {
 
 func.func @iota_op_test_bf16_dim_1() {
   %0 = stablehlo.iota dim = 1 : tensor<3x4xbf16>
-  check.almost_eq %0, dense<[[0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00], [0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00], [0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00]]> : tensor<3x4xbf16>
+  check.expect_almost_eq_const %0, dense<[[0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00], [0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00], [0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00]]> : tensor<3x4xbf16>
   func.return
 }
 
@@ -122,7 +122,7 @@ func.func @iota_op_test_bf16_dim_1() {
 
 func.func @iota_op_test_f16_dim_0() {
   %0 = stablehlo.iota dim = 0 : tensor<3x4xf16>
-  check.almost_eq %0, dense<[[0.000000e+00, 0.000000e+00, 0.000000e+00, 0.000000e+00], [1.000000e+00, 1.000000e+00, 1.000000e+00, 1.000000e+00], [2.000000e+00, 2.000000e+00, 2.000000e+00, 2.000000e+00]]> : tensor<3x4xf16>
+  check.expect_almost_eq_const %0, dense<[[0.000000e+00, 0.000000e+00, 0.000000e+00, 0.000000e+00], [1.000000e+00, 1.000000e+00, 1.000000e+00, 1.000000e+00], [2.000000e+00, 2.000000e+00, 2.000000e+00, 2.000000e+00]]> : tensor<3x4xf16>
   func.return
 }
 
@@ -130,7 +130,7 @@ func.func @iota_op_test_f16_dim_0() {
 
 func.func @iota_op_test_f16_dim_1() {
   %0 = stablehlo.iota dim = 1 : tensor<3x4xf16>
-  check.almost_eq %0, dense<[[0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00], [0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00], [0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00]]> : tensor<3x4xf16>
+  check.expect_almost_eq_const %0, dense<[[0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00], [0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00], [0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00]]> : tensor<3x4xf16>
   func.return
 }
 
@@ -138,7 +138,7 @@ func.func @iota_op_test_f16_dim_1() {
 
 func.func @iota_op_test_f32_dim_0() {
   %0 = stablehlo.iota dim = 0 : tensor<3x4xf32>
-  check.almost_eq %0, dense<[[0.000000e+00, 0.000000e+00, 0.000000e+00, 0.000000e+00], [1.000000e+00, 1.000000e+00, 1.000000e+00, 1.000000e+00], [2.000000e+00, 2.000000e+00, 2.000000e+00, 2.000000e+00]]> : tensor<3x4xf32>
+  check.expect_almost_eq_const %0, dense<[[0.000000e+00, 0.000000e+00, 0.000000e+00, 0.000000e+00], [1.000000e+00, 1.000000e+00, 1.000000e+00, 1.000000e+00], [2.000000e+00, 2.000000e+00, 2.000000e+00, 2.000000e+00]]> : tensor<3x4xf32>
   func.return
 }
 
@@ -146,7 +146,7 @@ func.func @iota_op_test_f32_dim_0() {
 
 func.func @iota_op_test_f32_dim_1() {
   %0 = stablehlo.iota dim = 1 : tensor<3x4xf32>
-  check.almost_eq %0, dense<[[0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00], [0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00], [0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00]]> : tensor<3x4xf32>
+  check.expect_almost_eq_const %0, dense<[[0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00], [0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00], [0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00]]> : tensor<3x4xf32>
   func.return
 }
 
@@ -154,7 +154,7 @@ func.func @iota_op_test_f32_dim_1() {
 
 func.func @iota_op_test_f64_dim_0() {
   %0 = stablehlo.iota dim = 0 : tensor<3x4xf64>
-  check.almost_eq %0, dense<[[0.000000e+00, 0.000000e+00, 0.000000e+00, 0.000000e+00], [1.000000e+00, 1.000000e+00, 1.000000e+00, 1.000000e+00], [2.000000e+00, 2.000000e+00, 2.000000e+00, 2.000000e+00]]> : tensor<3x4xf64>
+  check.expect_almost_eq_const %0, dense<[[0.000000e+00, 0.000000e+00, 0.000000e+00, 0.000000e+00], [1.000000e+00, 1.000000e+00, 1.000000e+00, 1.000000e+00], [2.000000e+00, 2.000000e+00, 2.000000e+00, 2.000000e+00]]> : tensor<3x4xf64>
   func.return
 }
 
@@ -162,7 +162,7 @@ func.func @iota_op_test_f64_dim_0() {
 
 func.func @iota_op_test_f64_dim_1() {
   %0 = stablehlo.iota dim = 1 : tensor<3x4xf64>
-  check.almost_eq %0, dense<[[0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00], [0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00], [0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00]]> : tensor<3x4xf64>
+  check.expect_almost_eq_const %0, dense<[[0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00], [0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00], [0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00]]> : tensor<3x4xf64>
   func.return
 }
 
@@ -170,7 +170,7 @@ func.func @iota_op_test_f64_dim_1() {
 
 func.func @iota_op_test_c64_dim_0() {
   %0 = stablehlo.iota dim = 0 : tensor<3x4xcomplex<f32>>
-  check.almost_eq %0, dense<[[(0.000000e+00, 0.000000e+00), (0.000000e+00, 0.000000e+00), (0.000000e+00, 0.000000e+00), (0.000000e+00, 0.000000e+00)], [(1.000000e+00, 0.000000e+00), (1.000000e+00, 0.000000e+00), (1.000000e+00, 0.000000e+00), (1.000000e+00, 0.000000e+00)], [(2.000000e+00, 0.000000e+00), (2.000000e+00, 0.000000e+00), (2.000000e+00, 0.000000e+00), (2.000000e+00, 0.000000e+00)]]> : tensor<3x4xcomplex<f32>>
+  check.expect_almost_eq_const %0, dense<[[(0.000000e+00, 0.000000e+00), (0.000000e+00, 0.000000e+00), (0.000000e+00, 0.000000e+00), (0.000000e+00, 0.000000e+00)], [(1.000000e+00, 0.000000e+00), (1.000000e+00, 0.000000e+00), (1.000000e+00, 0.000000e+00), (1.000000e+00, 0.000000e+00)], [(2.000000e+00, 0.000000e+00), (2.000000e+00, 0.000000e+00), (2.000000e+00, 0.000000e+00), (2.000000e+00, 0.000000e+00)]]> : tensor<3x4xcomplex<f32>>
   func.return
 }
 
@@ -178,7 +178,7 @@ func.func @iota_op_test_c64_dim_0() {
 
 func.func @iota_op_test_c64_dim_1() {
   %0 = stablehlo.iota dim = 1 : tensor<3x4xcomplex<f32>>
-  check.almost_eq %0, dense<[[(0.000000e+00, 0.000000e+00), (1.000000e+00, 0.000000e+00), (2.000000e+00, 0.000000e+00), (3.000000e+00, 0.000000e+00)], [(0.000000e+00, 0.000000e+00), (1.000000e+00, 0.000000e+00), (2.000000e+00, 0.000000e+00), (3.000000e+00, 0.000000e+00)], [(0.000000e+00, 0.000000e+00), (1.000000e+00, 0.000000e+00), (2.000000e+00, 0.000000e+00), (3.000000e+00, 0.000000e+00)]]> : tensor<3x4xcomplex<f32>>
+  check.expect_almost_eq_const %0, dense<[[(0.000000e+00, 0.000000e+00), (1.000000e+00, 0.000000e+00), (2.000000e+00, 0.000000e+00), (3.000000e+00, 0.000000e+00)], [(0.000000e+00, 0.000000e+00), (1.000000e+00, 0.000000e+00), (2.000000e+00, 0.000000e+00), (3.000000e+00, 0.000000e+00)], [(0.000000e+00, 0.000000e+00), (1.000000e+00, 0.000000e+00), (2.000000e+00, 0.000000e+00), (3.000000e+00, 0.000000e+00)]]> : tensor<3x4xcomplex<f32>>
   func.return
 }
 
@@ -186,7 +186,7 @@ func.func @iota_op_test_c64_dim_1() {
 
 func.func @iota_op_test_c128_dim_0() {
   %0 = stablehlo.iota dim = 0 : tensor<3x4xcomplex<f64>>
-  check.almost_eq %0, dense<[[(0.000000e+00, 0.000000e+00), (0.000000e+00, 0.000000e+00), (0.000000e+00, 0.000000e+00), (0.000000e+00, 0.000000e+00)], [(1.000000e+00, 0.000000e+00), (1.000000e+00, 0.000000e+00), (1.000000e+00, 0.000000e+00), (1.000000e+00, 0.000000e+00)], [(2.000000e+00, 0.000000e+00), (2.000000e+00, 0.000000e+00), (2.000000e+00, 0.000000e+00), (2.000000e+00, 0.000000e+00)]]> : tensor<3x4xcomplex<f64>>
+  check.expect_almost_eq_const %0, dense<[[(0.000000e+00, 0.000000e+00), (0.000000e+00, 0.000000e+00), (0.000000e+00, 0.000000e+00), (0.000000e+00, 0.000000e+00)], [(1.000000e+00, 0.000000e+00), (1.000000e+00, 0.000000e+00), (1.000000e+00, 0.000000e+00), (1.000000e+00, 0.000000e+00)], [(2.000000e+00, 0.000000e+00), (2.000000e+00, 0.000000e+00), (2.000000e+00, 0.000000e+00), (2.000000e+00, 0.000000e+00)]]> : tensor<3x4xcomplex<f64>>
   func.return
 }
 
@@ -194,6 +194,6 @@ func.func @iota_op_test_c128_dim_0() {
 
 func.func @iota_op_test_c128_dim_1() {
   %0 = stablehlo.iota dim = 1 : tensor<3x4xcomplex<f64>>
-  check.almost_eq %0, dense<[[(0.000000e+00, 0.000000e+00), (1.000000e+00, 0.000000e+00), (2.000000e+00, 0.000000e+00), (3.000000e+00, 0.000000e+00)], [(0.000000e+00, 0.000000e+00), (1.000000e+00, 0.000000e+00), (2.000000e+00, 0.000000e+00), (3.000000e+00, 0.000000e+00)], [(0.000000e+00, 0.000000e+00), (1.000000e+00, 0.000000e+00), (2.000000e+00, 0.000000e+00), (3.000000e+00, 0.000000e+00)]]> : tensor<3x4xcomplex<f64>>
+  check.expect_almost_eq_const %0, dense<[[(0.000000e+00, 0.000000e+00), (1.000000e+00, 0.000000e+00), (2.000000e+00, 0.000000e+00), (3.000000e+00, 0.000000e+00)], [(0.000000e+00, 0.000000e+00), (1.000000e+00, 0.000000e+00), (2.000000e+00, 0.000000e+00), (3.000000e+00, 0.000000e+00)], [(0.000000e+00, 0.000000e+00), (1.000000e+00, 0.000000e+00), (2.000000e+00, 0.000000e+00), (3.000000e+00, 0.000000e+00)]]> : tensor<3x4xcomplex<f64>>
   func.return
 }

--- a/stablehlo/tests/interpret_log.mlir
+++ b/stablehlo/tests/interpret_log.mlir
@@ -3,7 +3,7 @@
 func.func @log_op_test_i64() {
   %operand = stablehlo.constant dense<[[1.0, 2.0], [3.0, 4.0]]> : tensor<2x2xf64>
   %result = stablehlo.log %operand : tensor<2x2xf64>
-  check.almost_eq %result, dense<[[0.000000e+00, 0.69314718055994529], [1.0986122886681098, 1.3862943611198906]]> : tensor<2x2xf64>
+  check.expect_almost_eq_const %result, dense<[[0.000000e+00, 0.69314718055994529], [1.0986122886681098, 1.3862943611198906]]> : tensor<2x2xf64>
   func.return
 }
 
@@ -12,6 +12,6 @@ func.func @log_op_test_i64() {
 func.func @log_op_test_c128() {
   %operand = stablehlo.constant dense<(1.0, 2.0)> : tensor<complex<f64>>
   %result = stablehlo.log %operand : tensor<complex<f64>>
-  check.almost_eq %result, dense<(0.80471895621705025, 1.1071487177940904)> : tensor<complex<f64>>
+  check.expect_almost_eq_const %result, dense<(0.80471895621705025, 1.1071487177940904)> : tensor<complex<f64>>
   func.return
 }

--- a/stablehlo/tests/interpret_maximum.mlir
+++ b/stablehlo/tests/interpret_maximum.mlir
@@ -4,7 +4,7 @@ func.func @max_op_test_si4() {
   %0 = stablehlo.constant dense<[0, 1, 2, -3, 0]> : tensor<5xi4>
   %1 = stablehlo.constant dense<[-8, -1, 2, -3, 7]> : tensor<5xi4>
   %2 = stablehlo.maximum %0, %1 : tensor<5xi4>
-  check.eq %2, dense<[0, 1, 2, -3, 7]> : tensor<5xi4>
+  check.expect_eq_const %2, dense<[0, 1, 2, -3, 7]> : tensor<5xi4>
   func.return
 }
 
@@ -14,7 +14,7 @@ func.func @max_op_test_ui4() {
   %0 = stablehlo.constant dense<[0, 2]> : tensor<2xui4>
   %1 = stablehlo.constant dense<[15, 3]> : tensor<2xui4>
   %2 = stablehlo.maximum %0, %1 : tensor<2xui4>
-  check.eq %2, dense<[15, 3]> : tensor<2xui4>
+  check.expect_eq_const %2, dense<[15, 3]> : tensor<2xui4>
   func.return
 }
 
@@ -24,7 +24,7 @@ func.func @max_op_test_si8() {
   %0 = stablehlo.constant dense<[0, 1, 8, -9, 0]> : tensor<5xi8>
   %1 = stablehlo.constant dense<[-128, -1, 8, -9, 127]> : tensor<5xi8>
   %2 = stablehlo.maximum %0, %1 : tensor<5xi8>
-  check.eq %2, dense<[0, 1, 8, -9, 127]> : tensor<5xi8>
+  check.expect_eq_const %2, dense<[0, 1, 8, -9, 127]> : tensor<5xi8>
   func.return
 }
 
@@ -34,7 +34,7 @@ func.func @max_op_test_ui8() {
   %0 = stablehlo.constant dense<[0, 16]> : tensor<2xui8>
   %1 = stablehlo.constant dense<[255, 16]> : tensor<2xui8>
   %2 = stablehlo.maximum %0, %1 : tensor<2xui8>
-  check.eq %2, dense<[255, 16]> : tensor<2xui8>
+  check.expect_eq_const %2, dense<[255, 16]> : tensor<2xui8>
   func.return
 }
 
@@ -44,7 +44,7 @@ func.func @max_op_test_si16() {
   %0 = stablehlo.constant dense<[0, 1, 128, -129, 0]> : tensor<5xi16>
   %1 = stablehlo.constant dense<[-32768, -1, 128, -129, 32767]> : tensor<5xi16>
   %2 = stablehlo.maximum %0, %1 : tensor<5xi16>
-  check.eq %2, dense<[0, 1, 128, -129, 32767]> : tensor<5xi16>
+  check.expect_eq_const %2, dense<[0, 1, 128, -129, 32767]> : tensor<5xi16>
   func.return
 }
 
@@ -54,7 +54,7 @@ func.func @max_op_test_ui16() {
   %0 = stablehlo.constant dense<[0, 256]> : tensor<2xui16>
   %1 = stablehlo.constant dense<[65535, 256]> : tensor<2xui16>
   %2 = stablehlo.maximum %0, %1 : tensor<2xui16>
-  check.eq %2, dense<[65535, 256]> : tensor<2xui16>
+  check.expect_eq_const %2, dense<[65535, 256]> : tensor<2xui16>
   func.return
 }
 
@@ -64,7 +64,7 @@ func.func @max_op_test_si32() {
   %0 = stablehlo.constant dense<[0, 1, 32768, -32769, 0]> : tensor<5xi32>
   %1 = stablehlo.constant dense<[-2147483648, -1, 32768, -32769, 2147483647]> : tensor<5xi32>
   %2 = stablehlo.maximum %0, %1 : tensor<5xi32>
-  check.eq %2, dense<[0, 1, 32768, -32769, 2147483647]> : tensor<5xi32>
+  check.expect_eq_const %2, dense<[0, 1, 32768, -32769, 2147483647]> : tensor<5xi32>
   func.return
 }
 
@@ -74,7 +74,7 @@ func.func @max_op_test_ui32() {
   %0 = stablehlo.constant dense<[0, 65536]> : tensor<2xui32>
   %1 = stablehlo.constant dense<[4294967295, 65536]> : tensor<2xui32>
   %2 = stablehlo.maximum %0, %1 : tensor<2xui32>
-  check.eq %2, dense<[4294967295, 65536]> : tensor<2xui32>
+  check.expect_eq_const %2, dense<[4294967295, 65536]> : tensor<2xui32>
   func.return
 }
 
@@ -84,7 +84,7 @@ func.func @max_op_test_si64() {
   %0 = stablehlo.constant dense<[0, 1, 2147483648, -2147483649, 0]> : tensor<5xi64>
   %1 = stablehlo.constant dense<[-9223372036854775808, -1, 2147483648, -2147483649, 9223372036854775807]> : tensor<5xi64>
   %2 = stablehlo.maximum %0, %1 : tensor<5xi64>
-  check.eq %2, dense<[0, 1, 2147483648, -2147483649, 9223372036854775807]> : tensor<5xi64>
+  check.expect_eq_const %2, dense<[0, 1, 2147483648, -2147483649, 9223372036854775807]> : tensor<5xi64>
   func.return
 }
 
@@ -94,7 +94,7 @@ func.func @max_op_test_ui64() {
   %0 = stablehlo.constant dense<[0, 4294967296]> : tensor<2xui64>
   %1 = stablehlo.constant dense<[18446744073709551615, 4294967296]> : tensor<2xui64>
   %2 = stablehlo.maximum %0, %1 : tensor<2xui64>
-  check.eq %2, dense<[18446744073709551615, 4294967296]> : tensor<2xui64>
+  check.expect_eq_const %2, dense<[18446744073709551615, 4294967296]> : tensor<2xui64>
   func.return
 }
 
@@ -104,7 +104,7 @@ func.func @max_op_test_i1() {
   %0 = stablehlo.constant dense<[false, false, true, true]> : tensor<4xi1>
   %1 = stablehlo.constant dense<[false, true, false, true]> : tensor<4xi1>
   %2 = stablehlo.maximum %0, %1 : tensor<4xi1>
-  check.eq %2, dense<[false, true, true, true]> : tensor<4xi1>
+  check.expect_eq_const %2, dense<[false, true, true, true]> : tensor<4xi1>
   func.return
 }
 
@@ -115,7 +115,7 @@ func.func @max_op_test_bf16() {
   %0 = stablehlo.constant dense<[0xFF80, 0xFF80, -1.0, 0x8001, 0.0, 0.0, 0x0001, 1.0, 0x7F80, 0x7F80, 0x7FC0]>  : tensor<11xbf16>
   %1 = stablehlo.constant dense<[0xFF80, -1.0, 0x8001, -0.0, -0.0, 0x0001, 1.0, 0x7F80, 0x7F80, 0xFF80, 0x7F80]> : tensor<11xbf16>
   %2 = stablehlo.maximum %0, %1 : tensor<11xbf16>
-  check.almost_eq %2, dense<[0xFF80, -1.000000e+00, -9.183550e-41, -0.000000e+00, 0.000000e+00, 9.183550e-41, 1.000000e+00, 0x7F80, 0x7F80, 0x7F80, 0x7FC0]> : tensor<11xbf16>
+  check.expect_almost_eq_const %2, dense<[0xFF80, -1.000000e+00, -9.183550e-41, -0.000000e+00, 0.000000e+00, 9.183550e-41, 1.000000e+00, 0x7F80, 0x7F80, 0x7F80, 0x7FC0]> : tensor<11xbf16>
   func.return
 }
 
@@ -125,7 +125,7 @@ func.func @max_op_test_f16() {
   %0 = stablehlo.constant dense<[0xFC00, 0xFC00, -1.0, 0x8001, 0.0, 0.0, 0x0001, 1.0, 0x7C00, 0x7C00, 0x7E00]>  : tensor<11xf16>
   %1 = stablehlo.constant dense<[0xFC00, -1.0, 0x8001, -0.0, -0.0, 0x0001, 1.0, 0x7C00, 0x7C00, 0xFC00, 0x7C00]> : tensor<11xf16>
   %2 = stablehlo.maximum %0, %1 : tensor<11xf16>
-  check.almost_eq %2, dense<[0xFC00, -1.000000e+00, -5.960460e-08, -0.000000e+00, 0.000000e+00, 5.960460e-08, 1.000000e+00, 0x7C00, 0x7C00, 0x7C00, 0x7E00]> : tensor<11xf16>
+  check.expect_almost_eq_const %2, dense<[0xFC00, -1.000000e+00, -5.960460e-08, -0.000000e+00, 0.000000e+00, 5.960460e-08, 1.000000e+00, 0x7C00, 0x7C00, 0x7C00, 0x7E00]> : tensor<11xf16>
   func.return
 }
 
@@ -135,7 +135,7 @@ func.func @max_op_test_f32() {
   %0 = stablehlo.constant dense<[0xFF800000, 0xFF800000, -1.0, 0x80000001, 0.0, 0.0, 0x00000001, 1.0, 0x7F800000, 0x7F800000, 0x7FC00000]>  : tensor<11xf32>
   %1 = stablehlo.constant dense<[0xFF800000, -1.0, 0x80000001, -0.0, -0.0, 0x00000001, 1.0, 0x7F800000, 0x7F800000, 0xFF800000, 0x7F800000]> : tensor<11xf32>
   %2 = stablehlo.maximum %0, %1 : tensor<11xf32>
-  check.almost_eq %2, dense<[0xFF800000, -1.000000e+00, -1.401300e-45, -0.000000e+00, 0.000000e+00, 1.401300e-45, 1.000000e+00, 0x7F800000, 0x7F800000, 0x7F800000, 0x7FC00000]> : tensor<11xf32>
+  check.expect_almost_eq_const %2, dense<[0xFF800000, -1.000000e+00, -1.401300e-45, -0.000000e+00, 0.000000e+00, 1.401300e-45, 1.000000e+00, 0x7F800000, 0x7F800000, 0x7F800000, 0x7FC00000]> : tensor<11xf32>
   func.return
 }
 
@@ -145,7 +145,7 @@ func.func @max_op_test_f64() {
   %0 = stablehlo.constant dense<[0xFFF0000000000000, 0xFFF0000000000000, -1.0, 0x8000000000000001, 0.0, 0.0, 0x0000000000000001, 1.0, 0x7FF0000000000000, 0x7FF0000000000000, 0x7FF8000000000000]>  : tensor<11xf64>
   %1 = stablehlo.constant dense<[0xFFF0000000000000, -1.0, 0x8000000000000001, -0.0, -0.0, 0x0000000000000001, 1.0, 0x7FF0000000000000, 0x7FF0000000000000, 0xFFF0000000000000, 0x7FF0000000000000]> : tensor<11xf64>
   %2 = stablehlo.maximum %0, %1 : tensor<11xf64>
-  check.almost_eq %2, dense<[0xFFF0000000000000, -1.000000e+00, -4.940660e-324, -0.000000e+00, 0.000000e+00, 4.940660e-324, 1.000000e+00, 0x7FF0000000000000, 0x7FF0000000000000, 0x7FF0000000000000, 0x7FF8000000000000]> : tensor<11xf64>
+  check.expect_almost_eq_const %2, dense<[0xFFF0000000000000, -1.000000e+00, -4.940660e-324, -0.000000e+00, 0.000000e+00, 4.940660e-324, 1.000000e+00, 0x7FF0000000000000, 0x7FF0000000000000, 0x7FF0000000000000, 0x7FF8000000000000]> : tensor<11xf64>
   func.return
 }
 
@@ -155,7 +155,7 @@ func.func @max_op_test_c64() {
   %0 = stablehlo.constant dense<[(1.5, 2.5), (1.5, 7.5), (0.0, 1.5), (0.0, 1.5)]> : tensor<4xcomplex<f32>>
   %1 = stablehlo.constant dense<[(7.5, 1.5), (1.5, 2.5), (-0.0, 2.5), (0.0, 1.5)]> : tensor<4xcomplex<f32>>
   %2 = stablehlo.maximum %0, %1 : tensor<4xcomplex<f32>>
-  check.almost_eq %2, dense<[(7.500000e+00, 1.500000e+00), (1.500000e+00, 7.500000e+00), (-0.000000e+00, 2.500000e+00), (0.000000e+00, 1.500000e+00)]> : tensor<4xcomplex<f32>>
+  check.expect_almost_eq_const %2, dense<[(7.500000e+00, 1.500000e+00), (1.500000e+00, 7.500000e+00), (-0.000000e+00, 2.500000e+00), (0.000000e+00, 1.500000e+00)]> : tensor<4xcomplex<f32>>
   func.return
 }
 
@@ -165,6 +165,6 @@ func.func @max_op_test_c128() {
   %0 = stablehlo.constant dense<[(1.5, 2.5), (1.5, 7.5), (0.0, 1.5), (0.0, 1.5)]> : tensor<4xcomplex<f64>>
   %1 = stablehlo.constant dense<[(7.5, 1.5), (1.5, 2.5), (-0.0, 2.5), (0.0, 1.5)]> : tensor<4xcomplex<f64>>
   %2 = stablehlo.maximum %0, %1 : tensor<4xcomplex<f64>>
-  check.almost_eq %2, dense<[(7.500000e+00, 1.500000e+00), (1.500000e+00, 7.500000e+00), (-0.000000e+00, 2.500000e+00), (0.000000e+00, 1.500000e+00)]> : tensor<4xcomplex<f64>>
+  check.expect_almost_eq_const %2, dense<[(7.500000e+00, 1.500000e+00), (1.500000e+00, 7.500000e+00), (-0.000000e+00, 2.500000e+00), (0.000000e+00, 1.500000e+00)]> : tensor<4xcomplex<f64>>
   func.return
 }

--- a/stablehlo/tests/interpret_minimum.mlir
+++ b/stablehlo/tests/interpret_minimum.mlir
@@ -4,7 +4,7 @@ func.func @min_op_test_si4() {
   %0 = stablehlo.constant dense<[0, 1, 2, -3, 0]> : tensor<5xi4>
   %1 = stablehlo.constant dense<[-8, -1, 2, -3, 7]> : tensor<5xi4>
   %2 = stablehlo.minimum %0, %1 : tensor<5xi4>
-  check.eq %2, dense<[-8, -1, 2, -3, 0]> : tensor<5xi4>
+  check.expect_eq_const %2, dense<[-8, -1, 2, -3, 0]> : tensor<5xi4>
   func.return
 }
 
@@ -14,7 +14,7 @@ func.func @min_op_test_ui4() {
   %0 = stablehlo.constant dense<[0, 2]> : tensor<2xui4>
   %1 = stablehlo.constant dense<[15, 3]> : tensor<2xui4>
   %2 = stablehlo.minimum %0, %1 : tensor<2xui4>
-  check.eq %2, dense<[0, 2]> : tensor<2xui4>
+  check.expect_eq_const %2, dense<[0, 2]> : tensor<2xui4>
   func.return
 }
 
@@ -24,7 +24,7 @@ func.func @min_op_test_si8() {
   %0 = stablehlo.constant dense<[0, 1, 8, -9, 0]> : tensor<5xi8>
   %1 = stablehlo.constant dense<[-128, -1, 8, -9, 127]> : tensor<5xi8>
   %2 = stablehlo.minimum %0, %1 : tensor<5xi8>
-  check.eq %2, dense<[-128, -1, 8, -9, 0]> : tensor<5xi8>
+  check.expect_eq_const %2, dense<[-128, -1, 8, -9, 0]> : tensor<5xi8>
   func.return
 }
 
@@ -34,7 +34,7 @@ func.func @min_op_test_ui8() {
   %0 = stablehlo.constant dense<[0, 16]> : tensor<2xui8>
   %1 = stablehlo.constant dense<[255, 16]> : tensor<2xui8>
   %2 = stablehlo.minimum %0, %1 : tensor<2xui8>
-  check.eq %2, dense<[0, 16]> : tensor<2xui8>
+  check.expect_eq_const %2, dense<[0, 16]> : tensor<2xui8>
   func.return
 }
 
@@ -44,7 +44,7 @@ func.func @min_op_test_si16() {
   %0 = stablehlo.constant dense<[0, 1, 128, -129, 0]> : tensor<5xi16>
   %1 = stablehlo.constant dense<[-32768, -1, 128, -129, 32767]> : tensor<5xi16>
   %2 = stablehlo.minimum %0, %1 : tensor<5xi16>
-  check.eq %2, dense<[-32768, -1, 128, -129, 0]> : tensor<5xi16>
+  check.expect_eq_const %2, dense<[-32768, -1, 128, -129, 0]> : tensor<5xi16>
   func.return
 }
 
@@ -54,7 +54,7 @@ func.func @min_op_test_ui16() {
   %0 = stablehlo.constant dense<[0, 256]> : tensor<2xui16>
   %1 = stablehlo.constant dense<[65535, 256]> : tensor<2xui16>
   %2 = stablehlo.minimum %0, %1 : tensor<2xui16>
-  check.eq %2, dense<[0, 256]> : tensor<2xui16>
+  check.expect_eq_const %2, dense<[0, 256]> : tensor<2xui16>
   func.return
 }
 
@@ -64,7 +64,7 @@ func.func @min_op_test_si32() {
   %0 = stablehlo.constant dense<[0, 1, 32768, -32769, 0]> : tensor<5xi32>
   %1 = stablehlo.constant dense<[-2147483648, -1, 32768, -32769, 2147483647]> : tensor<5xi32>
   %2 = stablehlo.minimum %0, %1 : tensor<5xi32>
-  check.eq %2, dense<[-2147483648, -1, 32768, -32769, 0]> : tensor<5xi32>
+  check.expect_eq_const %2, dense<[-2147483648, -1, 32768, -32769, 0]> : tensor<5xi32>
   func.return
 }
 
@@ -74,7 +74,7 @@ func.func @min_op_test_ui32() {
   %0 = stablehlo.constant dense<[0, 65536]> : tensor<2xui32>
   %1 = stablehlo.constant dense<[4294967295, 65536]> : tensor<2xui32>
   %2 = stablehlo.minimum %0, %1 : tensor<2xui32>
-  check.eq %2, dense<[0, 65536]> : tensor<2xui32>
+  check.expect_eq_const %2, dense<[0, 65536]> : tensor<2xui32>
   func.return
 }
 
@@ -84,7 +84,7 @@ func.func @min_op_test_si64() {
   %0 = stablehlo.constant dense<[0, 1, 2147483648, -2147483649, 0]> : tensor<5xi64>
   %1 = stablehlo.constant dense<[-9223372036854775808, -1, 2147483648, -2147483649, 9223372036854775807]> : tensor<5xi64>
   %2 = stablehlo.minimum %0, %1 : tensor<5xi64>
-  check.eq %2, dense<[-9223372036854775808, -1, 2147483648, -2147483649, 0]> : tensor<5xi64>
+  check.expect_eq_const %2, dense<[-9223372036854775808, -1, 2147483648, -2147483649, 0]> : tensor<5xi64>
   func.return
 }
 
@@ -94,7 +94,7 @@ func.func @min_op_test_ui64() {
   %0 = stablehlo.constant dense<[0, 4294967296]> : tensor<2xui64>
   %1 = stablehlo.constant dense<[18446744073709551615, 4294967296]> : tensor<2xui64>
   %2 = stablehlo.minimum %0, %1 : tensor<2xui64>
-  check.eq %2, dense<[0, 4294967296]> : tensor<2xui64>
+  check.expect_eq_const %2, dense<[0, 4294967296]> : tensor<2xui64>
   func.return
 }
 
@@ -104,7 +104,7 @@ func.func @min_op_test_i1() {
   %0 = stablehlo.constant dense<[false, false, true, true]> : tensor<4xi1>
   %1 = stablehlo.constant dense<[false, true, false, true]> : tensor<4xi1>
   %2 = stablehlo.minimum %0, %1 : tensor<4xi1>
-  check.eq %2, dense<[false, false, false, true]> : tensor<4xi1>
+  check.expect_eq_const %2, dense<[false, false, false, true]> : tensor<4xi1>
   func.return
 }
 
@@ -115,7 +115,7 @@ func.func @min_op_test_bf16() {
   %0 = stablehlo.constant dense<[0xFF80, 0xFF80, -1.0, 0x8001, 0.0, 0.0, 0x0001, 1.0, 0x7F80, 0x7F80, 0x7FC0]>  : tensor<11xbf16>
   %1 = stablehlo.constant dense<[0xFF80, -1.0, 0x8001, -0.0, -0.0, 0x0001, 1.0, 0x7F80, 0x7F80, 0xFF80, 0x7F80]> : tensor<11xbf16>
   %2 = stablehlo.minimum %0, %1 : tensor<11xbf16>
-  check.almost_eq %2, dense<[0xFF80, 0xFF80, -1.000000e+00, -9.183550e-41, -0.000000e+00, 0.000000e+00, 9.183550e-41, 1.000000e+00, 0x7F80, 0xFF80, 0x7FC0]> : tensor<11xbf16>
+  check.expect_almost_eq_const %2, dense<[0xFF80, 0xFF80, -1.000000e+00, -9.183550e-41, -0.000000e+00, 0.000000e+00, 9.183550e-41, 1.000000e+00, 0x7F80, 0xFF80, 0x7FC0]> : tensor<11xbf16>
   func.return
 }
 
@@ -125,7 +125,7 @@ func.func @min_op_test_f16() {
   %0 = stablehlo.constant dense<[0xFC00, 0xFC00, -1.0, 0x8001, 0.0, 0.0, 0x0001, 1.0, 0x7C00, 0x7C00, 0x7E00]>  : tensor<11xf16>
   %1 = stablehlo.constant dense<[0xFC00, -1.0, 0x8001, -0.0, -0.0, 0x0001, 1.0, 0x7C00, 0x7C00, 0xFC00, 0x7C00]> : tensor<11xf16>
   %2 = stablehlo.minimum %0, %1 : tensor<11xf16>
-  check.almost_eq %2, dense<[0xFC00, 0xFC00, -1.000000e+00, -5.960460e-08, -0.000000e+00, 0.000000e+00, 5.960460e-08, 1.000000e+00, 0x7C00, 0xFC00, 0x7E00]> : tensor<11xf16>
+  check.expect_almost_eq_const %2, dense<[0xFC00, 0xFC00, -1.000000e+00, -5.960460e-08, -0.000000e+00, 0.000000e+00, 5.960460e-08, 1.000000e+00, 0x7C00, 0xFC00, 0x7E00]> : tensor<11xf16>
   func.return
 }
 
@@ -135,7 +135,7 @@ func.func @min_op_test_f32() {
   %0 = stablehlo.constant dense<[0xFF800000, 0xFF800000, -1.0, 0x80000001, 0.0, 0.0, 0x00000001, 1.0, 0x7F800000, 0x7F800000, 0x7FC00000]>  : tensor<11xf32>
   %1 = stablehlo.constant dense<[0xFF800000, -1.0, 0x80000001, -0.0, -0.0, 0x00000001, 1.0, 0x7F800000, 0x7F800000, 0xFF800000, 0x7F800000]> : tensor<11xf32>
   %2 = stablehlo.minimum %0, %1 : tensor<11xf32>
-  check.almost_eq %2, dense<[0xFF800000, 0xFF800000, -1.000000e+00, -1.401300e-45, -0.000000e+00, 0.000000e+00, 1.401300e-45, 1.000000e+00, 0x7F800000, 0xFF800000, 0x7FC00000]> : tensor<11xf32>
+  check.expect_almost_eq_const %2, dense<[0xFF800000, 0xFF800000, -1.000000e+00, -1.401300e-45, -0.000000e+00, 0.000000e+00, 1.401300e-45, 1.000000e+00, 0x7F800000, 0xFF800000, 0x7FC00000]> : tensor<11xf32>
   func.return
 }
 
@@ -145,7 +145,7 @@ func.func @min_op_test_f64() {
   %0 = stablehlo.constant dense<[0xFFF0000000000000, 0xFFF0000000000000, -1.0, 0x8000000000000001, 0.0, 0.0, 0x0000000000000001, 1.0, 0x7FF0000000000000, 0x7FF0000000000000, 0x7FF8000000000000]>  : tensor<11xf64>
   %1 = stablehlo.constant dense<[0xFFF0000000000000, -1.0, 0x8000000000000001, -0.0, -0.0, 0x0000000000000001, 1.0, 0x7FF0000000000000, 0x7FF0000000000000, 0xFFF0000000000000, 0x7FF0000000000000]> : tensor<11xf64>
   %2 = stablehlo.minimum %0, %1 : tensor<11xf64>
-  check.almost_eq %2, dense<[0xFFF0000000000000, 0xFFF0000000000000, -1.000000e+00, -4.940660e-324, -0.000000e+00, 0.000000e+00, 4.940660e-324, 1.000000e+00, 0x7FF0000000000000, 0xFFF0000000000000, 0x7FF8000000000000]> : tensor<11xf64>
+  check.expect_almost_eq_const %2, dense<[0xFFF0000000000000, 0xFFF0000000000000, -1.000000e+00, -4.940660e-324, -0.000000e+00, 0.000000e+00, 4.940660e-324, 1.000000e+00, 0x7FF0000000000000, 0xFFF0000000000000, 0x7FF8000000000000]> : tensor<11xf64>
   func.return
 }
 
@@ -155,7 +155,7 @@ func.func @min_op_test_c64() {
   %0 = stablehlo.constant dense<[(1.5, 2.5), (1.5, 7.5), (0.0, 1.5), (0.0, 1.5)]> : tensor<4xcomplex<f32>>
   %1 = stablehlo.constant dense<[(7.5, 1.5), (1.5, 2.5), (-0.0, 2.5), (0.0, 1.5)]> : tensor<4xcomplex<f32>>
   %2 = stablehlo.minimum %0, %1 : tensor<4xcomplex<f32>>
-  check.almost_eq %2, dense<[(1.500000e+00, 2.500000e+00), (1.500000e+00, 2.500000e+00), (0.000000e+00, 1.500000e+00), (0.000000e+00, 1.500000e+00)]> : tensor<4xcomplex<f32>>
+  check.expect_almost_eq_const %2, dense<[(1.500000e+00, 2.500000e+00), (1.500000e+00, 2.500000e+00), (0.000000e+00, 1.500000e+00), (0.000000e+00, 1.500000e+00)]> : tensor<4xcomplex<f32>>
   func.return
 }
 
@@ -165,6 +165,6 @@ func.func @min_op_test_c128() {
   %0 = stablehlo.constant dense<[(1.5, 2.5), (1.5, 7.5), (0.0, 1.5), (0.0, 1.5)]> : tensor<4xcomplex<f64>>
   %1 = stablehlo.constant dense<[(7.5, 1.5), (1.5, 2.5), (-0.0, 2.5), (0.0, 1.5)]> : tensor<4xcomplex<f64>>
   %2 = stablehlo.minimum %0, %1 : tensor<4xcomplex<f64>>
-  check.almost_eq %2, dense<[(1.500000e+00, 2.500000e+00), (1.500000e+00, 2.500000e+00), (0.000000e+00, 1.500000e+00), (0.000000e+00, 1.500000e+00)]> : tensor<4xcomplex<f64>>
+  check.expect_almost_eq_const %2, dense<[(1.500000e+00, 2.500000e+00), (1.500000e+00, 2.500000e+00), (0.000000e+00, 1.500000e+00), (0.000000e+00, 1.500000e+00)]> : tensor<4xcomplex<f64>>
   func.return
 }

--- a/stablehlo/tests/interpret_multiply.mlir
+++ b/stablehlo/tests/interpret_multiply.mlir
@@ -4,7 +4,7 @@ func.func @mul_op_test_si8() {
   %0 = stablehlo.constant dense<[0, 1, 8, -9, 0]> : tensor<5xi8>
   %1 = stablehlo.constant dense<[-128, -1, 8, -9, 127]> : tensor<5xi8>
   %2 = stablehlo.multiply %0, %1 : tensor<5xi8>
-  check.eq %2, dense<[0, -1, 64, 81, 0]> : tensor<5xi8>
+  check.expect_eq_const %2, dense<[0, -1, 64, 81, 0]> : tensor<5xi8>
   func.return
 }
 
@@ -14,7 +14,7 @@ func.func @mul_op_test_ui8() {
   %0 = stablehlo.constant dense<[0, 16, 16]> : tensor<3xui8>
   %1 = stablehlo.constant dense<[255, 16, 17]> : tensor<3xui8>
   %2 = stablehlo.multiply %0, %1 : tensor<3xui8>
-  check.eq %2, dense<[0, 0, 16]> : tensor<3xui8>
+  check.expect_eq_const %2, dense<[0, 0, 16]> : tensor<3xui8>
   func.return
 }
 
@@ -24,7 +24,7 @@ func.func @mul_op_test_si16() {
   %0 = stablehlo.constant dense<[0, 1, 128, -129, 0]> : tensor<5xi16>
   %1 = stablehlo.constant dense<[-32768, -1, 128, -129, 32767]> : tensor<5xi16>
   %2 = stablehlo.multiply %0, %1 : tensor<5xi16>
-  check.eq %2, dense<[0, -1, 16384, 16641, 0]> : tensor<5xi16>
+  check.expect_eq_const %2, dense<[0, -1, 16384, 16641, 0]> : tensor<5xi16>
   func.return
 }
 
@@ -34,7 +34,7 @@ func.func @mul_op_test_ui16() {
   %0 = stablehlo.constant dense<[0, 256]> : tensor<2xui16>
   %1 = stablehlo.constant dense<[65535, 256]> : tensor<2xui16>
   %2 = stablehlo.multiply %0, %1 : tensor<2xui16>
-  check.eq %2, dense<[0, 0]> : tensor<2xui16>
+  check.expect_eq_const %2, dense<[0, 0]> : tensor<2xui16>
   func.return
 }
 
@@ -44,7 +44,7 @@ func.func @mul_op_test_si32() {
   %0 = stablehlo.constant dense<[0, 1, 32768, -32769, 0]> : tensor<5xi32>
   %1 = stablehlo.constant dense<[-2147483648, -1, 32768, -32769, 2147483647]> : tensor<5xi32>
   %2 = stablehlo.multiply %0, %1 : tensor<5xi32>
-  check.eq %2, dense<[0, -1, 1073741824, 1073807361, 0]> : tensor<5xi32>
+  check.expect_eq_const %2, dense<[0, -1, 1073741824, 1073807361, 0]> : tensor<5xi32>
   func.return
 }
 
@@ -54,7 +54,7 @@ func.func @mul_op_test_ui32() {
   %0 = stablehlo.constant dense<[0, 65536]> : tensor<2xui32>
   %1 = stablehlo.constant dense<[4294967295, 65536]> : tensor<2xui32>
   %2 = stablehlo.multiply %0, %1 : tensor<2xui32>
-  check.eq %2, dense<[0, 0]> : tensor<2xui32>
+  check.expect_eq_const %2, dense<[0, 0]> : tensor<2xui32>
   func.return
 }
 
@@ -65,7 +65,7 @@ func.func @mul_op_test_si64() {
   %0 = stablehlo.constant dense<[0, 1, 2147483648, -2147483649, 0]> : tensor<5xi64>
   %1 = stablehlo.constant dense<[-9223372036854775808, -1, 2147483648, -2147483649, 9223372036854775807]> : tensor<5xi64>
   %2 = stablehlo.multiply %0, %1 : tensor<5xi64>
-  check.eq %2, dense<[0, -1, 4611686018427387904, 4611686022722355201, 0]> : tensor<5xi64>
+  check.expect_eq_const %2, dense<[0, -1, 4611686018427387904, 4611686022722355201, 0]> : tensor<5xi64>
   func.return
 }
 
@@ -75,7 +75,7 @@ func.func @mul_op_test_ui64() {
   %0 = stablehlo.constant dense<[0, 4294967296]> : tensor<2xui64>
   %1 = stablehlo.constant dense<[18446744073709551615, 4294967296]> : tensor<2xui64>
   %2 = stablehlo.multiply %0, %1 : tensor<2xui64>
-  check.eq %2, dense<[0, 0]> : tensor<2xui64>
+  check.expect_eq_const %2, dense<[0, 0]> : tensor<2xui64>
   func.return
 }
 
@@ -85,7 +85,7 @@ func.func @mul_op_test_i1() {
   %0 = stablehlo.constant dense<[false, false, true, true]> : tensor<4xi1>
   %1 = stablehlo.constant dense<[false, true, false, true]> : tensor<4xi1>
   %2 = stablehlo.multiply %0, %1 : tensor<4xi1>
-  check.eq %2, dense<[false, false, false, true]> : tensor<4xi1>
+  check.expect_eq_const %2, dense<[false, false, false, true]> : tensor<4xi1>
   func.return
 }
 
@@ -95,7 +95,7 @@ func.func @mul_op_test_bf16() {
   %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.141, 0x7C00, 0x7C00, 0xFC00, 0x7C00, 0x0001]> : tensor<11xbf16>
   %1 = stablehlo.constant dense<[0.0, -0.0, 7.0, 0.75, 0.3, 3.141, 0.0, 0x7C00, 0xFC00, 0xFC00, 0x8001]> : tensor<11xbf16>
   %2 = stablehlo.multiply %0, %1 : tensor<11xbf16>
-  check.almost_eq %2, dense<[0.000000e+00, 0.000000e+00, 7.000000e+00, 9.375000e-02, 3.015140e-02, 9.875000e+00, 0.000000e+00, 0x7F80, 0x7F80, 0xFF80, -0.000000e+00]> : tensor<11xbf16>
+  check.expect_almost_eq_const %2, dense<[0.000000e+00, 0.000000e+00, 7.000000e+00, 9.375000e-02, 3.015140e-02, 9.875000e+00, 0.000000e+00, 0x7F80, 0x7F80, 0xFF80, -0.000000e+00]> : tensor<11xbf16>
   func.return
 }
 
@@ -105,7 +105,7 @@ func.func @mul_op_test_f16() {
   %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.141, 0x7C00, 0x7C00, 0xFC00, 0x7C00, 0x0001]> : tensor<11xf16>
   %1 = stablehlo.constant dense<[0.0, -0.0, 7.0, 0.75, 0.3, 3.141, 0.0, 0x7C00, 0xFC00, 0xFC00, 0x8001]> : tensor<11xf16>
   %2 = stablehlo.multiply %0, %1 : tensor<11xf16>
-  check.almost_eq %2, dense<[0.000000e+00, 0.000000e+00, 7.000000e+00, 9.375000e-02, 2.999880e-02, 9.867180e+00, 0x7E00, 0x7C00, 0x7C00, 0xFC00, -0.000000e+00]> : tensor<11xf16>
+  check.expect_almost_eq_const %2, dense<[0.000000e+00, 0.000000e+00, 7.000000e+00, 9.375000e-02, 2.999880e-02, 9.867180e+00, 0x7E00, 0x7C00, 0x7C00, 0xFC00, -0.000000e+00]> : tensor<11xf16>
   func.return
 
 }
@@ -116,7 +116,7 @@ func.func @mul_op_test_f32() {
   %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.14159265, 0x7F800000, 0x7F800000, 0xFF800000, 0x7F800000, 0x00000001]> : tensor<11xf32>
   %1 = stablehlo.constant dense<[0.0, -0.0, 7.0, 0.75, 0.3, 3.14159265, 0.0, 0x7F800000, 0xFF800000, 0xFF800000, 0x80000001]> : tensor<11xf32>
   %2 = stablehlo.multiply %0, %1 : tensor<11xf32>
-  check.almost_eq %2, dense<[0.000000e+00, 0.000000e+00, 7.000000e+00, 9.375000e-02, 0.0300000012, 9.86960506, 0x7FC00000, 0x7F800000, 0x7F800000, 0xFF800000, -0.000000e+00]> : tensor<11xf32>
+  check.expect_almost_eq_const %2, dense<[0.000000e+00, 0.000000e+00, 7.000000e+00, 9.375000e-02, 0.0300000012, 9.86960506, 0x7FC00000, 0x7F800000, 0x7F800000, 0xFF800000, -0.000000e+00]> : tensor<11xf32>
   func.return
 }
 
@@ -126,7 +126,7 @@ func.func @mul_op_test_f64() {
   %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.14159265358979323846, 0x7FF0000000000000, 0x7FF0000000000000, 0xFFF0000000000000, 0x7FF0000000000000, 0x0000000000000001]> : tensor<11xf64>
   %1 = stablehlo.constant dense<[0.0, -0.0, 7.0, 0.75, 0.3, 3.14159265358979323846, 0.0, 0x7FF0000000000000, 0xFFF0000000000000, 0xFFF0000000000000, 0x8000000000000001]> : tensor<11xf64>
   %2 = stablehlo.multiply %0, %1 : tensor<11xf64>
-  check.almost_eq %2, dense<[0.000000e+00, 0.000000e+00, 7.000000e+00, 9.375000e-02, 3.000000e-02, 9.869604401089358, 0x7FF8000000000000, 0x7FF0000000000000, 0x7FF0000000000000, 0xFFF0000000000000, -0.000000e+00]> : tensor<11xf64>
+  check.expect_almost_eq_const %2, dense<[0.000000e+00, 0.000000e+00, 7.000000e+00, 9.375000e-02, 3.000000e-02, 9.869604401089358, 0x7FF8000000000000, 0x7FF0000000000000, 0x7FF0000000000000, 0xFFF0000000000000, -0.000000e+00]> : tensor<11xf64>
   func.return
 }
 
@@ -136,7 +136,7 @@ func.func @mul_op_test_c64() {
   %0 = stablehlo.constant dense<[(1.5, 2.5), (7.5, 5.5)]> : tensor<2xcomplex<f32>>
   %1 = stablehlo.constant dense<[(1.5, 2.5), (7.5, 5.5)]> : tensor<2xcomplex<f32>>
   %2 = stablehlo.multiply %0, %1 : tensor<2xcomplex<f32>>
-  check.almost_eq %2, dense<[(-4.000000e+00, 7.500000e+00), (2.600000e+01, 8.250000e+01)]> : tensor<2xcomplex<f32>>
+  check.expect_almost_eq_const %2, dense<[(-4.000000e+00, 7.500000e+00), (2.600000e+01, 8.250000e+01)]> : tensor<2xcomplex<f32>>
   func.return
 }
 
@@ -146,6 +146,6 @@ func.func @mul_op_test_c128() {
   %0 = stablehlo.constant dense<[(1.5, 2.5), (7.5, 5.5)]> : tensor<2xcomplex<f64>>
   %1 = stablehlo.constant dense<[(1.5, 2.5), (7.5, 5.5)]> : tensor<2xcomplex<f64>>
   %2 = stablehlo.multiply %0, %1 : tensor<2xcomplex<f64>>
-  check.almost_eq %2, dense<[(-4.000000e+00, 7.500000e+00), (2.600000e+01, 8.250000e+01)]> : tensor<2xcomplex<f64>>
+  check.expect_almost_eq_const %2, dense<[(-4.000000e+00, 7.500000e+00), (2.600000e+01, 8.250000e+01)]> : tensor<2xcomplex<f64>>
   func.return
 }

--- a/stablehlo/tests/interpret_negate.mlir
+++ b/stablehlo/tests/interpret_negate.mlir
@@ -3,7 +3,7 @@
 func.func @negate_op_test_si4() {
   %0 = stablehlo.constant dense<[-8, -1, 0, 1, 7]> : tensor<5xi4>
   %1 = stablehlo.negate %0 : tensor<5xi4>
-  check.eq %1, dense<[-8, 1, 0, -1, -7]> : tensor<5xi4>
+  check.expect_eq_const %1, dense<[-8, 1, 0, -1, -7]> : tensor<5xi4>
   func.return
 }
 
@@ -12,7 +12,7 @@ func.func @negate_op_test_si4() {
 func.func @negate_op_test_ui4() {
   %0 = stablehlo.constant dense<[0, 8, 15]> : tensor<3xui4>
   %1 = stablehlo.negate %0 : tensor<3xui4>
-  check.eq %1, dense<[0, 8, 1]> : tensor<3xui4>
+  check.expect_eq_const %1, dense<[0, 8, 1]> : tensor<3xui4>
   func.return
 }
 
@@ -21,7 +21,7 @@ func.func @negate_op_test_ui4() {
 func.func @negate_op_test_si8() {
   %0 = stablehlo.constant dense<[-128, -9, 0, 8, 127]> : tensor<5xi8>
   %1 = stablehlo.negate %0 : tensor<5xi8>
-  check.eq %1, dense<[-128, 9, 0, -8, -127]> : tensor<5xi8>
+  check.expect_eq_const %1, dense<[-128, 9, 0, -8, -127]> : tensor<5xi8>
   func.return
 }
 
@@ -30,7 +30,7 @@ func.func @negate_op_test_si8() {
 func.func @negate_op_test_ui8() {
   %0 = stablehlo.constant dense<[0, 16, 255]> : tensor<3xui8>
   %1 = stablehlo.negate %0 : tensor<3xui8>
-  check.eq %1, dense<[0, 240, 1]> : tensor<3xui8>
+  check.expect_eq_const %1, dense<[0, 240, 1]> : tensor<3xui8>
   func.return
 }
 
@@ -39,7 +39,7 @@ func.func @negate_op_test_ui8() {
 func.func @negate_op_test_si16() {
   %0 = stablehlo.constant dense<[-32768, -129, 0, 128, 32767]> : tensor<5xi16>
   %1 = stablehlo.negate %0 : tensor<5xi16>
-  check.eq %1, dense<[-32768, 129, 0, -128, -32767]> : tensor<5xi16>
+  check.expect_eq_const %1, dense<[-32768, 129, 0, -128, -32767]> : tensor<5xi16>
   func.return
 }
 
@@ -48,7 +48,7 @@ func.func @negate_op_test_si16() {
 func.func @negate_op_test_ui16() {
   %0 = stablehlo.constant dense<[0, 256, 65535]> : tensor<3xui16>
   %1 = stablehlo.negate %0 : tensor<3xui16>
-  check.eq %1, dense<[0, 65280, 1]> : tensor<3xui16>
+  check.expect_eq_const %1, dense<[0, 65280, 1]> : tensor<3xui16>
   func.return
 }
 
@@ -57,7 +57,7 @@ func.func @negate_op_test_ui16() {
 func.func @negate_op_test_si32() {
   %0 = stablehlo.constant dense<[-2147483648, -65537, 0, 65536, 2147483647]> : tensor<5xi32>
   %1 = stablehlo.negate %0 : tensor<5xi32>
-  check.eq %1, dense<[-2147483648, 65537, 0, -65536, -2147483647]> : tensor<5xi32>
+  check.expect_eq_const %1, dense<[-2147483648, 65537, 0, -65536, -2147483647]> : tensor<5xi32>
   func.return
 }
 
@@ -66,7 +66,7 @@ func.func @negate_op_test_si32() {
 func.func @negate_op_test_ui32() {
   %0 = stablehlo.constant dense<[0, 65536, 4294967295]> : tensor<3xui32>
   %1 = stablehlo.negate %0 : tensor<3xui32>
-  check.eq %1, dense<[0, 4294901760, 1]> : tensor<3xui32>
+  check.expect_eq_const %1, dense<[0, 4294901760, 1]> : tensor<3xui32>
   func.return
 }
 
@@ -75,7 +75,7 @@ func.func @negate_op_test_ui32() {
 func.func @negate_op_test_si64() {
   %0 = stablehlo.constant dense<[-9223372036854775808, -2147483649, 0, 2147483648, 9223372036854775807]> : tensor<5xi64>
   %1 = stablehlo.negate %0 : tensor<5xi64>
-  check.eq %1, dense<[-9223372036854775808, 2147483649, 0, -2147483648, -9223372036854775807]> : tensor<5xi64>
+  check.expect_eq_const %1, dense<[-9223372036854775808, 2147483649, 0, -2147483648, -9223372036854775807]> : tensor<5xi64>
   func.return
 }
 
@@ -84,7 +84,7 @@ func.func @negate_op_test_si64() {
 func.func @negate_op_test_ui64() {
   %0 = stablehlo.constant dense<[0, 4294967296, 18446744073709551615]> : tensor<3xui64>
   %1 = stablehlo.negate %0 : tensor<3xui64>
-  check.eq %1, dense<[0, 18446744069414584320, 1]> : tensor<3xui64>
+  check.expect_eq_const %1, dense<[0, 18446744069414584320, 1]> : tensor<3xui64>
   func.return
 }
 
@@ -93,7 +93,7 @@ func.func @negate_op_test_ui64() {
 func.func @negate_op_test_bf16() {
   %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.140630, 0x7F80, 0xFF80, 0x7FFF, 0x0001, 0x8001]> : tensor<11xbf16>
   %1 = stablehlo.negate %0 : tensor<11xbf16>
-  check.almost_eq %1, dense<[-0.000000e+00, 0.000000e+00, -1.000000e+00, -1.250000e-01, -1.000980e-01, -3.140630e+00, 0xFF80, 0x7F80, 0xFFFF, -9.183550e-41, 9.183550e-41]> : tensor<11xbf16>
+  check.expect_almost_eq_const %1, dense<[-0.000000e+00, 0.000000e+00, -1.000000e+00, -1.250000e-01, -1.000980e-01, -3.140630e+00, 0xFF80, 0x7F80, 0xFFFF, -9.183550e-41, 9.183550e-41]> : tensor<11xbf16>
   func.return
 }
 
@@ -102,7 +102,7 @@ func.func @negate_op_test_bf16() {
 func.func @negate_op_test_f16() {
   %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.140630, 0x7C00, 0xFC00, 0x7FFF, 0x0001, 0x8001]> : tensor<11xf16>
   %1 = stablehlo.negate %0 : tensor<11xf16>
-  check.almost_eq %1, dense<[-0.000000e+00, 0.000000e+00, -1.000000e+00, -1.250000e-01, -9.997550e-02, -3.140630e+00, 0xFC00, 0x7C00, 0xFFFF, -5.960460e-08, 5.960460e-08]> : tensor<11xf16>
+  check.expect_almost_eq_const %1, dense<[-0.000000e+00, 0.000000e+00, -1.000000e+00, -1.250000e-01, -9.997550e-02, -3.140630e+00, 0xFC00, 0x7C00, 0xFFFF, -5.960460e-08, 5.960460e-08]> : tensor<11xf16>
   func.return
 }
 
@@ -111,7 +111,7 @@ func.func @negate_op_test_f16() {
 func.func @negate_op_test_f32() {
   %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.14159274, 0x7F800000, 0xFF800000, 0x7FFFFFFF, 0x00000001, 0x80000001]> : tensor<11xf32>
   %1 = stablehlo.negate %0 : tensor<11xf32>
-  check.almost_eq %1, dense<[-0.000000e+00, 0.000000e+00, -1.000000e+00, -1.250000e-01, -1.000000e-01, -3.14159274, 0xFF800000, 0x7F800000, 0xFFFFFFFF, -1.401300e-45, 1.401300e-45]> : tensor<11xf32>
+  check.expect_almost_eq_const %1, dense<[-0.000000e+00, 0.000000e+00, -1.000000e+00, -1.250000e-01, -1.000000e-01, -3.14159274, 0xFF800000, 0x7F800000, 0xFFFFFFFF, -1.401300e-45, 1.401300e-45]> : tensor<11xf32>
   func.return
 }
 
@@ -120,7 +120,7 @@ func.func @negate_op_test_f32() {
 func.func @negate_op_test_f64() {
   %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.1415926535897931, 0x7FF0000000000000, 0xFFF0000000000000, 0x7FFFFFFFFFFFFFFF, 0x0000000000000001, 0x8000000000000001]> : tensor<11xf64>
   %1 = stablehlo.negate %0 : tensor<11xf64>
-  check.almost_eq %1, dense<[-0.000000e+00, 0.000000e+00, -1.000000e+00, -1.250000e-01, -1.000000e-01, -3.1415926535897931, 0xFFF0000000000000, 0x7FF0000000000000, 0xFFFFFFFFFFFFFFFF, -4.940660e-324, 4.940660e-324]> : tensor<11xf64>
+  check.expect_almost_eq_const %1, dense<[-0.000000e+00, 0.000000e+00, -1.000000e+00, -1.250000e-01, -1.000000e-01, -3.1415926535897931, 0xFFF0000000000000, 0x7FF0000000000000, 0xFFFFFFFFFFFFFFFF, -4.940660e-324, 4.940660e-324]> : tensor<11xf64>
   func.return
 }
 
@@ -129,7 +129,7 @@ func.func @negate_op_test_f64() {
 func.func @negate_op_test_c64() {
   %0 = stablehlo.constant dense<[(1.5, 2.5), (3.5, 4.5)]> : tensor<2xcomplex<f32>>
   %1 = stablehlo.negate %0 : tensor<2xcomplex<f32>>
-  check.almost_eq %1, dense<[(-1.500000e+00, -2.500000e+00), (-3.500000e+00, -4.500000e+00)]> : tensor<2xcomplex<f32>>
+  check.expect_almost_eq_const %1, dense<[(-1.500000e+00, -2.500000e+00), (-3.500000e+00, -4.500000e+00)]> : tensor<2xcomplex<f32>>
   func.return
 }
 
@@ -138,6 +138,6 @@ func.func @negate_op_test_c64() {
 func.func @negate_op_test_c128() {
   %0 = stablehlo.constant dense<[(1.5, 2.5), (3.5, 4.5)]> : tensor<2xcomplex<f64>>
   %1 = stablehlo.negate %0 : tensor<2xcomplex<f64>>
-  check.almost_eq %1, dense<[(-1.500000e+00, -2.500000e+00), (-3.500000e+00, -4.500000e+00)]> : tensor<2xcomplex<f64>>
+  check.expect_almost_eq_const %1, dense<[(-1.500000e+00, -2.500000e+00), (-3.500000e+00, -4.500000e+00)]> : tensor<2xcomplex<f64>>
   func.return
 }

--- a/stablehlo/tests/interpret_not.mlir
+++ b/stablehlo/tests/interpret_not.mlir
@@ -3,7 +3,7 @@
 func.func @not_op_test_si4() {
   %0 = stablehlo.constant dense<[7, -8, 0]> : tensor<3xi4>
   %1 = stablehlo.not %0 : tensor<3xi4>
-  check.eq %1, dense<[-8, 7, -1]> : tensor<3xi4>
+  check.expect_eq_const %1, dense<[-8, 7, -1]> : tensor<3xi4>
   func.return
 }
 
@@ -12,7 +12,7 @@ func.func @not_op_test_si4() {
 func.func @not_op_test_ui4() {
   %0 = stablehlo.constant dense<[0, 7, 15]> : tensor<3xui4>
   %1 = stablehlo.not %0 : tensor<3xui4>
-  check.eq %1, dense<[15, 8, 0]> : tensor<3xui4>
+  check.expect_eq_const %1, dense<[15, 8, 0]> : tensor<3xui4>
   func.return
 }
 
@@ -21,7 +21,7 @@ func.func @not_op_test_ui4() {
 func.func @not_op_test_si8() {
   %0 = stablehlo.constant dense<[127, -128, 0]> : tensor<3xi8>
   %1 = stablehlo.not %0 : tensor<3xi8>
-  check.eq %1, dense<[-128, 127, -1]> : tensor<3xi8>
+  check.expect_eq_const %1, dense<[-128, 127, -1]> : tensor<3xi8>
   func.return
 }
 
@@ -30,7 +30,7 @@ func.func @not_op_test_si8() {
 func.func @not_op_test_ui8() {
   %0 = stablehlo.constant dense<[0, 127, 255]> : tensor<3xui8>
   %1 = stablehlo.not %0 : tensor<3xui8>
-  check.eq %1, dense<[255, 128, 0]> : tensor<3xui8>
+  check.expect_eq_const %1, dense<[255, 128, 0]> : tensor<3xui8>
   func.return
 }
 
@@ -39,7 +39,7 @@ func.func @not_op_test_ui8() {
 func.func @not_op_test_si16() {
   %0 = stablehlo.constant dense<[32767, -32768, 0]> : tensor<3xi16>
   %1 = stablehlo.not %0 : tensor<3xi16>
-  check.eq %1, dense<[-32768, 32767, -1]> : tensor<3xi16>
+  check.expect_eq_const %1, dense<[-32768, 32767, -1]> : tensor<3xi16>
   func.return
 }
 
@@ -48,7 +48,7 @@ func.func @not_op_test_si16() {
 func.func @not_op_test_ui16() {
   %0 = stablehlo.constant dense<[0, 32767, 65535]> : tensor<3xui16>
   %1 = stablehlo.not %0 : tensor<3xui16>
-  check.eq %1, dense<[65535, 32768, 0]> : tensor<3xui16>
+  check.expect_eq_const %1, dense<[65535, 32768, 0]> : tensor<3xui16>
   func.return
 }
 
@@ -57,7 +57,7 @@ func.func @not_op_test_ui16() {
 func.func @not_op_test_si32() {
   %0 = stablehlo.constant dense<[2147483647, -2147483648, 0]> : tensor<3xi32>
   %1 = stablehlo.not %0 : tensor<3xi32>
-  check.eq %1, dense<[-2147483648, 2147483647, -1]> : tensor<3xi32>
+  check.expect_eq_const %1, dense<[-2147483648, 2147483647, -1]> : tensor<3xi32>
   func.return
 }
 
@@ -66,7 +66,7 @@ func.func @not_op_test_si32() {
 func.func @not_op_test_ui32() {
   %0 = stablehlo.constant dense<[0, 2147483647, 4294967295]> : tensor<3xui32>
   %1 = stablehlo.not %0 : tensor<3xui32>
-  check.eq %1, dense<[4294967295, 2147483648, 0]> : tensor<3xui32>
+  check.expect_eq_const %1, dense<[4294967295, 2147483648, 0]> : tensor<3xui32>
   func.return
 }
 
@@ -75,7 +75,7 @@ func.func @not_op_test_ui32() {
 func.func @not_op_test_si64() {
   %0 = stablehlo.constant dense<[9223372036854775807, -9223372036854775808, 0]> : tensor<3xi64>
   %1 = stablehlo.not %0 : tensor<3xi64>
-  check.eq %1, dense<[-9223372036854775808, 9223372036854775807, -1]> : tensor<3xi64>
+  check.expect_eq_const %1, dense<[-9223372036854775808, 9223372036854775807, -1]> : tensor<3xi64>
   func.return
 }
 
@@ -84,7 +84,7 @@ func.func @not_op_test_si64() {
 func.func @not_op_test_ui64() {
   %0 = stablehlo.constant dense<[0, 9223372036854775807, 18446744073709551615]> : tensor<3xui64>
   %1 = stablehlo.not %0 : tensor<3xui64>
-  check.eq %1, dense<[18446744073709551615, 9223372036854775808, 0]> : tensor<3xui64>
+  check.expect_eq_const %1, dense<[18446744073709551615, 9223372036854775808, 0]> : tensor<3xui64>
   func.return
 }
 
@@ -93,7 +93,7 @@ func.func @not_op_test_ui64() {
 func.func @not_op_test_i1() {
   %0 = stablehlo.constant dense<[false, true]> : tensor<2xi1>
   %1 = stablehlo.not %0 : tensor<2xi1>
-  check.eq %1, dense<[true, false]> : tensor<2xi1>
+  check.expect_eq_const %1, dense<[true, false]> : tensor<2xi1>
   func.return
 }
 
@@ -102,7 +102,7 @@ func.func @not_op_test_i1() {
 func.func @not_op_test_i1_splat_false() {
   %0 = stablehlo.constant dense<false> : tensor<i1>
   %1 = stablehlo.not %0 : tensor<i1>
-  check.eq %1, dense<true> : tensor<i1>
+  check.expect_eq_const %1, dense<true> : tensor<i1>
   func.return
 }
 
@@ -111,6 +111,6 @@ func.func @not_op_test_i1_splat_false() {
 func.func @not_op_test_i1_splat_true() {
   %0 = stablehlo.constant dense<true> : tensor<i1>
   %1 = stablehlo.not %0 : tensor<i1>
-  check.eq %1, dense<false> : tensor<i1>
+  check.expect_eq_const %1, dense<false> : tensor<i1>
   func.return
 }

--- a/stablehlo/tests/interpret_or.mlir
+++ b/stablehlo/tests/interpret_or.mlir
@@ -4,7 +4,7 @@ func.func @or_op_test_si4() {
   %0 = stablehlo.constant dense<[7, -8, -8]> : tensor<3xi4>
   %1 = stablehlo.constant dense<[0, 7, -8]> : tensor<3xi4>
   %2 = stablehlo.or %0, %1 : tensor<3xi4>
-  check.eq %2, dense<[7, -1, -8]> : tensor<3xi4>
+  check.expect_eq_const %2, dense<[7, -1, -8]> : tensor<3xi4>
   func.return
 }
 
@@ -14,7 +14,7 @@ func.func @or_op_test_ui4() {
   %0 = stablehlo.constant dense<[0, 7, 15]> : tensor<3xui4>
   %1 = stablehlo.constant dense<15> : tensor<3xui4>
   %2 = stablehlo.or %0, %1 : tensor<3xui4>
-  check.eq %2, dense<[15, 15, 15]> : tensor<3xui4>
+  check.expect_eq_const %2, dense<[15, 15, 15]> : tensor<3xui4>
   func.return
 }
 
@@ -24,7 +24,7 @@ func.func @or_op_test_si8() {
   %0 = stablehlo.constant dense<[127, -128, -128]> : tensor<3xi8>
   %1 = stablehlo.constant dense<[0, 127, -128]> : tensor<3xi8>
   %2 = stablehlo.or %0, %1 : tensor<3xi8>
-  check.eq %2, dense<[127, -1, -128]> : tensor<3xi8>
+  check.expect_eq_const %2, dense<[127, -1, -128]> : tensor<3xi8>
   func.return
 }
 
@@ -34,7 +34,7 @@ func.func @or_op_test_ui8() {
   %0 = stablehlo.constant dense<[0, 127, 255]> : tensor<3xui8>
   %1 = stablehlo.constant dense<255> : tensor<3xui8>
   %2 = stablehlo.or %0, %1 : tensor<3xui8>
-  check.eq %2, dense<[255, 255, 255]> : tensor<3xui8>
+  check.expect_eq_const %2, dense<[255, 255, 255]> : tensor<3xui8>
   func.return
 }
 
@@ -44,7 +44,7 @@ func.func @or_op_test_si16() {
   %0 = stablehlo.constant dense<[32767, -32768, -32768]> : tensor<3xi16>
   %1 = stablehlo.constant dense<[0, 32767, -32768]> : tensor<3xi16>
   %2 = stablehlo.or %0, %1 : tensor<3xi16>
-  check.eq %2, dense<[32767, -1, -32768]> : tensor<3xi16>
+  check.expect_eq_const %2, dense<[32767, -1, -32768]> : tensor<3xi16>
   func.return
 }
 
@@ -54,7 +54,7 @@ func.func @or_op_test_ui16() {
   %0 = stablehlo.constant dense<[0, 32767, 65535]> : tensor<3xui16>
   %1 = stablehlo.constant dense<65535> : tensor<3xui16>
   %2 = stablehlo.or %0, %1 : tensor<3xui16>
-  check.eq %2, dense<[65535, 65535, 65535]> : tensor<3xui16>
+  check.expect_eq_const %2, dense<[65535, 65535, 65535]> : tensor<3xui16>
   func.return
 }
 
@@ -64,7 +64,7 @@ func.func @or_op_test_si32() {
   %0 = stablehlo.constant dense<[2147483647, -2147483648, -2147483648]> : tensor<3xi32>
   %1 = stablehlo.constant dense<[0, 2147483647, -2147483648]> : tensor<3xi32>
   %2 = stablehlo.or %0, %1 : tensor<3xi32>
-  check.eq %2, dense<[2147483647, -1, -2147483648]> : tensor<3xi32>
+  check.expect_eq_const %2, dense<[2147483647, -1, -2147483648]> : tensor<3xi32>
   func.return
 }
 
@@ -74,7 +74,7 @@ func.func @or_op_test_ui32() {
   %0 = stablehlo.constant dense<[0, 2147483647, 4294967295]> : tensor<3xui32>
   %1 = stablehlo.constant dense<4294967295> : tensor<3xui32>
   %2 = stablehlo.or %0, %1 : tensor<3xui32>
-  check.eq %2, dense<[4294967295, 4294967295, 4294967295]> : tensor<3xui32>
+  check.expect_eq_const %2, dense<[4294967295, 4294967295, 4294967295]> : tensor<3xui32>
   func.return
 }
 
@@ -84,7 +84,7 @@ func.func @or_op_test_si64() {
   %0 = stablehlo.constant dense<[9223372036854775807, -9223372036854775808, -9223372036854775808]> : tensor<3xi64>
   %1 = stablehlo.constant dense<[0, 9223372036854775807, -9223372036854775808]> : tensor<3xi64>
   %2 = stablehlo.or %0, %1 : tensor<3xi64>
-  check.eq %2, dense<[9223372036854775807, -1, -9223372036854775808]> : tensor<3xi64>
+  check.expect_eq_const %2, dense<[9223372036854775807, -1, -9223372036854775808]> : tensor<3xi64>
   func.return
 }
 
@@ -94,7 +94,7 @@ func.func @or_op_test_ui64() {
   %0 = stablehlo.constant dense<[0, 9223372036854775807, 18446744073709551615]> : tensor<3xui64>
   %1 = stablehlo.constant dense<18446744073709551615> : tensor<3xui64>
   %2 = stablehlo.or %0, %1 : tensor<3xui64>
-  check.eq %2, dense<[18446744073709551615, 18446744073709551615, 18446744073709551615]> : tensor<3xui64>
+  check.expect_eq_const %2, dense<[18446744073709551615, 18446744073709551615, 18446744073709551615]> : tensor<3xui64>
   func.return
 }
 
@@ -104,7 +104,7 @@ func.func @or_op_test_i1() {
   %0 = stablehlo.constant dense<[false, false, true, true]> : tensor<4xi1>
   %1 = stablehlo.constant dense<[false, true, false, true]> : tensor<4xi1>
   %2 = stablehlo.or %0, %1 : tensor<4xi1>
-  check.eq %2, dense<[false, true, true, true]> : tensor<4xi1>
+  check.expect_eq_const %2, dense<[false, true, true, true]> : tensor<4xi1>
   func.return
 }
 
@@ -114,7 +114,7 @@ func.func @or_op_test_i1_splat_false() {
   %0 = stablehlo.constant dense<false> : tensor<2xi1>
   %1 = stablehlo.constant dense<[false, true]> : tensor<2xi1>
   %2 = stablehlo.or %0, %1 : tensor<2xi1>
-  check.eq %2, dense<[false, true]> : tensor<2xi1>
+  check.expect_eq_const %2, dense<[false, true]> : tensor<2xi1>
   func.return
 }
 
@@ -124,6 +124,6 @@ func.func @or_op_test_i1_splat_true() {
   %0 = stablehlo.constant dense<true> : tensor<2xi1>
   %1 = stablehlo.constant dense<[false, true]> : tensor<2xi1>
   %2 = stablehlo.or %0, %1 : tensor<2xi1>
-  check.eq %2, dense<[true, true]> : tensor<2xi1>
+  check.expect_eq_const %2, dense<[true, true]> : tensor<2xi1>
   func.return
 }

--- a/stablehlo/tests/interpret_pad.mlir
+++ b/stablehlo/tests/interpret_pad.mlir
@@ -9,7 +9,7 @@ func.func @pad() {
   %padding_value = stablehlo.constant dense<-1> : tensor<i64>
   %result = stablehlo.pad %operand, %padding_value, low = [1, -1], high = [1, -1], interior = [0, 1]
     : (tensor<5x4xi64>, tensor<i64>) -> tensor<7x5xi64>
-  check.eq %result, dense<[[-1, -1, -1, -1, -1], [-1, 0, -1, 0, -1], [-1, 1, -1, 2, -1],
+  check.expect_eq_const %result, dense<[[-1, -1, -1, -1, -1], [-1, 0, -1, 0, -1], [-1, 1, -1, 2, -1],
                            [-1, 3, -1, 4, -1], [-1, 5, -1, 6, -1], [-1, 0, -1, 0, -1],
                            [-1, -1, -1, -1, -1]]> : tensor<7x5xi64>
   func.return

--- a/stablehlo/tests/interpret_real.mlir
+++ b/stablehlo/tests/interpret_real.mlir
@@ -3,7 +3,7 @@
 func.func @real_op_test_f64() {
   %0 = stablehlo.constant dense<[1.0, 2.0]> : tensor<2xf64>
   %1 = stablehlo.real %0 : tensor<2xf64>
-  check.almost_eq %1, dense<[1.0, 2.0]> : tensor<2xf64>
+  check.expect_almost_eq_const %1, dense<[1.0, 2.0]> : tensor<2xf64>
   func.return
 }
 
@@ -12,6 +12,6 @@ func.func @real_op_test_f64() {
 func.func @real_op_test_c128() {
   %0 = stablehlo.constant dense<[(1.0, 2.0), (3.0, 4.0)]> : tensor<2xcomplex<f64>>
   %1 = stablehlo.real %0 : (tensor<2xcomplex<f64>>) -> tensor<2xf64>
-  check.almost_eq %1, dense<[1.0, 3.0]> : tensor<2xf64>
+  check.expect_almost_eq_const %1, dense<[1.0, 3.0]> : tensor<2xf64>
   func.return
 }

--- a/stablehlo/tests/interpret_rem.mlir
+++ b/stablehlo/tests/interpret_rem.mlir
@@ -4,7 +4,7 @@ func.func @remainder_op_test_si64() {
   %lhs = stablehlo.constant dense<[17, -17, 17, -17]> : tensor<4xi64>
   %rhs = stablehlo.constant dense<[3, 3, -3, -3]> : tensor<4xi64>
   %result = stablehlo.remainder %lhs, %rhs : tensor<4xi64>
-  check.eq %result, dense<[2, -2, 2, -2]> : tensor<4xi64>
+  check.expect_eq_const %result, dense<[2, -2, 2, -2]> : tensor<4xi64>
   func.return
 }
 
@@ -14,7 +14,7 @@ func.func @remainder_op_test_ui64() {
   %lhs = stablehlo.constant dense<[17, 18, 19, 20]> : tensor<4xui64>
   %rhs = stablehlo.constant dense<[3, 4, 5, 7]> : tensor<4xui64>
   %result = stablehlo.remainder %lhs, %rhs : tensor<4xui64>
-  check.eq %result, dense<[2, 2, 4, 6]> : tensor<4xui64>
+  check.expect_eq_const %result, dense<[2, 2, 4, 6]> : tensor<4xui64>
   func.return
 }
 
@@ -24,6 +24,6 @@ func.func @remainder_op_test_f64() {
   %lhs = stablehlo.constant dense<[17.1, -17.1, 17.1, -17.1]> : tensor<4xf64>
   %rhs = stablehlo.constant dense<[3.0, 3.0, -3.0, -3.0]> : tensor<4xf64>
   %result = stablehlo.remainder %lhs, %rhs : tensor<4xf64>
-  check.eq %result, dense<[2.1000000000000014, -2.1000000000000014, 2.1000000000000014, -2.1000000000000014]> : tensor<4xf64>
+  check.expect_eq_const %result, dense<[2.1000000000000014, -2.1000000000000014, 2.1000000000000014, -2.1000000000000014]> : tensor<4xf64>
   func.return
 }

--- a/stablehlo/tests/interpret_reshape.mlir
+++ b/stablehlo/tests/interpret_reshape.mlir
@@ -3,7 +3,7 @@
 func.func @reshape_op_test_si32() {
   %0 = stablehlo.constant dense<[[1,2,3,4,5,6]]> : tensor<1x6xi32>
   %1 = stablehlo.reshape %0 : (tensor<1x6xi32>) -> tensor<6xi32>
-  check.eq %1, dense<[1, 2, 3, 4, 5, 6]> : tensor<6xi32>
+  check.expect_eq_const %1, dense<[1, 2, 3, 4, 5, 6]> : tensor<6xi32>
   func.return
 }
 
@@ -12,7 +12,7 @@ func.func @reshape_op_test_si32() {
 func.func @reshape_op_test_si32() {
   %0 = stablehlo.constant dense<[1,2,3,4,5,6]> : tensor<6xi32>
   %1 = stablehlo.reshape %0 : (tensor<6xi32>) -> tensor<2x3xi32>
-  check.eq %1, dense<[[1, 2, 3], [4, 5, 6]]> : tensor<2x3xi32>
+  check.expect_eq_const %1, dense<[[1, 2, 3], [4, 5, 6]]> : tensor<2x3xi32>
   func.return
 }
 
@@ -21,7 +21,7 @@ func.func @reshape_op_test_si32() {
 func.func @reshape_op_test_si32() {
   %0 = stablehlo.constant dense<[[1,2,3],[4,5,6]]> : tensor<2x3xi32>
   %1 = stablehlo.reshape %0 : (tensor<2x3xi32>) -> tensor<3x2xi32>
-  check.eq %1, dense<[[1, 2], [3, 4], [5, 6]]> : tensor<3x2xi32>
+  check.expect_eq_const %1, dense<[[1, 2], [3, 4], [5, 6]]> : tensor<3x2xi32>
   func.return
 }
 
@@ -30,6 +30,6 @@ func.func @reshape_op_test_si32() {
 func.func @reshape_op_test_si32() {
   %0 = stablehlo.constant dense<[[1,2],[3,4],[5,6]]> : tensor<3x2xi32>
   %1 = stablehlo.reshape %0 : (tensor<3x2xi32>) -> tensor<6xi32>
-  check.eq %1, dense<[1, 2, 3, 4, 5, 6]> : tensor<6xi32>
+  check.expect_eq_const %1, dense<[1, 2, 3, 4, 5, 6]> : tensor<6xi32>
   func.return
 }

--- a/stablehlo/tests/interpret_reverse.mlir
+++ b/stablehlo/tests/interpret_reverse.mlir
@@ -5,6 +5,6 @@ func.func @reverse() {
   %result = "stablehlo.reverse"(%operand) {
     dimensions = dense<[1, 0]> : tensor<2xi64>
   } : (tensor<3x2xi64>) -> tensor<3x2xi64>
-  check.eq %result, dense<[[6, 5], [4, 3], [2, 1]]> : tensor<3x2xi64>
+  check.expect_eq_const %result, dense<[[6, 5], [4, 3], [2, 1]]> : tensor<3x2xi64>
   func.return
 }

--- a/stablehlo/tests/interpret_rsqrt.mlir
+++ b/stablehlo/tests/interpret_rsqrt.mlir
@@ -3,7 +3,7 @@
 func.func @rsqrt_op_test_f64() {
   %operand = stablehlo.constant dense<[[1.0, 4.0], [9.0, 25.0]]> : tensor<2x2xf64>
   %result = stablehlo.rsqrt %operand : tensor<2x2xf64>
-  check.almost_eq %result, dense<[[1.000000e+00, 5.000000e-01], [0.33333333333333331, 2.000000e-01]]> : tensor<2x2xf64>
+  check.expect_almost_eq_const %result, dense<[[1.000000e+00, 5.000000e-01], [0.33333333333333331, 2.000000e-01]]> : tensor<2x2xf64>
   func.return
 }
 
@@ -12,6 +12,6 @@ func.func @rsqrt_op_test_f64() {
 func.func @rsqrt_op_test_c128() {
   %operand = stablehlo.constant dense<[(-1.0, 0.0), (3.0, 4.0)]> : tensor<2xcomplex<f64>>
   %result = stablehlo.rsqrt %operand : tensor<2xcomplex<f64>>
-  check.almost_eq %result, dense<[(0.000000e+00, -1.000000e+00), (4.000000e-01, -2.000000e-01)]> : tensor<2xcomplex<f64>>
+  check.expect_almost_eq_const %result, dense<[(0.000000e+00, -1.000000e+00), (4.000000e-01, -2.000000e-01)]> : tensor<2xcomplex<f64>>
   func.return
 }

--- a/stablehlo/tests/interpret_select.mlir
+++ b/stablehlo/tests/interpret_select.mlir
@@ -5,7 +5,7 @@ func.func @select_op_test_si64() {
   %on_true = stablehlo.constant dense<[2, 3, -1]> : tensor<3xi64>
   %on_false = stablehlo.constant dense<[3, 7, -3]> : tensor<3xi64>
   %result = stablehlo.select %pred, %on_true, %on_false : (tensor<3xi1>, tensor<3xi64>, tensor<3xi64>) -> tensor<3xi64>
-  check.eq %result, dense<[2, 7, -1]> : tensor<3xi64>
+  check.expect_eq_const %result, dense<[2, 7, -1]> : tensor<3xi64>
   func.return
 }
 
@@ -16,6 +16,6 @@ func.func @select_op_test_si64_scalar() {
   %on_true = stablehlo.constant dense<[2, 3, -1]> : tensor<3xi64>
   %on_false = stablehlo.constant dense<[3, 7, -3]> : tensor<3xi64>
   %result = stablehlo.select %pred, %on_true, %on_false : (tensor<i1>, tensor<3xi64>, tensor<3xi64>) -> tensor<3xi64>
-  check.eq %result, dense<[3, 7, -3]> : tensor<3xi64>
+  check.expect_eq_const %result, dense<[3, 7, -3]> : tensor<3xi64>
   func.return
 }

--- a/stablehlo/tests/interpret_sine.mlir
+++ b/stablehlo/tests/interpret_sine.mlir
@@ -3,7 +3,7 @@
 func.func @sine_op_test_bf16() {
   %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.140630, 0x7F80, 0xFF80, 0x7FFF, 0x0001, 0x8001]> : tensor<11xbf16>
   %1 = stablehlo.sine %0 : tensor<11xbf16>
-  check.almost_eq %1, dense<[0.000000e+00, -0.000000e+00, 8.398430e-01, 1.245120e-01, 1.000980e-01, 9.689330e-04, 0xFFC0, 0xFFC0, 0x7FFF, 9.183550e-41, -9.183550e-41]> : tensor<11xbf16>
+  check.expect_almost_eq_const %1, dense<[0.000000e+00, -0.000000e+00, 8.398430e-01, 1.245120e-01, 1.000980e-01, 9.689330e-04, 0xFFC0, 0xFFC0, 0x7FFF, 9.183550e-41, -9.183550e-41]> : tensor<11xbf16>
   func.return
 }
 
@@ -12,7 +12,7 @@ func.func @sine_op_test_bf16() {
 func.func @sine_op_test_f16() {
   %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.140630, 0x7C00, 0xFC00, 0x7FFF, 0x0001, 0x8001]> : tensor<11xf16>
   %1 = stablehlo.sine %0 : tensor<11xf16>
-  check.almost_eq %1, dense<[0.000000e+00, -0.000000e+00, 8.413080e-01, 1.246950e-01, 9.979240e-02, 9.675020e-04, 0xFE00, 0xFE00, 0x7FFF, 5.960460e-08, -5.960460e-08]> : tensor<11xf16>
+  check.expect_almost_eq_const %1, dense<[0.000000e+00, -0.000000e+00, 8.413080e-01, 1.246950e-01, 9.979240e-02, 9.675020e-04, 0xFE00, 0xFE00, 0x7FFF, 5.960460e-08, -5.960460e-08]> : tensor<11xf16>
   func.return
 }
 
@@ -21,7 +21,7 @@ func.func @sine_op_test_f16() {
 func.func @sine_op_test_f32() {
   %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.14159274, 0x7F800000, 0xFF800000, 0x7FFFFFFF, 0x00000001, 0x80000001]> : tensor<11xf32>
   %1 = stablehlo.sine %0 : tensor<11xf32>
-  check.almost_eq %1, dense<[0.000000e+00, -0.000000e+00, 0.841470957, 0.12467473, 0.0998334214, -8.74227765E-8, 0xFFC00000, 0xFFC00000, 0x7FFFFFFF, 1.401300e-45, -1.401300e-45]> : tensor<11xf32>
+  check.expect_almost_eq_const %1, dense<[0.000000e+00, -0.000000e+00, 0.841470957, 0.12467473, 0.0998334214, -8.74227765E-8, 0xFFC00000, 0xFFC00000, 0x7FFFFFFF, 1.401300e-45, -1.401300e-45]> : tensor<11xf32>
   func.return
 }
 
@@ -30,7 +30,7 @@ func.func @sine_op_test_f32() {
 func.func @sine_op_test_f64() {
   %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.1415926535897931, 0x7FF0000000000000, 0xFFF0000000000000, 0x7FFFFFFFFFFFFFFF, 0x0000000000000001, 0x8000000000000001]> : tensor<11xf64>
   %1 = stablehlo.sine %0 : tensor<11xf64>
-  check.almost_eq %1, dense<[0.000000e+00, -0.000000e+00, 0.8414709848078965, 0.12467473338522769, 0.099833416646828154, 1.2246467991473532E-16, 0xFFF8000000000000, 0xFFF8000000000000, 0x7FFFFFFFFFFFFFFF, 4.940660e-324, -4.940660e-324]> : tensor<11xf64>
+  check.expect_almost_eq_const %1, dense<[0.000000e+00, -0.000000e+00, 0.8414709848078965, 0.12467473338522769, 0.099833416646828154, 1.2246467991473532E-16, 0xFFF8000000000000, 0xFFF8000000000000, 0x7FFFFFFFFFFFFFFF, 4.940660e-324, -4.940660e-324]> : tensor<11xf64>
   func.return
 }
 
@@ -39,7 +39,7 @@ func.func @sine_op_test_f64() {
 func.func @sine_op_test_c64() {
   %0 = stablehlo.constant dense<[(1.5, 2.5), (3.5, 4.5)]> : tensor<2xcomplex<f32>>
   %1 = stablehlo.sine %0 : tensor<2xcomplex<f32>>
-  check.almost_eq %1, dense<[(6.1169281, 0.427974522), (-15.7901983, -42.1433716)]> : tensor<2xcomplex<f32>>
+  check.expect_almost_eq_const %1, dense<[(6.1169281, 0.427974522), (-15.7901983, -42.1433716)]> : tensor<2xcomplex<f32>>
   func.return
 }
 
@@ -48,6 +48,6 @@ func.func @sine_op_test_c64() {
 func.func @sine_op_test_c128() {
   %0 = stablehlo.constant dense<[(1.5, 2.5), (3.5, 4.5)]> : tensor<2xcomplex<f64>>
   %1 = stablehlo.sine %0 : tensor<2xcomplex<f64>>
-  check.almost_eq %1, dense<[(6.1169280123693124, 0.42797453450615125), (-15.790198357309713, -42.143370741504995)]> : tensor<2xcomplex<f64>>
+  check.expect_almost_eq_const %1, dense<[(6.1169280123693124, 0.42797453450615125), (-15.790198357309713, -42.143370741504995)]> : tensor<2xcomplex<f64>>
   func.return
 }

--- a/stablehlo/tests/interpret_slice.mlir
+++ b/stablehlo/tests/interpret_slice.mlir
@@ -9,6 +9,6 @@ func.func @slice_op() {
     limit_indices = dense<[3, 6]> : tensor<2xi64>,
     strides = dense<[2, 3]> : tensor<2xi64>
   } : (tensor<3x6xi64>) -> tensor<2x2xi64>
-  check.eq %result, dense<[[1, 1], [1, 1]]> : tensor<2x2xi64>
+  check.expect_eq_const %result, dense<[[1, 1], [1, 1]]> : tensor<2x2xi64>
   func.return
 }

--- a/stablehlo/tests/interpret_sqrt.mlir
+++ b/stablehlo/tests/interpret_sqrt.mlir
@@ -3,7 +3,7 @@
 func.func @square_root_op_test_f64() {
   %operand = stablehlo.constant dense<[[0.0, 1.0], [4.0, 9.0]]> : tensor<2x2xf64>
   %result = stablehlo.sqrt %operand : tensor<2x2xf64>
-  check.almost_eq %result, dense<[[0.000000e+00, 1.000000e+00], [2.000000e+00, 3.000000e+00]]> : tensor<2x2xf64>
+  check.expect_almost_eq_const %result, dense<[[0.000000e+00, 1.000000e+00], [2.000000e+00, 3.000000e+00]]> : tensor<2x2xf64>
   func.return
 }
 
@@ -12,6 +12,6 @@ func.func @square_root_op_test_f64() {
 func.func @square_root_op_test_c128() {
   %operand = stablehlo.constant dense<[(-1.0, 0.0), (3.0, 4.0)]> : tensor<2xcomplex<f64>>
   %result = stablehlo.sqrt %operand : tensor<2xcomplex<f64>>
-  check.almost_eq %result, dense<[(0.000000e+00, 1.000000e+00), (2.000000e+00, 1.000000e+00)]> : tensor<2xcomplex<f64>>
+  check.expect_almost_eq_const %result, dense<[(0.000000e+00, 1.000000e+00), (2.000000e+00, 1.000000e+00)]> : tensor<2xcomplex<f64>>
   func.return
 }

--- a/stablehlo/tests/interpret_subtract.mlir
+++ b/stablehlo/tests/interpret_subtract.mlir
@@ -4,7 +4,7 @@ func.func @subtract_op_test_si4() {
   %0 = stablehlo.constant dense<[0, 1, 2, -3, 0]> : tensor<5xi4>
   %1 = stablehlo.constant dense<[-8, -1, 2, -3, 7]> : tensor<5xi4>
   %2 = stablehlo.subtract %0, %1 : tensor<5xi4>
-  check.eq %2, dense<[-8, 2, 0, 0, -7]> : tensor<5xi4>
+  check.expect_eq_const %2, dense<[-8, 2, 0, 0, -7]> : tensor<5xi4>
   func.return
 }
 
@@ -14,7 +14,7 @@ func.func @subtract_op_test_ui4() {
   %0 = stablehlo.constant dense<[0, 2]> : tensor<2xui4>
   %1 = stablehlo.constant dense<[15, 3]> : tensor<2xui4>
   %2 = stablehlo.subtract %0, %1 : tensor<2xui4>
-  check.eq %2, dense<[1, 15]> : tensor<2xui4>
+  check.expect_eq_const %2, dense<[1, 15]> : tensor<2xui4>
   func.return
 }
 
@@ -24,7 +24,7 @@ func.func @subtract_op_test_si8() {
   %0 = stablehlo.constant dense<[0, 1, 8, -9, 0]> : tensor<5xi8>
   %1 = stablehlo.constant dense<[-128, -1, 8, -9, 127]> : tensor<5xi8>
   %2 = stablehlo.subtract %0, %1 : tensor<5xi8>
-  check.eq %2, dense<[-128, 2, 0, 0, -127]> : tensor<5xi8>
+  check.expect_eq_const %2, dense<[-128, 2, 0, 0, -127]> : tensor<5xi8>
   func.return
 }
 
@@ -34,7 +34,7 @@ func.func @subtract_op_test_ui8() {
   %0 = stablehlo.constant dense<[0, 16]> : tensor<2xui8>
   %1 = stablehlo.constant dense<[255, 16]> : tensor<2xui8>
   %2 = stablehlo.subtract %0, %1 : tensor<2xui8>
-  check.eq %2, dense<[1, 0]> : tensor<2xui8>
+  check.expect_eq_const %2, dense<[1, 0]> : tensor<2xui8>
   func.return
 }
 
@@ -44,7 +44,7 @@ func.func @subtract_op_test_si16() {
   %0 = stablehlo.constant dense<[0, 1, 128, -129, 0]> : tensor<5xi16>
   %1 = stablehlo.constant dense<[-32768, -1, 128, -129, 32767]> : tensor<5xi16>
   %2 = stablehlo.subtract %0, %1 : tensor<5xi16>
-  check.eq %2, dense<[-32768, 2, 0, 0, -32767]> : tensor<5xi16>
+  check.expect_eq_const %2, dense<[-32768, 2, 0, 0, -32767]> : tensor<5xi16>
   func.return
 }
 
@@ -54,7 +54,7 @@ func.func @subtract_op_test_ui16() {
   %0 = stablehlo.constant dense<[0, 256]> : tensor<2xui16>
   %1 = stablehlo.constant dense<[65535, 256]> : tensor<2xui16>
   %2 = stablehlo.subtract %0, %1 : tensor<2xui16>
-  check.eq %2, dense<[1, 0]> : tensor<2xui16>
+  check.expect_eq_const %2, dense<[1, 0]> : tensor<2xui16>
   func.return
 }
 
@@ -64,7 +64,7 @@ func.func @subtract_op_test_si32() {
   %0 = stablehlo.constant dense<[0, 1, 32768, -32769, 0]> : tensor<5xi32>
   %1 = stablehlo.constant dense<[-2147483648, -1, 32768, -32769, 2147483647]> : tensor<5xi32>
   %2 = stablehlo.subtract %0, %1 : tensor<5xi32>
-  check.eq %2, dense<[-2147483648, 2, 0, 0, -2147483647]> : tensor<5xi32>
+  check.expect_eq_const %2, dense<[-2147483648, 2, 0, 0, -2147483647]> : tensor<5xi32>
   func.return
 }
 
@@ -74,7 +74,7 @@ func.func @subtract_op_test_ui32() {
   %0 = stablehlo.constant dense<[0, 65536]> : tensor<2xui32>
   %1 = stablehlo.constant dense<[4294967295, 65536]> : tensor<2xui32>
   %2 = stablehlo.subtract %0, %1 : tensor<2xui32>
-  check.eq %2, dense<[1, 0]> : tensor<2xui32>
+  check.expect_eq_const %2, dense<[1, 0]> : tensor<2xui32>
   func.return
 }
 
@@ -84,7 +84,7 @@ func.func @subtract_op_test_si64() {
   %0 = stablehlo.constant dense<[0, 1, 2147483648, -2147483649, 0]> : tensor<5xi64>
   %1 = stablehlo.constant dense<[-9223372036854775808, -1, 2147483648, -2147483649, 9223372036854775807]> : tensor<5xi64>
   %2 = stablehlo.subtract %0, %1 : tensor<5xi64>
-  check.eq %2, dense<[-9223372036854775808, 2, 0, 0, -9223372036854775807]> : tensor<5xi64>
+  check.expect_eq_const %2, dense<[-9223372036854775808, 2, 0, 0, -9223372036854775807]> : tensor<5xi64>
   func.return
 }
 
@@ -94,7 +94,7 @@ func.func @subtract_op_test_ui64() {
   %0 = stablehlo.constant dense<[0, 4294967296]> : tensor<2xui64>
   %1 = stablehlo.constant dense<[18446744073709551615, 4294967296]> : tensor<2xui64>
   %2 = stablehlo.subtract %0, %1 : tensor<2xui64>
-  check.eq %2, dense<[1, 0]> : tensor<2xui64>
+  check.expect_eq_const %2, dense<[1, 0]> : tensor<2xui64>
   func.return
 }
 
@@ -104,7 +104,7 @@ func.func @subtract_op_test_bf16() {
   %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.140625, 0x7F80, 0x7F80, 0xFF80, 0x7F80, 0x0001]> : tensor<11xbf16>
   %1 = stablehlo.constant dense<[0.0, -0.0, 7.0, 0.75, 0.3, 3.140625, 0.0, 0x7F80, 0xFF80, 0xFF80, 0x8001]> : tensor<11xbf16>
   %2 = stablehlo.subtract %0, %1 : tensor<11xbf16>
-  check.almost_eq %2, dense<[0.000000e+00, 0.000000e+00, -6.000000e+00, -6.250000e-01, -2.011720e-01, 0.000000e+00, 0x7F80, 0x7FC0, 0x7FC0, 0x7F80, 1.836710e-40]> : tensor<11xbf16>
+  check.expect_almost_eq_const %2, dense<[0.000000e+00, 0.000000e+00, -6.000000e+00, -6.250000e-01, -2.011720e-01, 0.000000e+00, 0x7F80, 0x7FC0, 0x7FC0, 0x7F80, 1.836710e-40]> : tensor<11xbf16>
   func.return
 }
 
@@ -114,7 +114,7 @@ func.func @subtract_op_test_f16() {
   %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.141, 0x7C00, 0x7C00, 0xFC00, 0x7C00, 0x0001]> : tensor<11xf16>
   %1 = stablehlo.constant dense<[0.0, -0.0, 7.0, 0.75, 0.3, 3.141, 0.0, 0x7C00, 0xFC00, 0xFC00, 0x8001]> : tensor<11xf16>
   %2 = stablehlo.subtract %0, %1 : tensor<11xf16>
-  check.almost_eq %2, dense<[0.000000e+00, 0.000000e+00, -6.000000e+00, -6.250000e-01, -2.000730e-01, 0.000000e+00, 0x7C00, 0x7E00, 0x7E00, 0x7C00, 1.192090e-07]> : tensor<11xf16>
+  check.expect_almost_eq_const %2, dense<[0.000000e+00, 0.000000e+00, -6.000000e+00, -6.250000e-01, -2.000730e-01, 0.000000e+00, 0x7C00, 0x7E00, 0x7E00, 0x7C00, 1.192090e-07]> : tensor<11xf16>
   func.return
 }
 
@@ -124,7 +124,7 @@ func.func @subtract_op_test_f32() {
   %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.14159265, 0x7F800000, 0x7F800000, 0xFF800000, 0x7F800000, 0x00000001]> : tensor<11xf32>
   %1 = stablehlo.constant dense<[0.0, -0.0, 7.0, 0.75, 0.3, 3.14159265, 0.0, 0x7F800000, 0xFF800000, 0xFF800000, 0x80000001]> : tensor<11xf32>
   %2 = stablehlo.subtract %0, %1 : tensor<11xf32>
-  check.almost_eq %2, dense<[0.000000e+00, 0.000000e+00, -6.000000e+00, -6.250000e-01, -0.200000018, 0.000000e+00, 0x7F800000, 0x7FC00000, 0x7FC00000, 0x7F800000, 2.802600e-45]> : tensor<11xf32>
+  check.expect_almost_eq_const %2, dense<[0.000000e+00, 0.000000e+00, -6.000000e+00, -6.250000e-01, -0.200000018, 0.000000e+00, 0x7F800000, 0x7FC00000, 0x7FC00000, 0x7F800000, 2.802600e-45]> : tensor<11xf32>
   func.return
 }
 
@@ -134,7 +134,7 @@ func.func @subtract_op_test_f64() {
   %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.14159265358979323846, 0x7FF0000000000000, 0x7FF0000000000000, 0xFFF0000000000000, 0x7FF0000000000000, 0x0000000000000001]> : tensor<11xf64>
   %1 = stablehlo.constant dense<[0.0, -0.0, 7.0, 0.75, 0.3, 3.14159265358979323846, 0.0, 0x7FF0000000000000, 0xFFF0000000000000, 0xFFF0000000000000, 0x8000000000000001]> : tensor<11xf64>
   %2 = stablehlo.subtract %0, %1 : tensor<11xf64>
-  check.almost_eq %2, dense<[0.000000e+00, 0.000000e+00, -6.000000e+00, -6.250000e-01, -0.19999999999999998, 0.000000e+00, 0x7FF0000000000000, 0x7FF8000000000000, 0x7FF8000000000000, 0x7FF0000000000000, 9.881310e-324]> : tensor<11xf64>
+  check.expect_almost_eq_const %2, dense<[0.000000e+00, 0.000000e+00, -6.000000e+00, -6.250000e-01, -0.19999999999999998, 0.000000e+00, 0x7FF0000000000000, 0x7FF8000000000000, 0x7FF8000000000000, 0x7FF0000000000000, 9.881310e-324]> : tensor<11xf64>
   func.return
 }
 
@@ -144,7 +144,7 @@ func.func @subtract_op_test_c64() {
   %0 = stablehlo.constant dense<[(1.5, 2.5), (7.5, 5.5)]> : tensor<2xcomplex<f32>>
   %1 = stablehlo.constant dense<[(1.5, 2.5), (7.5, 5.5)]> : tensor<2xcomplex<f32>>
   %2 = stablehlo.subtract %0, %1 : tensor<2xcomplex<f32>>
-  check.almost_eq %2, dense<[(0.000000e+00, 0.000000e+00), (0.000000e+00, 0.000000e+00)]> : tensor<2xcomplex<f32>>
+  check.expect_almost_eq_const %2, dense<[(0.000000e+00, 0.000000e+00), (0.000000e+00, 0.000000e+00)]> : tensor<2xcomplex<f32>>
   func.return
 }
 
@@ -154,6 +154,6 @@ func.func @subtract_op_test_c128() {
   %0 = stablehlo.constant dense<[(1.5, 2.5), (7.5, 5.5)]> : tensor<2xcomplex<f64>>
   %1 = stablehlo.constant dense<[(1.5, 2.5), (7.5, 5.5)]> : tensor<2xcomplex<f64>>
   %2 = stablehlo.subtract %0, %1 : tensor<2xcomplex<f64>>
-  check.almost_eq %2, dense<[(0.000000e+00, 0.000000e+00), (0.000000e+00, 0.000000e+00)]> : tensor<2xcomplex<f64>>
+  check.expect_almost_eq_const %2, dense<[(0.000000e+00, 0.000000e+00), (0.000000e+00, 0.000000e+00)]> : tensor<2xcomplex<f64>>
   func.return
 }

--- a/stablehlo/tests/interpret_tanh.mlir
+++ b/stablehlo/tests/interpret_tanh.mlir
@@ -3,7 +3,7 @@
 func.func @tanh_op_test_bf16() {
   %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.140630, 0x7F80, 0xFF80, 0x7FFF, 0x0001, 0x8001]> : tensor<11xbf16>
   %1 = stablehlo.tanh %0 : tensor<11xbf16>
-  check.almost_eq %1, dense<[0.000000e+00, -0.000000e+00, 7.617180e-01, 1.245120e-01, 9.960930e-02, 9.960930e-01, 1.000000e+00, -1.000000e+00, 0x7FFF, 9.183550e-41, -9.183550e-41]> : tensor<11xbf16>
+  check.expect_almost_eq_const %1, dense<[0.000000e+00, -0.000000e+00, 7.617180e-01, 1.245120e-01, 9.960930e-02, 9.960930e-01, 1.000000e+00, -1.000000e+00, 0x7FFF, 9.183550e-41, -9.183550e-41]> : tensor<11xbf16>
   func.return
 }
 
@@ -12,7 +12,7 @@ func.func @tanh_op_test_bf16() {
 func.func @tanh_op_test_f16() {
   %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.140630, 0x7C00, 0xFC00, 0x7FFF, 0x0001, 0x8001]> : tensor<11xf16>
   %1 = stablehlo.tanh %0 : tensor<11xf16>
-  check.almost_eq %1, dense<[0.000000e+00, -0.000000e+00, 7.617180e-01, 1.243290e-01, 9.967040e-02, 9.960930e-01, 1.000000e+00, -1.000000e+00, 0x7FFF, 5.960460e-08, -5.960460e-08]> : tensor<11xf16>
+  check.expect_almost_eq_const %1, dense<[0.000000e+00, -0.000000e+00, 7.617180e-01, 1.243290e-01, 9.967040e-02, 9.960930e-01, 1.000000e+00, -1.000000e+00, 0x7FFF, 5.960460e-08, -5.960460e-08]> : tensor<11xf16>
   func.return
 }
 
@@ -21,7 +21,7 @@ func.func @tanh_op_test_f16() {
 func.func @tanh_op_test_f32() {
   %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.14159274, 0x7F800000, 0xFF800000, 0x7FFFFFFF, 0x00000001, 0x80000001]> : tensor<11xf32>
   %1 = stablehlo.tanh %0 : tensor<11xf32>
-  check.almost_eq %1, dense<[0.000000e+00, -0.000000e+00, 0.761594176, 1.243530e-01, 0.0996679961, 0.996272087, 1.000000e+00, -1.000000e+00, 0x7FFFFFFF, 1.401300e-45, -1.401300e-45]> : tensor<11xf32>
+  check.expect_almost_eq_const %1, dense<[0.000000e+00, -0.000000e+00, 0.761594176, 1.243530e-01, 0.0996679961, 0.996272087, 1.000000e+00, -1.000000e+00, 0x7FFFFFFF, 1.401300e-45, -1.401300e-45]> : tensor<11xf32>
   func.return
 }
 
@@ -30,7 +30,7 @@ func.func @tanh_op_test_f32() {
 func.func @tanh_op_test_f64() {
   %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.1415926535897931, 0x7FF0000000000000, 0xFFF0000000000000, 0x7FFFFFFFFFFFFFFF, 0x0000000000000001, 0x8000000000000001]> : tensor<11xf64>
   %1 = stablehlo.tanh %0 : tensor<11xf64>
-  check.almost_eq %1, dense<[0.000000e+00, -0.000000e+00, 0.76159415595576485, 0.12435300177159619, 0.099667994624955819, 0.99627207622074998, 1.000000e+00, -1.000000e+00, 0x7FFFFFFFFFFFFFFF, 4.940660e-324, -4.940660e-324]> : tensor<11xf64>
+  check.expect_almost_eq_const %1, dense<[0.000000e+00, -0.000000e+00, 0.76159415595576485, 0.12435300177159619, 0.099667994624955819, 0.99627207622074998, 1.000000e+00, -1.000000e+00, 0x7FFFFFFFFFFFFFFF, 4.940660e-324, -4.940660e-324]> : tensor<11xf64>
   func.return
 }
 
@@ -39,7 +39,7 @@ func.func @tanh_op_test_f64() {
 func.func @tanh_op_test_c64() {
   %0 = stablehlo.constant dense<[(1.5, 2.5), (3.5, 4.5)]> : tensor<2xcomplex<f32>>
   %1 = stablehlo.tanh %0 : tensor<2xcomplex<f32>>
-  check.almost_eq %1, dense<[(0.967786788, -0.0926378369), (1.00166273, 7.52857188E-4)]> : tensor<2xcomplex<f32>>
+  check.expect_almost_eq_const %1, dense<[(0.967786788, -0.0926378369), (1.00166273, 7.52857188E-4)]> : tensor<2xcomplex<f32>>
   func.return
 }
 
@@ -48,6 +48,6 @@ func.func @tanh_op_test_c64() {
 func.func @tanh_op_test_c128() {
   %0 = stablehlo.constant dense<[(1.5, 2.5), (3.5, 4.5)]> : tensor<2xcomplex<f64>>
   %1 = stablehlo.tanh %0 : tensor<2xcomplex<f64>>
-  check.almost_eq %1, dense<[(0.96778680215277412, -0.092637836268419898), (1.0016627850956348, 7.5285721538218659E-4)]> : tensor<2xcomplex<f64>>
+  check.expect_almost_eq_const %1, dense<[(0.96778680215277412, -0.092637836268419898), (1.0016627850956348, 7.5285721538218659E-4)]> : tensor<2xcomplex<f64>>
   func.return
 }

--- a/stablehlo/tests/interpret_transpose.mlir
+++ b/stablehlo/tests/interpret_transpose.mlir
@@ -3,7 +3,7 @@
 func.func @transpose_op_test_si32() {
   %0 = stablehlo.constant dense<[[[1,2],[3,4],[5,6]], [[7,8],[9,10],[11,12]]]> : tensor<2x3x2xi32>
   %1 = "stablehlo.transpose"(%0) {permutation = dense<[1,0,2]> : tensor<3xi64>} : (tensor<2x3x2xi32>) -> tensor<3x2x2xi32>
-  check.eq %1, dense<[[[1, 2], [7, 8]], [[3, 4], [9, 10]], [[5, 6], [11, 12]]]> : tensor<3x2x2xi32>
+  check.expect_eq_const %1, dense<[[[1, 2], [7, 8]], [[3, 4], [9, 10]], [[5, 6], [11, 12]]]> : tensor<3x2x2xi32>
   func.return
 }
 
@@ -12,7 +12,7 @@ func.func @transpose_op_test_si32() {
 func.func @transpose_op_test_si32() {
   %0 = stablehlo.constant dense<[[[1,2],[3,4],[5,6]], [[7,8],[9,10],[11,12]]]> : tensor<2x3x2xi32>
   %1 = "stablehlo.transpose"(%0) {permutation = dense<[2,1,0]> : tensor<3xi64>} : (tensor<2x3x2xi32>) -> tensor<2x3x2xi32>
-  check.eq %1, dense<[[[1, 7], [3, 9], [5, 11]], [[2, 8], [4, 10], [6, 12]]]> : tensor<2x3x2xi32>
+  check.expect_eq_const %1, dense<[[[1, 7], [3, 9], [5, 11]], [[2, 8], [4, 10], [6, 12]]]> : tensor<2x3x2xi32>
   func.return
 }
 
@@ -22,6 +22,6 @@ func.func @transpose_op_test_si32() {
   %0 = stablehlo.constant dense<[[[1,2],[3,4],[5,6]], [[7,8],[9,10],[11,12]]]> : tensor<2x3x2xi32>
   %1 = "stablehlo.transpose"(%0) {permutation = dense<[2,1,0]> : tensor<3xi64>} : (tensor<2x3x2xi32>) -> tensor<2x3x2xi32>
   %2 = "stablehlo.transpose"(%1) {permutation = dense<[2,1,0]> : tensor<3xi64>} : (tensor<2x3x2xi32>) -> tensor<2x3x2xi32>
-  check.eq %2, dense<[[[1, 2], [3, 4], [5, 6]], [[7, 8], [9, 10], [11, 12]]]> : tensor<2x3x2xi32>
+  check.expect_eq_const %2, dense<[[[1, 2], [3, 4], [5, 6]], [[7, 8], [9, 10], [11, 12]]]> : tensor<2x3x2xi32>
   func.return
 }

--- a/stablehlo/tests/interpret_while.mlir
+++ b/stablehlo/tests/interpret_while.mlir
@@ -21,6 +21,6 @@ func.func @while() {
       stablehlo.return %new_i, %new_state : tensor<i64>, tensor<i64>
   }) : (tensor<i64>, tensor<i64>) -> (tensor<i64>, tensor<i64>)
 
-  check.eq %result_state, dense<10> : tensor<i64>
+  check.expect_eq_const %result_state, dense<10> : tensor<i64>
   func.return
 }

--- a/stablehlo/tests/interpret_xor.mlir
+++ b/stablehlo/tests/interpret_xor.mlir
@@ -4,7 +4,7 @@ func.func @xor_op_test_si4() {
   %0 = stablehlo.constant dense<[7, -8, -8]> : tensor<3xi4>
   %1 = stablehlo.constant dense<[0, 7, -8]> : tensor<3xi4>
   %2 = stablehlo.xor %0, %1 : tensor<3xi4>
-  check.eq %2, dense<[7, -1, 0]> : tensor<3xi4>
+  check.expect_eq_const %2, dense<[7, -1, 0]> : tensor<3xi4>
   func.return
 }
 
@@ -14,7 +14,7 @@ func.func @xor_op_test_ui4() {
   %0 = stablehlo.constant dense<[0, 7, 15]> : tensor<3xui4>
   %1 = stablehlo.constant dense<15> : tensor<3xui4>
   %2 = stablehlo.xor %0, %1 : tensor<3xui4>
-  check.eq %2, dense<[15, 8, 0]> : tensor<3xui4>
+  check.expect_eq_const %2, dense<[15, 8, 0]> : tensor<3xui4>
   func.return
 }
 
@@ -24,7 +24,7 @@ func.func @xor_op_test_si8() {
   %0 = stablehlo.constant dense<[127, -128, -128]> : tensor<3xi8>
   %1 = stablehlo.constant dense<[0, 127, -128]> : tensor<3xi8>
   %2 = stablehlo.xor %0, %1 : tensor<3xi8>
-  check.eq %2, dense<[127, -1, 0]> : tensor<3xi8>
+  check.expect_eq_const %2, dense<[127, -1, 0]> : tensor<3xi8>
   func.return
 }
 
@@ -34,7 +34,7 @@ func.func @xor_op_test_ui8() {
   %0 = stablehlo.constant dense<[0, 127, 255]> : tensor<3xui8>
   %1 = stablehlo.constant dense<255> : tensor<3xui8>
   %2 = stablehlo.xor %0, %1 : tensor<3xui8>
-  check.eq %2, dense<[255, 128, 0]> : tensor<3xui8>
+  check.expect_eq_const %2, dense<[255, 128, 0]> : tensor<3xui8>
   func.return
 }
 
@@ -44,7 +44,7 @@ func.func @xor_op_test_si16() {
   %0 = stablehlo.constant dense<[32767, -32768, -32768]> : tensor<3xi16>
   %1 = stablehlo.constant dense<[0, 32767, -32768]> : tensor<3xi16>
   %2 = stablehlo.xor %0, %1 : tensor<3xi16>
-  check.eq %2, dense<[32767, -1, 0]> : tensor<3xi16>
+  check.expect_eq_const %2, dense<[32767, -1, 0]> : tensor<3xi16>
   func.return
 }
 
@@ -54,7 +54,7 @@ func.func @xor_op_test_ui16() {
   %0 = stablehlo.constant dense<[0, 32767, 65535]> : tensor<3xui16>
   %1 = stablehlo.constant dense<65535> : tensor<3xui16>
   %2 = stablehlo.xor %0, %1 : tensor<3xui16>
-  check.eq %2, dense<[65535, 32768, 0]> : tensor<3xui16>
+  check.expect_eq_const %2, dense<[65535, 32768, 0]> : tensor<3xui16>
   func.return
 }
 
@@ -64,7 +64,7 @@ func.func @xor_op_test_si32() {
   %0 = stablehlo.constant dense<[2147483647, -2147483648, -2147483648]> : tensor<3xi32>
   %1 = stablehlo.constant dense<[0, 2147483647, -2147483648]> : tensor<3xi32>
   %2 = stablehlo.xor %0, %1 : tensor<3xi32>
-  check.eq %2, dense<[2147483647, -1, 0]> : tensor<3xi32>
+  check.expect_eq_const %2, dense<[2147483647, -1, 0]> : tensor<3xi32>
   func.return
 }
 
@@ -74,7 +74,7 @@ func.func @xor_op_test_ui32() {
   %0 = stablehlo.constant dense<[0, 2147483647, 4294967295]> : tensor<3xui32>
   %1 = stablehlo.constant dense<4294967295> : tensor<3xui32>
   %2 = stablehlo.xor %0, %1 : tensor<3xui32>
-  check.eq %2, dense<[4294967295, 2147483648, 0]> : tensor<3xui32>
+  check.expect_eq_const %2, dense<[4294967295, 2147483648, 0]> : tensor<3xui32>
   func.return
 }
 
@@ -84,7 +84,7 @@ func.func @xor_op_test_si64() {
   %0 = stablehlo.constant dense<[9223372036854775807, -9223372036854775808, -9223372036854775808]> : tensor<3xi64>
   %1 = stablehlo.constant dense<[0, 9223372036854775807, -9223372036854775808]> : tensor<3xi64>
   %2 = stablehlo.xor %0, %1 : tensor<3xi64>
-  check.eq %2, dense<[9223372036854775807, -1, 0]> : tensor<3xi64>
+  check.expect_eq_const %2, dense<[9223372036854775807, -1, 0]> : tensor<3xi64>
   func.return
 }
 
@@ -94,7 +94,7 @@ func.func @xor_op_test_ui64() {
   %0 = stablehlo.constant dense<[0, 9223372036854775807, 18446744073709551615]> : tensor<3xui64>
   %1 = stablehlo.constant dense<18446744073709551615> : tensor<3xui64>
   %2 = stablehlo.xor %0, %1 : tensor<3xui64>
-  check.eq %2, dense<[18446744073709551615, 9223372036854775808, 0]> : tensor<3xui64>
+  check.expect_eq_const %2, dense<[18446744073709551615, 9223372036854775808, 0]> : tensor<3xui64>
   func.return
 }
 
@@ -104,7 +104,7 @@ func.func @xor_op_test_i1() {
   %0 = stablehlo.constant dense<[false, false, true, true]> : tensor<4xi1>
   %1 = stablehlo.constant dense<[false, true, false, true]> : tensor<4xi1>
   %2 = stablehlo.xor %0, %1 : tensor<4xi1>
-  check.eq %2, dense<[false, true, true, false]> : tensor<4xi1>
+  check.expect_eq_const %2, dense<[false, true, true, false]> : tensor<4xi1>
   func.return
 }
 
@@ -114,7 +114,7 @@ func.func @xor_op_test_i1_splat_false() {
   %0 = stablehlo.constant dense<false> : tensor<2xi1>
   %1 = stablehlo.constant dense<[false, true]> : tensor<2xi1>
   %2 = stablehlo.xor %0, %1 : tensor<2xi1>
-  check.eq %2, dense<[false, true]> : tensor<2xi1>
+  check.expect_eq_const %2, dense<[false, true]> : tensor<2xi1>
   func.return
 }
 
@@ -124,6 +124,6 @@ func.func @xor_op_test_i1_splat_true() {
   %0 = stablehlo.constant dense<true> : tensor<2xi1>
   %1 = stablehlo.constant dense<[false, true]> : tensor<2xi1>
   %2 = stablehlo.xor %0, %1 : tensor<2xi1>
-  check.eq %2, dense<[true, false]> : tensor<2xi1>
+  check.expect_eq_const %2, dense<[true, false]> : tensor<2xi1>
   func.return
 }


### PR DESCRIPTION
fixes https://github.com/openxla/stablehlo/issues/1219

Aligning [our Check dialect](https://github.com/openxla/stablehlo/blob/main/stablehlo/tests/CheckOps.td) with [IREE's Check dialect](https://github.com/openxla/iree/blob/main/compiler/src/iree/compiler/Modules/Check/IR/CheckOps.td), so that the conformance suite could also be used verbatim as a test suite for IREE.


 - **Alignment w.r.t the op signature:** The PR aligns the `stablehlo::check` ops to have signature comparable with IREE's check dialect ops so as to meet the purpose mentioned above.
- **Alignment w.r.t op semantics:** Ops from both the dialects are using a tolerance based approach to compare floating point values for near equality. 
The error bound for IREE ops ([here](https://github.com/openxla/iree/blob/0312dd3c67852c6fa97df072cc10bbc00aecb9c3/runtime/src/iree/modules/check/module.cc#L69)) is a flat epsilon value used for all float comparisons. The  StableHLO  check ops uses a relative (w.r.t the magnitude of the values under comaparison) epsilon value ([here](https://github.com/openxla/stablehlo/blob/8496d542f13b2f81ef6648ba1ac414d0f9343ade/stablehlo/reference/Element.cpp#L124)). From the choice of epsilon values, we can roughly say that the error bound, for StableHLO check ops, will be tighter  while comparing  normal values whose absolute values is less than a threshold (~840 = `0.0001 / std::numeric_limits<float>::epsilon()` for float dtype), beyond which the bound will be more generous.  The quality of the errors bounds can be further evaluated (and ,if needed, can be adjusted) based on the conformance test runs.