### PR TITLE
Use _v1 in VHLO mnemonics

### DIFF
--- a/stablehlo/dialect/VhloAttrs.td
+++ b/stablehlo/dialect/VhloAttrs.td
@@ -56,7 +56,7 @@ class VHLO_AttrDef<string name, string minVersion, string maxVersion>
 // At the moment, it is used to represent buffer donation, and we're planning
 // to look into it as part of the work on speccing buffer donation in StableHLO.
 def VHLO_ArgResultAliasAttrV1 : VHLO_AttrDef<"ArgResultAliasV1", "0.9.0", "current"> {
-  let mnemonic = "result_alias";
+  let mnemonic = "result_alias_v1";
   let parameters = (ins
     VHLO_Dims:$argTupleIndices,
     "int64_t":$resultIndex,
@@ -69,7 +69,7 @@ def VHLO_ArgResultAliasAttrV1 : VHLO_AttrDef<"ArgResultAliasV1", "0.9.0", "curre
 // Represents attributes from the StableHLO spec which say "variadic number of",
 // although not called out explicitly in the "Constants" section.
 def VHLO_ArrayAttrV1 : VHLO_AttrDef<"ArrayV1", "0.9.0", "current"> {
-  let mnemonic = "array";
+  let mnemonic = "array_v1";
   let parameters = (ins ArrayRefParameter<"mlir::Attribute">:$value);
   let genVerifyDecl = 1;
   let extraClassDefinition = [{
@@ -84,7 +84,7 @@ def VHLO_ArrayAttrV1 : VHLO_AttrDef<"ArrayV1", "0.9.0", "current"> {
 
 // Corresponds to BooleanConstant from the StableHLO spec.
 def VHLO_BooleanAttrV1 : VHLO_AttrDef<"BooleanV1", "0.9.0", "current"> {
-  let mnemonic = "bool";
+  let mnemonic = "bool_v1";
   let parameters = (ins "bool":$value);
   let assemblyFormat = "`<` $value `>`";
 }
@@ -94,7 +94,7 @@ def VHLO_BooleanAttrV1 : VHLO_AttrDef<"BooleanV1", "0.9.0", "current"> {
 // StableHLO functions, and we're planning to look into it as part of the work
 // on speccing Module/Func/Call/Return ops in StableHLO.
 def VHLO_DictionaryAttrV1 : VHLO_AttrDef<"DictionaryV1", "0.9.0", "current"> {
-  let mnemonic = "dict";
+  let mnemonic = "dict_v1";
   let parameters = (ins ArrayRefParameter<"std::pair<mlir::Attribute, mlir::Attribute>", "">:$value);
   let genVerifyDecl = 1;
   let extraClassDefinition = [{
@@ -112,7 +112,7 @@ def VHLO_DictionaryAttrV1 : VHLO_AttrDef<"DictionaryV1", "0.9.0", "current"> {
 
 // Corresponds to FloatConstant from the StableHLO spec.
 def VHLO_FloatAttrV1 : VHLO_AttrDef<"FloatV1", "0.9.0", "current"> {
-  let mnemonic = "float";
+  let mnemonic = "float_v1";
   let parameters = (ins "mlir::Type":$type, VHLO_APFloatV1:$value);
   let genVerifyDecl = 1;
   let extraClassDefinition = [{
@@ -127,7 +127,7 @@ def VHLO_FloatAttrV1 : VHLO_AttrDef<"FloatV1", "0.9.0", "current"> {
 
 // Corresponds to IntegerConstant from the StableHLO spec.
 def VHLO_IntegerAttrV1 : VHLO_AttrDef<"IntegerV1", "0.9.0", "current"> {
-  let mnemonic = "integer";
+  let mnemonic = "integer_v1";
   let parameters = (ins "mlir::Type":$type, "APInt":$value);
   let genVerifyDecl = 1;
   let extraClassDefinition = [{
@@ -144,7 +144,7 @@ def VHLO_IntegerAttrV1 : VHLO_AttrDef<"IntegerV1", "0.9.0", "current"> {
 // At the moment, it is used to represent buffer donation, and we're planning
 // to look into it as part of the work on speccing buffer donation in StableHLO.
 def VHLO_OutputOperandAliasAttrV1 : VHLO_AttrDef<"OutputOperandAliasV1", "0.9.0", "current"> {
-  let mnemonic = "output_operand_alias";
+  let mnemonic = "output_operand_alias_v1";
   let parameters = (ins
     VHLO_Dims:$outputTupleIndices,
     "int64_t":$operandIndex,
@@ -155,7 +155,7 @@ def VHLO_OutputOperandAliasAttrV1 : VHLO_AttrDef<"OutputOperandAliasV1", "0.9.0"
 
 // Corresponds to StringConstant from the StableHLO spec.
 def VHLO_StringAttrV1 : VHLO_AttrDef<"StringV1", "0.9.0", "current"> {
-  let mnemonic = "string";
+  let mnemonic = "string_v1";
   let parameters = (ins StringRefParameter<"">:$value);
   let assemblyFormat = "`<` custom<EscapedString>($value) `>`";
 }
@@ -165,7 +165,7 @@ def VHLO_TensorDataV1 : AttrParameter<"::llvm::ArrayRef<char>", ""> {
   let allocator = "$_dst = $_allocator.copyInto($_self);";
 }
 def VHLO_TensorAttrV1 : VHLO_AttrDef<"TensorV1", "0.9.0", "current"> {
-  let mnemonic = "tensor";
+  let mnemonic = "tensor_v1";
   let parameters = (ins "::mlir::Type":$type, VHLO_TensorDataV1:$data);
   let genVerifyDecl = 1;
   let extraClassDefinition = [{
@@ -183,7 +183,7 @@ def VHLO_TensorAttrV1 : VHLO_AttrDef<"TensorV1", "0.9.0", "current"> {
 // we're planning to look into it as part of the work on speccing
 // Module/Func/Call/Return ops in StableHLO.
 def VHLO_TypeAttrV1 : VHLO_AttrDef<"TypeV1", "0.9.0", "current"> {
-  let mnemonic = "type";
+  let mnemonic = "type_v1";
   let parameters = (ins "::mlir::Type":$value);
   let genVerifyDecl = 1;
   let extraClassDefinition = [{
@@ -201,7 +201,7 @@ def VHLO_TypeAttrV1 : VHLO_AttrDef<"TypeV1", "0.9.0", "current"> {
 // dynamism, and we're planning to look into it as part of the work on the
 // dynamism RFC.
 def VHLO_TypeExtensionsAttrV1 : VHLO_AttrDef<"TypeExtensionsV1", "0.9.0", "current"> {
-  let mnemonic = "type_extensions";
+  let mnemonic = "type_extensions_v1";
   let parameters = (ins VHLO_Dims:$bounds);
   let assemblyFormat = "`<` struct(params) `>`";
 }

--- a/stablehlo/dialect/VhloEnums.td
+++ b/stablehlo/dialect/VhloEnums.td
@@ -49,153 +49,153 @@ class VHLO_EnumAttr<EnumAttrInfo enumInfo, string name, string minVersion, strin
 // ComparisonDirection
 //===----------------------------------------------------------------------===//
 
-def VHLO_COMPARISON_DIRECTION_EQ : I32EnumAttrCase<"EQ", 0>;
-def VHLO_COMPARISON_DIRECTION_NE : I32EnumAttrCase<"NE", 1>;
-def VHLO_COMPARISON_DIRECTION_GE : I32EnumAttrCase<"GE", 2>;
-def VHLO_COMPARISON_DIRECTION_GT : I32EnumAttrCase<"GT", 3>;
-def VHLO_COMPARISON_DIRECTION_LE : I32EnumAttrCase<"LE", 4>;
-def VHLO_COMPARISON_DIRECTION_LT : I32EnumAttrCase<"LT", 5>;
+def VHLO_COMPARISON_DIRECTION_V1_EQ : I32EnumAttrCase<"EQ", 0>;
+def VHLO_COMPARISON_DIRECTION_V1_NE : I32EnumAttrCase<"NE", 1>;
+def VHLO_COMPARISON_DIRECTION_V1_GE : I32EnumAttrCase<"GE", 2>;
+def VHLO_COMPARISON_DIRECTION_V1_GT : I32EnumAttrCase<"GT", 3>;
+def VHLO_COMPARISON_DIRECTION_V1_LE : I32EnumAttrCase<"LE", 4>;
+def VHLO_COMPARISON_DIRECTION_V1_LT : I32EnumAttrCase<"LT", 5>;
 
 def VHLO_ComparisonDirectionV1 : VHLO_I32EnumAttr<"ComparisonDirectionV1", [
-  VHLO_COMPARISON_DIRECTION_EQ,
-  VHLO_COMPARISON_DIRECTION_NE,
-  VHLO_COMPARISON_DIRECTION_GE,
-  VHLO_COMPARISON_DIRECTION_GT,
-  VHLO_COMPARISON_DIRECTION_LE,
-  VHLO_COMPARISON_DIRECTION_LT
+  VHLO_COMPARISON_DIRECTION_V1_EQ,
+  VHLO_COMPARISON_DIRECTION_V1_NE,
+  VHLO_COMPARISON_DIRECTION_V1_GE,
+  VHLO_COMPARISON_DIRECTION_V1_GT,
+  VHLO_COMPARISON_DIRECTION_V1_LE,
+  VHLO_COMPARISON_DIRECTION_V1_LT
 ]> {}
 
 def VHLO_ComparisonDirectionAttrV1
-  : VHLO_EnumAttr<VHLO_ComparisonDirectionV1, "comparison_direction", "0.9.0", "current">;
+  : VHLO_EnumAttr<VHLO_ComparisonDirectionV1, "comparison_direction_v1", "0.9.0", "current">;
 
 //===----------------------------------------------------------------------===//
 // ComparisonType
 //===----------------------------------------------------------------------===//
 
 // TODO(#1186): NOTYPE is not part of the StableHLO spec.
-def VHLO_COMPARISON_TYPE_NOTYPE : I32EnumAttrCase<"NOTYPE", 0>;
-def VHLO_COMPARISON_TYPE_FLOAT : I32EnumAttrCase<"FLOAT", 1>;
-def VHLO_COMPARISON_TYPE_FLOAT_TOTAL_ORDER : I32EnumAttrCase<"TOTALORDER", 2>;
-def VHLO_COMPARISON_TYPE_SIGNED : I32EnumAttrCase<"SIGNED", 3>;
-def VHLO_COMPARISON_TYPE_UNSIGNED : I32EnumAttrCase<"UNSIGNED", 4>;
+def VHLO_COMPARISON_TYPE_V1_NOTYPE : I32EnumAttrCase<"NOTYPE", 0>;
+def VHLO_COMPARISON_TYPE_V1_FLOAT : I32EnumAttrCase<"FLOAT", 1>;
+def VHLO_COMPARISON_TYPE_V1_FLOAT_TOTAL_ORDER : I32EnumAttrCase<"TOTALORDER", 2>;
+def VHLO_COMPARISON_TYPE_V1_SIGNED : I32EnumAttrCase<"SIGNED", 3>;
+def VHLO_COMPARISON_TYPE_V1_UNSIGNED : I32EnumAttrCase<"UNSIGNED", 4>;
 
 def VHLO_ComparisonTypeV1 : VHLO_I32EnumAttr<"ComparisonTypeV1", [
-  VHLO_COMPARISON_TYPE_NOTYPE,
-  VHLO_COMPARISON_TYPE_FLOAT,
-  VHLO_COMPARISON_TYPE_FLOAT_TOTAL_ORDER,
-  VHLO_COMPARISON_TYPE_SIGNED,
-  VHLO_COMPARISON_TYPE_UNSIGNED
+  VHLO_COMPARISON_TYPE_V1_NOTYPE,
+  VHLO_COMPARISON_TYPE_V1_FLOAT,
+  VHLO_COMPARISON_TYPE_V1_FLOAT_TOTAL_ORDER,
+  VHLO_COMPARISON_TYPE_V1_SIGNED,
+  VHLO_COMPARISON_TYPE_V1_UNSIGNED
 ]> {}
 
 def VHLO_ComparisonTypeAttrV1
-  : VHLO_EnumAttr<VHLO_ComparisonTypeV1, "comparison_type", "0.9.0", "current">;
+  : VHLO_EnumAttr<VHLO_ComparisonTypeV1, "comparison_type_v1", "0.9.0", "current">;
 
 //===----------------------------------------------------------------------===//
 // CustomCallApiVersion
 //===----------------------------------------------------------------------===//
 
 // TODO(#1187): CustomCallApiVersion is not part of the StableHLO spec.
-def VHLO_CUSTOM_CALL_API_VERSION_UNSPECIFIED : I32EnumAttrCase<"API_VERSION_UNSPECIFIED", 0>;
-def VHLO_CUSTOM_CALL_API_VERSION_ORIGINAL : I32EnumAttrCase<"API_VERSION_ORIGINAL", 1>;
-def VHLO_CUSTOM_CALL_API_VERSION_STATUS_RETURNING : I32EnumAttrCase<"API_VERSION_STATUS_RETURNING", 2>;
-def VHLO_CUSTOM_CALL_API_VERSION_STATUS_RETURNING_UNIFIED : I32EnumAttrCase<"API_VERSION_STATUS_RETURNING_UNIFIED", 3>;
+def VHLO_CUSTOM_CALL_API_VERSION_V1_UNSPECIFIED : I32EnumAttrCase<"API_VERSION_UNSPECIFIED", 0>;
+def VHLO_CUSTOM_CALL_API_VERSION_V1_ORIGINAL : I32EnumAttrCase<"API_VERSION_ORIGINAL", 1>;
+def VHLO_CUSTOM_CALL_API_VERSION_V1_STATUS_RETURNING : I32EnumAttrCase<"API_VERSION_STATUS_RETURNING", 2>;
+def VHLO_CUSTOM_CALL_API_VERSION_V1_STATUS_RETURNING_UNIFIED : I32EnumAttrCase<"API_VERSION_STATUS_RETURNING_UNIFIED", 3>;
 
 def VHLO_CustomCallApiVersionV1 : VHLO_I32EnumAttr<"CustomCallApiVersionV1", [
-    VHLO_CUSTOM_CALL_API_VERSION_UNSPECIFIED,
-    VHLO_CUSTOM_CALL_API_VERSION_ORIGINAL,
-    VHLO_CUSTOM_CALL_API_VERSION_STATUS_RETURNING,
-    VHLO_CUSTOM_CALL_API_VERSION_STATUS_RETURNING_UNIFIED
+    VHLO_CUSTOM_CALL_API_VERSION_V1_UNSPECIFIED,
+    VHLO_CUSTOM_CALL_API_VERSION_V1_ORIGINAL,
+    VHLO_CUSTOM_CALL_API_VERSION_V1_STATUS_RETURNING,
+    VHLO_CUSTOM_CALL_API_VERSION_V1_STATUS_RETURNING_UNIFIED
 ]> {}
 
 def VHLO_CustomCallApiVersionAttrV1
-  : VHLO_EnumAttr<VHLO_CustomCallApiVersionV1, "api_version", "0.9.0", "current">;
+  : VHLO_EnumAttr<VHLO_CustomCallApiVersionV1, "api_version_v1", "0.9.0", "current">;
 
 //===----------------------------------------------------------------------===//
 // FftType
 //===----------------------------------------------------------------------===//
 
-def VHLO_FFT_TYPE_FFT : I32EnumAttrCase<"FFT", 0>;
-def VHLO_FFT_TYPE_IFFT : I32EnumAttrCase<"IFFT", 1>;
-def VHLO_FFT_TYPE_RFFT : I32EnumAttrCase<"RFFT", 2>;
-def VHLO_FFT_TYPE_IRFFT : I32EnumAttrCase<"IRFFT", 3>;
+def VHLO_FFT_TYPE_V1_FFT : I32EnumAttrCase<"FFT", 0>;
+def VHLO_FFT_TYPE_V1_IFFT : I32EnumAttrCase<"IFFT", 1>;
+def VHLO_FFT_TYPE_V1_RFFT : I32EnumAttrCase<"RFFT", 2>;
+def VHLO_FFT_TYPE_V1_IRFFT : I32EnumAttrCase<"IRFFT", 3>;
 
 def VHLO_FftTypeV1 : VHLO_I32EnumAttr<"FftTypeV1", [
-  VHLO_FFT_TYPE_FFT,
-  VHLO_FFT_TYPE_IFFT,
-  VHLO_FFT_TYPE_RFFT,
-  VHLO_FFT_TYPE_IRFFT
+  VHLO_FFT_TYPE_V1_FFT,
+  VHLO_FFT_TYPE_V1_IFFT,
+  VHLO_FFT_TYPE_V1_RFFT,
+  VHLO_FFT_TYPE_V1_IRFFT
 ]> {}
 
 def VHLO_FftTypeAttrV1
-  : VHLO_EnumAttr<VHLO_FftTypeV1, "fft_type", "0.9.0", "current">;
+  : VHLO_EnumAttr<VHLO_FftTypeV1, "fft_type_v1", "0.9.0", "current">;
 
 //===----------------------------------------------------------------------===//
 // Precision
 //===----------------------------------------------------------------------===//
 
-def VHLO_PRECISION_DEFAULT : I32EnumAttrCase<"DEFAULT", 0>;
-def VHLO_PRECISION_HIGH : I32EnumAttrCase<"HIGH", 1>;
-def VHLO_PRECISION_HIGHEST : I32EnumAttrCase<"HIGHEST", 2>;
+def VHLO_PRECISION_V1_DEFAULT : I32EnumAttrCase<"DEFAULT", 0>;
+def VHLO_PRECISION_V1_HIGH : I32EnumAttrCase<"HIGH", 1>;
+def VHLO_PRECISION_V1_HIGHEST : I32EnumAttrCase<"HIGHEST", 2>;
 
 def VHLO_PrecisionV1 : VHLO_I32EnumAttr<"PrecisionV1", [
-  VHLO_PRECISION_DEFAULT,
-  VHLO_PRECISION_HIGH,
-  VHLO_PRECISION_HIGHEST
+  VHLO_PRECISION_V1_DEFAULT,
+  VHLO_PRECISION_V1_HIGH,
+  VHLO_PRECISION_V1_HIGHEST
 ]> {}
 
 def VHLO_PrecisionAttrV1
-  : VHLO_EnumAttr<VHLO_PrecisionV1, "precision", "0.9.0", "current">;
+  : VHLO_EnumAttr<VHLO_PrecisionV1, "precision_v1", "0.9.0", "current">;
 
 //===----------------------------------------------------------------------===//
 // RngAlgorithm
 //===----------------------------------------------------------------------===//
 
-def VHLO_RNG_ALGORITHM_DEFAULT : I32EnumAttrCase<"DEFAULT", 0>;
-def VHLO_RNG_ALGORITHM_THREE_FRY : I32EnumAttrCase<"THREE_FRY", 1>;
-def VHLO_RNG_ALGORITHM_PHILOX : I32EnumAttrCase<"PHILOX", 2>;
+def VHLO_RNG_ALGORITHM_V1_DEFAULT : I32EnumAttrCase<"DEFAULT", 0>;
+def VHLO_RNG_ALGORITHM_V1_THREE_FRY : I32EnumAttrCase<"THREE_FRY", 1>;
+def VHLO_RNG_ALGORITHM_V1_PHILOX : I32EnumAttrCase<"PHILOX", 2>;
 
 def VHLO_RngAlgorithmV1 : VHLO_I32EnumAttr<"RngAlgorithmV1", [
-  VHLO_RNG_ALGORITHM_DEFAULT,
-  VHLO_RNG_ALGORITHM_THREE_FRY,
-  VHLO_RNG_ALGORITHM_PHILOX
+  VHLO_RNG_ALGORITHM_V1_DEFAULT,
+  VHLO_RNG_ALGORITHM_V1_THREE_FRY,
+  VHLO_RNG_ALGORITHM_V1_PHILOX
 ]> {}
 
 def VHLO_RngAlgorithmAttrV1
-  : VHLO_EnumAttr<VHLO_RngAlgorithmV1, "rng_algorithm", "0.9.0", "current">;
+  : VHLO_EnumAttr<VHLO_RngAlgorithmV1, "rng_algorithm_v1", "0.9.0", "current">;
 
 //===----------------------------------------------------------------------===//
 // RngDistribution
 //===----------------------------------------------------------------------===//
 
-def VHLO_RNG_DISTRIBUTION_UNIFORM : I32EnumAttrCase<"UNIFORM", 1>;
-def VHLO_RNG_DISTRIBUTION_NORMAL : I32EnumAttrCase<"NORMAL", 2>;
+def VHLO_RNG_DISTRIBUTION_V1_UNIFORM : I32EnumAttrCase<"UNIFORM", 1>;
+def VHLO_RNG_DISTRIBUTION_V1_NORMAL : I32EnumAttrCase<"NORMAL", 2>;
 
 def VHLO_RngDistributionV1 : VHLO_I32EnumAttr<"RngDistributionV1", [
-  VHLO_RNG_DISTRIBUTION_UNIFORM,
-  VHLO_RNG_DISTRIBUTION_NORMAL
+  VHLO_RNG_DISTRIBUTION_V1_UNIFORM,
+  VHLO_RNG_DISTRIBUTION_V1_NORMAL
 ]> {}
 
 def VHLO_RngDistributionAttrV1
-  : VHLO_EnumAttr<VHLO_RngDistributionV1, "rng_distribution", "0.9.0", "current">;
+  : VHLO_EnumAttr<VHLO_RngDistributionV1, "rng_distribution_v1", "0.9.0", "current">;
 
 //===----------------------------------------------------------------------===//
 // Transpose
 //===----------------------------------------------------------------------===//
 
 // TODO(#1186): TRANSPOSE_INVALID is not part of the StableHLO spec.
-def VHLO_TRANSPOSE_INVALID : I32EnumAttrCase<"TRANSPOSE_INVALID", 0>;
-def VHLO_NO_TRANSPOSE : I32EnumAttrCase<"NO_TRANSPOSE", 1>;
-def VHLO_TRANSPOSE : I32EnumAttrCase<"TRANSPOSE", 2>;
-def VHLO_ADJOINT : I32EnumAttrCase<"ADJOINT", 3>;
+def VHLO_TRANSPOSE_V1_TRANSPOSE_INVALID : I32EnumAttrCase<"TRANSPOSE_INVALID", 0>;
+def VHLO_TRANSPOSE_V1_NO_TRANSPOSE : I32EnumAttrCase<"NO_TRANSPOSE", 1>;
+def VHLO_TRANSPOSE_V1_TRANSPOSE : I32EnumAttrCase<"TRANSPOSE", 2>;
+def VHLO_TRANSPOSE_V1_ADJOINT : I32EnumAttrCase<"ADJOINT", 3>;
 
 def VHLO_TransposeV1 : VHLO_I32EnumAttr<"TransposeV1", [
-  VHLO_TRANSPOSE_INVALID,
-  VHLO_NO_TRANSPOSE,
-  VHLO_TRANSPOSE,
-  VHLO_ADJOINT
+  VHLO_TRANSPOSE_V1_TRANSPOSE_INVALID,
+  VHLO_TRANSPOSE_V1_NO_TRANSPOSE,
+  VHLO_TRANSPOSE_V1_TRANSPOSE,
+  VHLO_TRANSPOSE_V1_ADJOINT
 ]> {}
 
 def VHLO_TransposeAttrV1
-  : VHLO_EnumAttr<VHLO_TransposeV1, "transpose", "0.9.0", "current">;
+  : VHLO_EnumAttr<VHLO_TransposeV1, "transpose_v1", "0.9.0", "current">;
 
 #endif // STABLEHLO_DIALECT_VHLO_ENUMS

--- a/stablehlo/dialect/VhloOps.td
+++ b/stablehlo/dialect/VhloOps.td
@@ -67,22 +67,22 @@ class VHLO_Op<string mnemonic, string minVersion, string maxVersion, list<Trait>
 // 6) Don't use verifiers, shape functions, etc. The only exception is
 //    assembly format for FuncOp, because printouts get unreadable otherwise.
 
-def VHLO_AbsOpV1 : VHLO_Op<"abs", "0.9.0", "current"> {
+def VHLO_AbsOpV1 : VHLO_Op<"abs_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$operand);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_AddOpV1 : VHLO_Op<"add", "0.9.0", "current"> {
+def VHLO_AddOpV1 : VHLO_Op<"add_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_AfterAllOpV1 : VHLO_Op<"after_all", "0.9.0", "current"> {
+def VHLO_AfterAllOpV1 : VHLO_Op<"after_all_v1", "0.9.0", "current"> {
   let arguments = (ins Variadic<VHLO_AnyType>:$inputs);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_AllGatherOpV1 : VHLO_Op<"all_gather", "0.9.0", "current"> {
+def VHLO_AllGatherOpV1 : VHLO_Op<"all_gather_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$operand,
     VHLO_AnyAttr:$all_gather_dim,
@@ -93,7 +93,7 @@ def VHLO_AllGatherOpV1 : VHLO_Op<"all_gather", "0.9.0", "current"> {
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_AllReduceOpV1 : VHLO_Op<"all_reduce", "0.9.0", "current"> {
+def VHLO_AllReduceOpV1 : VHLO_Op<"all_reduce_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$operand,
     VHLO_AnyAttr:$replica_groups,
@@ -104,7 +104,7 @@ def VHLO_AllReduceOpV1 : VHLO_Op<"all_reduce", "0.9.0", "current"> {
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_AllToAllOpV1 : VHLO_Op<"all_to_all", "0.9.0", "current"> {
+def VHLO_AllToAllOpV1 : VHLO_Op<"all_to_all_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$operand,
     VHLO_AnyAttr:$split_dimension,
@@ -116,17 +116,17 @@ def VHLO_AllToAllOpV1 : VHLO_Op<"all_to_all", "0.9.0", "current"> {
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_AndOpV1 : VHLO_Op<"and", "0.9.0", "current"> {
+def VHLO_AndOpV1 : VHLO_Op<"and_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_Atan2OpV1 : VHLO_Op<"atan2", "0.9.0", "current"> {
+def VHLO_Atan2OpV1 : VHLO_Op<"atan2_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_BatchNormGradOpV1 : VHLO_Op<"batch_norm_grad", "0.9.0", "current"> {
+def VHLO_BatchNormGradOpV1 : VHLO_Op<"batch_norm_grad_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$operand,
     VHLO_AnyType:$scale,
@@ -143,7 +143,7 @@ def VHLO_BatchNormGradOpV1 : VHLO_Op<"batch_norm_grad", "0.9.0", "current"> {
   );
 }
 
-def VHLO_BatchNormInferenceOpV1 : VHLO_Op<"batch_norm_inference", "0.9.0", "current"> {
+def VHLO_BatchNormInferenceOpV1 : VHLO_Op<"batch_norm_inference_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$operand,
     VHLO_AnyType:$scale,
@@ -156,7 +156,7 @@ def VHLO_BatchNormInferenceOpV1 : VHLO_Op<"batch_norm_inference", "0.9.0", "curr
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_BatchNormTrainingOpV1 : VHLO_Op<"batch_norm_training", "0.9.0", "current"> {
+def VHLO_BatchNormTrainingOpV1 : VHLO_Op<"batch_norm_training_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$operand,
     VHLO_AnyType:$scale,
@@ -171,12 +171,12 @@ def VHLO_BatchNormTrainingOpV1 : VHLO_Op<"batch_norm_training", "0.9.0", "curren
   );
 }
 
-def VHLO_BitcastConvertOpV1 : VHLO_Op<"bitcast_convert", "0.9.0", "current"> {
+def VHLO_BitcastConvertOpV1 : VHLO_Op<"bitcast_convert_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$operand);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_BroadcastInDimOpV1 : VHLO_Op<"broadcast_in_dim", "0.9.0", "current"> {
+def VHLO_BroadcastInDimOpV1 : VHLO_Op<"broadcast_in_dim_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$operand,
     VHLO_AnyAttr:$broadcast_dimensions
@@ -187,7 +187,7 @@ def VHLO_BroadcastInDimOpV1 : VHLO_Op<"broadcast_in_dim", "0.9.0", "current"> {
 // TODO(#3): BroadcastOp is not part of the StableHLO spec.
 // This operation is on its way out of StableHLO, so it is not included in
 // the StableHLO specification.
-def VHLO_BroadcastOpV1 : VHLO_Op<"broadcast", "0.9.0", "current"> {
+def VHLO_BroadcastOpV1 : VHLO_Op<"broadcast_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$operand,
     VHLO_AnyAttr:$broadcast_sizes
@@ -198,28 +198,28 @@ def VHLO_BroadcastOpV1 : VHLO_Op<"broadcast", "0.9.0", "current"> {
 // TODO(#425): CallOp is not part of the StableHLO spec.
 // We're planning to look into it as part of the work on speccing
 // Module/Func/Call/Return ops in StableHLO.
-def VHLO_CallOpV1 : VHLO_Op<"call", "0.9.0", "current"> {
+def VHLO_CallOpV1 : VHLO_Op<"call_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyAttr:$callee, Variadic<VHLO_AnyType>:$operands);
   let results = (outs Variadic<VHLO_AnyType>:$results);
 }
 
-def VHLO_CaseOpV1 : VHLO_Op<"case", "0.9.0", "current"> {
+def VHLO_CaseOpV1 : VHLO_Op<"case_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$index);
   let regions = (region VariadicRegion<VHLO_AnyRegion>:$branches);
   let results = (outs Variadic<VHLO_AnyType>:$results);
 }
 
-def VHLO_CbrtOpV1 : VHLO_Op<"cbrt", "0.9.0", "current"> {
+def VHLO_CbrtOpV1 : VHLO_Op<"cbrt_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$operand);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_CeilOpV1 : VHLO_Op<"ceil", "0.9.0", "current"> {
+def VHLO_CeilOpV1 : VHLO_Op<"ceil_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$operand);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_CholeskyOpV1 : VHLO_Op<"cholesky", "0.9.0", "current"> {
+def VHLO_CholeskyOpV1 : VHLO_Op<"cholesky_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$a,
     VHLO_AnyAttr:$lower
@@ -227,7 +227,7 @@ def VHLO_CholeskyOpV1 : VHLO_Op<"cholesky", "0.9.0", "current"> {
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_ClampOpV1 : VHLO_Op<"clamp", "0.9.0", "current"> {
+def VHLO_ClampOpV1 : VHLO_Op<"clamp_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$min,
     VHLO_AnyType:$operand,
@@ -236,12 +236,12 @@ def VHLO_ClampOpV1 : VHLO_Op<"clamp", "0.9.0", "current"> {
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_ClzOpV1 : VHLO_Op<"count_leading_zeros", "0.9.0", "current"> {
+def VHLO_ClzOpV1 : VHLO_Op<"count_leading_zeros_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$operand);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_CollectivePermuteOpV1 : VHLO_Op<"collective_permute", "0.9.0", "current"> {
+def VHLO_CollectivePermuteOpV1 : VHLO_Op<"collective_permute_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$operand,
     VHLO_AnyAttr:$source_target_pairs,
@@ -250,7 +250,7 @@ def VHLO_CollectivePermuteOpV1 : VHLO_Op<"collective_permute", "0.9.0", "current
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_CompareOpV1 : VHLO_Op<"compare", "0.9.0", "current"> {
+def VHLO_CompareOpV1 : VHLO_Op<"compare_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$lhs,
     VHLO_AnyType:$rhs,
@@ -260,7 +260,7 @@ def VHLO_CompareOpV1 : VHLO_Op<"compare", "0.9.0", "current"> {
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_ComplexOpV1 : VHLO_Op<"complex", "0.9.0", "current"> {
+def VHLO_ComplexOpV1 : VHLO_Op<"complex_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
   let results = (outs VHLO_AnyType:$result);
 }
@@ -268,12 +268,12 @@ def VHLO_ComplexOpV1 : VHLO_Op<"complex", "0.9.0", "current"> {
 // TODO(#8): ComputeReshapeShapeOp is not part of the StableHLO spec.
 // This operation is a work in progress, so it is not yet included in
 // the StableHLO specification.
-def VHLO_ComputeReshapeShapeOpV1 : VHLO_Op<"compute_reshape_shape", "0.9.0", "current"> {
+def VHLO_ComputeReshapeShapeOpV1 : VHLO_Op<"compute_reshape_shape_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$num_elements, VHLO_AnyType:$dynamic_shape);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_ConcatenateOpV1 : VHLO_Op<"concatenate", "0.9.0", "current"> {
+def VHLO_ConcatenateOpV1 : VHLO_Op<"concatenate_v1", "0.9.0", "current"> {
   let arguments = (ins
     Variadic<VHLO_AnyType>:$inputs,
     VHLO_AnyAttr:$dimension
@@ -281,17 +281,17 @@ def VHLO_ConcatenateOpV1 : VHLO_Op<"concatenate", "0.9.0", "current"> {
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_ConstantOpV1 : VHLO_Op<"constant", "0.9.0", "current"> {
+def VHLO_ConstantOpV1 : VHLO_Op<"constant_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyAttr:$value);
   let results = (outs VHLO_AnyType:$output);
 }
 
-def VHLO_ConvertOpV1 : VHLO_Op<"convert", "0.9.0", "current"> {
+def VHLO_ConvertOpV1 : VHLO_Op<"convert_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$operand);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_ConvolutionOpV1 : VHLO_Op<"convolution", "0.9.0", "current"> {
+def VHLO_ConvolutionOpV1 : VHLO_Op<"convolution_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$lhs,
     VHLO_AnyType:$rhs,
@@ -316,7 +316,7 @@ def VHLO_ConvolutionOpV1 : VHLO_Op<"convolution", "0.9.0", "current"> {
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_CosineOpV1 : VHLO_Op<"cosine", "0.9.0", "current"> {
+def VHLO_CosineOpV1 : VHLO_Op<"cosine_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$operand);
   let results = (outs VHLO_AnyType:$result);
 }
@@ -324,14 +324,14 @@ def VHLO_CosineOpV1 : VHLO_Op<"cosine", "0.9.0", "current"> {
 // TODO(#3): CreateTokenOp is not part of the StableHLO spec.
 // This operation is on its way out of StableHLO, so it is not included in
 // the StableHLO specification.
-def VHLO_CreateTokenOpV1 : VHLO_Op<"create_token", "0.9.0", "current"> {
+def VHLO_CreateTokenOpV1 : VHLO_Op<"create_token_v1", "0.9.0", "current"> {
   let results = (outs VHLO_AnyType:$output);
 }
 
 // TODO(#3): CrossReplicaSumOp is not part of the StableHLO spec.
 // This operation is on its way out of StableHLO, so it is not included in
 // the StableHLO specification.
-def VHLO_CrossReplicaSumOpV1 : VHLO_Op<"cross-replica-sum", "0.9.0", "current"> {
+def VHLO_CrossReplicaSumOpV1 : VHLO_Op<"cross-replica-sum_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$operand,
     VHLO_AnyAttr:$replica_groups
@@ -342,7 +342,7 @@ def VHLO_CrossReplicaSumOpV1 : VHLO_Op<"cross-replica-sum", "0.9.0", "current"> 
 // TODO(#8): CstrReshapableOp is not part of the StableHLO spec.
 // This operation is a work in progress, so it is not yet included in
 // the StableHLO specification.
-def VHLO_CstrReshapableOpV1 : VHLO_Op<"cstr_reshapable", "0.9.0", "current"> {
+def VHLO_CstrReshapableOpV1 : VHLO_Op<"cstr_reshapable_v1", "0.9.0", "current"> {
   let results = (outs VHLO_AnyType:$result);
   let arguments = (ins VHLO_AnyType:$num_elements, VHLO_AnyType:$dynamic_shape);
 }
@@ -353,7 +353,7 @@ def VHLO_CstrReshapableOpV1 : VHLO_Op<"cstr_reshapable", "0.9.0", "current"> {
 // TODO(#740): output_operand_aliases is not part of the spec.
 // CustomCallOp has proven to be one of the trickiest ops to fully spec.
 // We're aiming to address all these todos by the release of StableHLO v1.0.
-def VHLO_CustomCallOpV1 : VHLO_Op<"custom_call", "0.9.0", "current"> {
+def VHLO_CustomCallOpV1 : VHLO_Op<"custom_call_v1", "0.9.0", "current"> {
   let arguments = (ins
     Variadic<VHLO_AnyType>:$inputs,
     VHLO_AnyAttr:$call_target_name,
@@ -368,12 +368,12 @@ def VHLO_CustomCallOpV1 : VHLO_Op<"custom_call", "0.9.0", "current"> {
   let results = (outs Variadic<VHLO_AnyType>:$results);
 }
 
-def VHLO_DivOpV1 : VHLO_Op<"divide", "0.9.0", "current"> {
+def VHLO_DivOpV1 : VHLO_Op<"divide_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_DotGeneralOpV1 : VHLO_Op<"dot_general", "0.9.0", "current"> {
+def VHLO_DotGeneralOpV1 : VHLO_Op<"dot_general_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$lhs,
     VHLO_AnyType:$rhs,
@@ -389,7 +389,7 @@ def VHLO_DotGeneralOpV1 : VHLO_Op<"dot_general", "0.9.0", "current"> {
 // TODO(#3): DotOp is not part of the StableHLO spec.
 // This operation is on its way out of StableHLO, so it is not included in
 // the StableHLO specification.
-def VHLO_DotOpV1 : VHLO_Op<"dot", "0.9.0", "current"> {
+def VHLO_DotOpV1 : VHLO_Op<"dot_v1", "0.9.0", "current"> {
   let arguments = (
     ins VHLO_AnyType:$lhs,
     VHLO_AnyType:$rhs,
@@ -401,7 +401,7 @@ def VHLO_DotOpV1 : VHLO_Op<"dot", "0.9.0", "current"> {
 // TODO(#8): DynamicBroadcastInDimOp is not part of the StableHLO spec.
 // This operation is a work in progress, so it is not yet included in
 // the StableHLO specification.
-def VHLO_DynamicBroadcastInDimOpV1 : VHLO_Op<"dynamic_broadcast_in_dim", "0.9.0", "current"> {
+def VHLO_DynamicBroadcastInDimOpV1 : VHLO_Op<"dynamic_broadcast_in_dim_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$operand,
     VHLO_AnyType:$output_dimensions,
@@ -415,7 +415,7 @@ def VHLO_DynamicBroadcastInDimOpV1 : VHLO_Op<"dynamic_broadcast_in_dim", "0.9.0"
 // TODO(#8): DynamicConvOp is not part of the StableHLO spec.
 // This operation is a work in progress, so it is not yet included in
 // the StableHLO specification.
-def VHLO_DynamicConvOpV1 : VHLO_Op<"dynamic_conv", "0.9.0", "current"> {
+def VHLO_DynamicConvOpV1 : VHLO_Op<"dynamic_conv_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$lhs,
     VHLO_AnyType:$rhs,
@@ -444,7 +444,7 @@ def VHLO_DynamicConvOpV1 : VHLO_Op<"dynamic_conv", "0.9.0", "current"> {
 // TODO(#8): DynamicGatherOp is not part of the StableHLO spec.
 // This operation is a work in progress, so it is not yet included in
 // the StableHLO specification.
-def VHLO_DynamicGatherOpV1 : VHLO_Op<"dynamic_gather", "0.9.0", "current"> {
+def VHLO_DynamicGatherOpV1 : VHLO_Op<"dynamic_gather_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$operand,
     VHLO_AnyType:$start_indices,
@@ -461,7 +461,7 @@ def VHLO_DynamicGatherOpV1 : VHLO_Op<"dynamic_gather", "0.9.0", "current"> {
 // TODO(#8): DynamicIotaOp is not part of the StableHLO spec.
 // This operation is a work in progress, so it is not yet included in
 // the StableHLO specification.
-def VHLO_DynamicIotaOpV1 : VHLO_Op<"dynamic_iota", "0.9.0", "current"> {
+def VHLO_DynamicIotaOpV1 : VHLO_Op<"dynamic_iota_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$output_shape, VHLO_AnyAttr:$iota_dimension);
   let results = (outs VHLO_AnyType:$result);
 }
@@ -469,7 +469,7 @@ def VHLO_DynamicIotaOpV1 : VHLO_Op<"dynamic_iota", "0.9.0", "current"> {
 // TODO(#8): DynamicPadOp is not part of the StableHLO spec.
 // This operation is a work in progress, so it is not yet included in
 // the StableHLO specification.
-def VHLO_DynamicPadOpV1 : VHLO_Op<"dynamic_pad", "0.9.0", "current"> {
+def VHLO_DynamicPadOpV1 : VHLO_Op<"dynamic_pad_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$operand,
     VHLO_AnyType:$padding_value,
@@ -483,12 +483,12 @@ def VHLO_DynamicPadOpV1 : VHLO_Op<"dynamic_pad", "0.9.0", "current"> {
 // TODO(#8): DynamicReshapeOp is not part of the StableHLO spec.
 // This operation is a work in progress, so it is not yet included in
 // the StableHLO specification.
-def VHLO_DynamicReshapeOpV1 : VHLO_Op<"dynamic_reshape", "0.9.0", "current"> {
+def VHLO_DynamicReshapeOpV1 : VHLO_Op<"dynamic_reshape_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$operand, VHLO_AnyType:$output_shape);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_DynamicSliceOpV1 : VHLO_Op<"dynamic_slice", "0.9.0", "current"> {
+def VHLO_DynamicSliceOpV1 : VHLO_Op<"dynamic_slice_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$operand,
     Variadic<VHLO_AnyType>:$start_indices,
@@ -497,7 +497,7 @@ def VHLO_DynamicSliceOpV1 : VHLO_Op<"dynamic_slice", "0.9.0", "current"> {
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_DynamicUpdateSliceOpV1 : VHLO_Op<"dynamic_update_slice", "0.9.0", "current"> {
+def VHLO_DynamicUpdateSliceOpV1 : VHLO_Op<"dynamic_update_slice_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$operand,
     VHLO_AnyType:$update,
@@ -509,7 +509,7 @@ def VHLO_DynamicUpdateSliceOpV1 : VHLO_Op<"dynamic_update_slice", "0.9.0", "curr
 // TODO(#3): EinsumOp is not part of the StableHLO spec.
 // This operation is on its way out of StableHLO, so it is not included in
 // the StableHLO specification.
-def VHLO_EinsumOpV1 : VHLO_Op<"einsum", "0.9.0", "current"> {
+def VHLO_EinsumOpV1 : VHLO_Op<"einsum_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$lhs,
     VHLO_AnyType:$rhs,
@@ -518,17 +518,17 @@ def VHLO_EinsumOpV1 : VHLO_Op<"einsum", "0.9.0", "current"> {
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_Expm1OpV1 : VHLO_Op<"exponential_minus_one", "0.9.0", "current"> {
+def VHLO_Expm1OpV1 : VHLO_Op<"exponential_minus_one_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$operand);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_ExpOpV1 : VHLO_Op<"exponential", "0.9.0", "current"> {
+def VHLO_ExpOpV1 : VHLO_Op<"exponential_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$operand);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_FftOpV1 : VHLO_Op<"fft", "0.9.0", "current"> {
+def VHLO_FftOpV1 : VHLO_Op<"fft_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$operand,
     VHLO_AnyAttr:$fft_type,
@@ -537,7 +537,7 @@ def VHLO_FftOpV1 : VHLO_Op<"fft", "0.9.0", "current"> {
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_FloorOpV1 : VHLO_Op<"floor", "0.9.0", "current"> {
+def VHLO_FloorOpV1 : VHLO_Op<"floor_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$operand);
   let results = (outs VHLO_AnyType:$result);
 }
@@ -545,7 +545,7 @@ def VHLO_FloorOpV1 : VHLO_Op<"floor", "0.9.0", "current"> {
 // TODO(#425): FuncOp is not part of the StableHLO spec.
 // We're planning to look into it as part of the work on speccing
 // Module/Func/Call/Return ops in StableHLO.
-def VHLO_FuncOpV1 : VHLO_Op<"func", "0.9.0", "current"> {
+def VHLO_FuncOpV1 : VHLO_Op<"func_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyAttr:$sym_name,
     VHLO_AnyAttr:$function_type,
@@ -556,7 +556,7 @@ def VHLO_FuncOpV1 : VHLO_Op<"func", "0.9.0", "current"> {
   let assemblyFormat = "custom<FunctionBody>($sym_name, $body, $function_type) attr-dict";
 }
 
-def VHLO_GatherOpV1 : VHLO_Op<"gather", "0.9.0", "current"> {
+def VHLO_GatherOpV1 : VHLO_Op<"gather_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$operand,
     VHLO_AnyType:$start_indices,
@@ -570,7 +570,7 @@ def VHLO_GatherOpV1 : VHLO_Op<"gather", "0.9.0", "current"> {
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_GetDimensionSizeOpV1 : VHLO_Op<"get_dimension_size", "0.9.0", "current"> {
+def VHLO_GetDimensionSizeOpV1 : VHLO_Op<"get_dimension_size_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$operand,
     VHLO_AnyAttr:$dimension
@@ -578,7 +578,7 @@ def VHLO_GetDimensionSizeOpV1 : VHLO_Op<"get_dimension_size", "0.9.0", "current"
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_GetTupleElementOpV1 : VHLO_Op<"get_tuple_element", "0.9.0", "current"> {
+def VHLO_GetTupleElementOpV1 : VHLO_Op<"get_tuple_element_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$operand,
     VHLO_AnyAttr:$index
@@ -586,7 +586,7 @@ def VHLO_GetTupleElementOpV1 : VHLO_Op<"get_tuple_element", "0.9.0", "current"> 
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_IfOpV1 : VHLO_Op<"if", "0.9.0", "current"> {
+def VHLO_IfOpV1 : VHLO_Op<"if_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$pred);
   let regions = (region
     VHLO_AnyRegion:$true_branch,
@@ -595,7 +595,7 @@ def VHLO_IfOpV1 : VHLO_Op<"if", "0.9.0", "current"> {
   let results = (outs Variadic<VHLO_AnyType>:$results);
 }
 
-def VHLO_ImagOpV1 : VHLO_Op<"imag", "0.9.0", "current"> {
+def VHLO_ImagOpV1 : VHLO_Op<"imag_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$operand);
   let results = (outs VHLO_AnyType:$result);
 }
@@ -603,7 +603,7 @@ def VHLO_ImagOpV1 : VHLO_Op<"imag", "0.9.0", "current"> {
 // TODO(#629): layout is not part of the StableHLO spec.
 // The notion of layouts is a work in progress, so it is not yet included in
 // the StableHLO specification.
-def VHLO_InfeedOpV1 : VHLO_Op<"infeed", "0.9.0", "current"> {
+def VHLO_InfeedOpV1 : VHLO_Op<"infeed_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$token,
     VHLO_AnyAttr:$infeed_config,
@@ -612,32 +612,32 @@ def VHLO_InfeedOpV1 : VHLO_Op<"infeed", "0.9.0", "current"> {
   let results = (outs Variadic<VHLO_AnyType>:$results);
 }
 
-def VHLO_IotaOpV1 : VHLO_Op<"iota", "0.9.0", "current"> {
+def VHLO_IotaOpV1 : VHLO_Op<"iota_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyAttr:$iota_dimension);
   let results = (outs VHLO_AnyType:$output);
 }
 
-def VHLO_IsFiniteOpV1 : VHLO_Op<"is_finite", "0.9.0", "current"> {
+def VHLO_IsFiniteOpV1 : VHLO_Op<"is_finite_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$x);
   let results = (outs VHLO_AnyType:$y);
 }
 
-def VHLO_Log1pOpV1 : VHLO_Op<"log_plus_one", "0.9.0", "current"> {
+def VHLO_Log1pOpV1 : VHLO_Op<"log_plus_one_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$operand);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_LogisticOpV1 : VHLO_Op<"logistic", "0.9.0", "current"> {
+def VHLO_LogisticOpV1 : VHLO_Op<"logistic_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$operand);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_LogOpV1 : VHLO_Op<"log", "0.9.0", "current"> {
+def VHLO_LogOpV1 : VHLO_Op<"log_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$operand);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_MapOpV1 : VHLO_Op<"map", "0.9.0", "current"> {
+def VHLO_MapOpV1 : VHLO_Op<"map_v1", "0.9.0", "current"> {
   let arguments = (ins
     Variadic<VHLO_AnyType>:$inputs,
     VHLO_AnyAttr:$dimensions
@@ -646,37 +646,37 @@ def VHLO_MapOpV1 : VHLO_Op<"map", "0.9.0", "current"> {
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_MaxOpV1 : VHLO_Op<"maximum", "0.9.0", "current"> {
+def VHLO_MaxOpV1 : VHLO_Op<"maximum_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_MinOpV1 : VHLO_Op<"minimum", "0.9.0", "current"> {
+def VHLO_MinOpV1 : VHLO_Op<"minimum_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_MulOpV1 : VHLO_Op<"multiply", "0.9.0", "current"> {
+def VHLO_MulOpV1 : VHLO_Op<"multiply_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_NegOpV1 : VHLO_Op<"negate", "0.9.0", "current"> {
+def VHLO_NegOpV1 : VHLO_Op<"negate_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$operand);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_NotOpV1 : VHLO_Op<"not", "0.9.0", "current"> {
+def VHLO_NotOpV1 : VHLO_Op<"not_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$operand);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_OptimizationBarrierOpV1 : VHLO_Op<"optimization_barrier", "0.9.0", "current"> {
+def VHLO_OptimizationBarrierOpV1 : VHLO_Op<"optimization_barrier_v1", "0.9.0", "current"> {
   let arguments = (ins Variadic<VHLO_AnyType>:$operand);
   let results = (outs Variadic<VHLO_AnyType>:$result);
 }
 
-def VHLO_OrOpV1 : VHLO_Op<"or", "0.9.0", "current"> {
+def VHLO_OrOpV1 : VHLO_Op<"or_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
   let results = (outs VHLO_AnyType:$result);
 }
@@ -684,7 +684,7 @@ def VHLO_OrOpV1 : VHLO_Op<"or", "0.9.0", "current"> {
 // TODO(#629): layout is not part of the StableHLO spec.
 // The notion of layouts is a work in progress, so it is not yet included in
 // the StableHLO specification.
-def VHLO_OutfeedOpV1 : VHLO_Op<"outfeed", "0.9.0", "current"> {
+def VHLO_OutfeedOpV1 : VHLO_Op<"outfeed_v1", "0.9.0", "current"> {
   let arguments = (ins
     Variadic<VHLO_AnyType>:$inputs,
     VHLO_AnyType:$token,
@@ -693,7 +693,7 @@ def VHLO_OutfeedOpV1 : VHLO_Op<"outfeed", "0.9.0", "current"> {
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_PadOpV1 : VHLO_Op<"pad", "0.9.0", "current"> {
+def VHLO_PadOpV1 : VHLO_Op<"pad_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$operand,
     VHLO_AnyType:$padding_value,
@@ -704,16 +704,16 @@ def VHLO_PadOpV1 : VHLO_Op<"pad", "0.9.0", "current"> {
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_PartitionIdOpV1 : VHLO_Op<"partition_id", "0.9.0", "current"> {
+def VHLO_PartitionIdOpV1 : VHLO_Op<"partition_id_v1", "0.9.0", "current"> {
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_PopulationCountOpV1 : VHLO_Op<"popcnt", "0.9.0", "current"> {
+def VHLO_PopulationCountOpV1 : VHLO_Op<"popcnt_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$operand);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_PowOpV1 : VHLO_Op<"power", "0.9.0", "current"> {
+def VHLO_PowOpV1 : VHLO_Op<"power_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
   let results = (outs VHLO_AnyType:$result);
 }
@@ -721,7 +721,7 @@ def VHLO_PowOpV1 : VHLO_Op<"power", "0.9.0", "current"> {
 // TODO(#8): RealDynamicSliceOp is not part of the StableHLO spec.
 // This operation is a work in progress, so it is not yet included in
 // the StableHLO specification.
-def VHLO_RealDynamicSliceOpV1 : VHLO_Op<"real_dynamic_slice", "0.9.0", "current"> {
+def VHLO_RealDynamicSliceOpV1 : VHLO_Op<"real_dynamic_slice_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$operand,
     VHLO_AnyType:$start_indices,
@@ -731,12 +731,12 @@ def VHLO_RealDynamicSliceOpV1 : VHLO_Op<"real_dynamic_slice", "0.9.0", "current"
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_RealOpV1 : VHLO_Op<"real", "0.9.0", "current"> {
+def VHLO_RealOpV1 : VHLO_Op<"real_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$operand);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_RecvOpV1 : VHLO_Op<"recv", "0.9.0", "current"> {
+def VHLO_RecvOpV1 : VHLO_Op<"recv_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$token,
     VHLO_AnyAttr:$channel_id,
@@ -746,7 +746,7 @@ def VHLO_RecvOpV1 : VHLO_Op<"recv", "0.9.0", "current"> {
   let results = (outs Variadic<VHLO_AnyType>:$results);
 }
 
-def VHLO_ReduceOpV1 : VHLO_Op<"reduce", "0.9.0", "current", [SameVariadicOperandSize]> {
+def VHLO_ReduceOpV1 : VHLO_Op<"reduce_v1", "0.9.0", "current", [SameVariadicOperandSize]> {
   let arguments = (ins
     Variadic<VHLO_AnyType>:$inputs,
     Variadic<VHLO_AnyType>:$init_values,
@@ -756,7 +756,7 @@ def VHLO_ReduceOpV1 : VHLO_Op<"reduce", "0.9.0", "current", [SameVariadicOperand
   let results = (outs Variadic<VHLO_AnyType>:$results);
 }
 
-def VHLO_ReducePrecisionOpV1 : VHLO_Op<"reduce_precision", "0.9.0", "current"> {
+def VHLO_ReducePrecisionOpV1 : VHLO_Op<"reduce_precision_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$operand,
     VHLO_AnyAttr:$exponent_bits,
@@ -765,7 +765,7 @@ def VHLO_ReducePrecisionOpV1 : VHLO_Op<"reduce_precision", "0.9.0", "current"> {
   let results = (outs VHLO_AnyType:$output);
 }
 
-def VHLO_ReduceScatterOpV1 : VHLO_Op<"reduce_scatter", "0.9.0", "current"> {
+def VHLO_ReduceScatterOpV1 : VHLO_Op<"reduce_scatter_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$operand,
     VHLO_AnyAttr:$scatter_dimension,
@@ -777,7 +777,7 @@ def VHLO_ReduceScatterOpV1 : VHLO_Op<"reduce_scatter", "0.9.0", "current"> {
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_ReduceWindowOpV1 : VHLO_Op<"reduce_window", "0.9.0", "current", [SameVariadicOperandSize]> {
+def VHLO_ReduceWindowOpV1 : VHLO_Op<"reduce_window_v1", "0.9.0", "current", [SameVariadicOperandSize]> {
   let arguments = (ins
     Variadic<VHLO_AnyType>:$inputs,
     Variadic<VHLO_AnyType>:$init_values,
@@ -791,16 +791,16 @@ def VHLO_ReduceWindowOpV1 : VHLO_Op<"reduce_window", "0.9.0", "current", [SameVa
   let results = (outs Variadic<VHLO_AnyType>:$results);
 }
 
-def VHLO_RemOpV1 : VHLO_Op<"remainder", "0.9.0", "current"> {
+def VHLO_RemOpV1 : VHLO_Op<"remainder_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_ReplicaIdOpV1 : VHLO_Op<"replica_id", "0.9.0", "current"> {
+def VHLO_ReplicaIdOpV1 : VHLO_Op<"replica_id_v1", "0.9.0", "current"> {
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_ReshapeOpV1 : VHLO_Op<"reshape", "0.9.0", "current"> {
+def VHLO_ReshapeOpV1 : VHLO_Op<"reshape_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$operand);
   let results = (outs VHLO_AnyType:$result);
 }
@@ -808,11 +808,11 @@ def VHLO_ReshapeOpV1 : VHLO_Op<"reshape", "0.9.0", "current"> {
 // TODO(#425): ReturnOp is not part of the StableHLO spec.
 // We're planning to look into it as part of the work on speccing
 // Module/Func/Call/Return ops in StableHLO.
-def VHLO_ReturnOpV1 : VHLO_Op<"return", "0.9.0", "current", [Terminator]> {
+def VHLO_ReturnOpV1 : VHLO_Op<"return_v1", "0.9.0", "current", [Terminator]> {
   let arguments = (ins Variadic<VHLO_AnyType>:$results);
 }
 
-def VHLO_ReverseOpV1 : VHLO_Op<"reverse", "0.9.0", "current"> {
+def VHLO_ReverseOpV1 : VHLO_Op<"reverse_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$operand,
     VHLO_AnyAttr:$dimensions
@@ -820,7 +820,7 @@ def VHLO_ReverseOpV1 : VHLO_Op<"reverse", "0.9.0", "current"> {
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_RngBitGeneratorOpV1 : VHLO_Op<"rng_bit_generator", "0.9.0", "current"> {
+def VHLO_RngBitGeneratorOpV1 : VHLO_Op<"rng_bit_generator_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyAttr:$rng_algorithm,
     VHLO_AnyType:$initial_state
@@ -831,7 +831,7 @@ def VHLO_RngBitGeneratorOpV1 : VHLO_Op<"rng_bit_generator", "0.9.0", "current"> 
   );
 }
 
-def VHLO_RngOpV1 : VHLO_Op<"rng", "0.9.0", "current"> {
+def VHLO_RngOpV1 : VHLO_Op<"rng_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$a,
     VHLO_AnyType:$b,
@@ -841,22 +841,22 @@ def VHLO_RngOpV1 : VHLO_Op<"rng", "0.9.0", "current"> {
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_RoundNearestEvenOpV1 : VHLO_Op<"round_nearest_even", "0.9.0", "current"> {
+def VHLO_RoundNearestEvenOpV1 : VHLO_Op<"round_nearest_even_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$operand);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_RoundOpV1 : VHLO_Op<"round_nearest_afz", "0.9.0", "current"> {
+def VHLO_RoundOpV1 : VHLO_Op<"round_nearest_afz_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$operand);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_RsqrtOpV1 : VHLO_Op<"rsqrt", "0.9.0", "current"> {
+def VHLO_RsqrtOpV1 : VHLO_Op<"rsqrt_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$operand);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_ScatterOpV1 : VHLO_Op<"scatter", "0.9.0", "current", [SameVariadicOperandSize]> {
+def VHLO_ScatterOpV1 : VHLO_Op<"scatter_v1", "0.9.0", "current", [SameVariadicOperandSize]> {
   let arguments = (ins
     Variadic<VHLO_AnyType>:$inputs,
     VHLO_AnyType:$scatter_indices,
@@ -872,7 +872,7 @@ def VHLO_ScatterOpV1 : VHLO_Op<"scatter", "0.9.0", "current", [SameVariadicOpera
   let results = (outs Variadic<VHLO_AnyType>:$results);
 }
 
-def VHLO_SelectAndScatterOpV1 : VHLO_Op<"select_and_scatter", "0.9.0", "current"> {
+def VHLO_SelectAndScatterOpV1 : VHLO_Op<"select_and_scatter_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$operand,
     VHLO_AnyType:$source,
@@ -885,7 +885,7 @@ def VHLO_SelectAndScatterOpV1 : VHLO_Op<"select_and_scatter", "0.9.0", "current"
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_SelectOpV1 : VHLO_Op<"select", "0.9.0", "current"> {
+def VHLO_SelectOpV1 : VHLO_Op<"select_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$pred,
     VHLO_AnyType:$on_true,
@@ -894,7 +894,7 @@ def VHLO_SelectOpV1 : VHLO_Op<"select", "0.9.0", "current"> {
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_SendOpV1 : VHLO_Op<"send", "0.9.0", "current"> {
+def VHLO_SendOpV1 : VHLO_Op<"send_v1", "0.9.0", "current"> {
   let arguments = (ins
     Variadic<VHLO_AnyType>:$inputs,
     VHLO_AnyType:$token,
@@ -905,7 +905,7 @@ def VHLO_SendOpV1 : VHLO_Op<"send", "0.9.0", "current"> {
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_SetDimensionSizeOpV1 : VHLO_Op<"set_dimension_size", "0.9.0", "current"> {
+def VHLO_SetDimensionSizeOpV1 : VHLO_Op<"set_dimension_size_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$operand,
     VHLO_AnyType:$size,
@@ -914,32 +914,32 @@ def VHLO_SetDimensionSizeOpV1 : VHLO_Op<"set_dimension_size", "0.9.0", "current"
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_ShiftLeftOpV1 : VHLO_Op<"shift_left", "0.9.0", "current"> {
+def VHLO_ShiftLeftOpV1 : VHLO_Op<"shift_left_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_ShiftRightArithmeticOpV1 : VHLO_Op<"shift_right_arithmetic", "0.9.0", "current"> {
+def VHLO_ShiftRightArithmeticOpV1 : VHLO_Op<"shift_right_arithmetic_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_ShiftRightLogicalOpV1 : VHLO_Op<"shift_right_logical", "0.9.0", "current"> {
+def VHLO_ShiftRightLogicalOpV1 : VHLO_Op<"shift_right_logical_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_SignOpV1 : VHLO_Op<"sign", "0.9.0", "current"> {
+def VHLO_SignOpV1 : VHLO_Op<"sign_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$operand);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_SineOpV1 : VHLO_Op<"sine", "0.9.0", "current"> {
+def VHLO_SineOpV1 : VHLO_Op<"sine_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$operand);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_SliceOpV1 : VHLO_Op<"slice", "0.9.0", "current"> {
+def VHLO_SliceOpV1 : VHLO_Op<"slice_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$operand,
     VHLO_AnyAttr:$start_indices,
@@ -949,7 +949,7 @@ def VHLO_SliceOpV1 : VHLO_Op<"slice", "0.9.0", "current"> {
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_SortOpV1 : VHLO_Op<"sort", "0.9.0", "current"> {
+def VHLO_SortOpV1 : VHLO_Op<"sort_v1", "0.9.0", "current"> {
   let arguments = (ins
     Variadic<VHLO_AnyType>:$inputs,
     VHLO_AnyAttr:$dimension,
@@ -959,17 +959,17 @@ def VHLO_SortOpV1 : VHLO_Op<"sort", "0.9.0", "current"> {
   let results = (outs Variadic<VHLO_AnyType>:$results);
 }
 
-def VHLO_SqrtOpV1 : VHLO_Op<"sqrt", "0.9.0", "current"> {
+def VHLO_SqrtOpV1 : VHLO_Op<"sqrt_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$operand);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_SubtractOpV1 : VHLO_Op<"subtract", "0.9.0", "current"> {
+def VHLO_SubtractOpV1 : VHLO_Op<"subtract_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_TanhOpV1 : VHLO_Op<"tanh", "0.9.0", "current"> {
+def VHLO_TanhOpV1 : VHLO_Op<"tanh_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$operand);
   let results = (outs VHLO_AnyType:$result);
 }
@@ -977,7 +977,7 @@ def VHLO_TanhOpV1 : VHLO_Op<"tanh", "0.9.0", "current"> {
 // TODO(#3): TorchIndexSelectOp is not part of the StableHLO spec.
 // This operation is on its way out of StableHLO, so it is not included in
 // the StableHLO specification.
-def VHLO_TorchIndexSelectOpV1 : VHLO_Op<"torch_index_select", "0.9.0", "current"> {
+def VHLO_TorchIndexSelectOpV1 : VHLO_Op<"torch_index_select_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$operand,
     VHLO_AnyType:$index,
@@ -990,14 +990,14 @@ def VHLO_TorchIndexSelectOpV1 : VHLO_Op<"torch_index_select", "0.9.0", "current"
 // TODO(#3): TraceOp is not part of the StableHLO spec.
 // This operation is on its way out of StableHLO, so it is not included in
 // the StableHLO specification.
-def VHLO_TraceOpV1 : VHLO_Op<"trace", "0.9.0", "current"> {
+def VHLO_TraceOpV1 : VHLO_Op<"trace_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$operand,
     VHLO_AnyAttr:$tag
   );
 }
 
-def VHLO_TransposeOpV1 : VHLO_Op<"transpose", "0.9.0", "current"> {
+def VHLO_TransposeOpV1 : VHLO_Op<"transpose_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$operand,
     VHLO_AnyAttr:$permutation
@@ -1005,7 +1005,7 @@ def VHLO_TransposeOpV1 : VHLO_Op<"transpose", "0.9.0", "current"> {
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_TriangularSolveOpV1 : VHLO_Op<"triangular_solve", "0.9.0", "current"> {
+def VHLO_TriangularSolveOpV1 : VHLO_Op<"triangular_solve_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$a,
     VHLO_AnyType:$b,
@@ -1017,7 +1017,7 @@ def VHLO_TriangularSolveOpV1 : VHLO_Op<"triangular_solve", "0.9.0", "current"> {
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_TupleOpV1 : VHLO_Op<"tuple", "0.9.0", "current"> {
+def VHLO_TupleOpV1 : VHLO_Op<"tuple_v1", "0.9.0", "current"> {
   let arguments = (ins Variadic<VHLO_AnyType>:$val);
   let results = (outs VHLO_AnyType:$result);
 }
@@ -1025,7 +1025,7 @@ def VHLO_TupleOpV1 : VHLO_Op<"tuple", "0.9.0", "current"> {
 // TODO(#3): UnaryEinsumOp is not part of the StableHLO spec.
 // This operation is on its way out of StableHLO, so it is not included in
 // the StableHLO specification.
-def VHLO_UnaryEinsumOpV1 : VHLO_Op<"unary_einsum", "0.9.0", "current"> {
+def VHLO_UnaryEinsumOpV1 : VHLO_Op<"unary_einsum_v1", "0.9.0", "current"> {
   let arguments = (ins
     VHLO_AnyType:$operand,
     VHLO_AnyAttr:$einsum_config
@@ -1036,7 +1036,7 @@ def VHLO_UnaryEinsumOpV1 : VHLO_Op<"unary_einsum", "0.9.0", "current"> {
 // TODO(#588): UniformDequantizeOp is not part of the StableHLO spec.
 // This operation is a work in progress, so it is not yet included in
 // the StableHLO specification.
-def VHLO_UniformDequantizeOpV1 : VHLO_Op<"uniform_dequantize", "0.9.0", "current"> {
+def VHLO_UniformDequantizeOpV1 : VHLO_Op<"uniform_dequantize_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$operand);
   let results = (outs VHLO_AnyType:$result);
 }
@@ -1044,18 +1044,18 @@ def VHLO_UniformDequantizeOpV1 : VHLO_Op<"uniform_dequantize", "0.9.0", "current
 // TODO(#588): UniformQuantizeOp is not part of the StableHLO spec.
 // This operation is a work in progress, so it is not yet included in
 // the StableHLO specification.
-def VHLO_UniformQuantizeOpV1 : VHLO_Op<"uniform_quantize", "0.9.0", "current"> {
+def VHLO_UniformQuantizeOpV1 : VHLO_Op<"uniform_quantize_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$operand);
   let results = (outs VHLO_AnyType:$result);
 }
 
-def VHLO_WhileOpV1 : VHLO_Op<"while", "0.9.0", "current"> {
+def VHLO_WhileOpV1 : VHLO_Op<"while_v1", "0.9.0", "current"> {
   let arguments = (ins Variadic<VHLO_AnyType>:$operand);
   let regions = (region VHLO_AnyRegion:$cond, VHLO_AnyRegion:$body);
   let results = (outs Variadic<VHLO_AnyType>:$results);
 }
 
-def VHLO_XorOpV1 : VHLO_Op<"xor", "0.9.0", "current"> {
+def VHLO_XorOpV1 : VHLO_Op<"xor_v1", "0.9.0", "current"> {
   let arguments = (ins VHLO_AnyType:$lhs, VHLO_AnyType:$rhs);
   let results = (outs VHLO_AnyType:$result);
 }

--- a/stablehlo/dialect/VhloTypes.td
+++ b/stablehlo/dialect/VhloTypes.td
@@ -52,10 +52,10 @@ class VHLO_TypeDef<string cppName, string name, string minVersion, string maxVer
 }
 
 // Corresponds to BooleanType from the StableHLO spec.
-def VHLO_BooleanV1 : VHLO_TypeDef<"BooleanV1", "bool", "0.9.0", "current">;
+def VHLO_BooleanV1 : VHLO_TypeDef<"BooleanV1", "bool_v1", "0.9.0", "current">;
 
 // Corresponds to ComplexType from the StableHLO spec.
-def VHLO_ComplexV1 : VHLO_TypeDef<"ComplexV1", "complex", "0.9.0", "current"> {
+def VHLO_ComplexV1 : VHLO_TypeDef<"ComplexV1", "complex_v1", "0.9.0", "current"> {
   let parameters = (ins "Type":$elementType);
   let genVerifyDecl = 1;
   let extraClassDefinition = [{
@@ -69,25 +69,25 @@ def VHLO_ComplexV1 : VHLO_TypeDef<"ComplexV1", "complex", "0.9.0", "current"> {
 }
 
 // Corresponds to the 'bf16' FloatType from the StableHLO spec.
-def VHLO_FloatBF16V1 : VHLO_TypeDef<"FloatBF16V1", "bf16", "0.9.0", "current">;
+def VHLO_FloatBF16V1 : VHLO_TypeDef<"FloatBF16V1", "bf16_v1", "0.9.0", "current">;
 
 // Corresponds to the 'f16' FloatType from the StableHLO spec.
-def VHLO_FloatF16V1 : VHLO_TypeDef<"FloatF16V1", "f16", "0.9.0", "current">;
+def VHLO_FloatF16V1 : VHLO_TypeDef<"FloatF16V1", "f16_v1", "0.9.0", "current">;
 
 // Corresponds to the 'f32' FloatType from the StableHLO spec.
-def VHLO_FloatF32V1 : VHLO_TypeDef<"FloatF32V1", "f32", "0.9.0", "current">;
+def VHLO_FloatF32V1 : VHLO_TypeDef<"FloatF32V1", "f32_v1", "0.9.0", "current">;
 
 // Corresponds to the 'f64' FloatType from the StableHLO spec.
-def VHLO_FloatF64V1 : VHLO_TypeDef<"FloatF64V1","f64", "0.9.0", "current">;
+def VHLO_FloatF64V1 : VHLO_TypeDef<"FloatF64V1","f64_v1", "0.9.0", "current">;
 
 // Corresponds to the 'f8E4M3FN' FloatType from the StableHLO spec.
-def VHLO_FloatF8E4M3FNV1 : VHLO_TypeDef<"FloatF8E4M3FNV1", "f8E4M3FN", "0.9.0", "current">;
+def VHLO_FloatF8E4M3FNV1 : VHLO_TypeDef<"FloatF8E4M3FNV1", "f8E4M3FN_v1", "0.9.0", "current">;
 
 // Corresponds to the 'f8E5M2' FloatType from the StableHLO spec.
-def VHLO_FloatF8E5M2V1 : VHLO_TypeDef<"FloatF8E5M2V1", "f8E5M2", "0.9.0", "current">;
+def VHLO_FloatF8E5M2V1 : VHLO_TypeDef<"FloatF8E5M2V1", "f8E5M2_v1", "0.9.0", "current">;
 
 // Corresponds to FunctionType from the StableHLO spec.
-def VHLO_FunctionV1 : VHLO_TypeDef<"FunctionV1", "func", "0.9.0", "current"> {
+def VHLO_FunctionV1 : VHLO_TypeDef<"FunctionV1", "func_v1", "0.9.0", "current"> {
   let parameters = (ins
     ArrayRefParameter<"::mlir::Type">:$inputs,
     ArrayRefParameter<"mlir::Type">:$outputs
@@ -109,44 +109,44 @@ def VHLO_FunctionV1 : VHLO_TypeDef<"FunctionV1", "func", "0.9.0", "current"> {
 // At the moment, it is used to represent values participating in shape
 // computations, and we're planning to look into it as part of the work on the
 // dynamism RFC.
-def VHLO_IndexV1 : VHLO_TypeDef<"IndexV1", "index", "0.9.0", "current">;
+def VHLO_IndexV1 : VHLO_TypeDef<"IndexV1", "index_v1", "0.9.0", "current">;
 
 // Corresponds to the 'si4' FloatType from the StableHLO spec.
-def VHLO_IntegerSI4V1 : VHLO_TypeDef<"IntegerSI4V1", "i4", "0.9.0", "current">;
+def VHLO_IntegerSI4V1 : VHLO_TypeDef<"IntegerSI4V1", "i4_v1", "0.9.0", "current">;
 
 // Corresponds to the 'si8' FloatType from the StableHLO spec.
-def VHLO_IntegerSI8V1 : VHLO_TypeDef<"IntegerSI8V1", "i8", "0.9.0", "current">;
+def VHLO_IntegerSI8V1 : VHLO_TypeDef<"IntegerSI8V1", "i8_v1", "0.9.0", "current">;
 
 // Corresponds to the 'si16' FloatType from the StableHLO spec.
-def VHLO_IntegerSI16V1 : VHLO_TypeDef<"IntegerSI16V1", "i16", "0.9.0", "current">;
+def VHLO_IntegerSI16V1 : VHLO_TypeDef<"IntegerSI16V1", "i16_v1", "0.9.0", "current">;
 
 // Corresponds to the 'si32' FloatType from the StableHLO spec.
-def VHLO_IntegerSI32V1 : VHLO_TypeDef<"IntegerSI32V1", "i32", "0.9.0", "current">;
+def VHLO_IntegerSI32V1 : VHLO_TypeDef<"IntegerSI32V1", "i32_v1", "0.9.0", "current">;
 
 // Corresponds to the 'si64' FloatType from the StableHLO spec.
-def VHLO_IntegerSI64V1 : VHLO_TypeDef<"IntegerSI64V1", "i64", "0.9.0", "current">;
+def VHLO_IntegerSI64V1 : VHLO_TypeDef<"IntegerSI64V1", "i64_v1", "0.9.0", "current">;
 
 // Corresponds to the 'ui4' FloatType from the StableHLO spec.
-def VHLO_IntegerUI4V1 : VHLO_TypeDef<"IntegerUI4V1", "ui4", "0.9.0", "current">;
+def VHLO_IntegerUI4V1 : VHLO_TypeDef<"IntegerUI4V1", "ui4_v1", "0.9.0", "current">;
 
 // Corresponds to the 'ui8' FloatType from the StableHLO spec.
-def VHLO_IntegerUI8V1 : VHLO_TypeDef<"IntegerUI8V1", "ui8", "0.9.0", "current">;
+def VHLO_IntegerUI8V1 : VHLO_TypeDef<"IntegerUI8V1", "ui8_v1", "0.9.0", "current">;
 
 // Corresponds to the 'ui16' FloatType from the StableHLO spec.
-def VHLO_IntegerUI16V1 : VHLO_TypeDef<"IntegerUI16V1", "ui16", "0.9.0", "current">;
+def VHLO_IntegerUI16V1 : VHLO_TypeDef<"IntegerUI16V1", "ui16_v1", "0.9.0", "current">;
 
 // Corresponds to the 'ui32' FloatType from the StableHLO spec.
-def VHLO_IntegerUI32V1 : VHLO_TypeDef<"IntegerUI32V1", "ui32", "0.9.0", "current">;
+def VHLO_IntegerUI32V1 : VHLO_TypeDef<"IntegerUI32V1", "ui32_v1", "0.9.0", "current">;
 
 // Corresponds to the 'ui64' FloatType from the StableHLO spec.
-def VHLO_IntegerUI64V1 : VHLO_TypeDef<"IntegerUI64V1", "ui64", "0.9.0", "current">;
+def VHLO_IntegerUI64V1 : VHLO_TypeDef<"IntegerUI64V1", "ui64_v1", "0.9.0", "current">;
 
 // Corresponds to TensorType from the StableHLO spec.
 // TODO(#8): Encoding is not part of the StableHLO spec.
 // At the moment, it is used to represent dimension bounds to support bounded
 // dynamism, and we're planning to look into it as part of the work on the
 // dynamism RFC.
-def VHLO_RankedTensorV1 : VHLO_TypeDef<"RankedTensorV1", "tensor", "0.9.0", "current"> {
+def VHLO_RankedTensorV1 : VHLO_TypeDef<"RankedTensorV1", "tensor_v1", "0.9.0", "current"> {
   let parameters = (ins
     VHLO_Dims:$shape,
     "::mlir::Type":$elementType,
@@ -166,10 +166,10 @@ def VHLO_RankedTensorV1 : VHLO_TypeDef<"RankedTensorV1", "tensor", "0.9.0", "cur
 }
 
 // Corresponds to TokenType from the StableHLO spec.
-def VHLO_TokenV1 : VHLO_TypeDef<"TokenV1", "token", "0.9.0", "current">;
+def VHLO_TokenV1 : VHLO_TypeDef<"TokenV1", "token_v1", "0.9.0", "current">;
 
 // Corresponds to TupleType from the StableHLO spec.
-def VHLO_TupleV1 : VHLO_TypeDef<"TupleV1", "tuple", "0.9.0", "current"> {
+def VHLO_TupleV1 : VHLO_TypeDef<"TupleV1", "tuple_v1", "0.9.0", "current"> {
   let parameters = (ins ArrayRefParameter<"::mlir::Type">:$types);
   let genVerifyDecl = 1;
   let extraClassDefinition = [{
@@ -197,7 +197,7 @@ def VHLO_APFloatV1 : APFloatParameter<""> {
   }];
   let printer = "$_printer.printFloat($_self);";
 }
-def VHLO_UniformQuantizedV1 : VHLO_TypeDef<"UniformQuantizedV1", "quant", "0.9.0", "current"> {
+def VHLO_UniformQuantizedV1 : VHLO_TypeDef<"UniformQuantizedV1", "quant_v1", "0.9.0", "current"> {
   let parameters = (ins
     "unsigned":$flags,
     "::mlir::Type":$storageType,
@@ -224,7 +224,7 @@ def VHLO_UniformQuantizedV1 : VHLO_TypeDef<"UniformQuantizedV1", "quant", "0.9.0
 // TODO(#8): UnrankedTensor is not part of the StableHLO spec.
 // At the moment, it is used to represent unranked dynamism, and we will likely
 // remove it as part of the work on the dynamism RFC.
-def VHLO_UnrankedTensorV1 : VHLO_TypeDef<"UnrankedTensorV1", "unranked_tensor", "0.9.0", "current"> {
+def VHLO_UnrankedTensorV1 : VHLO_TypeDef<"UnrankedTensorV1", "unranked_tensor_v1", "0.9.0", "current"> {
   let parameters = (ins "::mlir::Type":$elementType);
   let genVerifyDecl = 1;
   let extraClassDefinition = [{
@@ -240,6 +240,6 @@ def VHLO_UnrankedTensorV1 : VHLO_TypeDef<"UnrankedTensorV1", "unranked_tensor", 
 // TODO(#8): Witness is not part of the StableHLO spec.
 // At the moment, it is used to represent constraints for dynamic shapes,
 // and we're planning to look into it as part of the work on the dynamism RFC.
-def VHLO_WitnessV1 : VHLO_TypeDef<"WitnessV1", "witness", "0.9.0", "current">;
+def VHLO_WitnessV1 : VHLO_TypeDef<"WitnessV1", "witness_v1", "0.9.0", "current">;
 
 #endif // STABLEHLO_DIALECT_VHLO_TYPES

--- a/stablehlo/integrations/python/tests/vhlo.py
+++ b/stablehlo/integrations/python/tests/vhlo.py
@@ -30,12 +30,12 @@ def run(f):
 @run
 def test_parse():
   asm = """
-    vhlo.func @main() -> () {
-      "vhlo.return"() : () -> ()
+    vhlo.func_v1 @main() -> () {
+      "vhlo.return_v1"() : () -> ()
     } {
-      arg_attrs = #vhlo.array<[]>,
-      res_attrs = #vhlo.array<[]>,
-      sym_visibility = #vhlo.string<"public">
+      arg_attrs = #vhlo.array_v1<[]>,
+      res_attrs = #vhlo.array_v1<[]>,
+      sym_visibility = #vhlo.string_v1<"public">
     }
   """
   ir.Module.parse(asm)

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.mlir
@@ -7,7 +7,7 @@
 
 func.func @attr_comparison_direction_eq(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<i1> {
   %0 = "stablehlo.compare"(%arg0, %arg1) {
-    // CHECK: comparison_direction = #vhlo<comparison_direction EQ>
+    // CHECK: comparison_direction = #vhlo<comparison_direction_v1 EQ>
     comparison_direction = #stablehlo<comparison_direction EQ>
   } : (tensor<f32>, tensor<f32>) -> tensor<i1>
   func.return %0 : tensor<i1>
@@ -16,7 +16,7 @@ func.func @attr_comparison_direction_eq(%arg0: tensor<f32>, %arg1: tensor<f32>) 
 
 func.func @attr_comparison_direction_ne(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<i1> {
   %0 = "stablehlo.compare"(%arg0, %arg1) {
-    // CHECK: comparison_direction = #vhlo<comparison_direction NE>
+    // CHECK: comparison_direction = #vhlo<comparison_direction_v1 NE>
     comparison_direction = #stablehlo<comparison_direction NE>
   } : (tensor<f32>, tensor<f32>) -> tensor<i1>
   func.return %0 : tensor<i1>
@@ -25,7 +25,7 @@ func.func @attr_comparison_direction_ne(%arg0: tensor<f32>, %arg1: tensor<f32>) 
 
 func.func @attr_comparison_direction_ge(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<i1> {
   %0 = "stablehlo.compare"(%arg0, %arg1) {
-    // CHECK: comparison_direction = #vhlo<comparison_direction GE>
+    // CHECK: comparison_direction = #vhlo<comparison_direction_v1 GE>
     comparison_direction = #stablehlo<comparison_direction GE>
   } : (tensor<f32>, tensor<f32>) -> tensor<i1>
   func.return %0 : tensor<i1>
@@ -34,7 +34,7 @@ func.func @attr_comparison_direction_ge(%arg0: tensor<f32>, %arg1: tensor<f32>) 
 
 func.func @attr_comparison_direction_gt(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<i1> {
   %0 = "stablehlo.compare"(%arg0, %arg1) {
-    // CHECK: comparison_direction = #vhlo<comparison_direction GT>
+    // CHECK: comparison_direction = #vhlo<comparison_direction_v1 GT>
     comparison_direction = #stablehlo<comparison_direction GT>
   } : (tensor<f32>, tensor<f32>) -> tensor<i1>
   func.return %0 : tensor<i1>
@@ -43,7 +43,7 @@ func.func @attr_comparison_direction_gt(%arg0: tensor<f32>, %arg1: tensor<f32>) 
 
 func.func @attr_comparison_direction_le(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<i1> {
   %0 = "stablehlo.compare"(%arg0, %arg1) {
-    // CHECK: comparison_direction = #vhlo<comparison_direction LE>
+    // CHECK: comparison_direction = #vhlo<comparison_direction_v1 LE>
     comparison_direction = #stablehlo<comparison_direction LE>
   } : (tensor<f32>, tensor<f32>) -> tensor<i1>
   func.return %0 : tensor<i1>
@@ -52,7 +52,7 @@ func.func @attr_comparison_direction_le(%arg0: tensor<f32>, %arg1: tensor<f32>) 
 
 func.func @attr_comparison_direction_lt(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<i1> {
   %0 = "stablehlo.compare"(%arg0, %arg1) {
-    // CHECK: comparison_direction = #vhlo<comparison_direction LT>
+    // CHECK: comparison_direction = #vhlo<comparison_direction_v1 LT>
     comparison_direction = #stablehlo<comparison_direction LT>
   } : (tensor<f32>, tensor<f32>) -> tensor<i1>
   func.return %0 : tensor<i1>
@@ -62,7 +62,7 @@ func.func @attr_comparison_direction_lt(%arg0: tensor<f32>, %arg1: tensor<f32>) 
 func.func @attr_comparison_type_notype(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<i1> {
   %0 = "stablehlo.compare"(%arg0, %arg1) {
     comparison_direction = #stablehlo<comparison_direction EQ>,
-    // CHECK: compare_type = #vhlo<comparison_type NOTYPE>,
+    // CHECK: compare_type = #vhlo<comparison_type_v1 NOTYPE>,
     compare_type = #stablehlo<comparison_type NOTYPE>
   } : (tensor<f32>, tensor<f32>) -> tensor<i1>
   func.return %0 : tensor<i1>
@@ -72,7 +72,7 @@ func.func @attr_comparison_type_notype(%arg0: tensor<f32>, %arg1: tensor<f32>) -
 func.func @attr_comparison_type_float(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<i1> {
   %0 = "stablehlo.compare"(%arg0, %arg1) {
     comparison_direction = #stablehlo<comparison_direction EQ>,
-    // CHECK: compare_type = #vhlo<comparison_type FLOAT>,
+    // CHECK: compare_type = #vhlo<comparison_type_v1 FLOAT>,
     compare_type = #stablehlo<comparison_type FLOAT>
   } : (tensor<f32>, tensor<f32>) -> tensor<i1>
   func.return %0 : tensor<i1>
@@ -82,7 +82,7 @@ func.func @attr_comparison_type_float(%arg0: tensor<f32>, %arg1: tensor<f32>) ->
 func.func @attr_comparison_type_totalorder(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<i1> {
   %0 = "stablehlo.compare"(%arg0, %arg1) {
     comparison_direction = #stablehlo<comparison_direction EQ>,
-    // CHECK: compare_type = #vhlo<comparison_type TOTALORDER>,
+    // CHECK: compare_type = #vhlo<comparison_type_v1 TOTALORDER>,
     compare_type = #stablehlo<comparison_type TOTALORDER>
   } : (tensor<f32>, tensor<f32>) -> tensor<i1>
   func.return %0 : tensor<i1>
@@ -92,7 +92,7 @@ func.func @attr_comparison_type_totalorder(%arg0: tensor<f32>, %arg1: tensor<f32
 func.func @attr_comparison_type_signed(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<i1> {
   %0 = "stablehlo.compare"(%arg0, %arg1) {
     comparison_direction = #stablehlo<comparison_direction EQ>,
-    // CHECK: compare_type = #vhlo<comparison_type SIGNED>,
+    // CHECK: compare_type = #vhlo<comparison_type_v1 SIGNED>,
     compare_type = #stablehlo<comparison_type SIGNED>
   } : (tensor<f32>, tensor<f32>) -> tensor<i1>
   func.return %0 : tensor<i1>
@@ -102,7 +102,7 @@ func.func @attr_comparison_type_signed(%arg0: tensor<f32>, %arg1: tensor<f32>) -
 func.func @attr_comparison_type_unsigned(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<i1> {
   %0 = "stablehlo.compare"(%arg0, %arg1) {
     comparison_direction = #stablehlo<comparison_direction EQ>,
-    // CHECK: compare_type = #vhlo<comparison_type UNSIGNED>,
+    // CHECK: compare_type = #vhlo<comparison_type_v1 UNSIGNED>,
     compare_type = #stablehlo<comparison_type UNSIGNED>
   } : (tensor<f32>, tensor<f32>) -> tensor<i1>
   func.return %0 : tensor<i1>
@@ -114,7 +114,7 @@ func.func @attr_comparison_type_unsigned(%arg0: tensor<f32>, %arg1: tensor<f32>)
 func.func @attr_custom_call_api_version_unspecified(%arg0: tensor<f32>) -> tensor<f32> {
   %0 = "stablehlo.custom_call"(%arg0) {
     call_target_name = "foo",
-    // CHECK: api_version = #vhlo<api_version API_VERSION_UNSPECIFIED>
+    // CHECK: api_version = #vhlo<api_version_v1 API_VERSION_UNSPECIFIED>
     api_version = 0 : i32
   } : (tensor<f32>) -> tensor<f32>
   func.return %0 : tensor<f32>
@@ -124,7 +124,7 @@ func.func @attr_custom_call_api_version_unspecified(%arg0: tensor<f32>) -> tenso
 func.func @attr_custom_call_api_version_original(%arg0: tensor<f32>) -> tensor<f32> {
   %0 = "stablehlo.custom_call"(%arg0) {
     call_target_name = "foo",
-    // CHECK: api_version = #vhlo<api_version API_VERSION_ORIGINAL>
+    // CHECK: api_version = #vhlo<api_version_v1 API_VERSION_ORIGINAL>
     api_version = 1 : i32
   } : (tensor<f32>) -> tensor<f32>
   func.return %0 : tensor<f32>
@@ -134,7 +134,7 @@ func.func @attr_custom_call_api_version_original(%arg0: tensor<f32>) -> tensor<f
 func.func @attr_custom_call_api_version_status_returning(%arg0: tensor<f32>) -> tensor<f32> {
   %0 = "stablehlo.custom_call"(%arg0) {
     call_target_name = "foo",
-    // CHECK: api_version = #vhlo<api_version API_VERSION_STATUS_RETURNING>
+    // CHECK: api_version = #vhlo<api_version_v1 API_VERSION_STATUS_RETURNING>
     api_version = 2 : i32
   } : (tensor<f32>) -> tensor<f32>
   func.return %0 : tensor<f32>
@@ -144,7 +144,7 @@ func.func @attr_custom_call_api_version_status_returning(%arg0: tensor<f32>) -> 
 func.func @attr_custom_call_api_version_status_returning_unified(%arg0: tensor<f32>) -> tensor<f32> {
   %0 = "stablehlo.custom_call"(%arg0) {
     call_target_name = "foo",
-    // CHECK: api_version = #vhlo<api_version API_VERSION_STATUS_RETURNING_UNIFIED>
+    // CHECK: api_version = #vhlo<api_version_v1 API_VERSION_STATUS_RETURNING_UNIFIED>
     api_version = 3 : i32
   } : (tensor<f32>) -> tensor<f32>
   func.return %0 : tensor<f32>
@@ -155,7 +155,7 @@ func.func @attr_custom_call_api_version_status_returning_unified(%arg0: tensor<f
 
 func.func @attr_fft_type_fft(%arg0: tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>> {
   %0 = "stablehlo.fft"(%arg0) {
-    // CHECK: fft_type = #vhlo<fft_type FFT>
+    // CHECK: fft_type = #vhlo<fft_type_v1 FFT>
     fft_type = #stablehlo<fft_type FFT>,
     fft_length = dense<16> : tensor<1xi64>
   } : (tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>>
@@ -165,7 +165,7 @@ func.func @attr_fft_type_fft(%arg0: tensor<16xcomplex<f32>>) -> tensor<16xcomple
 
 func.func @attr_fft_type_ifft(%arg0: tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>> {
   %0 = "stablehlo.fft"(%arg0) {
-    // CHECK: fft_type = #vhlo<fft_type IFFT>
+    // CHECK: fft_type = #vhlo<fft_type_v1 IFFT>
     fft_type = #stablehlo<fft_type IFFT>,
     fft_length = dense<16> : tensor<1xi64>
   } : (tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>>
@@ -175,7 +175,7 @@ func.func @attr_fft_type_ifft(%arg0: tensor<16xcomplex<f32>>) -> tensor<16xcompl
 
 func.func @attr_fft_type_rfft(%arg0: tensor<16xf32>) -> tensor<9xcomplex<f32>> {
   %0 = "stablehlo.fft"(%arg0) {
-    // CHECK: fft_type = #vhlo<fft_type RFFT>
+    // CHECK: fft_type = #vhlo<fft_type_v1 RFFT>
     fft_type = #stablehlo<fft_type RFFT>,
     fft_length = dense<16> : tensor<1xi64>
   } : (tensor<16xf32>) -> tensor<9xcomplex<f32>>
@@ -185,7 +185,7 @@ func.func @attr_fft_type_rfft(%arg0: tensor<16xf32>) -> tensor<9xcomplex<f32>> {
 
 func.func @attr_fft_type_irfft(%arg0: tensor<9xcomplex<f32>>) -> tensor<16xf32> {
   %0 = "stablehlo.fft"(%arg0) {
-    // CHECK: fft_type = #vhlo<fft_type IRFFT>
+    // CHECK: fft_type = #vhlo<fft_type_v1 IRFFT>
     fft_type = #stablehlo<fft_type IRFFT>,
     fft_length = dense<16> : tensor<1xi64>
   } : (tensor<9xcomplex<f32>>) -> tensor<16xf32>
@@ -197,7 +197,7 @@ func.func @attr_fft_type_irfft(%arg0: tensor<9xcomplex<f32>>) -> tensor<16xf32> 
 
 func.func @attr_precision_config_default(%arg0: tensor<8x16xf32>, %arg1: tensor<16x8xf32>) -> tensor<8x8xf32> {
   %0 = "stablehlo.dot"(%arg0, %arg1) {
-    // CHECK: precision_config = #vhlo.array<[#vhlo<precision DEFAULT>, #vhlo<precision DEFAULT>]>
+    // CHECK: precision_config = #vhlo.array_v1<[#vhlo<precision_v1 DEFAULT>, #vhlo<precision_v1 DEFAULT>]>
     precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
   } : (tensor<8x16xf32>, tensor<16x8xf32>) -> tensor<8x8xf32>
   func.return %0 : tensor<8x8xf32>
@@ -206,7 +206,7 @@ func.func @attr_precision_config_default(%arg0: tensor<8x16xf32>, %arg1: tensor<
 
 func.func @attr_precision_config_high(%arg0: tensor<8x16xf32>, %arg1: tensor<16x8xf32>) -> tensor<8x8xf32> {
   %0 = "stablehlo.dot"(%arg0, %arg1) {
-    // CHECK: precision_config = #vhlo.array<[#vhlo<precision HIGH>, #vhlo<precision HIGH>]>
+    // CHECK: precision_config = #vhlo.array_v1<[#vhlo<precision_v1 HIGH>, #vhlo<precision_v1 HIGH>]>
     precision_config = [#stablehlo<precision HIGH>, #stablehlo<precision HIGH>]
   } : (tensor<8x16xf32>, tensor<16x8xf32>) -> tensor<8x8xf32>
   func.return %0 : tensor<8x8xf32>
@@ -215,7 +215,7 @@ func.func @attr_precision_config_high(%arg0: tensor<8x16xf32>, %arg1: tensor<16x
 
 func.func @attr_precision_config_highest(%arg0: tensor<8x16xf32>, %arg1: tensor<16x8xf32>) -> tensor<8x8xf32> {
   %0 = "stablehlo.dot"(%arg0, %arg1) {
-    // CHECK: precision_config = #vhlo.array<[#vhlo<precision HIGHEST>, #vhlo<precision HIGHEST>]>
+    // CHECK: precision_config = #vhlo.array_v1<[#vhlo<precision_v1 HIGHEST>, #vhlo<precision_v1 HIGHEST>]>
     precision_config = [#stablehlo<precision HIGHEST>, #stablehlo<precision HIGHEST>]
   } : (tensor<8x16xf32>, tensor<16x8xf32>) -> tensor<8x8xf32>
   func.return %0 : tensor<8x8xf32>
@@ -224,7 +224,7 @@ func.func @attr_precision_config_highest(%arg0: tensor<8x16xf32>, %arg1: tensor<
 
 func.func @attr_rng_algorithm_default(%arg0: tensor<f32>) -> (tensor<f32>, tensor<f32>) {
   %0:2 = "stablehlo.rng_bit_generator"(%arg0) {
-    // CHECK: rng_algorithm = #vhlo<rng_algorithm DEFAULT>
+    // CHECK: rng_algorithm = #vhlo<rng_algorithm_v1 DEFAULT>
     rng_algorithm = #stablehlo<rng_algorithm DEFAULT>
   } : (tensor<f32>) -> (tensor<f32>, tensor<f32>)
   func.return %0#0, %0#1 : tensor<f32>, tensor<f32>
@@ -233,7 +233,7 @@ func.func @attr_rng_algorithm_default(%arg0: tensor<f32>) -> (tensor<f32>, tenso
 
 func.func @attr_rng_algorithm_three_fry(%arg0: tensor<f32>) -> (tensor<f32>, tensor<f32>) {
   %0:2 = "stablehlo.rng_bit_generator"(%arg0) {
-    // CHECK: rng_algorithm = #vhlo<rng_algorithm THREE_FRY>
+    // CHECK: rng_algorithm = #vhlo<rng_algorithm_v1 THREE_FRY>
     rng_algorithm = #stablehlo<rng_algorithm THREE_FRY>
   } : (tensor<f32>) -> (tensor<f32>, tensor<f32>)
   func.return %0#0, %0#1 : tensor<f32>, tensor<f32>
@@ -242,7 +242,7 @@ func.func @attr_rng_algorithm_three_fry(%arg0: tensor<f32>) -> (tensor<f32>, ten
 
 func.func @attr_rng_algorithm_philox(%arg0: tensor<f32>) -> (tensor<f32>, tensor<f32>) {
   %0:2 = "stablehlo.rng_bit_generator"(%arg0) {
-    // CHECK: rng_algorithm = #vhlo<rng_algorithm PHILOX>
+    // CHECK: rng_algorithm = #vhlo<rng_algorithm_v1 PHILOX>
     rng_algorithm = #stablehlo<rng_algorithm PHILOX>
   } : (tensor<f32>) -> (tensor<f32>, tensor<f32>)
   func.return %0#0, %0#1 : tensor<f32>, tensor<f32>
@@ -251,7 +251,7 @@ func.func @attr_rng_algorithm_philox(%arg0: tensor<f32>) -> (tensor<f32>, tensor
 
 func.func @attr_rng_distribution_uniform(%arg0: tensor<f32>, %arg1: tensor<f32>, %arg2: tensor<?xindex>) -> tensor<f32> {
   %0 = "stablehlo.rng"(%arg0, %arg1, %arg2) {
-    // CHECK: rng_distribution = #vhlo<rng_distribution UNIFORM>
+    // CHECK: rng_distribution = #vhlo<rng_distribution_v1 UNIFORM>
     rng_distribution = #stablehlo<rng_distribution UNIFORM>
   } : (tensor<f32>, tensor<f32>, tensor<?xindex>) -> tensor<f32>
   func.return %0 : tensor<f32>
@@ -260,7 +260,7 @@ func.func @attr_rng_distribution_uniform(%arg0: tensor<f32>, %arg1: tensor<f32>,
 
 func.func @attr_rng_distribution_normal(%arg0: tensor<f32>, %arg1: tensor<f32>, %arg2: tensor<?xindex>) -> tensor<f32> {
   %0 = "stablehlo.rng"(%arg0, %arg1, %arg2) {
-    // CHECK: rng_distribution = #vhlo<rng_distribution NORMAL>
+    // CHECK: rng_distribution = #vhlo<rng_distribution_v1 NORMAL>
     rng_distribution = #stablehlo<rng_distribution NORMAL>
   } : (tensor<f32>, tensor<f32>, tensor<?xindex>) -> tensor<f32>
   func.return %0 : tensor<f32>
@@ -274,7 +274,7 @@ func.func @attr_transpose_no_transpose(%arg0: tensor<16x16xf32>, %arg1: tensor<1
     left_side = true,
     lower = true,
     unit_diagonal = true,
-    // transpose_a = #vhlo<transpose NO_TRANSPOSE>,
+    // transpose_a = #vhlo<transpose_v1 NO_TRANSPOSE>,
     transpose_a = #stablehlo<transpose NO_TRANSPOSE>
   } : (tensor<16x16xf32>, tensor<16x16xf32>) -> tensor<16x16xf32>
   func.return %0 : tensor<16x16xf32>
@@ -286,7 +286,7 @@ func.func @attr_transpose_transpose(%arg0: tensor<16x16xf32>, %arg1: tensor<16x1
     left_side = true,
     lower = true,
     unit_diagonal = true,
-    // transpose_a = #vhlo<transpose TRANSPOSE>,
+    // transpose_a = #vhlo<transpose_v1 TRANSPOSE>,
     transpose_a = #stablehlo<transpose TRANSPOSE>
   } : (tensor<16x16xf32>, tensor<16x16xf32>) -> tensor<16x16xf32>
   func.return %0 : tensor<16x16xf32>
@@ -298,7 +298,7 @@ func.func @attr_transpose_adjoint(%arg0: tensor<16x16xf32>, %arg1: tensor<16x16x
     left_side = true,
     lower = true,
     unit_diagonal = true,
-    // transpose_a = #vhlo<transpose ADJOINT>,
+    // transpose_a = #vhlo<transpose_v1 ADJOINT>,
     transpose_a = #stablehlo<transpose ADJOINT>
   } : (tensor<16x16xf32>, tensor<16x16xf32>) -> tensor<16x16xf32>
   func.return %0 : tensor<16x16xf32>
@@ -310,7 +310,7 @@ func.func @attr_transpose_adjoint(%arg0: tensor<16x16xf32>, %arg1: tensor<16x16x
 func.func @attr_type_extensions_bounds(
     %arg0: tensor<?x?xf32, #stablehlo.type_extensions<bounds = [16, ?]>>)
     -> tensor<?x?xf32, #stablehlo.type_extensions<bounds = [16, ?]>> {
-  // CHECK: "vhlo.return"(%arg0) : (!vhlo.tensor<?x?x!vhlo.f32, #vhlo.type_extensions<bounds = [16, ?]>>) -> ()
+  // CHECK: "vhlo.return_v1"(%arg0) : (!vhlo.tensor_v1<?x?x!vhlo.f32_v1, #vhlo.type_extensions_v1<bounds = [16, ?]>>) -> ()
   func.return %arg0 : tensor<?x?xf32, #stablehlo.type_extensions<bounds = [16, ?]>>
 }
 
@@ -319,12 +319,12 @@ func.func @attr_type_extensions_bounds(
 // ============ DEFAULTS ============
 
 func.func @default_all_gather(%arg0: tensor<16x8xf32>) -> tensor<16x16xf32> {
-  //               CHECK: "vhlo.all_gather"(%arg0) {
-  //          CHECK-SAME:   all_gather_dim = #vhlo.integer<1 : i64>
-  //          CHECK-SAME:   channel_id = #vhlo.integer<0 : i64>,
-  // CHECK-SAME{LITERAL}:   replica_groups = #vhlo.tensor<dense<[[0], [1]]> : tensor<2x1xi64>>,
-  //          CHECK-SAME:   use_global_device_ids = #vhlo.bool<false>
-  //          CHECK-SAME: } : (!vhlo.tensor<16x8x!vhlo.f32>) -> !vhlo.tensor<16x16x!vhlo.f32>
+  //               CHECK: "vhlo.all_gather_v1"(%arg0) {
+  //          CHECK-SAME:   all_gather_dim = #vhlo.integer_v1<1 : i64>
+  //          CHECK-SAME:   channel_id = #vhlo.integer_v1<0 : i64>,
+  // CHECK-SAME{LITERAL}:   replica_groups = #vhlo.tensor_v1<dense<[[0], [1]]> : tensor<2x1xi64>>,
+  //          CHECK-SAME:   use_global_device_ids = #vhlo.bool_v1<false>
+  //          CHECK-SAME: } : (!vhlo.tensor_v1<16x8x!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x16x!vhlo.f32_v1>
   %0 = "stablehlo.all_gather"(%arg0) {
     all_gather_dim = 1 : i64,
     replica_groups = dense<[[0], [1]]> : tensor<2x1xi64>
@@ -334,15 +334,15 @@ func.func @default_all_gather(%arg0: tensor<16x8xf32>) -> tensor<16x16xf32> {
 // CHECK-LABEL: "default_all_gather"
 
 func.func @default_all_reduce(%arg0: tensor<f32>) -> tensor<f32> {
-  //               CHECK: "vhlo.all_reduce"(%arg0) ({
-  //          CHECK-NEXT:   ^[[BB:bb.*]](%[[ARG1:arg.*]]: !vhlo.tensor<!vhlo.f32>, %[[ARG2:arg.*]]: !vhlo.tensor<!vhlo.f32>):
-  //          CHECK-NEXT:     %[[VAL1:.*]] = "vhlo.add"(%[[ARG1]], %[[ARG2]]) : (!vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
-  //          CHECK-NEXT:     "vhlo.return"(%[[VAL1]]) : (!vhlo.tensor<!vhlo.f32>) -> ()
+  //               CHECK: "vhlo.all_reduce_v1"(%arg0) ({
+  //          CHECK-NEXT:   ^[[BB:bb.*]](%[[ARG1:arg.*]]: !vhlo.tensor_v1<!vhlo.f32_v1>, %[[ARG2:arg.*]]: !vhlo.tensor_v1<!vhlo.f32_v1>):
+  //          CHECK-NEXT:     %[[VAL1:.*]] = "vhlo.add_v1"(%[[ARG1]], %[[ARG2]]) : (!vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
+  //          CHECK-NEXT:     "vhlo.return_v1"(%[[VAL1]]) : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> ()
   //          CHECK-NEXT: }) {
-  //          CHECK-SAME:   channel_id = #vhlo.integer<0 : i64>,
-  // CHECK-SAME{LITERAL}:   replica_groups = #vhlo.tensor<dense<[[0], [1]]> : tensor<2x1xi64>>,
-  //          CHECK-SAME:   use_global_device_ids = #vhlo.bool<false>
-  //          CHECK-SAME: } : (!vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
+  //          CHECK-SAME:   channel_id = #vhlo.integer_v1<0 : i64>,
+  // CHECK-SAME{LITERAL}:   replica_groups = #vhlo.tensor_v1<dense<[[0], [1]]> : tensor<2x1xi64>>,
+  //          CHECK-SAME:   use_global_device_ids = #vhlo.bool_v1<false>
+  //          CHECK-SAME: } : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.all_reduce"(%arg0) ({
     ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
       %1 = "stablehlo.add"(%arg1, %arg2) : (tensor<f32>, tensor<f32>) -> tensor<f32>
@@ -355,13 +355,13 @@ func.func @default_all_reduce(%arg0: tensor<f32>) -> tensor<f32> {
 // CHECK-LABEL: "default_all_reduce"
 
 func.func @default_all_to_all(%arg0: tensor<4x16xf32>) -> tensor<16x4xf32> {
-  //               CHECK: "vhlo.all_to_all"(%arg0) {
-  //          CHECK-SAME:   channel_id = #vhlo.integer<0 : i64>,
-  //          CHECK-SAME:   concat_dimension = #vhlo.integer<0 : i64>,
-  // CHECK-SAME{LITERAL}:   replica_groups = #vhlo.tensor<dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>>,
-  //          CHECK-SAME:   split_count = #vhlo.integer<4 : i64>
-  //          CHECK-SAME:   split_dimension = #vhlo.integer<1 : i64>
-  //          CHECK-SAME: } : (!vhlo.tensor<4x16x!vhlo.f32>) -> !vhlo.tensor<16x4x!vhlo.f32>
+  //               CHECK: "vhlo.all_to_all_v1"(%arg0) {
+  //          CHECK-SAME:   channel_id = #vhlo.integer_v1<0 : i64>,
+  //          CHECK-SAME:   concat_dimension = #vhlo.integer_v1<0 : i64>,
+  // CHECK-SAME{LITERAL}:   replica_groups = #vhlo.tensor_v1<dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>>,
+  //          CHECK-SAME:   split_count = #vhlo.integer_v1<4 : i64>
+  //          CHECK-SAME:   split_dimension = #vhlo.integer_v1<1 : i64>
+  //          CHECK-SAME: } : (!vhlo.tensor_v1<4x16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x4x!vhlo.f32_v1>
   %0 = "stablehlo.all_to_all"(%arg0) {
     split_dimension = 1 : i64,
     concat_dimension = 0 : i64,
@@ -373,19 +373,19 @@ func.func @default_all_to_all(%arg0: tensor<4x16xf32>) -> tensor<16x4xf32> {
 // CHECK-LABEL: "default_all_to_all"
 
 func.func @default_cholesky(%arg0: tensor<1x16x16xf32>) -> tensor<1x16x16xf32> {
-  //      CHECK: "vhlo.cholesky"(%arg0) {
-  // CHECK-SAME:   lower = #vhlo.bool<false>
-  // CHECK-SAME: } : (!vhlo.tensor<1x16x16x!vhlo.f32>) -> !vhlo.tensor<1x16x16x!vhlo.f32>
+  //      CHECK: "vhlo.cholesky_v1"(%arg0) {
+  // CHECK-SAME:   lower = #vhlo.bool_v1<false>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<1x16x16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<1x16x16x!vhlo.f32_v1>
   %0 = "stablehlo.cholesky"(%arg0) : (tensor<1x16x16xf32>) -> tensor<1x16x16xf32>
   func.return %0 : tensor<1x16x16xf32>
 }
 // CHECK-LABEL: "default_cholesky"
 
 func.func @default_collective_permute(%arg0: tensor<16x8xf32>) -> tensor<16x8xf32> {
-  //               CHECK: "vhlo.collective_permute"(%arg0) {
-  //          CHECK-SAME:   channel_id = #vhlo.integer<0 : i64>,
-  // CHECK-SAME{LITERAL}:   source_target_pairs = #vhlo.tensor<dense<[[0, 1], [1, 2], [2, 3]]> : tensor<3x2xi64>>
-  //          CHECK-SAME: } : (!vhlo.tensor<16x8x!vhlo.f32>) -> !vhlo.tensor<16x8x!vhlo.f32>
+  //               CHECK: "vhlo.collective_permute_v1"(%arg0) {
+  //          CHECK-SAME:   channel_id = #vhlo.integer_v1<0 : i64>,
+  // CHECK-SAME{LITERAL}:   source_target_pairs = #vhlo.tensor_v1<dense<[[0, 1], [1, 2], [2, 3]]> : tensor<3x2xi64>>
+  //          CHECK-SAME: } : (!vhlo.tensor_v1<16x8x!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x8x!vhlo.f32_v1>
   %0 = "stablehlo.collective_permute"(%arg0) {
     source_target_pairs = dense<[[0, 1], [1, 2], [2, 3]]> : tensor<3x2xi64>
   } : (tensor<16x8xf32>) -> tensor<16x8xf32>
@@ -394,10 +394,10 @@ func.func @default_collective_permute(%arg0: tensor<16x8xf32>) -> tensor<16x8xf3
 // CHECK-LABEL: "default_collective_permute"
 
 func.func @default_compare(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<i1> {
-  //      CHECK: "vhlo.compare"(%arg0, %arg1) {
-  // CHECK-SAME:   compare_type = #vhlo<comparison_type NOTYPE>,
-  // CHECK-SAME:   comparison_direction = #vhlo<comparison_direction EQ>
-  // CHECK-SAME: } : (!vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.bool>
+  //      CHECK: "vhlo.compare_v1"(%arg0, %arg1) {
+  // CHECK-SAME:   compare_type = #vhlo<comparison_type_v1 NOTYPE>,
+  // CHECK-SAME:   comparison_direction = #vhlo<comparison_direction_v1 EQ>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.bool_v1>
   %0 = "stablehlo.compare"(%arg0, %arg1) {
     comparison_direction = #stablehlo<comparison_direction EQ>
   } : (tensor<f32>, tensor<f32>) -> tensor<i1>
@@ -406,25 +406,25 @@ func.func @default_compare(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<i1>
 // CHECK-LABEL: "default_compare"
 
 func.func @default_convolution(%arg0: tensor<1x8x8x207xf32>, %arg1: tensor<3x3x207x16xf32>) -> tensor<1x6x6x16xf32> {
-  //      CHECK: "vhlo.convolution"(%arg0, %arg1) {
-  // CHECK-SAME:   batch_group_count = #vhlo.integer<1 : i64>,
-  // CHECK-SAME:   feature_group_count = #vhlo.integer<1 : i64>,
-  // CHECK-SAME:   input_batch_dimension = #vhlo.integer<0 : i64>,
-  // CHECK-SAME:   input_feature_dimension = #vhlo.integer<3 : i64>,
-  // CHECK-SAME:   input_spatial_dimensions = #vhlo.tensor<dense<[1, 2]> : tensor<2xi64>>,
-  // CHECK-SAME:   kernel_input_feature_dimension = #vhlo.integer<2 : i64>,
-  // CHECK-SAME:   kernel_output_feature_dimension = #vhlo.integer<3 : i64>,
-  // CHECK-SAME:   kernel_spatial_dimensions = #vhlo.tensor<dense<[0, 1]> : tensor<2xi64>>,
-  // CHECK-SAME:   lhs_dilation = #vhlo.tensor<dense<1> : tensor<2xi64>>,
-  // CHECK-SAME:   output_batch_dimension = #vhlo.integer<0 : i64>,
-  // CHECK-SAME:   output_feature_dimension = #vhlo.integer<3 : i64>,
-  // CHECK-SAME:   output_spatial_dimensions = #vhlo.tensor<dense<[1, 2]> : tensor<2xi64>>,
-  // CHECK-SAME:   padding = #vhlo.tensor<dense<0> : tensor<2x2xi64>>,
-  // CHECK-SAME:   precision_config = #vhlo.array<[#vhlo<precision DEFAULT>, #vhlo<precision DEFAULT>]>,
-  // CHECK-SAME:   rhs_dilation = #vhlo.tensor<dense<1> : tensor<2xi64>>,
-  // CHECK-SAME:   window_reversal = #vhlo.tensor<dense<false> : tensor<2xi1>>,
-  // CHECK-SAME:   window_strides = #vhlo.tensor<dense<1> : tensor<2xi64>>
-  // CHECK-SAME: } : (!vhlo.tensor<1x8x8x207x!vhlo.f32>, !vhlo.tensor<3x3x207x16x!vhlo.f32>) -> !vhlo.tensor<1x6x6x16x!vhlo.f32>
+  //      CHECK: "vhlo.convolution_v1"(%arg0, %arg1) {
+  // CHECK-SAME:   batch_group_count = #vhlo.integer_v1<1 : i64>,
+  // CHECK-SAME:   feature_group_count = #vhlo.integer_v1<1 : i64>,
+  // CHECK-SAME:   input_batch_dimension = #vhlo.integer_v1<0 : i64>,
+  // CHECK-SAME:   input_feature_dimension = #vhlo.integer_v1<3 : i64>,
+  // CHECK-SAME:   input_spatial_dimensions = #vhlo.tensor_v1<dense<[1, 2]> : tensor<2xi64>>,
+  // CHECK-SAME:   kernel_input_feature_dimension = #vhlo.integer_v1<2 : i64>,
+  // CHECK-SAME:   kernel_output_feature_dimension = #vhlo.integer_v1<3 : i64>,
+  // CHECK-SAME:   kernel_spatial_dimensions = #vhlo.tensor_v1<dense<[0, 1]> : tensor<2xi64>>,
+  // CHECK-SAME:   lhs_dilation = #vhlo.tensor_v1<dense<1> : tensor<2xi64>>,
+  // CHECK-SAME:   output_batch_dimension = #vhlo.integer_v1<0 : i64>,
+  // CHECK-SAME:   output_feature_dimension = #vhlo.integer_v1<3 : i64>,
+  // CHECK-SAME:   output_spatial_dimensions = #vhlo.tensor_v1<dense<[1, 2]> : tensor<2xi64>>,
+  // CHECK-SAME:   padding = #vhlo.tensor_v1<dense<0> : tensor<2x2xi64>>,
+  // CHECK-SAME:   precision_config = #vhlo.array_v1<[#vhlo<precision_v1 DEFAULT>, #vhlo<precision_v1 DEFAULT>]>,
+  // CHECK-SAME:   rhs_dilation = #vhlo.tensor_v1<dense<1> : tensor<2xi64>>,
+  // CHECK-SAME:   window_reversal = #vhlo.tensor_v1<dense<false> : tensor<2xi1>>,
+  // CHECK-SAME:   window_strides = #vhlo.tensor_v1<dense<1> : tensor<2xi64>>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<1x8x8x207x!vhlo.f32_v1>, !vhlo.tensor_v1<3x3x207x16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<1x6x6x16x!vhlo.f32_v1>
   %0 = "stablehlo.convolution"(%arg0, %arg1) {
     dimension_numbers = #stablehlo.conv<[b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f]>,
     feature_group_count = 1 : i64,
@@ -435,16 +435,16 @@ func.func @default_convolution(%arg0: tensor<1x8x8x207xf32>, %arg1: tensor<3x3x2
 // CHECK-LABEL: "default_convolution"
 
 func.func @default_custom_call(%arg0: tensor<f32>) -> tensor<f32> {
-  //      CHECK: "vhlo.custom_call"(%arg0) {
-  // CHECK-SAME:   api_version = #vhlo<api_version API_VERSION_ORIGINAL>,
-  // CHECK-SAME:   backend_config = #vhlo.string<"">,
-  // CHECK-SAME:   call_target_name = #vhlo.string<"foo">,
-  // CHECK-SAME:   called_computations = #vhlo.array<[]>,
-  // CHECK-SAME:   has_side_effect = #vhlo.bool<false>,
-  // CHECK-SAME:   operand_layouts = #vhlo.array<[]>,
-  // CHECK-SAME:   output_operand_aliases = #vhlo.array<[]>
-  // CHECK-SAME:   result_layouts = #vhlo.array<[]>
-  // CHECK-SAME: } : (!vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
+  //      CHECK: "vhlo.custom_call_v1"(%arg0) {
+  // CHECK-SAME:   api_version = #vhlo<api_version_v1 API_VERSION_ORIGINAL>,
+  // CHECK-SAME:   backend_config = #vhlo.string_v1<"">,
+  // CHECK-SAME:   call_target_name = #vhlo.string_v1<"foo">,
+  // CHECK-SAME:   called_computations = #vhlo.array_v1<[]>,
+  // CHECK-SAME:   has_side_effect = #vhlo.bool_v1<false>,
+  // CHECK-SAME:   operand_layouts = #vhlo.array_v1<[]>,
+  // CHECK-SAME:   output_operand_aliases = #vhlo.array_v1<[]>
+  // CHECK-SAME:   result_layouts = #vhlo.array_v1<[]>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.custom_call"(%arg0) {
     call_target_name = "foo"
   } : (tensor<f32>) -> tensor<f32>
@@ -453,13 +453,13 @@ func.func @default_custom_call(%arg0: tensor<f32>) -> tensor<f32> {
 // CHECK-LABEL: "default_custom_call"
 
 func.func @default_dot_general(%arg0: tensor<8x8x16xf32>, %arg1: tensor<8x16x8xf32>) -> tensor<8x8x8xf32> {
-  //      CHECK: "vhlo.dot_general"(%arg0, %arg1) {
-  // CHECK-SAME:   lhs_batching_dimensions = #vhlo.tensor<dense<0> : tensor<1xi64>>,
-  // CHECK-SAME:   lhs_contracting_dimensions = #vhlo.tensor<dense<2> : tensor<1xi64>>,
-  // CHECK-SAME:   precision_config = #vhlo.array<[#vhlo<precision DEFAULT>, #vhlo<precision DEFAULT>]>,
-  // CHECK-SAME:   rhs_batching_dimensions = #vhlo.tensor<dense<0> : tensor<1xi64>>,
-  // CHECK-SAME:   rhs_contracting_dimensions = #vhlo.tensor<dense<1> : tensor<1xi64>>
-  // CHECK-SAME: } : (!vhlo.tensor<8x8x16x!vhlo.f32>, !vhlo.tensor<8x16x8x!vhlo.f32>) -> !vhlo.tensor<8x8x8x!vhlo.f32>
+  //      CHECK: "vhlo.dot_general_v1"(%arg0, %arg1) {
+  // CHECK-SAME:   lhs_batching_dimensions = #vhlo.tensor_v1<dense<0> : tensor<1xi64>>,
+  // CHECK-SAME:   lhs_contracting_dimensions = #vhlo.tensor_v1<dense<2> : tensor<1xi64>>,
+  // CHECK-SAME:   precision_config = #vhlo.array_v1<[#vhlo<precision_v1 DEFAULT>, #vhlo<precision_v1 DEFAULT>]>,
+  // CHECK-SAME:   rhs_batching_dimensions = #vhlo.tensor_v1<dense<0> : tensor<1xi64>>,
+  // CHECK-SAME:   rhs_contracting_dimensions = #vhlo.tensor_v1<dense<1> : tensor<1xi64>>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<8x8x16x!vhlo.f32_v1>, !vhlo.tensor_v1<8x16x8x!vhlo.f32_v1>) -> !vhlo.tensor_v1<8x8x8x!vhlo.f32_v1>
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
       lhs_batching_dimensions = [0],
@@ -473,20 +473,20 @@ func.func @default_dot_general(%arg0: tensor<8x8x16xf32>, %arg1: tensor<8x16x8xf
 // CHECK-LABEL: "default_dot_general"
 
 func.func @default_dot(%arg0: tensor<8x16xf32>, %arg1: tensor<16x8xf32>) -> tensor<8x8xf32> {
-  //      CHECK: "vhlo.dot"(%arg0, %arg1) {
-  // CHECK-SAME:   precision_config = #vhlo.array<[#vhlo<precision DEFAULT>, #vhlo<precision DEFAULT>]>
-  // CHECK-SAME: } : (!vhlo.tensor<8x16x!vhlo.f32>, !vhlo.tensor<16x8x!vhlo.f32>) -> !vhlo.tensor<8x8x!vhlo.f32>
+  //      CHECK: "vhlo.dot_v1"(%arg0, %arg1) {
+  // CHECK-SAME:   precision_config = #vhlo.array_v1<[#vhlo<precision_v1 DEFAULT>, #vhlo<precision_v1 DEFAULT>]>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<8x16x!vhlo.f32_v1>, !vhlo.tensor_v1<16x8x!vhlo.f32_v1>) -> !vhlo.tensor_v1<8x8x!vhlo.f32_v1>
   %0 = "stablehlo.dot"(%arg0, %arg1) : (tensor<8x16xf32>, tensor<16x8xf32>) -> tensor<8x8xf32>
   func.return %0 : tensor<8x8xf32>
 }
 // CHECK-LABEL: "default_dot"
 
 func.func @default_dynamic_broadcast_in_dim(%arg0: tensor<?x?xf32>, %arg1: tensor<2xindex>) -> tensor<?x?xf32> {
-  //      CHECK: "vhlo.dynamic_broadcast_in_dim"(%arg0, %arg1) {
-  // CHECK-SAME:   broadcast_dimensions = #vhlo.tensor<dense<[0, 1]> : tensor<2xi64>>,
-  // CHECK-SAME:   known_expanding_dimensions = #vhlo.tensor<dense<> : tensor<0xi64>>,
-  // CHECK-SAME:   known_nonexpanding_dimensions = #vhlo.tensor<dense<> : tensor<0xi64>>
-  // CHECK-SAME: } : (!vhlo.tensor<?x?x!vhlo.f32>, !vhlo.tensor<2x!vhlo.index>) -> !vhlo.tensor<?x?x!vhlo.f32>
+  //      CHECK: "vhlo.dynamic_broadcast_in_dim_v1"(%arg0, %arg1) {
+  // CHECK-SAME:   broadcast_dimensions = #vhlo.tensor_v1<dense<[0, 1]> : tensor<2xi64>>,
+  // CHECK-SAME:   known_expanding_dimensions = #vhlo.tensor_v1<dense<> : tensor<0xi64>>,
+  // CHECK-SAME:   known_nonexpanding_dimensions = #vhlo.tensor_v1<dense<> : tensor<0xi64>>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<?x?x!vhlo.f32_v1>, !vhlo.tensor_v1<2x!vhlo.index_v1>) -> !vhlo.tensor_v1<?x?x!vhlo.f32_v1>
   %0 = "stablehlo.dynamic_broadcast_in_dim"(%arg0, %arg1) {
     broadcast_dimensions = dense<[0, 1]> : tensor<2xi64>
   } : (tensor<?x?xf32>, tensor<2xindex>) -> tensor<?x?xf32>
@@ -495,25 +495,25 @@ func.func @default_dynamic_broadcast_in_dim(%arg0: tensor<?x?xf32>, %arg1: tenso
 // CHECK-LABEL: "default_dynamic_broadcast_in_dim"
 
 func.func @default_dynamic_conv(%arg0: tensor<1x8x8x207xf32>, %arg1: tensor<3x3x207x16xf32>, %arg2: tensor<4xi32>) -> tensor<1x?x?x16xf32> {
-  //      CHECK: "vhlo.dynamic_conv"(%arg0, %arg1, %arg2) {
-  // CHECK-SAME:   batch_group_count = #vhlo.integer<1 : i64>,
-  // CHECK-SAME:   feature_group_count = #vhlo.integer<1 : i64>,
-  // CHECK-SAME:   input_batch_dimension = #vhlo.integer<0 : i64>,
-  // CHECK-SAME:   input_feature_dimension = #vhlo.integer<3 : i64>,
-  // CHECK-SAME:   input_spatial_dimensions = #vhlo.tensor<dense<[1, 2]> : tensor<2xi64>>,
-  // CHECK-SAME:   kernel_input_feature_dimension = #vhlo.integer<2 : i64>,
-  // CHECK-SAME:   kernel_output_feature_dimension = #vhlo.integer<3 : i64>,
-  // CHECK-SAME:   kernel_spatial_dimensions = #vhlo.tensor<dense<[0, 1]> : tensor<2xi64>>,
-  // CHECK-SAME:   lhs_dilation = #vhlo.tensor<dense<1> : tensor<2xi64>>,
-  // CHECK-SAME:   output_batch_dimension = #vhlo.integer<0 : i64>,
-  // CHECK-SAME:   output_feature_dimension = #vhlo.integer<3 : i64>,
-  // CHECK-SAME:   output_spatial_dimensions = #vhlo.tensor<dense<[1, 2]> : tensor<2xi64>>,
-  // CHECK-SAME:   padding = #vhlo.tensor<dense<0> : tensor<2x2xi64>>,
-  // CHECK-SAME:   precision_config = #vhlo.array<[#vhlo<precision DEFAULT>, #vhlo<precision DEFAULT>]>,
-  // CHECK-SAME:   rhs_dilation = #vhlo.tensor<dense<1> : tensor<2xi64>>,
-  // CHECK-SAME:   window_reversal = #vhlo.tensor<dense<false> : tensor<2xi1>>,
-  // CHECK-SAME:   window_strides = #vhlo.tensor<dense<1> : tensor<2xi64>>
-  // CHECK-SAME: } : (!vhlo.tensor<1x8x8x207x!vhlo.f32>, !vhlo.tensor<3x3x207x16x!vhlo.f32>, !vhlo.tensor<4x!vhlo.i32>) -> !vhlo.tensor<1x?x?x16x!vhlo.f32>
+  //      CHECK: "vhlo.dynamic_conv_v1"(%arg0, %arg1, %arg2) {
+  // CHECK-SAME:   batch_group_count = #vhlo.integer_v1<1 : i64>,
+  // CHECK-SAME:   feature_group_count = #vhlo.integer_v1<1 : i64>,
+  // CHECK-SAME:   input_batch_dimension = #vhlo.integer_v1<0 : i64>,
+  // CHECK-SAME:   input_feature_dimension = #vhlo.integer_v1<3 : i64>,
+  // CHECK-SAME:   input_spatial_dimensions = #vhlo.tensor_v1<dense<[1, 2]> : tensor<2xi64>>,
+  // CHECK-SAME:   kernel_input_feature_dimension = #vhlo.integer_v1<2 : i64>,
+  // CHECK-SAME:   kernel_output_feature_dimension = #vhlo.integer_v1<3 : i64>,
+  // CHECK-SAME:   kernel_spatial_dimensions = #vhlo.tensor_v1<dense<[0, 1]> : tensor<2xi64>>,
+  // CHECK-SAME:   lhs_dilation = #vhlo.tensor_v1<dense<1> : tensor<2xi64>>,
+  // CHECK-SAME:   output_batch_dimension = #vhlo.integer_v1<0 : i64>,
+  // CHECK-SAME:   output_feature_dimension = #vhlo.integer_v1<3 : i64>,
+  // CHECK-SAME:   output_spatial_dimensions = #vhlo.tensor_v1<dense<[1, 2]> : tensor<2xi64>>,
+  // CHECK-SAME:   padding = #vhlo.tensor_v1<dense<0> : tensor<2x2xi64>>,
+  // CHECK-SAME:   precision_config = #vhlo.array_v1<[#vhlo<precision_v1 DEFAULT>, #vhlo<precision_v1 DEFAULT>]>,
+  // CHECK-SAME:   rhs_dilation = #vhlo.tensor_v1<dense<1> : tensor<2xi64>>,
+  // CHECK-SAME:   window_reversal = #vhlo.tensor_v1<dense<false> : tensor<2xi1>>,
+  // CHECK-SAME:   window_strides = #vhlo.tensor_v1<dense<1> : tensor<2xi64>>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<1x8x8x207x!vhlo.f32_v1>, !vhlo.tensor_v1<3x3x207x16x!vhlo.f32_v1>, !vhlo.tensor_v1<4x!vhlo.i32_v1>) -> !vhlo.tensor_v1<1x?x?x16x!vhlo.f32_v1>
   %0 = "stablehlo.dynamic_conv"(%arg0, %arg1, %arg2) {
     dimension_numbers = #stablehlo.conv<[b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f]>,
     feature_group_count = 1 : i64,
@@ -524,13 +524,13 @@ func.func @default_dynamic_conv(%arg0: tensor<1x8x8x207xf32>, %arg1: tensor<3x3x
 // CHECK-LABEL: "default_dynamic_conv"
 
 func.func @default_dynamic_gather(%arg0 : tensor<2x4x9xf32>, %arg1 : tensor<1x5x2xi32>, %arg2 : tensor<3xi32>) -> tensor<1x5x8xf32> {
-  //      CHECK: "vhlo.dynamic_gather"(%arg0, %arg1, %arg2) {
-  // CHECK-SAME:   collapsed_slice_dims = #vhlo.tensor<dense<[0, 1]> : tensor<2xi64>>,
-  // CHECK-SAME:   index_vector_dim = #vhlo.integer<2 : i64>,
-  // CHECK-SAME:   indices_are_sorted = #vhlo.bool<false>,
-  // CHECK-SAME:   offset_dims = #vhlo.tensor<dense<2> : tensor<1xi64>>,
-  // CHECK-SAME:   start_index_map = #vhlo.tensor<dense<[0, 1]> : tensor<2xi64>>
-  // CHECK-SAME: } : (!vhlo.tensor<2x4x9x!vhlo.f32>, !vhlo.tensor<1x5x2x!vhlo.i32>, !vhlo.tensor<3x!vhlo.i32>) -> !vhlo.tensor<1x5x8x!vhlo.f32>
+  //      CHECK: "vhlo.dynamic_gather_v1"(%arg0, %arg1, %arg2) {
+  // CHECK-SAME:   collapsed_slice_dims = #vhlo.tensor_v1<dense<[0, 1]> : tensor<2xi64>>,
+  // CHECK-SAME:   index_vector_dim = #vhlo.integer_v1<2 : i64>,
+  // CHECK-SAME:   indices_are_sorted = #vhlo.bool_v1<false>,
+  // CHECK-SAME:   offset_dims = #vhlo.tensor_v1<dense<2> : tensor<1xi64>>,
+  // CHECK-SAME:   start_index_map = #vhlo.tensor_v1<dense<[0, 1]> : tensor<2xi64>>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<2x4x9x!vhlo.f32_v1>, !vhlo.tensor_v1<1x5x2x!vhlo.i32_v1>, !vhlo.tensor_v1<3x!vhlo.i32_v1>) -> !vhlo.tensor_v1<1x5x8x!vhlo.f32_v1>
   %0 = "stablehlo.dynamic_gather"(%arg0, %arg1, %arg2) {
     dimension_numbers = #stablehlo.gather<
       offset_dims = [2],
@@ -545,28 +545,28 @@ func.func @default_dynamic_gather(%arg0 : tensor<2x4x9xf32>, %arg1 : tensor<1x5x
 // CHECK-LABEL: "default_dynamic_gather"
 
 func.func @default_func(%arg0: tensor<f32>) -> tensor<f32> {
-  // CHECK:      "vhlo.func"() ({
-  // CHECK-NEXT:   ^[[BB:bb.*]](%arg0: !vhlo.tensor<!vhlo.f32>):
-  // CHECK-NEXT:     "vhlo.return"(%arg0) : (!vhlo.tensor<!vhlo.f32>) -> ()
+  // CHECK:      "vhlo.func_v1"() ({
+  // CHECK-NEXT:   ^[[BB:bb.*]](%arg0: !vhlo.tensor_v1<!vhlo.f32_v1>):
+  // CHECK-NEXT:     "vhlo.return_v1"(%arg0) : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> ()
   // CHECK-NEXT: }) {
-  // CHECK-SAME:   arg_attrs = #vhlo.array<[]>,
-  // CHECK-SAME:   function_type = #vhlo.type<!vhlo.func<(!vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>>>,
-  // CHECK-SAME:   res_attrs = #vhlo.array<[]>,
-  // CHECK-SAME:   sym_name = #vhlo.string<"default_func">,
-  // CHECK-SAME:   sym_visibility = #vhlo.string<"public">
+  // CHECK-SAME:   arg_attrs = #vhlo.array_v1<[]>,
+  // CHECK-SAME:   function_type = #vhlo.type_v1<!vhlo.func_v1<(!vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>>>,
+  // CHECK-SAME:   res_attrs = #vhlo.array_v1<[]>,
+  // CHECK-SAME:   sym_name = #vhlo.string_v1<"default_func">,
+  // CHECK-SAME:   sym_visibility = #vhlo.string_v1<"public">
   // CHECK-SAME: } : () -> ()
   func.return %arg0 : tensor<f32>
 }
 
 func.func @dynamic_gather(%arg0 : tensor<2x4x9xf32>, %arg1 : tensor<1x5x2xi32>) -> tensor<1x5x1xf32> {
-  //      CHECK: "vhlo.gather"(%arg0, %arg1) {
-  // CHECK-SAME:   collapsed_slice_dims = #vhlo.tensor<dense<[0, 1]> : tensor<2xi64>>,
-  // CHECK-SAME:   index_vector_dim = #vhlo.integer<2 : i64>,
-  // CHECK-SAME:   indices_are_sorted = #vhlo.bool<false>,
-  // CHECK-SAME:   offset_dims = #vhlo.tensor<dense<2> : tensor<1xi64>>,
-  // CHECK-SAME:   slice_sizes = #vhlo.tensor<dense<1> : tensor<3xi64>>,
-  // CHECK-SAME:   start_index_map = #vhlo.tensor<dense<[0, 1]> : tensor<2xi64>>
-  // CHECK-SAME: } : (!vhlo.tensor<2x4x9x!vhlo.f32>, !vhlo.tensor<1x5x2x!vhlo.i32>) -> !vhlo.tensor<1x5x1x!vhlo.f32>
+  //      CHECK: "vhlo.gather_v1"(%arg0, %arg1) {
+  // CHECK-SAME:   collapsed_slice_dims = #vhlo.tensor_v1<dense<[0, 1]> : tensor<2xi64>>,
+  // CHECK-SAME:   index_vector_dim = #vhlo.integer_v1<2 : i64>,
+  // CHECK-SAME:   indices_are_sorted = #vhlo.bool_v1<false>,
+  // CHECK-SAME:   offset_dims = #vhlo.tensor_v1<dense<2> : tensor<1xi64>>,
+  // CHECK-SAME:   slice_sizes = #vhlo.tensor_v1<dense<1> : tensor<3xi64>>,
+  // CHECK-SAME:   start_index_map = #vhlo.tensor_v1<dense<[0, 1]> : tensor<2xi64>>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<2x4x9x!vhlo.f32_v1>, !vhlo.tensor_v1<1x5x2x!vhlo.i32_v1>) -> !vhlo.tensor_v1<1x5x1x!vhlo.f32_v1>
   %0 = "stablehlo.gather"(%arg0, %arg1) {
     dimension_numbers = #stablehlo.gather<
       offset_dims = [2],
@@ -581,30 +581,30 @@ func.func @dynamic_gather(%arg0 : tensor<2x4x9xf32>, %arg1 : tensor<1x5x2xi32>) 
 // CHECK-LABEL: "dynamic_gather"
 
 func.func @default_infeed(%arg0: !stablehlo.token) -> (tensor<f32>, !stablehlo.token) {
-  //               CHECK: "vhlo.infeed"(%arg0) {
-  //          CHECK-SAME:   infeed_config = #vhlo.string<"">,
-  // CHECK-SAME{LITERAL}:   layout = #vhlo.array<[]>
-  //          CHECK-SAME: } : (!vhlo.token) -> (!vhlo.tensor<!vhlo.f32>, !vhlo.token)
+  //               CHECK: "vhlo.infeed_v1"(%arg0) {
+  //          CHECK-SAME:   infeed_config = #vhlo.string_v1<"">,
+  // CHECK-SAME{LITERAL}:   layout = #vhlo.array_v1<[]>
+  //          CHECK-SAME: } : (!vhlo.token_v1) -> (!vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.token_v1)
   %0:2 = "stablehlo.infeed"(%arg0) : (!stablehlo.token) -> (tensor<f32>, !stablehlo.token)
   func.return %0#0, %0#1 : tensor<f32>, !stablehlo.token
 }
 // CHECK-LABEL: "default_infeed"
 
 func.func @default_outfeed(%arg0: tensor<f32>, %arg1: !stablehlo.token) -> !stablehlo.token {
-  //      CHECK: "vhlo.outfeed"(%arg0, %arg1) {
-  // CHECK-SAME:   outfeed_config = #vhlo.string<"">
-  // CHECK-SAME: } : (!vhlo.tensor<!vhlo.f32>, !vhlo.token) -> !vhlo.token
+  //      CHECK: "vhlo.outfeed_v1"(%arg0, %arg1) {
+  // CHECK-SAME:   outfeed_config = #vhlo.string_v1<"">
+  // CHECK-SAME: } : (!vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.token_v1) -> !vhlo.token_v1
   %0 = "stablehlo.outfeed"(%arg0, %arg1) : (tensor<f32>, !stablehlo.token) -> !stablehlo.token
   func.return %0 : !stablehlo.token
 }
 // CHECK-LABEL: "default_outfeed"
 
 func.func @default_recv(%arg0: !stablehlo.token) -> (tensor<f32>, !stablehlo.token) {
-  //      CHECK: "vhlo.recv"(%arg0) {
-  // CHECK-SAME:   channel_id = #vhlo.integer<0 : i64>,
-  // CHECK-SAME:   channel_type = #vhlo.integer<0 : i64>,
-  // CHECK-SAME:   is_host_transfer = #vhlo.bool<false>
-  // CHECK-SAME: } : (!vhlo.token) -> (!vhlo.tensor<!vhlo.f32>, !vhlo.token)
+  //      CHECK: "vhlo.recv_v1"(%arg0) {
+  // CHECK-SAME:   channel_id = #vhlo.integer_v1<0 : i64>,
+  // CHECK-SAME:   channel_type = #vhlo.integer_v1<0 : i64>,
+  // CHECK-SAME:   is_host_transfer = #vhlo.bool_v1<false>
+  // CHECK-SAME: } : (!vhlo.token_v1) -> (!vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.token_v1)
   %0:2 = "stablehlo.recv"(%arg0) {
     channel_handle = #stablehlo.channel_handle<handle = 0, type = 0>
   } : (!stablehlo.token) -> (tensor<f32>, !stablehlo.token)
@@ -613,11 +613,11 @@ func.func @default_recv(%arg0: !stablehlo.token) -> (tensor<f32>, !stablehlo.tok
 // CHECK-LABEL: "default_recv"
 
 func.func @default_send(%arg0: tensor<f32>, %arg1: !stablehlo.token) -> !stablehlo.token {
-  //      CHECK: "vhlo.send"(%arg0, %arg1) {
-  // CHECK-SAME:   channel_id = #vhlo.integer<0 : i64>,
-  // CHECK-SAME:   channel_type = #vhlo.integer<0 : i64>,
-  // CHECK-SAME:   is_host_transfer = #vhlo.bool<false>
-  // CHECK-SAME: } : (!vhlo.tensor<!vhlo.f32>, !vhlo.token) -> !vhlo.token
+  //      CHECK: "vhlo.send_v1"(%arg0, %arg1) {
+  // CHECK-SAME:   channel_id = #vhlo.integer_v1<0 : i64>,
+  // CHECK-SAME:   channel_type = #vhlo.integer_v1<0 : i64>,
+  // CHECK-SAME:   is_host_transfer = #vhlo.bool_v1<false>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.token_v1) -> !vhlo.token_v1
   %0 = "stablehlo.send"(%arg0, %arg1) {
     channel_handle = #stablehlo.channel_handle<handle = 0, type = 0>
   } : (tensor<f32>, !stablehlo.token) -> !stablehlo.token
@@ -626,16 +626,16 @@ func.func @default_send(%arg0: tensor<f32>, %arg1: !stablehlo.token) -> !stableh
 // CHECK-LABEL: "default_send"
 
 func.func @default_reduce_scatter(%arg0: tensor<16xf32>) -> tensor<16xf32> {
-  //               CHECK: "vhlo.reduce_scatter"(%arg0) ({
-  //          CHECK-NEXT:   ^[[BB:bb.*]](%[[ARG1:arg.*]]: !vhlo.tensor<!vhlo.f32>, %[[ARG2:arg.*]]: !vhlo.tensor<!vhlo.f32>):
-  //          CHECK-NEXT:     %[[VAL1:.*]] = "vhlo.add"(%[[ARG1]], %[[ARG2]]) : (!vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
-  //          CHECK-NEXT:     "vhlo.return"(%[[VAL1]]) : (!vhlo.tensor<!vhlo.f32>) -> ()
+  //               CHECK: "vhlo.reduce_scatter_v1"(%arg0) ({
+  //          CHECK-NEXT:   ^[[BB:bb.*]](%[[ARG1:arg.*]]: !vhlo.tensor_v1<!vhlo.f32_v1>, %[[ARG2:arg.*]]: !vhlo.tensor_v1<!vhlo.f32_v1>):
+  //          CHECK-NEXT:     %[[VAL1:.*]] = "vhlo.add_v1"(%[[ARG1]], %[[ARG2]]) : (!vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
+  //          CHECK-NEXT:     "vhlo.return_v1"(%[[VAL1]]) : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> ()
   //          CHECK-NEXT: }) {
-  //          CHECK-SAME:   channel_id = #vhlo.integer<0 : i64>,
-  // CHECK-SAME{LITERAL}:   replica_groups = #vhlo.tensor<dense<[[0], [1]]> : tensor<2x1xi64>>,
-  //          CHECK-SAME:   scatter_dimension = #vhlo.integer<0 : i64>
-  //          CHECK-SAME:   use_global_device_ids = #vhlo.bool<false>
-  //          CHECK-SAME: } : (!vhlo.tensor<16x!vhlo.f32>) -> !vhlo.tensor<16x!vhlo.f32>
+  //          CHECK-SAME:   channel_id = #vhlo.integer_v1<0 : i64>,
+  // CHECK-SAME{LITERAL}:   replica_groups = #vhlo.tensor_v1<dense<[[0], [1]]> : tensor<2x1xi64>>,
+  //          CHECK-SAME:   scatter_dimension = #vhlo.integer_v1<0 : i64>
+  //          CHECK-SAME:   use_global_device_ids = #vhlo.bool_v1<false>
+  //          CHECK-SAME: } : (!vhlo.tensor_v1<16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x!vhlo.f32_v1>
   %0 = "stablehlo.reduce_scatter"(%arg0) ({
     ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
       %1 = "stablehlo.add"(%arg1, %arg2) : (tensor<f32>, tensor<f32>) -> tensor<f32>
@@ -649,17 +649,17 @@ func.func @default_reduce_scatter(%arg0: tensor<16xf32>) -> tensor<16xf32> {
 // CHECK-LABEL: "default_reduce_scatter"
 
 func.func @default_reduce_window(%arg0: tensor<2x17x31x7xf32>, %arg1: tensor<f32>) -> tensor<2x16x30x7xf32> {
-  //               CHECK: "vhlo.reduce_window"(%arg0, %arg1) ({
-  //          CHECK-NEXT:   ^[[BB:bb.*]](%[[ARG2:arg.*]]: !vhlo.tensor<!vhlo.f32>, %[[ARG3:arg.*]]: !vhlo.tensor<!vhlo.f32>):
-  //          CHECK-NEXT:     %[[VAL1:.*]] = "vhlo.maximum"(%[[ARG2]], %[[ARG3]]) : (!vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
-  //          CHECK-NEXT:     "vhlo.return"(%[[VAL1]]) : (!vhlo.tensor<!vhlo.f32>) -> ()
+  //               CHECK: "vhlo.reduce_window_v1"(%arg0, %arg1) ({
+  //          CHECK-NEXT:   ^[[BB:bb.*]](%[[ARG2:arg.*]]: !vhlo.tensor_v1<!vhlo.f32_v1>, %[[ARG3:arg.*]]: !vhlo.tensor_v1<!vhlo.f32_v1>):
+  //          CHECK-NEXT:     %[[VAL1:.*]] = "vhlo.maximum_v1"(%[[ARG2]], %[[ARG3]]) : (!vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
+  //          CHECK-NEXT:     "vhlo.return_v1"(%[[VAL1]]) : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> ()
   //          CHECK-NEXT: }) {
-  //          CHECK-SAME:   base_dilations = #vhlo.tensor<dense<1> : tensor<4xi64>>,
-  // CHECK-SAME{LITERAL}:   padding = #vhlo.tensor<dense<0> : tensor<4x2xi64>>,
-  //          CHECK-SAME:   window_dilations = #vhlo.tensor<dense<1> : tensor<4xi64>>,
-  //          CHECK-SAME:   window_dimensions = #vhlo.tensor<dense<[1, 2, 2, 1]> : tensor<4xi64>>,
-  //          CHECK-SAME:   window_strides = #vhlo.tensor<dense<1> : tensor<4xi64>>
-  //          CHECK-SAME: } : (!vhlo.tensor<2x17x31x7x!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<2x16x30x7x!vhlo.f32>
+  //          CHECK-SAME:   base_dilations = #vhlo.tensor_v1<dense<1> : tensor<4xi64>>,
+  // CHECK-SAME{LITERAL}:   padding = #vhlo.tensor_v1<dense<0> : tensor<4x2xi64>>,
+  //          CHECK-SAME:   window_dilations = #vhlo.tensor_v1<dense<1> : tensor<4xi64>>,
+  //          CHECK-SAME:   window_dimensions = #vhlo.tensor_v1<dense<[1, 2, 2, 1]> : tensor<4xi64>>,
+  //          CHECK-SAME:   window_strides = #vhlo.tensor_v1<dense<1> : tensor<4xi64>>
+  //          CHECK-SAME: } : (!vhlo.tensor_v1<2x17x31x7x!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<2x16x30x7x!vhlo.f32_v1>
   %0 = "stablehlo.reduce_window"(%arg0, %arg1) ({
     ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
       %1 = "stablehlo.maximum"(%arg2, %arg3) : (tensor<f32>, tensor<f32>) -> tensor<f32>
@@ -672,18 +672,18 @@ func.func @default_reduce_window(%arg0: tensor<2x17x31x7xf32>, %arg1: tensor<f32
 // CHECK-LABEL: "default_reduce_window"
 
 func.func @default_scatter(%arg0: tensor<200x100x300xf32>, %arg1: tensor<10x2xi32>, %arg2: tensor<10x300xf32>) -> tensor<200x100x300xf32> {
-  //      CHECK: "vhlo.scatter"(%arg0, %arg1, %arg2) ({
-  // CHECK-NEXT:   ^[[BB:bb.*]](%[[ARG3:arg.*]]: !vhlo.tensor<!vhlo.f32>, %[[ARG4:arg.*]]: !vhlo.tensor<!vhlo.f32>):
-  // CHECK-NEXT:     %[[VAL1:.*]] = "vhlo.add"(%[[ARG3]], %[[ARG4]]) : (!vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
-  // CHECK-NEXT:     "vhlo.return"(%[[VAL1]]) : (!vhlo.tensor<!vhlo.f32>) -> ()
+  //      CHECK: "vhlo.scatter_v1"(%arg0, %arg1, %arg2) ({
+  // CHECK-NEXT:   ^[[BB:bb.*]](%[[ARG3:arg.*]]: !vhlo.tensor_v1<!vhlo.f32_v1>, %[[ARG4:arg.*]]: !vhlo.tensor_v1<!vhlo.f32_v1>):
+  // CHECK-NEXT:     %[[VAL1:.*]] = "vhlo.add_v1"(%[[ARG3]], %[[ARG4]]) : (!vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
+  // CHECK-NEXT:     "vhlo.return_v1"(%[[VAL1]]) : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> ()
   // CHECK-NEXT: }) {
-  // CHECK-SAME:   index_vector_dim = #vhlo.integer<1 : i64>,
-  // CHECK-SAME:   indices_are_sorted = #vhlo.bool<false>,
-  // CHECK-SAME:   inserted_window_dims = #vhlo.tensor<dense<[0, 1]> : tensor<2xi64>>,
-  // CHECK-SAME:   scatter_dims_to_operand_dims = #vhlo.tensor<dense<[0, 1]> : tensor<2xi64>>,
-  // CHECK-SAME:   unique_indices = #vhlo.bool<false>,
-  // CHECK-SAME:   update_window_dims = #vhlo.tensor<dense<1> : tensor<1xi64>>
-  // CHECK-SAME: } : (!vhlo.tensor<200x100x300x!vhlo.f32>, !vhlo.tensor<10x2x!vhlo.i32>, !vhlo.tensor<10x300x!vhlo.f32>) -> !vhlo.tensor<200x100x300x!vhlo.f32>
+  // CHECK-SAME:   index_vector_dim = #vhlo.integer_v1<1 : i64>,
+  // CHECK-SAME:   indices_are_sorted = #vhlo.bool_v1<false>,
+  // CHECK-SAME:   inserted_window_dims = #vhlo.tensor_v1<dense<[0, 1]> : tensor<2xi64>>,
+  // CHECK-SAME:   scatter_dims_to_operand_dims = #vhlo.tensor_v1<dense<[0, 1]> : tensor<2xi64>>,
+  // CHECK-SAME:   unique_indices = #vhlo.bool_v1<false>,
+  // CHECK-SAME:   update_window_dims = #vhlo.tensor_v1<dense<1> : tensor<1xi64>>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<200x100x300x!vhlo.f32_v1>, !vhlo.tensor_v1<10x2x!vhlo.i32_v1>, !vhlo.tensor_v1<10x300x!vhlo.f32_v1>) -> !vhlo.tensor_v1<200x100x300x!vhlo.f32_v1>
   %0 = "stablehlo.scatter"(%arg0, %arg1, %arg2) ({
     ^bb0(%arg3: tensor<f32>, %arg4: tensor<f32>):
       %1 = "stablehlo.add"(%arg3, %arg4) : (tensor<f32>, tensor<f32>) -> tensor<f32>
@@ -701,19 +701,19 @@ func.func @default_scatter(%arg0: tensor<200x100x300xf32>, %arg1: tensor<10x2xi3
 // CHECK-LABEL: "default_scatter"
 
 func.func @default_select_and_scatter(%arg0: tensor<10x24x24x64xf32>, %arg1: tensor<10x23x23x64xf32>, %arg2: tensor<f32>) -> tensor<10x24x24x64xf32> {
-  //      CHECK: "vhlo.select_and_scatter"(%arg0, %arg1, %arg2) ({
-  // CHECK-NEXT:   ^[[BB:bb.*]](%[[ARG31:arg.*]]: !vhlo.tensor<!vhlo.f32>, %[[ARG41:arg.*]]: !vhlo.tensor<!vhlo.f32>):
-  // CHECK-NEXT:     %[[VAL11:.*]] = "vhlo.compare"(%[[ARG31]], %[[ARG41]]) {compare_type = #vhlo<comparison_type TOTALORDER>, comparison_direction = #vhlo<comparison_direction GE>} : (!vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.bool>
-  // CHECK-NEXT:     "vhlo.return"(%[[VAL11]]) : (!vhlo.tensor<!vhlo.bool>) -> ()
+  //      CHECK: "vhlo.select_and_scatter_v1"(%arg0, %arg1, %arg2) ({
+  // CHECK-NEXT:   ^[[BB:bb.*]](%[[ARG31:arg.*]]: !vhlo.tensor_v1<!vhlo.f32_v1>, %[[ARG41:arg.*]]: !vhlo.tensor_v1<!vhlo.f32_v1>):
+  // CHECK-NEXT:     %[[VAL11:.*]] = "vhlo.compare_v1"(%[[ARG31]], %[[ARG41]]) {compare_type = #vhlo<comparison_type_v1 TOTALORDER>, comparison_direction = #vhlo<comparison_direction_v1 GE>} : (!vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.bool_v1>
+  // CHECK-NEXT:     "vhlo.return_v1"(%[[VAL11]]) : (!vhlo.tensor_v1<!vhlo.bool_v1>) -> ()
   // CHECK-NEXT: }, {
-  // CHECK-NEXT:   ^[[BB:bb.*]](%[[ARG32:arg.*]]: !vhlo.tensor<!vhlo.f32>, %[[ARG42:arg.*]]: !vhlo.tensor<!vhlo.f32>):
-  // CHECK-NEXT:     %[[VAL12:.*]] = "vhlo.add"(%[[ARG32]], %[[ARG42]]) : (!vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
-  // CHECK-NEXT:     "vhlo.return"(%[[VAL12]]) : (!vhlo.tensor<!vhlo.f32>) -> ()
+  // CHECK-NEXT:   ^[[BB:bb.*]](%[[ARG32:arg.*]]: !vhlo.tensor_v1<!vhlo.f32_v1>, %[[ARG42:arg.*]]: !vhlo.tensor_v1<!vhlo.f32_v1>):
+  // CHECK-NEXT:     %[[VAL12:.*]] = "vhlo.add_v1"(%[[ARG32]], %[[ARG42]]) : (!vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
+  // CHECK-NEXT:     "vhlo.return_v1"(%[[VAL12]]) : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> ()
   // CHECK-NEXT: }) {
-  // CHECK-SAME:   padding = #vhlo.tensor<dense<0> : tensor<4x2xi64>>,
-  // CHECK-SAME:   window_dimensions = #vhlo.tensor<dense<[1, 2, 2, 1]> : tensor<4xi64>>,
-  // CHECK-SAME:   window_strides = #vhlo.tensor<dense<1> : tensor<4xi64>>
-  // CHECK-SAME: } : (!vhlo.tensor<10x24x24x64x!vhlo.f32>, !vhlo.tensor<10x23x23x64x!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<10x24x24x64x!vhlo.f32>
+  // CHECK-SAME:   padding = #vhlo.tensor_v1<dense<0> : tensor<4x2xi64>>,
+  // CHECK-SAME:   window_dimensions = #vhlo.tensor_v1<dense<[1, 2, 2, 1]> : tensor<4xi64>>,
+  // CHECK-SAME:   window_strides = #vhlo.tensor_v1<dense<1> : tensor<4xi64>>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<10x24x24x64x!vhlo.f32_v1>, !vhlo.tensor_v1<10x23x23x64x!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<10x24x24x64x!vhlo.f32_v1>
   %0 = "stablehlo.select_and_scatter"(%arg0, %arg1, %arg2) ({
     ^bb0(%arg3: tensor<f32>, %arg4: tensor<f32>):
       %1 = "stablehlo.compare"(%arg3, %arg4) {compare_type = #stablehlo<comparison_type TOTALORDER>, comparison_direction = #stablehlo<comparison_direction GE>} : (tensor<f32>, tensor<f32>) -> tensor<i1>
@@ -730,14 +730,14 @@ func.func @default_select_and_scatter(%arg0: tensor<10x24x24x64xf32>, %arg1: ten
 // CHECK-LABEL: "default_select_and_scatter"
 
 func.func @default_sort(%arg0: tensor<16xf32>) -> tensor<16xf32> {
-  //      CHECK: "vhlo.sort"(%arg0) ({
-  // CHECK-NEXT:   ^[[BB:bb.*]](%[[ARG1:arg.*]]: !vhlo.tensor<!vhlo.f32>, %[[ARG2:arg.*]]: !vhlo.tensor<!vhlo.f32>):
-  // CHECK-NEXT:     %[[VAL1:.*]] = "vhlo.compare"(%[[ARG1]], %[[ARG2]]) {compare_type = #vhlo<comparison_type FLOAT>, comparison_direction = #vhlo<comparison_direction GT>} : (!vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.bool>
-  // CHECK-NEXT:     "vhlo.return"(%[[VAL1]]) : (!vhlo.tensor<!vhlo.bool>) -> ()
+  //      CHECK: "vhlo.sort_v1"(%arg0) ({
+  // CHECK-NEXT:   ^[[BB:bb.*]](%[[ARG1:arg.*]]: !vhlo.tensor_v1<!vhlo.f32_v1>, %[[ARG2:arg.*]]: !vhlo.tensor_v1<!vhlo.f32_v1>):
+  // CHECK-NEXT:     %[[VAL1:.*]] = "vhlo.compare_v1"(%[[ARG1]], %[[ARG2]]) {compare_type = #vhlo<comparison_type_v1 FLOAT>, comparison_direction = #vhlo<comparison_direction_v1 GT>} : (!vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.bool_v1>
+  // CHECK-NEXT:     "vhlo.return_v1"(%[[VAL1]]) : (!vhlo.tensor_v1<!vhlo.bool_v1>) -> ()
   // CHECK-NEXT: }) {
-  // CHECK-SAME:   dimension = #vhlo.integer<-1 : i64>
-  // CHECK-SAME:   is_stable = #vhlo.bool<false>
-  // CHECK-SAME: } : (!vhlo.tensor<16x!vhlo.f32>) -> !vhlo.tensor<16x!vhlo.f32>
+  // CHECK-SAME:   dimension = #vhlo.integer_v1<-1 : i64>
+  // CHECK-SAME:   is_stable = #vhlo.bool_v1<false>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x!vhlo.f32_v1>
   %0 = "stablehlo.sort"(%arg0) ({
     ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
       %1 = "stablehlo.compare"(%arg1, %arg2) {compare_type = #stablehlo<comparison_type FLOAT>, comparison_direction = #stablehlo<comparison_direction GT>} : (tensor<f32>, tensor<f32>) -> tensor<i1>
@@ -750,33 +750,33 @@ func.func @default_sort(%arg0: tensor<16xf32>) -> tensor<16xf32> {
 // ============ OPS ============
 
 func.func @op_abs(%arg0: tensor<f32>) -> tensor<f32> {
-  // CHECK: "vhlo.abs"(%arg0) : (!vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
+  // CHECK: "vhlo.abs_v1"(%arg0) : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.abs"(%arg0) : (tensor<f32>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }
 // CHECK-LABEL: "op_abs"
 
 func.func @op_add(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<f32> {
-  // CHECK: "vhlo.add"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
+  // CHECK: "vhlo.add_v1"(%arg0, %arg1) : (!vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.add"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }
 // CHECK-LABEL: "op_add"
 
 func.func @op_after_all(%arg0: !stablehlo.token) -> !stablehlo.token {
-  // CHECK: "vhlo.after_all"(%arg0) : (!vhlo.token) -> !vhlo.token
+  // CHECK: "vhlo.after_all_v1"(%arg0) : (!vhlo.token_v1) -> !vhlo.token_v1
   %0 = "stablehlo.after_all"(%arg0) : (!stablehlo.token) -> !stablehlo.token
   func.return %0 : !stablehlo.token
 }
 // CHECK-LABEL: "op_after_all"
 
 func.func @op_all_gather(%arg0: tensor<16x8xf32>) -> tensor<16x16xf32> {
-  //               CHECK: "vhlo.all_gather"(%arg0) {
-  //          CHECK-SAME:   all_gather_dim = #vhlo.integer<1 : i64>
-  //          CHECK-SAME:   channel_id = #vhlo.integer<1 : i64>,
-  // CHECK-SAME{LITERAL}:   replica_groups = #vhlo.tensor<dense<[[0], [1]]> : tensor<2x1xi64>>,
-  //          CHECK-SAME:   use_global_device_ids = #vhlo.bool<true>
-  //          CHECK-SAME: } : (!vhlo.tensor<16x8x!vhlo.f32>) -> !vhlo.tensor<16x16x!vhlo.f32>
+  //               CHECK: "vhlo.all_gather_v1"(%arg0) {
+  //          CHECK-SAME:   all_gather_dim = #vhlo.integer_v1<1 : i64>
+  //          CHECK-SAME:   channel_id = #vhlo.integer_v1<1 : i64>,
+  // CHECK-SAME{LITERAL}:   replica_groups = #vhlo.tensor_v1<dense<[[0], [1]]> : tensor<2x1xi64>>,
+  //          CHECK-SAME:   use_global_device_ids = #vhlo.bool_v1<true>
+  //          CHECK-SAME: } : (!vhlo.tensor_v1<16x8x!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x16x!vhlo.f32_v1>
   %0 = "stablehlo.all_gather"(%arg0) {
     all_gather_dim = 1 : i64,
     replica_groups = dense<[[0], [1]]> : tensor<2x1xi64>,
@@ -788,15 +788,15 @@ func.func @op_all_gather(%arg0: tensor<16x8xf32>) -> tensor<16x16xf32> {
 // CHECK-LABEL: "op_all_gather"
 
 func.func @op_all_reduce(%arg0: tensor<f32>) -> tensor<f32> {
-  //               CHECK: "vhlo.all_reduce"(%arg0) ({
-  //          CHECK-NEXT:   ^[[BB:bb.*]](%[[ARG1:arg.*]]: !vhlo.tensor<!vhlo.f32>, %[[ARG2:arg.*]]: !vhlo.tensor<!vhlo.f32>):
-  //          CHECK-NEXT:     %[[VAL1:.*]] = "vhlo.add"(%[[ARG1]], %[[ARG2]]) : (!vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
-  //          CHECK-NEXT:     "vhlo.return"(%[[VAL1]]) : (!vhlo.tensor<!vhlo.f32>) -> ()
+  //               CHECK: "vhlo.all_reduce_v1"(%arg0) ({
+  //          CHECK-NEXT:   ^[[BB:bb.*]](%[[ARG1:arg.*]]: !vhlo.tensor_v1<!vhlo.f32_v1>, %[[ARG2:arg.*]]: !vhlo.tensor_v1<!vhlo.f32_v1>):
+  //          CHECK-NEXT:     %[[VAL1:.*]] = "vhlo.add_v1"(%[[ARG1]], %[[ARG2]]) : (!vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
+  //          CHECK-NEXT:     "vhlo.return_v1"(%[[VAL1]]) : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> ()
   //          CHECK-NEXT: }) {
-  //          CHECK-SAME:   channel_id = #vhlo.integer<1 : i64>,
-  // CHECK-SAME{LITERAL}:   replica_groups = #vhlo.tensor<dense<[[0], [1]]> : tensor<2x1xi64>>,
-  //          CHECK-SAME:   use_global_device_ids = #vhlo.bool<true>
-  //          CHECK-SAME: } : (!vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
+  //          CHECK-SAME:   channel_id = #vhlo.integer_v1<1 : i64>,
+  // CHECK-SAME{LITERAL}:   replica_groups = #vhlo.tensor_v1<dense<[[0], [1]]> : tensor<2x1xi64>>,
+  //          CHECK-SAME:   use_global_device_ids = #vhlo.bool_v1<true>
+  //          CHECK-SAME: } : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.all_reduce"(%arg0) ({
     ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
       %1 = "stablehlo.add"(%arg1, %arg2) : (tensor<f32>, tensor<f32>) -> tensor<f32>
@@ -811,13 +811,13 @@ func.func @op_all_reduce(%arg0: tensor<f32>) -> tensor<f32> {
 // CHECK-LABEL: "op_all_reduce"
 
 func.func @op_all_to_all(%arg0: tensor<4x16xf32>) -> tensor<16x4xf32> {
-  //               CHECK: "vhlo.all_to_all"(%arg0) {
-  //          CHECK-SAME:   channel_id = #vhlo.integer<1 : i64>,
-  //          CHECK-SAME:   concat_dimension = #vhlo.integer<0 : i64>,
-  // CHECK-SAME{LITERAL}:   replica_groups = #vhlo.tensor<dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>>,
-  //          CHECK-SAME:   split_count = #vhlo.integer<4 : i64>
-  //          CHECK-SAME:   split_dimension = #vhlo.integer<1 : i64>
-  //          CHECK-SAME: } : (!vhlo.tensor<4x16x!vhlo.f32>) -> !vhlo.tensor<16x4x!vhlo.f32>
+  //               CHECK: "vhlo.all_to_all_v1"(%arg0) {
+  //          CHECK-SAME:   channel_id = #vhlo.integer_v1<1 : i64>,
+  //          CHECK-SAME:   concat_dimension = #vhlo.integer_v1<0 : i64>,
+  // CHECK-SAME{LITERAL}:   replica_groups = #vhlo.tensor_v1<dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>>,
+  //          CHECK-SAME:   split_count = #vhlo.integer_v1<4 : i64>
+  //          CHECK-SAME:   split_dimension = #vhlo.integer_v1<1 : i64>
+  //          CHECK-SAME: } : (!vhlo.tensor_v1<4x16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x4x!vhlo.f32_v1>
   %0 = "stablehlo.all_to_all"(%arg0) {
     split_dimension = 1 : i64,
     concat_dimension = 0 : i64,
@@ -830,24 +830,24 @@ func.func @op_all_to_all(%arg0: tensor<4x16xf32>) -> tensor<16x4xf32> {
 // CHECK-LABEL: "op_all_to_all"
 
 func.func @op_and(%arg0: tensor<i1>, %arg1: tensor<i1>) -> tensor<i1> {
-  // CHECK: "vhlo.and"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.bool>, !vhlo.tensor<!vhlo.bool>) -> !vhlo.tensor<!vhlo.bool>
+  // CHECK: "vhlo.and_v1"(%arg0, %arg1) : (!vhlo.tensor_v1<!vhlo.bool_v1>, !vhlo.tensor_v1<!vhlo.bool_v1>) -> !vhlo.tensor_v1<!vhlo.bool_v1>
   %0 = "stablehlo.and"(%arg0, %arg1) : (tensor<i1>, tensor<i1>) -> tensor<i1>
   func.return %0 : tensor<i1>
 }
 // CHECK-LABEL: "op_and"
 
 func.func @op_atan2(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<f32> {
-  // CHECK: "vhlo.atan2"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
+  // CHECK: "vhlo.atan2_v1"(%arg0, %arg1) : (!vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.atan2"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }
 // CHECK-LABEL: "op_atan2"
 
 func.func @op_batch_norm_grad(%arg0: tensor<16x16x16x16xf32>, %arg1: tensor<16xf32>, %arg2: tensor<16xf32>, %arg3: tensor<16xf32>, %arg4: tensor<16x16x16x16xf32>) -> (tensor<16x16x16x16xf32>, tensor<16xf32>, tensor<16xf32>) {
-  //      CHECK: "vhlo.batch_norm_grad"(%arg0, %arg1, %arg2, %arg3, %arg4) {
-  // CHECK-SAME:   epsilon = #vhlo.float<1.000000e-03 : !vhlo.f32>,
-  // CHECK-SAME:   feature_index = #vhlo.integer<0 : i64>
-  // CHECK-SAME: } : (!vhlo.tensor<16x16x16x16x!vhlo.f32>, !vhlo.tensor<16x!vhlo.f32>, !vhlo.tensor<16x!vhlo.f32>, !vhlo.tensor<16x!vhlo.f32>, !vhlo.tensor<16x16x16x16x!vhlo.f32>) -> (!vhlo.tensor<16x16x16x16x!vhlo.f32>, !vhlo.tensor<16x!vhlo.f32>, !vhlo.tensor<16x!vhlo.f32>)
+  //      CHECK: "vhlo.batch_norm_grad_v1"(%arg0, %arg1, %arg2, %arg3, %arg4) {
+  // CHECK-SAME:   epsilon = #vhlo.float_v1<1.000000e-03 : !vhlo.f32_v1>,
+  // CHECK-SAME:   feature_index = #vhlo.integer_v1<0 : i64>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<16x16x16x16x!vhlo.f32_v1>, !vhlo.tensor_v1<16x!vhlo.f32_v1>, !vhlo.tensor_v1<16x!vhlo.f32_v1>, !vhlo.tensor_v1<16x!vhlo.f32_v1>, !vhlo.tensor_v1<16x16x16x16x!vhlo.f32_v1>) -> (!vhlo.tensor_v1<16x16x16x16x!vhlo.f32_v1>, !vhlo.tensor_v1<16x!vhlo.f32_v1>, !vhlo.tensor_v1<16x!vhlo.f32_v1>)
   %0:3 = "stablehlo.batch_norm_grad"(%arg0, %arg1, %arg2, %arg3, %arg4) {
     epsilon = 0.001 : f32,
     feature_index = 0 : i64
@@ -857,10 +857,10 @@ func.func @op_batch_norm_grad(%arg0: tensor<16x16x16x16xf32>, %arg1: tensor<16xf
 // CHECK-LABEL: "op_batch_norm_grad"
 
 func.func @op_batch_norm_inference(%arg0: tensor<16x16x16x16xf32>, %arg1: tensor<16xf32>, %arg2: tensor<16xf32>, %arg3: tensor<16xf32>, %arg4: tensor<16xf32>) -> tensor<16x16x16x16xf32> {
-  //      CHECK: "vhlo.batch_norm_inference"(%arg0, %arg1, %arg2, %arg3, %arg4) {
-  // CHECK-SAME:   epsilon = #vhlo.float<1.000000e-03 : !vhlo.f32>,
-  // CHECK-SAME:   feature_index = #vhlo.integer<0 : i64>
-  // CHECK-SAME: } : (!vhlo.tensor<16x16x16x16x!vhlo.f32>, !vhlo.tensor<16x!vhlo.f32>, !vhlo.tensor<16x!vhlo.f32>, !vhlo.tensor<16x!vhlo.f32>, !vhlo.tensor<16x!vhlo.f32>) -> !vhlo.tensor<16x16x16x16x!vhlo.f32>
+  //      CHECK: "vhlo.batch_norm_inference_v1"(%arg0, %arg1, %arg2, %arg3, %arg4) {
+  // CHECK-SAME:   epsilon = #vhlo.float_v1<1.000000e-03 : !vhlo.f32_v1>,
+  // CHECK-SAME:   feature_index = #vhlo.integer_v1<0 : i64>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<16x16x16x16x!vhlo.f32_v1>, !vhlo.tensor_v1<16x!vhlo.f32_v1>, !vhlo.tensor_v1<16x!vhlo.f32_v1>, !vhlo.tensor_v1<16x!vhlo.f32_v1>, !vhlo.tensor_v1<16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x16x16x16x!vhlo.f32_v1>
   %0 = "stablehlo.batch_norm_inference"(%arg0, %arg1, %arg2, %arg3, %arg4) {
     epsilon = 0.001 : f32,
     feature_index = 0 : i64
@@ -870,10 +870,10 @@ func.func @op_batch_norm_inference(%arg0: tensor<16x16x16x16xf32>, %arg1: tensor
 // CHECK-LABEL: "op_batch_norm_inference"
 
 func.func @op_batch_norm_training(%arg0: tensor<16x16x16x16xf32>, %arg1: tensor<16xf32>, %arg2: tensor<16xf32>) -> (tensor<16x16x16x16xf32>, tensor<16xf32>, tensor<16xf32>) {
-  //      CHECK: "vhlo.batch_norm_training"(%arg0, %arg1, %arg2) {
-  // CHECK-SAME:   epsilon = #vhlo.float<1.000000e-03 : !vhlo.f32>,
-  // CHECK-SAME:   feature_index = #vhlo.integer<0 : i64>
-  // CHECK-SAME: } : (!vhlo.tensor<16x16x16x16x!vhlo.f32>, !vhlo.tensor<16x!vhlo.f32>, !vhlo.tensor<16x!vhlo.f32>) -> (!vhlo.tensor<16x16x16x16x!vhlo.f32>, !vhlo.tensor<16x!vhlo.f32>, !vhlo.tensor<16x!vhlo.f32>)
+  //      CHECK: "vhlo.batch_norm_training_v1"(%arg0, %arg1, %arg2) {
+  // CHECK-SAME:   epsilon = #vhlo.float_v1<1.000000e-03 : !vhlo.f32_v1>,
+  // CHECK-SAME:   feature_index = #vhlo.integer_v1<0 : i64>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<16x16x16x16x!vhlo.f32_v1>, !vhlo.tensor_v1<16x!vhlo.f32_v1>, !vhlo.tensor_v1<16x!vhlo.f32_v1>) -> (!vhlo.tensor_v1<16x16x16x16x!vhlo.f32_v1>, !vhlo.tensor_v1<16x!vhlo.f32_v1>, !vhlo.tensor_v1<16x!vhlo.f32_v1>)
   %0:3 = "stablehlo.batch_norm_training"(%arg0, %arg1, %arg2) {
     epsilon = 0.001 : f32,
     feature_index = 0 : i64
@@ -883,16 +883,16 @@ func.func @op_batch_norm_training(%arg0: tensor<16x16x16x16xf32>, %arg1: tensor<
 // CHECK-LABEL: "op_batch_norm_training"
 
 func.func @op_bitcast_convert(%arg0: tensor<i32>) -> tensor<f32> {
-  // CHECK: "vhlo.bitcast_convert"(%arg0) : (!vhlo.tensor<!vhlo.i32>) -> !vhlo.tensor<!vhlo.f32>
+  // CHECK: "vhlo.bitcast_convert_v1"(%arg0) : (!vhlo.tensor_v1<!vhlo.i32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.bitcast_convert"(%arg0) : (tensor<i32>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }
 // CHECK-LABEL: "op_bitcast_convert"
 
 func.func @op_broadcast_in_dim(%arg0: tensor<16xf32>) -> tensor<16x16xf32> {
-  //      CHECK: "vhlo.broadcast_in_dim"(%arg0) {
-  // CHECK-SAME:   broadcast_dimensions = #vhlo.tensor<dense<1> : tensor<1xi64>>
-  // CHECK-SAME: } : (!vhlo.tensor<16x!vhlo.f32>) -> !vhlo.tensor<16x16x!vhlo.f32>
+  //      CHECK: "vhlo.broadcast_in_dim_v1"(%arg0) {
+  // CHECK-SAME:   broadcast_dimensions = #vhlo.tensor_v1<dense<1> : tensor<1xi64>>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x16x!vhlo.f32_v1>
   %0 = "stablehlo.broadcast_in_dim"(%arg0) {
     broadcast_dimensions = dense<1> : tensor<1xi64>
   } : (tensor<16xf32>) -> tensor<16x16xf32>
@@ -901,9 +901,9 @@ func.func @op_broadcast_in_dim(%arg0: tensor<16xf32>) -> tensor<16x16xf32> {
 // CHECK-LABEL: "op_broadcast_in_dim"
 
 func.func @op_broadcast(%arg0: tensor<16xf32>) -> tensor<16x16xf32> {
-  //      CHECK: "vhlo.broadcast"(%arg0) {
-  // CHECK-SAME:   broadcast_sizes = #vhlo.tensor<dense<16> : tensor<1xi64>>
-  // CHECK-SAME: } : (!vhlo.tensor<16x!vhlo.f32>) -> !vhlo.tensor<16x16x!vhlo.f32>
+  //      CHECK: "vhlo.broadcast_v1"(%arg0) {
+  // CHECK-SAME:   broadcast_sizes = #vhlo.tensor_v1<dense<16> : tensor<1xi64>>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x16x!vhlo.f32_v1>
   %0 = "stablehlo.broadcast"(%arg0) {
     broadcast_sizes = dense<16> : tensor<1xi64>
   } : (tensor<16xf32>) -> tensor<16x16xf32>
@@ -912,9 +912,9 @@ func.func @op_broadcast(%arg0: tensor<16xf32>) -> tensor<16x16xf32> {
 // CHECK-LABEL: "op_broadcast"
 
 func.func @op_case(%arg0: tensor<i32>, %arg1: tensor<f32>) -> tensor<f32> {
-  //      CHECK: "vhlo.case"(%arg0) ({
-  // CHECK-NEXT:   "vhlo.return"(%arg1) : (!vhlo.tensor<!vhlo.f32>) -> ()
-  // CHECK-NEXT: }) : (!vhlo.tensor<!vhlo.i32>) -> !vhlo.tensor<!vhlo.f32>
+  //      CHECK: "vhlo.case_v1"(%arg0) ({
+  // CHECK-NEXT:   "vhlo.return_v1"(%arg1) : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> ()
+  // CHECK-NEXT: }) : (!vhlo.tensor_v1<!vhlo.i32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.case"(%arg0) ({
     "stablehlo.return"(%arg1) : (tensor<f32>) -> ()
   }) : (tensor<i32>) -> tensor<f32>
@@ -923,23 +923,23 @@ func.func @op_case(%arg0: tensor<i32>, %arg1: tensor<f32>) -> tensor<f32> {
 // CHECK-LABEL: "op_case"
 
 func.func @op_cbrt(%arg0: tensor<f32>) -> tensor<f32> {
-  // CHECK: "vhlo.cbrt"(%arg0) : (!vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
+  // CHECK: "vhlo.cbrt_v1"(%arg0) : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.cbrt"(%arg0) : (tensor<f32>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }
 // CHECK-LABEL: "op_cbrt"
 
 func.func @op_ceil(%arg0: tensor<f32>) -> tensor<f32> {
-  // CHECK: "vhlo.ceil"(%arg0) : (!vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
+  // CHECK: "vhlo.ceil_v1"(%arg0) : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.ceil"(%arg0) : (tensor<f32>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }
 // CHECK-LABEL: "op_ceil"
 
 func.func @op_cholesky(%arg0: tensor<1x16x16xf32>) -> tensor<1x16x16xf32> {
-  //      CHECK: "vhlo.cholesky"(%arg0) {
-  // CHECK-SAME:   lower = #vhlo.bool<true>
-  // CHECK-SAME: } : (!vhlo.tensor<1x16x16x!vhlo.f32>) -> !vhlo.tensor<1x16x16x!vhlo.f32>
+  //      CHECK: "vhlo.cholesky_v1"(%arg0) {
+  // CHECK-SAME:   lower = #vhlo.bool_v1<true>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<1x16x16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<1x16x16x!vhlo.f32_v1>
   %0 = "stablehlo.cholesky"(%arg0) {
     lower = true
   } : (tensor<1x16x16xf32>) -> tensor<1x16x16xf32>
@@ -948,24 +948,24 @@ func.func @op_cholesky(%arg0: tensor<1x16x16xf32>) -> tensor<1x16x16xf32> {
 // CHECK-LABEL: "op_cholesky"
 
 func.func @op_clamp(%arg0: tensor<f32>, %arg1: tensor<f32>, %arg2: tensor<f32>) -> tensor<f32> {
-  // CHECK: "vhlo.clamp"(%arg0, %arg1, %arg2) : (!vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
+  // CHECK: "vhlo.clamp_v1"(%arg0, %arg1, %arg2) : (!vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.clamp"(%arg0, %arg1, %arg2) : (tensor<f32>, tensor<f32>, tensor<f32>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }
 // CHECK-LABEL: "op_clamp"
 
 func.func @op_count_leading_zeros(%arg0: tensor<i32>) -> tensor<i32> {
-  // CHECK: "vhlo.count_leading_zeros"(%arg0) : (!vhlo.tensor<!vhlo.i32>) -> !vhlo.tensor<!vhlo.i32>
+  // CHECK: "vhlo.count_leading_zeros_v1"(%arg0) : (!vhlo.tensor_v1<!vhlo.i32_v1>) -> !vhlo.tensor_v1<!vhlo.i32_v1>
   %0 = "stablehlo.count_leading_zeros"(%arg0) : (tensor<i32>) -> tensor<i32>
   func.return %0 : tensor<i32>
 }
 // CHECK-LABEL: "op_count_leading_zeros"
 
 func.func @op_collective_permute(%arg0: tensor<16x8xf32>) -> tensor<16x8xf32> {
-  //               CHECK: "vhlo.collective_permute"(%arg0) {
-  //          CHECK-SAME:   channel_id = #vhlo.integer<1 : i64>,
-  // CHECK-SAME{LITERAL}:   source_target_pairs = #vhlo.tensor<dense<[[0, 1], [1, 2], [2, 3]]> : tensor<3x2xi64>>
-  //          CHECK-SAME: } : (!vhlo.tensor<16x8x!vhlo.f32>) -> !vhlo.tensor<16x8x!vhlo.f32>
+  //               CHECK: "vhlo.collective_permute_v1"(%arg0) {
+  //          CHECK-SAME:   channel_id = #vhlo.integer_v1<1 : i64>,
+  // CHECK-SAME{LITERAL}:   source_target_pairs = #vhlo.tensor_v1<dense<[[0, 1], [1, 2], [2, 3]]> : tensor<3x2xi64>>
+  //          CHECK-SAME: } : (!vhlo.tensor_v1<16x8x!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x8x!vhlo.f32_v1>
   %0 = "stablehlo.collective_permute"(%arg0) {
     source_target_pairs = dense<[[0, 1], [1, 2], [2, 3]]> : tensor<3x2xi64>,
     channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>
@@ -975,10 +975,10 @@ func.func @op_collective_permute(%arg0: tensor<16x8xf32>) -> tensor<16x8xf32> {
 // CHECK-LABEL: "op_collective_permute"
 
 func.func @op_compare(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<i1> {
-  //      CHECK: "vhlo.compare"(%arg0, %arg1) {
-  // CHECK-SAME:   compare_type = #vhlo<comparison_type TOTALORDER>,
-  // CHECK-SAME:   comparison_direction = #vhlo<comparison_direction EQ>
-  // CHECK-SAME: } : (!vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.bool>
+  //      CHECK: "vhlo.compare_v1"(%arg0, %arg1) {
+  // CHECK-SAME:   compare_type = #vhlo<comparison_type_v1 TOTALORDER>,
+  // CHECK-SAME:   comparison_direction = #vhlo<comparison_direction_v1 EQ>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.bool_v1>
   %0 = "stablehlo.compare"(%arg0, %arg1) {
     comparison_direction = #stablehlo<comparison_direction EQ>,
     compare_type = #stablehlo<comparison_type TOTALORDER>
@@ -988,23 +988,23 @@ func.func @op_compare(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<i1> {
 // CHECK-LABEL: "op_compare"
 
 func.func @op_complex(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<complex<f32>> {
-  // CHECK: "vhlo.complex"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.complex<!vhlo.f32>>
+  // CHECK: "vhlo.complex_v1"(%arg0, %arg1) : (!vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.complex_v1<!vhlo.f32_v1>>
   %0 = "stablehlo.complex"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<complex<f32>>
   func.return %0 : tensor<complex<f32>>
 }
 // CHECK-LABEL: "op_complex"
 
 func.func @op_compute_reshape_shape(%arg0: index, %arg1: tensor<1xindex>) -> tensor<1xindex> {
-  // CHECK: "vhlo.compute_reshape_shape"(%arg0, %arg1) : (!vhlo.index, !vhlo.tensor<1x!vhlo.index>) -> !vhlo.tensor<1x!vhlo.index>
+  // CHECK: "vhlo.compute_reshape_shape_v1"(%arg0, %arg1) : (!vhlo.index_v1, !vhlo.tensor_v1<1x!vhlo.index_v1>) -> !vhlo.tensor_v1<1x!vhlo.index_v1>
   %0 = "stablehlo.compute_reshape_shape"(%arg0, %arg1) : (index, tensor<1xindex>) -> tensor<1xindex>
   func.return %0 : tensor<1xindex>
 }
 // CHECK-LABEL: "op_compute_reshape_shape"
 
 func.func @op_concatenate(%arg0: tensor<8xf32>, %arg1: tensor<8xf32>) -> tensor<16xf32> {
-  //      CHECK: "vhlo.concatenate"(%arg0, %arg1) {
-  // CHECK-SAME:   dimension = #vhlo.integer<0 : i64>
-  // CHECK-SAME: } : (!vhlo.tensor<8x!vhlo.f32>, !vhlo.tensor<8x!vhlo.f32>) -> !vhlo.tensor<16x!vhlo.f32>
+  //      CHECK: "vhlo.concatenate_v1"(%arg0, %arg1) {
+  // CHECK-SAME:   dimension = #vhlo.integer_v1<0 : i64>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<8x!vhlo.f32_v1>, !vhlo.tensor_v1<8x!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x!vhlo.f32_v1>
   %0 = "stablehlo.concatenate"(%arg0, %arg1) {
     dimension = 0 : i64
   } : (tensor<8xf32>, tensor<8xf32>) -> tensor<16xf32>
@@ -1013,9 +1013,9 @@ func.func @op_concatenate(%arg0: tensor<8xf32>, %arg1: tensor<8xf32>) -> tensor<
 // CHECK-LABEL: "op_concatenate"
 
 func.func @op_constant(%arg0: tensor<f32>) -> tensor<f32> {
-  //      CHECK: "vhlo.constant"() {
-  // CHECK-SAME:   value = #vhlo.tensor<dense<0.000000e+00> : tensor<f32>>
-  // CHECK-SAME: } : () -> !vhlo.tensor<!vhlo.f32>
+  //      CHECK: "vhlo.constant_v1"() {
+  // CHECK-SAME:   value = #vhlo.tensor_v1<dense<0.000000e+00> : tensor<f32>>
+  // CHECK-SAME: } : () -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.constant"() {
     value = dense<0.0> : tensor<f32>
   } : () -> tensor<f32>
@@ -1024,32 +1024,32 @@ func.func @op_constant(%arg0: tensor<f32>) -> tensor<f32> {
 // CHECK-LABEL: "op_constant"
 
 func.func @op_convert(%arg0: tensor<i32>) -> tensor<f32> {
-  // CHECK: "vhlo.convert"(%arg0) : (!vhlo.tensor<!vhlo.i32>) -> !vhlo.tensor<!vhlo.f32>
+  // CHECK: "vhlo.convert_v1"(%arg0) : (!vhlo.tensor_v1<!vhlo.i32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.convert"(%arg0) : (tensor<i32>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }
 // CHECK-LABEL: "op_convert"
 
 func.func @op_convolution(%arg0: tensor<1x8x8x207xf32>, %arg1: tensor<3x3x207x16xf32>) -> tensor<1x7x7x16xf32> {
-  //      CHECK: "vhlo.convolution"(%arg0, %arg1) {
-  // CHECK-SAME:   batch_group_count = #vhlo.integer<1 : i64>,
-  // CHECK-SAME:   feature_group_count = #vhlo.integer<1 : i64>,
-  // CHECK-SAME:   input_batch_dimension = #vhlo.integer<0 : i64>,
-  // CHECK-SAME:   input_feature_dimension = #vhlo.integer<3 : i64>,
-  // CHECK-SAME:   input_spatial_dimensions = #vhlo.tensor<dense<[1, 2]> : tensor<2xi64>>,
-  // CHECK-SAME:   kernel_input_feature_dimension = #vhlo.integer<2 : i64>,
-  // CHECK-SAME:   kernel_output_feature_dimension = #vhlo.integer<3 : i64>,
-  // CHECK-SAME:   kernel_spatial_dimensions = #vhlo.tensor<dense<[0, 1]> : tensor<2xi64>>,
-  // CHECK-SAME:   lhs_dilation = #vhlo.tensor<dense<2> : tensor<2xi64>>,
-  // CHECK-SAME:   output_batch_dimension = #vhlo.integer<0 : i64>,
-  // CHECK-SAME:   output_feature_dimension = #vhlo.integer<3 : i64>,
-  // CHECK-SAME:   output_spatial_dimensions = #vhlo.tensor<dense<[1, 2]> : tensor<2xi64>>,
-  // CHECK-SAME:   padding = #vhlo.tensor<dense<1> : tensor<2x2xi64>>,
-  // CHECK-SAME:   precision_config = #vhlo.array<[#vhlo<precision HIGHEST>, #vhlo<precision HIGHEST>]>,
-  // CHECK-SAME:   rhs_dilation = #vhlo.tensor<dense<2> : tensor<2xi64>>,
-  // CHECK-SAME:   window_reversal = #vhlo.tensor<dense<true> : tensor<2xi1>>,
-  // CHECK-SAME:   window_strides = #vhlo.tensor<dense<2> : tensor<2xi64>>
-  // CHECK-SAME: } : (!vhlo.tensor<1x8x8x207x!vhlo.f32>, !vhlo.tensor<3x3x207x16x!vhlo.f32>) -> !vhlo.tensor<1x7x7x16x!vhlo.f32>
+  //      CHECK: "vhlo.convolution_v1"(%arg0, %arg1) {
+  // CHECK-SAME:   batch_group_count = #vhlo.integer_v1<1 : i64>,
+  // CHECK-SAME:   feature_group_count = #vhlo.integer_v1<1 : i64>,
+  // CHECK-SAME:   input_batch_dimension = #vhlo.integer_v1<0 : i64>,
+  // CHECK-SAME:   input_feature_dimension = #vhlo.integer_v1<3 : i64>,
+  // CHECK-SAME:   input_spatial_dimensions = #vhlo.tensor_v1<dense<[1, 2]> : tensor<2xi64>>,
+  // CHECK-SAME:   kernel_input_feature_dimension = #vhlo.integer_v1<2 : i64>,
+  // CHECK-SAME:   kernel_output_feature_dimension = #vhlo.integer_v1<3 : i64>,
+  // CHECK-SAME:   kernel_spatial_dimensions = #vhlo.tensor_v1<dense<[0, 1]> : tensor<2xi64>>,
+  // CHECK-SAME:   lhs_dilation = #vhlo.tensor_v1<dense<2> : tensor<2xi64>>,
+  // CHECK-SAME:   output_batch_dimension = #vhlo.integer_v1<0 : i64>,
+  // CHECK-SAME:   output_feature_dimension = #vhlo.integer_v1<3 : i64>,
+  // CHECK-SAME:   output_spatial_dimensions = #vhlo.tensor_v1<dense<[1, 2]> : tensor<2xi64>>,
+  // CHECK-SAME:   padding = #vhlo.tensor_v1<dense<1> : tensor<2x2xi64>>,
+  // CHECK-SAME:   precision_config = #vhlo.array_v1<[#vhlo<precision_v1 HIGHEST>, #vhlo<precision_v1 HIGHEST>]>,
+  // CHECK-SAME:   rhs_dilation = #vhlo.tensor_v1<dense<2> : tensor<2xi64>>,
+  // CHECK-SAME:   window_reversal = #vhlo.tensor_v1<dense<true> : tensor<2xi1>>,
+  // CHECK-SAME:   window_strides = #vhlo.tensor_v1<dense<2> : tensor<2xi64>>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<1x8x8x207x!vhlo.f32_v1>, !vhlo.tensor_v1<3x3x207x16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<1x7x7x16x!vhlo.f32_v1>
   %0 = "stablehlo.convolution"(%arg0, %arg1) {
     window_strides = dense<2> : tensor<2xi64>,
     padding = dense<1> : tensor<2x2xi64>,
@@ -1066,23 +1066,23 @@ func.func @op_convolution(%arg0: tensor<1x8x8x207xf32>, %arg1: tensor<3x3x207x16
 // CHECK-LABEL: "op_convolution"
 
 func.func @op_cosine(%arg0: tensor<f32>) -> tensor<f32> {
-  // CHECK: "vhlo.cosine"(%arg0) : (!vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
+  // CHECK: "vhlo.cosine_v1"(%arg0) : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.cosine"(%arg0) : (tensor<f32>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }
 // CHECK-LABEL: "op_cosine"
 
 func.func @op_create_token() -> !stablehlo.token {
-  // CHECK: "vhlo.create_token"() : () -> !vhlo.token
+  // CHECK: "vhlo.create_token_v1"() : () -> !vhlo.token_v1
   %0 = "stablehlo.create_token"() : () -> !stablehlo.token
   func.return %0 : !stablehlo.token
 }
 // CHECK-LABEL: "op_create_token"
 
 func.func @op_cross_replica_sum(%arg0: tensor<f32>) -> tensor<f32> {
-  //               CHECK: "vhlo.cross-replica-sum"(%arg0) {
-  // CHECK-SAME{LITERAL}:   replica_groups = #vhlo.tensor<dense<[[0], [1]]> : tensor<2x1xi64>>
-  //          CHECK-SAME: } : (!vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
+  //               CHECK: "vhlo.cross-replica-sum_v1"(%arg0) {
+  // CHECK-SAME{LITERAL}:   replica_groups = #vhlo.tensor_v1<dense<[[0], [1]]> : tensor<2x1xi64>>
+  //          CHECK-SAME: } : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.cross-replica-sum"(%arg0) {
     replica_groups = dense<[[0], [1]]> : tensor<2x1xi64>
   } : (tensor<f32>) -> tensor<f32>
@@ -1091,27 +1091,27 @@ func.func @op_cross_replica_sum(%arg0: tensor<f32>) -> tensor<f32> {
 // CHECK-LABEL: "op_cross_replica_sum"
 
 func.func @op_cstr_reshapable(%arg0: index, %arg1: tensor<1xindex>) -> !shape.witness {
-  // CHECK: "vhlo.cstr_reshapable"(%arg0, %arg1) : (!vhlo.index, !vhlo.tensor<1x!vhlo.index>) -> !vhlo.witness
+  // CHECK: "vhlo.cstr_reshapable_v1"(%arg0, %arg1) : (!vhlo.index_v1, !vhlo.tensor_v1<1x!vhlo.index_v1>) -> !vhlo.witness_v1
   %0 = "stablehlo.cstr_reshapable"(%arg0, %arg1) : (index, tensor<1xindex>) -> !shape.witness
   func.return %0 : !shape.witness
 }
 // CHECK-LABEL: "op_cstr_reshapable"
 
 func.func @op_custom_call(%arg0: tensor<f32>) -> tensor<f32> {
-  //      CHECK: "vhlo.custom_call"(%arg0) {
-  // CHECK-SAME:   api_version = #vhlo<api_version API_VERSION_STATUS_RETURNING>,
-  // CHECK-SAME:   backend_config = #vhlo.string<"\08\03\1A\02">,
-  // CHECK-SAME:   call_target_name = #vhlo.string<"foo">,
-  // CHECK-SAME:   called_computations = #vhlo.array<[#vhlo.string<"foo">]>,
-  // CHECK-SAME:   has_side_effect = #vhlo.bool<true>,
-  // CHECK-SAME:   operand_layouts = #vhlo.array<[#vhlo.tensor<dense<> : tensor<0xindex>>]>,
-  // CHECK-SAME:   output_operand_aliases = #vhlo.array<[
-  // CHECK-SAME:     #vhlo.output_operand_alias<
+  //      CHECK: "vhlo.custom_call_v1"(%arg0) {
+  // CHECK-SAME:   api_version = #vhlo<api_version_v1 API_VERSION_STATUS_RETURNING>,
+  // CHECK-SAME:   backend_config = #vhlo.string_v1<"\08\03\1A\02">,
+  // CHECK-SAME:   call_target_name = #vhlo.string_v1<"foo">,
+  // CHECK-SAME:   called_computations = #vhlo.array_v1<[#vhlo.string_v1<"foo">]>,
+  // CHECK-SAME:   has_side_effect = #vhlo.bool_v1<true>,
+  // CHECK-SAME:   operand_layouts = #vhlo.array_v1<[#vhlo.tensor_v1<dense<> : tensor<0xindex>>]>,
+  // CHECK-SAME:   output_operand_aliases = #vhlo.array_v1<[
+  // CHECK-SAME:     #vhlo.output_operand_alias_v1<
   // CHECK-SAME:       outputTupleIndices = [],
   // CHECK-SAME:       operandIndex = 0,
   // CHECK-SAME:       operandTupleIndices = []>]>
-  // CHECK-SAME:   result_layouts = #vhlo.array<[#vhlo.tensor<dense<> : tensor<0xindex>>]>
-  // CHECK-SAME: } : (!vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
+  // CHECK-SAME:   result_layouts = #vhlo.array_v1<[#vhlo.tensor_v1<dense<> : tensor<0xindex>>]>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.custom_call"(%arg0) {
     call_target_name = "foo",
     has_side_effect = true,
@@ -1130,20 +1130,20 @@ func.func @op_custom_call(%arg0: tensor<f32>) -> tensor<f32> {
 // CHECK-LABEL: "op_custom_call"
 
 func.func @op_divide(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<f32> {
-  // CHECK: "vhlo.divide"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
+  // CHECK: "vhlo.divide_v1"(%arg0, %arg1) : (!vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.divide"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }
 // CHECK-LABEL: "op_divide"
 
 func.func @op_dot_general(%arg0: tensor<8x8x16xf32>, %arg1: tensor<8x16x8xf32>) -> tensor<8x8x8xf32> {
-  //      CHECK: "vhlo.dot_general"(%arg0, %arg1) {
-  // CHECK-SAME:   lhs_batching_dimensions = #vhlo.tensor<dense<0> : tensor<1xi64>>,
-  // CHECK-SAME:   lhs_contracting_dimensions = #vhlo.tensor<dense<2> : tensor<1xi64>>,
-  // CHECK-SAME:   precision_config = #vhlo.array<[#vhlo<precision HIGHEST>, #vhlo<precision HIGHEST>]>,
-  // CHECK-SAME:   rhs_batching_dimensions = #vhlo.tensor<dense<0> : tensor<1xi64>>,
-  // CHECK-SAME:   rhs_contracting_dimensions = #vhlo.tensor<dense<1> : tensor<1xi64>>
-  // CHECK-SAME: } : (!vhlo.tensor<8x8x16x!vhlo.f32>, !vhlo.tensor<8x16x8x!vhlo.f32>) -> !vhlo.tensor<8x8x8x!vhlo.f32>
+  //      CHECK: "vhlo.dot_general_v1"(%arg0, %arg1) {
+  // CHECK-SAME:   lhs_batching_dimensions = #vhlo.tensor_v1<dense<0> : tensor<1xi64>>,
+  // CHECK-SAME:   lhs_contracting_dimensions = #vhlo.tensor_v1<dense<2> : tensor<1xi64>>,
+  // CHECK-SAME:   precision_config = #vhlo.array_v1<[#vhlo<precision_v1 HIGHEST>, #vhlo<precision_v1 HIGHEST>]>,
+  // CHECK-SAME:   rhs_batching_dimensions = #vhlo.tensor_v1<dense<0> : tensor<1xi64>>,
+  // CHECK-SAME:   rhs_contracting_dimensions = #vhlo.tensor_v1<dense<1> : tensor<1xi64>>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<8x8x16x!vhlo.f32_v1>, !vhlo.tensor_v1<8x16x8x!vhlo.f32_v1>) -> !vhlo.tensor_v1<8x8x8x!vhlo.f32_v1>
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
       lhs_batching_dimensions = [0],
@@ -1158,9 +1158,9 @@ func.func @op_dot_general(%arg0: tensor<8x8x16xf32>, %arg1: tensor<8x16x8xf32>) 
 // CHECK-LABEL: "op_dot_general"
 
 func.func @op_dot(%arg0: tensor<8x16xf32>, %arg1: tensor<16x8xf32>) -> tensor<8x8xf32> {
-  //      CHECK: "vhlo.dot"(%arg0, %arg1) {
-  // CHECK-SAME:   precision_config = #vhlo.array<[#vhlo<precision HIGHEST>, #vhlo<precision HIGHEST>]>
-  // CHECK-SAME: } : (!vhlo.tensor<8x16x!vhlo.f32>, !vhlo.tensor<16x8x!vhlo.f32>) -> !vhlo.tensor<8x8x!vhlo.f32>
+  //      CHECK: "vhlo.dot_v1"(%arg0, %arg1) {
+  // CHECK-SAME:   precision_config = #vhlo.array_v1<[#vhlo<precision_v1 HIGHEST>, #vhlo<precision_v1 HIGHEST>]>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<8x16x!vhlo.f32_v1>, !vhlo.tensor_v1<16x8x!vhlo.f32_v1>) -> !vhlo.tensor_v1<8x8x!vhlo.f32_v1>
   %0 = "stablehlo.dot"(%arg0, %arg1) {
     precision_config = [#stablehlo<precision HIGHEST>, #stablehlo<precision HIGHEST>]
   } : (tensor<8x16xf32>, tensor<16x8xf32>) -> tensor<8x8xf32>
@@ -1169,11 +1169,11 @@ func.func @op_dot(%arg0: tensor<8x16xf32>, %arg1: tensor<16x8xf32>) -> tensor<8x
 // CHECK-LABEL: "op_dot"
 
 func.func @op_dynamic_broadcast_in_dim(%arg0: tensor<?x?xf32>, %arg1: tensor<2xindex>) -> tensor<?x?xf32> {
-  //      CHECK: "vhlo.dynamic_broadcast_in_dim"(%arg0, %arg1) {
-  // CHECK-SAME:   broadcast_dimensions = #vhlo.tensor<dense<[0, 1]> : tensor<2xi64>>,
-  // CHECK-SAME:   known_expanding_dimensions = #vhlo.tensor<dense<0> : tensor<1xi64>>,
-  // CHECK-SAME:   known_nonexpanding_dimensions = #vhlo.tensor<dense<1> : tensor<1xi64>>
-  // CHECK-SAME: } : (!vhlo.tensor<?x?x!vhlo.f32>, !vhlo.tensor<2x!vhlo.index>) -> !vhlo.tensor<?x?x!vhlo.f32>
+  //      CHECK: "vhlo.dynamic_broadcast_in_dim_v1"(%arg0, %arg1) {
+  // CHECK-SAME:   broadcast_dimensions = #vhlo.tensor_v1<dense<[0, 1]> : tensor<2xi64>>,
+  // CHECK-SAME:   known_expanding_dimensions = #vhlo.tensor_v1<dense<0> : tensor<1xi64>>,
+  // CHECK-SAME:   known_nonexpanding_dimensions = #vhlo.tensor_v1<dense<1> : tensor<1xi64>>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<?x?x!vhlo.f32_v1>, !vhlo.tensor_v1<2x!vhlo.index_v1>) -> !vhlo.tensor_v1<?x?x!vhlo.f32_v1>
   %0 = "stablehlo.dynamic_broadcast_in_dim"(%arg0, %arg1) {
     broadcast_dimensions = dense<[0, 1]> : tensor<2xi64>,
     known_expanding_dimensions = dense<0> : tensor<1xi64>,
@@ -1184,25 +1184,25 @@ func.func @op_dynamic_broadcast_in_dim(%arg0: tensor<?x?xf32>, %arg1: tensor<2xi
 // CHECK-LABEL: "op_dynamic_broadcast_in_dim"
 
 func.func @op_dynamic_conv(%arg0: tensor<1x8x8x207xf32>, %arg1: tensor<3x3x207x16xf32>, %arg2: tensor<4xi32>) -> tensor<1x?x?x16xf32> {
-  //      CHECK: "vhlo.dynamic_conv"(%arg0, %arg1, %arg2) {
-  // CHECK-SAME:   batch_group_count = #vhlo.integer<1 : i64>,
-  // CHECK-SAME:   feature_group_count = #vhlo.integer<1 : i64>,
-  // CHECK-SAME:   input_batch_dimension = #vhlo.integer<0 : i64>,
-  // CHECK-SAME:   input_feature_dimension = #vhlo.integer<3 : i64>,
-  // CHECK-SAME:   input_spatial_dimensions = #vhlo.tensor<dense<[1, 2]> : tensor<2xi64>>,
-  // CHECK-SAME:   kernel_input_feature_dimension = #vhlo.integer<2 : i64>,
-  // CHECK-SAME:   kernel_output_feature_dimension = #vhlo.integer<3 : i64>,
-  // CHECK-SAME:   kernel_spatial_dimensions = #vhlo.tensor<dense<[0, 1]> : tensor<2xi64>>,
-  // CHECK-SAME:   lhs_dilation = #vhlo.tensor<dense<2> : tensor<2xi64>>,
-  // CHECK-SAME:   output_batch_dimension = #vhlo.integer<0 : i64>,
-  // CHECK-SAME:   output_feature_dimension = #vhlo.integer<3 : i64>,
-  // CHECK-SAME:   output_spatial_dimensions = #vhlo.tensor<dense<[1, 2]> : tensor<2xi64>>,
-  // CHECK-SAME:   padding = #vhlo.tensor<dense<1> : tensor<2x2xi64>>,
-  // CHECK-SAME:   precision_config = #vhlo.array<[#vhlo<precision HIGHEST>, #vhlo<precision HIGHEST>]>,
-  // CHECK-SAME:   rhs_dilation = #vhlo.tensor<dense<2> : tensor<2xi64>>,
-  // CHECK-SAME:   window_reversal = #vhlo.tensor<dense<true> : tensor<2xi1>>,
-  // CHECK-SAME:   window_strides = #vhlo.tensor<dense<2> : tensor<2xi64>>
-  // CHECK-SAME: } : (!vhlo.tensor<1x8x8x207x!vhlo.f32>, !vhlo.tensor<3x3x207x16x!vhlo.f32>, !vhlo.tensor<4x!vhlo.i32>) -> !vhlo.tensor<1x?x?x16x!vhlo.f32>
+  //      CHECK: "vhlo.dynamic_conv_v1"(%arg0, %arg1, %arg2) {
+  // CHECK-SAME:   batch_group_count = #vhlo.integer_v1<1 : i64>,
+  // CHECK-SAME:   feature_group_count = #vhlo.integer_v1<1 : i64>,
+  // CHECK-SAME:   input_batch_dimension = #vhlo.integer_v1<0 : i64>,
+  // CHECK-SAME:   input_feature_dimension = #vhlo.integer_v1<3 : i64>,
+  // CHECK-SAME:   input_spatial_dimensions = #vhlo.tensor_v1<dense<[1, 2]> : tensor<2xi64>>,
+  // CHECK-SAME:   kernel_input_feature_dimension = #vhlo.integer_v1<2 : i64>,
+  // CHECK-SAME:   kernel_output_feature_dimension = #vhlo.integer_v1<3 : i64>,
+  // CHECK-SAME:   kernel_spatial_dimensions = #vhlo.tensor_v1<dense<[0, 1]> : tensor<2xi64>>,
+  // CHECK-SAME:   lhs_dilation = #vhlo.tensor_v1<dense<2> : tensor<2xi64>>,
+  // CHECK-SAME:   output_batch_dimension = #vhlo.integer_v1<0 : i64>,
+  // CHECK-SAME:   output_feature_dimension = #vhlo.integer_v1<3 : i64>,
+  // CHECK-SAME:   output_spatial_dimensions = #vhlo.tensor_v1<dense<[1, 2]> : tensor<2xi64>>,
+  // CHECK-SAME:   padding = #vhlo.tensor_v1<dense<1> : tensor<2x2xi64>>,
+  // CHECK-SAME:   precision_config = #vhlo.array_v1<[#vhlo<precision_v1 HIGHEST>, #vhlo<precision_v1 HIGHEST>]>,
+  // CHECK-SAME:   rhs_dilation = #vhlo.tensor_v1<dense<2> : tensor<2xi64>>,
+  // CHECK-SAME:   window_reversal = #vhlo.tensor_v1<dense<true> : tensor<2xi1>>,
+  // CHECK-SAME:   window_strides = #vhlo.tensor_v1<dense<2> : tensor<2xi64>>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<1x8x8x207x!vhlo.f32_v1>, !vhlo.tensor_v1<3x3x207x16x!vhlo.f32_v1>, !vhlo.tensor_v1<4x!vhlo.i32_v1>) -> !vhlo.tensor_v1<1x?x?x16x!vhlo.f32_v1>
   %0 = "stablehlo.dynamic_conv"(%arg0, %arg1, %arg2) {
     window_strides = dense<2> : tensor<2xi64>,
     padding = dense<1> : tensor<2x2xi64>,
@@ -1219,13 +1219,13 @@ func.func @op_dynamic_conv(%arg0: tensor<1x8x8x207xf32>, %arg1: tensor<3x3x207x1
 // CHECK-LABEL: "op_dynamic_conv"
 
 func.func @op_dynamic_gather(%arg0 : tensor<2x4x9xf32>, %arg1 : tensor<1x5x2xi32>, %arg2 : tensor<3xi32>) -> tensor<1x5x8xf32> {
-  //      CHECK: "vhlo.dynamic_gather"(%arg0, %arg1, %arg2) {
-  // CHECK-SAME:   collapsed_slice_dims = #vhlo.tensor<dense<[0, 1]> : tensor<2xi64>>,
-  // CHECK-SAME:   index_vector_dim = #vhlo.integer<2 : i64>,
-  // CHECK-SAME:   indices_are_sorted = #vhlo.bool<true>,
-  // CHECK-SAME:   offset_dims = #vhlo.tensor<dense<2> : tensor<1xi64>>,
-  // CHECK-SAME:   start_index_map = #vhlo.tensor<dense<[0, 1]> : tensor<2xi64>>
-  // CHECK-SAME: } : (!vhlo.tensor<2x4x9x!vhlo.f32>, !vhlo.tensor<1x5x2x!vhlo.i32>, !vhlo.tensor<3x!vhlo.i32>) -> !vhlo.tensor<1x5x8x!vhlo.f32>
+  //      CHECK: "vhlo.dynamic_gather_v1"(%arg0, %arg1, %arg2) {
+  // CHECK-SAME:   collapsed_slice_dims = #vhlo.tensor_v1<dense<[0, 1]> : tensor<2xi64>>,
+  // CHECK-SAME:   index_vector_dim = #vhlo.integer_v1<2 : i64>,
+  // CHECK-SAME:   indices_are_sorted = #vhlo.bool_v1<true>,
+  // CHECK-SAME:   offset_dims = #vhlo.tensor_v1<dense<2> : tensor<1xi64>>,
+  // CHECK-SAME:   start_index_map = #vhlo.tensor_v1<dense<[0, 1]> : tensor<2xi64>>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<2x4x9x!vhlo.f32_v1>, !vhlo.tensor_v1<1x5x2x!vhlo.i32_v1>, !vhlo.tensor_v1<3x!vhlo.i32_v1>) -> !vhlo.tensor_v1<1x5x8x!vhlo.f32_v1>
   %0 = "stablehlo.dynamic_gather"(%arg0, %arg1, %arg2) {
     dimension_numbers = #stablehlo.gather<
       offset_dims = [2],
@@ -1240,9 +1240,9 @@ func.func @op_dynamic_gather(%arg0 : tensor<2x4x9xf32>, %arg1 : tensor<1x5x2xi32
 // CHECK-LABEL: "op_dynamic_gather"
 
 func.func @op_dynamic_iota(%arg0: tensor<1xindex>) -> tensor<?xf32> {
-  //      CHECK: "vhlo.dynamic_iota"(%arg0) {
-  // CHECK-SAME:   iota_dimension = #vhlo.integer<0 : i64>
-  // CHECK-SAME: } : (!vhlo.tensor<1x!vhlo.index>) -> !vhlo.tensor<?x!vhlo.f32>
+  //      CHECK: "vhlo.dynamic_iota_v1"(%arg0) {
+  // CHECK-SAME:   iota_dimension = #vhlo.integer_v1<0 : i64>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<1x!vhlo.index_v1>) -> !vhlo.tensor_v1<?x!vhlo.f32_v1>
   %0 = "stablehlo.dynamic_iota"(%arg0) {
     iota_dimension = 0 : i64
   } : (tensor<1xindex>) -> tensor<?xf32>
@@ -1251,23 +1251,23 @@ func.func @op_dynamic_iota(%arg0: tensor<1xindex>) -> tensor<?xf32> {
 // CHECK-LABEL: "op_dynamic_iota"
 
 func.func @op_dynamic_pad(%arg0: tensor<?xf32>, %arg1: tensor<f32>, %arg2: tensor<1xindex>, %arg3: tensor<1xindex>, %arg4: tensor<1xindex>) -> tensor<?xf32> {
-  // CHECK: "vhlo.dynamic_pad"(%arg0, %arg1, %arg2, %arg3, %arg4) : (!vhlo.tensor<?x!vhlo.f32>, !vhlo.tensor<!vhlo.f32>, !vhlo.tensor<1x!vhlo.index>, !vhlo.tensor<1x!vhlo.index>, !vhlo.tensor<1x!vhlo.index>) -> !vhlo.tensor<?x!vhlo.f32>
+  // CHECK: "vhlo.dynamic_pad_v1"(%arg0, %arg1, %arg2, %arg3, %arg4) : (!vhlo.tensor_v1<?x!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.tensor_v1<1x!vhlo.index_v1>, !vhlo.tensor_v1<1x!vhlo.index_v1>, !vhlo.tensor_v1<1x!vhlo.index_v1>) -> !vhlo.tensor_v1<?x!vhlo.f32_v1>
   %0 = "stablehlo.dynamic_pad"(%arg0, %arg1, %arg2, %arg3, %arg4) : (tensor<?xf32>, tensor<f32>, tensor<1xindex>, tensor<1xindex>, tensor<1xindex>) -> tensor<?xf32>
   func.return %0 : tensor<?xf32>
 }
 // CHECK-LABEL: "op_dynamic_pad"
 
 func.func @op_dynamic_reshape(%arg0: tensor<16xf32>, %arg1: tensor<?xindex>) -> tensor<?x?xf32> {
-  // CHECK: "vhlo.dynamic_reshape"(%arg0, %arg1) : (!vhlo.tensor<16x!vhlo.f32>, !vhlo.tensor<?x!vhlo.index>) -> !vhlo.tensor<?x?x!vhlo.f32>
+  // CHECK: "vhlo.dynamic_reshape_v1"(%arg0, %arg1) : (!vhlo.tensor_v1<16x!vhlo.f32_v1>, !vhlo.tensor_v1<?x!vhlo.index_v1>) -> !vhlo.tensor_v1<?x?x!vhlo.f32_v1>
   %0 = "stablehlo.dynamic_reshape"(%arg0, %arg1) : (tensor<16xf32>, tensor<?xindex>) -> tensor<?x?xf32>
   func.return %0 : tensor<?x?xf32>
 }
 // CHECK-LABEL: "op_dynamic_reshape"
 
 func.func @op_dynamic_slice(%arg0: tensor<16xf32>, %arg1: tensor<i64>) -> tensor<4xf32> {
-  //      CHECK: "vhlo.dynamic_slice"(%arg0, %arg1) {
-  // CHECK-SAME:   slice_sizes = #vhlo.tensor<dense<4> : tensor<1xi64>>
-  // CHECK-SAME: } : (!vhlo.tensor<16x!vhlo.f32>, !vhlo.tensor<!vhlo.i64>) -> !vhlo.tensor<4x!vhlo.f32>
+  //      CHECK: "vhlo.dynamic_slice_v1"(%arg0, %arg1) {
+  // CHECK-SAME:   slice_sizes = #vhlo.tensor_v1<dense<4> : tensor<1xi64>>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<16x!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.i64_v1>) -> !vhlo.tensor_v1<4x!vhlo.f32_v1>
   %0 = "stablehlo.dynamic_slice"(%arg0, %arg1) {
     slice_sizes = dense<4> : tensor<1xi64>
   } : (tensor<16xf32>, tensor<i64>) -> tensor<4xf32>
@@ -1276,16 +1276,16 @@ func.func @op_dynamic_slice(%arg0: tensor<16xf32>, %arg1: tensor<i64>) -> tensor
 // CHECK-LABEL: "op_dynamic_slice"
 
 func.func @op_dynamic_update_slice(%arg0: tensor<16xf32>, %arg1: tensor<4xf32>, %arg2: tensor<i64>) -> tensor<16xf32> {
-  // CHECK: "vhlo.dynamic_update_slice"(%arg0, %arg1, %arg2) : (!vhlo.tensor<16x!vhlo.f32>, !vhlo.tensor<4x!vhlo.f32>, !vhlo.tensor<!vhlo.i64>) -> !vhlo.tensor<16x!vhlo.f32>
+  // CHECK: "vhlo.dynamic_update_slice_v1"(%arg0, %arg1, %arg2) : (!vhlo.tensor_v1<16x!vhlo.f32_v1>, !vhlo.tensor_v1<4x!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.i64_v1>) -> !vhlo.tensor_v1<16x!vhlo.f32_v1>
   %0 = "stablehlo.dynamic_update_slice"(%arg0, %arg1, %arg2) : (tensor<16xf32>, tensor<4xf32>, tensor<i64>) -> tensor<16xf32>
   func.return %0 : tensor<16xf32>
 }
 // CHECK-LABEL: "op_dynamic_update_slice"
 
 func.func @op_einsum(%arg0: tensor<8x16xf32>, %arg1: tensor<16x8xf32>) -> tensor<8x8xf32> {
-  //      CHECK: "vhlo.einsum"(%arg0, %arg1) {
-  // CHECK-SAME:   einsum_config = #vhlo.string<"ab,bc->ac">
-  // CHECK-SAME: } : (!vhlo.tensor<8x16x!vhlo.f32>, !vhlo.tensor<16x8x!vhlo.f32>) -> !vhlo.tensor<8x8x!vhlo.f32>
+  //      CHECK: "vhlo.einsum_v1"(%arg0, %arg1) {
+  // CHECK-SAME:   einsum_config = #vhlo.string_v1<"ab,bc->ac">
+  // CHECK-SAME: } : (!vhlo.tensor_v1<8x16x!vhlo.f32_v1>, !vhlo.tensor_v1<16x8x!vhlo.f32_v1>) -> !vhlo.tensor_v1<8x8x!vhlo.f32_v1>
   %0 = "stablehlo.einsum"(%arg0, %arg1) {
     einsum_config = "ab,bc->ac"
   } : (tensor<8x16xf32>, tensor<16x8xf32>) -> tensor<8x8xf32>
@@ -1294,24 +1294,24 @@ func.func @op_einsum(%arg0: tensor<8x16xf32>, %arg1: tensor<16x8xf32>) -> tensor
 // CHECK-LABEL: "op_einsum"
 
 func.func @op_exponential_minus_one(%arg0: tensor<f32>) -> tensor<f32> {
-  // CHECK: "vhlo.exponential_minus_one"(%arg0) : (!vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
+  // CHECK: "vhlo.exponential_minus_one_v1"(%arg0) : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.exponential_minus_one"(%arg0) : (tensor<f32>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }
 // CHECK-LABEL: "op_exponential_minus_one"
 
 func.func @op_exponential(%arg0: tensor<f32>) -> tensor<f32> {
-  // CHECK: "vhlo.exponential"(%arg0) : (!vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
+  // CHECK: "vhlo.exponential_v1"(%arg0) : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.exponential"(%arg0) : (tensor<f32>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }
 // CHECK-LABEL: "op_exponential"
 
 func.func @op_fft(%arg0: tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>> {
-  //      CHECK: "vhlo.fft"(%arg0) {
-  // CHECK-SAME:   fft_length = #vhlo.tensor<dense<16> : tensor<1xi64>>,
-  // CHECK-SAME:   fft_type = #vhlo<fft_type FFT>
-  // CHECK-SAME: } : (!vhlo.tensor<16x!vhlo.complex<!vhlo.f32>>) -> !vhlo.tensor<16x!vhlo.complex<!vhlo.f32>>
+  //      CHECK: "vhlo.fft_v1"(%arg0) {
+  // CHECK-SAME:   fft_length = #vhlo.tensor_v1<dense<16> : tensor<1xi64>>,
+  // CHECK-SAME:   fft_type = #vhlo<fft_type_v1 FFT>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<16x!vhlo.complex_v1<!vhlo.f32_v1>>) -> !vhlo.tensor_v1<16x!vhlo.complex_v1<!vhlo.f32_v1>>
   %0 = "stablehlo.fft"(%arg0) {
     fft_type = #stablehlo<fft_type FFT>,
     fft_length = dense<16> : tensor<1xi64>
@@ -1321,35 +1321,35 @@ func.func @op_fft(%arg0: tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>> {
 // CHECK-LABEL: "op_fft"
 
 func.func @op_floor(%arg0: tensor<f32>) -> tensor<f32> {
-  // CHECK: "vhlo.floor"(%arg0) : (!vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
+  // CHECK: "vhlo.floor_v1"(%arg0) : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.floor"(%arg0) : (tensor<f32>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }
 // CHECK-LABEL: "op_floor"
 
 func.func private @op_func(%arg0: tensor<f32> {stablehlo.arg = "0"}) -> (tensor<f32> {stablehlo.result = "0"}) {
-  // CHECK:      "vhlo.func"() ({
-  // CHECK-NEXT:   ^[[BB:bb.*]](%arg0: !vhlo.tensor<!vhlo.f32>):
-  // CHECK-NEXT:     "vhlo.return"(%arg0) : (!vhlo.tensor<!vhlo.f32>) -> ()
+  // CHECK:      "vhlo.func_v1"() ({
+  // CHECK-NEXT:   ^[[BB:bb.*]](%arg0: !vhlo.tensor_v1<!vhlo.f32_v1>):
+  // CHECK-NEXT:     "vhlo.return_v1"(%arg0) : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> ()
   // CHECK-NEXT: }) {
-  // CHECK-SAME:   arg_attrs = #vhlo.array<[#vhlo.dict<{#vhlo.string<"stablehlo.arg"> = #vhlo.string<"0">}>]>,
-  // CHECK-SAME:   function_type = #vhlo.type<!vhlo.func<(!vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>>>,
-  // CHECK-SAME:   res_attrs = #vhlo.array<[#vhlo.dict<{#vhlo.string<"stablehlo.result"> = #vhlo.string<"0">}>]>,
-  // CHECK-SAME:   sym_name = #vhlo.string<"op_func">,
-  // CHECK-SAME:   sym_visibility = #vhlo.string<"private">
+  // CHECK-SAME:   arg_attrs = #vhlo.array_v1<[#vhlo.dict_v1<{#vhlo.string_v1<"stablehlo.arg"> = #vhlo.string_v1<"0">}>]>,
+  // CHECK-SAME:   function_type = #vhlo.type_v1<!vhlo.func_v1<(!vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>>>,
+  // CHECK-SAME:   res_attrs = #vhlo.array_v1<[#vhlo.dict_v1<{#vhlo.string_v1<"stablehlo.result"> = #vhlo.string_v1<"0">}>]>,
+  // CHECK-SAME:   sym_name = #vhlo.string_v1<"op_func">,
+  // CHECK-SAME:   sym_visibility = #vhlo.string_v1<"private">
   // CHECK-SAME: } : () -> ()
   func.return %arg0 : tensor<f32>
 }
 
 func.func @op_gather(%arg0 : tensor<2x4x9xf32>, %arg1 : tensor<1x5x2xi32>) -> tensor<1x5x1xf32> {
-  //      CHECK: "vhlo.gather"(%arg0, %arg1) {
-  // CHECK-SAME:   collapsed_slice_dims = #vhlo.tensor<dense<[0, 1]> : tensor<2xi64>>,
-  // CHECK-SAME:   index_vector_dim = #vhlo.integer<2 : i64>,
-  // CHECK-SAME:   indices_are_sorted = #vhlo.bool<true>,
-  // CHECK-SAME:   offset_dims = #vhlo.tensor<dense<2> : tensor<1xi64>>,
-  // CHECK-SAME:   slice_sizes = #vhlo.tensor<dense<1> : tensor<3xi64>>,
-  // CHECK-SAME:   start_index_map = #vhlo.tensor<dense<[0, 1]> : tensor<2xi64>>
-  // CHECK-SAME: } : (!vhlo.tensor<2x4x9x!vhlo.f32>, !vhlo.tensor<1x5x2x!vhlo.i32>) -> !vhlo.tensor<1x5x1x!vhlo.f32>
+  //      CHECK: "vhlo.gather_v1"(%arg0, %arg1) {
+  // CHECK-SAME:   collapsed_slice_dims = #vhlo.tensor_v1<dense<[0, 1]> : tensor<2xi64>>,
+  // CHECK-SAME:   index_vector_dim = #vhlo.integer_v1<2 : i64>,
+  // CHECK-SAME:   indices_are_sorted = #vhlo.bool_v1<true>,
+  // CHECK-SAME:   offset_dims = #vhlo.tensor_v1<dense<2> : tensor<1xi64>>,
+  // CHECK-SAME:   slice_sizes = #vhlo.tensor_v1<dense<1> : tensor<3xi64>>,
+  // CHECK-SAME:   start_index_map = #vhlo.tensor_v1<dense<[0, 1]> : tensor<2xi64>>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<2x4x9x!vhlo.f32_v1>, !vhlo.tensor_v1<1x5x2x!vhlo.i32_v1>) -> !vhlo.tensor_v1<1x5x1x!vhlo.f32_v1>
   %0 = "stablehlo.gather"(%arg0, %arg1) {
     dimension_numbers = #stablehlo.gather<
       offset_dims = [2],
@@ -1365,9 +1365,9 @@ func.func @op_gather(%arg0 : tensor<2x4x9xf32>, %arg1 : tensor<1x5x2xi32>) -> te
 // CHECK-LABEL: "op_gather"
 
 func.func @op_get_dimension_size(%arg0: tensor<?xf32>) -> tensor<i32> {
-  //      CHECK: "vhlo.get_dimension_size"(%arg0) {
-  // CHECK-SAME:   dimension = #vhlo.integer<0 : i64>
-  // CHECK-SAME: } : (!vhlo.tensor<?x!vhlo.f32>) -> !vhlo.tensor<!vhlo.i32>
+  //      CHECK: "vhlo.get_dimension_size_v1"(%arg0) {
+  // CHECK-SAME:   dimension = #vhlo.integer_v1<0 : i64>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<?x!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.i32_v1>
   %0 = "stablehlo.get_dimension_size"(%arg0) {
     dimension = 0 : i64
   } : (tensor<?xf32>) -> tensor<i32>
@@ -1376,9 +1376,9 @@ func.func @op_get_dimension_size(%arg0: tensor<?xf32>) -> tensor<i32> {
 // CHECK-LABEL: "op_get_dimension_size"
 
 func.func @op_get_tuple_element(%arg0: tuple<tensor<f32>, tensor<i32>>) -> tensor<f32> {
-  //      CHECK: "vhlo.get_tuple_element"(%arg0) {
-  // CHECK-SAME:   index = #vhlo.integer<0 : i32>
-  // CHECK-SAME: } : (!vhlo.tuple<!vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.i32>>) -> !vhlo.tensor<!vhlo.f32>
+  //      CHECK: "vhlo.get_tuple_element_v1"(%arg0) {
+  // CHECK-SAME:   index = #vhlo.integer_v1<0 : i32>
+  // CHECK-SAME: } : (!vhlo.tuple_v1<!vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.i32_v1>>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.get_tuple_element"(%arg0) {
     index = 0 : i32
   } : (tuple<tensor<f32>, tensor<i32>>) -> tensor<f32>
@@ -1387,11 +1387,11 @@ func.func @op_get_tuple_element(%arg0: tuple<tensor<f32>, tensor<i32>>) -> tenso
 // CHECK-LABEL: "op_get_tuple_element"
 
 func.func @op_if(%arg0: tensor<i1>, %arg1: tensor<f32>, %arg2: tensor<f32>) -> tensor<f32> {
-  //      CHECK: "vhlo.if"(%arg0) ({
-  // CHECK-NEXT:   "vhlo.return"(%arg1) : (!vhlo.tensor<!vhlo.f32>) -> ()
+  //      CHECK: "vhlo.if_v1"(%arg0) ({
+  // CHECK-NEXT:   "vhlo.return_v1"(%arg1) : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> ()
   // CHECK-NEXT: }, {
-  // CHECK-NEXT:   "vhlo.return"(%arg2) : (!vhlo.tensor<!vhlo.f32>) -> ()
-  // CHECK-NEXT: }) : (!vhlo.tensor<!vhlo.bool>) -> !vhlo.tensor<!vhlo.f32>
+  // CHECK-NEXT:   "vhlo.return_v1"(%arg2) : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> ()
+  // CHECK-NEXT: }) : (!vhlo.tensor_v1<!vhlo.bool_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.if"(%arg0) ({
     "stablehlo.return"(%arg1) : (tensor<f32>) -> ()
   }, {
@@ -1402,17 +1402,17 @@ func.func @op_if(%arg0: tensor<i1>, %arg1: tensor<f32>, %arg2: tensor<f32>) -> t
 // CHECK-LABEL: "op_if"
 
 func.func @op_imag(%arg0: tensor<complex<f32>>) -> tensor<f32> {
-  // CHECK: "vhlo.imag"(%arg0) : (!vhlo.tensor<!vhlo.complex<!vhlo.f32>>) -> !vhlo.tensor<!vhlo.f32>
+  // CHECK: "vhlo.imag_v1"(%arg0) : (!vhlo.tensor_v1<!vhlo.complex_v1<!vhlo.f32_v1>>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.imag"(%arg0) : (tensor<complex<f32>>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }
 // CHECK-LABEL: "op_imag"
 
 func.func @op_infeed(%arg0: !stablehlo.token) -> (tensor<f32>, !stablehlo.token) {
-  //               CHECK: "vhlo.infeed"(%arg0) {
-  //          CHECK-SAME:   infeed_config = #vhlo.string<"foo">,
-  // CHECK-SAME{LITERAL}:   layout = #vhlo.array<[#vhlo.array<[]>]>
-  //          CHECK-SAME: } : (!vhlo.token) -> (!vhlo.tensor<!vhlo.f32>, !vhlo.token)
+  //               CHECK: "vhlo.infeed_v1"(%arg0) {
+  //          CHECK-SAME:   infeed_config = #vhlo.string_v1<"foo">,
+  // CHECK-SAME{LITERAL}:   layout = #vhlo.array_v1<[#vhlo.array_v1<[]>]>
+  //          CHECK-SAME: } : (!vhlo.token_v1) -> (!vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.token_v1)
   %0:2 = "stablehlo.infeed"(%arg0) {
     infeed_config = "foo",
     layout = [[]]
@@ -1422,9 +1422,9 @@ func.func @op_infeed(%arg0: !stablehlo.token) -> (tensor<f32>, !stablehlo.token)
 // CHECK-LABEL: "op_infeed"
 
 func.func @op_iota() -> tensor<16xf32> {
-  //      CHECK: "vhlo.iota"() {
-  // CHECK-SAME:   iota_dimension = #vhlo.integer<0 : i64>
-  // CHECK-SAME: } : () -> !vhlo.tensor<16x!vhlo.f32>
+  //      CHECK: "vhlo.iota_v1"() {
+  // CHECK-SAME:   iota_dimension = #vhlo.integer_v1<0 : i64>
+  // CHECK-SAME: } : () -> !vhlo.tensor_v1<16x!vhlo.f32_v1>
   %0 = "stablehlo.iota"() {
     iota_dimension = 0 : i64
   } : () -> tensor<16xf32>
@@ -1433,41 +1433,41 @@ func.func @op_iota() -> tensor<16xf32> {
 // CHECK-LABEL: "op_iota"
 
 func.func @op_is_finite(%arg0: tensor<f32>) -> tensor<i1> {
-  // CHECK: "vhlo.is_finite"(%arg0) : (!vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.bool>
+  // CHECK: "vhlo.is_finite_v1"(%arg0) : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.bool_v1>
   %0 = "stablehlo.is_finite"(%arg0) : (tensor<f32>) -> tensor<i1>
   func.return %0 : tensor<i1>
 }
 // CHECK-LABEL: "op_is_finite"
 
 func.func @op_log(%arg0: tensor<f32>) -> tensor<f32> {
-  // CHECK: "vhlo.log"(%arg0) : (!vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
+  // CHECK: "vhlo.log_v1"(%arg0) : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.log"(%arg0) : (tensor<f32>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }
 // CHECK-LABEL: "op_log"
 
 func.func @op_log_plus_one(%arg0: tensor<f32>) -> tensor<f32> {
-  // CHECK: "vhlo.log_plus_one"(%arg0) : (!vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
+  // CHECK: "vhlo.log_plus_one_v1"(%arg0) : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.log_plus_one"(%arg0) : (tensor<f32>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }
 // CHECK-LABEL: "op_log_plus_one"
 
 func.func @op_logistic(%arg0: tensor<f32>) -> tensor<f32> {
-  // CHECK: "vhlo.logistic"(%arg0) : (!vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
+  // CHECK: "vhlo.logistic_v1"(%arg0) : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.logistic"(%arg0) : (tensor<f32>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }
 // CHECK-LABEL: "op_logistic"
 
 func.func @op_map(%arg0: tensor<16xf32>) -> tensor<16xf32> {
-  //      CHECK: "vhlo.map"(%arg0) ({
-  // CHECK-NEXT:   ^[[BB:bb.*]](%[[ARG1:arg.*]]: !vhlo.tensor<!vhlo.f32>):
-  // CHECK-NEXT:     %[[VAL1:.*]] = "vhlo.abs"(%[[ARG1]]) : (!vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
-  // CHECK-NEXT:     "vhlo.return"(%[[VAL1]]) : (!vhlo.tensor<!vhlo.f32>) -> ()
+  //      CHECK: "vhlo.map_v1"(%arg0) ({
+  // CHECK-NEXT:   ^[[BB:bb.*]](%[[ARG1:arg.*]]: !vhlo.tensor_v1<!vhlo.f32_v1>):
+  // CHECK-NEXT:     %[[VAL1:.*]] = "vhlo.abs_v1"(%[[ARG1]]) : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
+  // CHECK-NEXT:     "vhlo.return_v1"(%[[VAL1]]) : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> ()
   // CHECK-NEXT: }) {
-  // CHECK-SAME:   dimensions = #vhlo.tensor<dense<0> : tensor<1xi64>>
-  // CHECK-SAME: } : (!vhlo.tensor<16x!vhlo.f32>) -> !vhlo.tensor<16x!vhlo.f32>
+  // CHECK-SAME:   dimensions = #vhlo.tensor_v1<dense<0> : tensor<1xi64>>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x!vhlo.f32_v1>
   %0 = "stablehlo.map"(%arg0) ({
     ^bb0(%arg1: tensor<f32>):
       %1 = "stablehlo.abs"(%arg1) : (tensor<f32>) -> tensor<f32>
@@ -1480,58 +1480,58 @@ func.func @op_map(%arg0: tensor<16xf32>) -> tensor<16xf32> {
 // CHECK-LABEL: "op_map"
 
 func.func @op_maximum(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<f32> {
-  // CHECK: "vhlo.maximum"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
+  // CHECK: "vhlo.maximum_v1"(%arg0, %arg1) : (!vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.maximum"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }
 // CHECK-LABEL: "op_maximum"
 
 func.func @op_minimum(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<f32> {
-  // CHECK: "vhlo.minimum"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
+  // CHECK: "vhlo.minimum_v1"(%arg0, %arg1) : (!vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.minimum"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }
 // CHECK-LABEL: "op_minimum"
 
 func.func @op_multiply(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<f32> {
-  // CHECK: "vhlo.multiply"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
+  // CHECK: "vhlo.multiply_v1"(%arg0, %arg1) : (!vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.multiply"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }
 // CHECK-LABEL: "op_multiply"
 
 func.func @op_negate(%arg0: tensor<f32>) -> tensor<f32> {
-  // CHECK: "vhlo.negate"(%arg0) : (!vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
+  // CHECK: "vhlo.negate_v1"(%arg0) : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.negate"(%arg0) : (tensor<f32>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }
 // CHECK-LABEL: "op_negate"
 
 func.func @op_not(%arg0: tensor<i1>) -> tensor<i1> {
-  // CHECK: "vhlo.not"(%arg0) : (!vhlo.tensor<!vhlo.bool>) -> !vhlo.tensor<!vhlo.bool>
+  // CHECK: "vhlo.not_v1"(%arg0) : (!vhlo.tensor_v1<!vhlo.bool_v1>) -> !vhlo.tensor_v1<!vhlo.bool_v1>
   %0 = "stablehlo.not"(%arg0) : (tensor<i1>) -> tensor<i1>
   func.return %0 : tensor<i1>
 }
 // CHECK-LABEL: "op_not"
 
 func.func @op_optimization_barrier(%arg0: tensor<f32>) -> tensor<f32> {
-  // CHECK: "vhlo.optimization_barrier"(%arg0) : (!vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
+  // CHECK: "vhlo.optimization_barrier_v1"(%arg0) : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.optimization_barrier"(%arg0) : (tensor<f32>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }
 // CHECK-LABEL: "op_optimization_barrier"
 
 func.func @op_or(%arg0: tensor<i1>, %arg1: tensor<i1>) -> tensor<i1> {
-  // CHECK: "vhlo.or"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.bool>, !vhlo.tensor<!vhlo.bool>) -> !vhlo.tensor<!vhlo.bool>
+  // CHECK: "vhlo.or_v1"(%arg0, %arg1) : (!vhlo.tensor_v1<!vhlo.bool_v1>, !vhlo.tensor_v1<!vhlo.bool_v1>) -> !vhlo.tensor_v1<!vhlo.bool_v1>
   %0 = "stablehlo.or"(%arg0, %arg1) : (tensor<i1>, tensor<i1>) -> tensor<i1>
   func.return %0 : tensor<i1>
 }
 // CHECK-LABEL: "op_or"
 
 func.func @op_outfeed(%arg0: tensor<f32>, %arg1: !stablehlo.token) -> !stablehlo.token {
-  //      CHECK: "vhlo.outfeed"(%arg0, %arg1) {
-  // CHECK-SAME:   outfeed_config = #vhlo.string<"foo">
-  // CHECK-SAME: } : (!vhlo.tensor<!vhlo.f32>, !vhlo.token) -> !vhlo.token
+  //      CHECK: "vhlo.outfeed_v1"(%arg0, %arg1) {
+  // CHECK-SAME:   outfeed_config = #vhlo.string_v1<"foo">
+  // CHECK-SAME: } : (!vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.token_v1) -> !vhlo.token_v1
   %0 = "stablehlo.outfeed"(%arg0, %arg1) {
     outfeed_config = "foo"
   } : (tensor<f32>, !stablehlo.token) -> !stablehlo.token
@@ -1540,11 +1540,11 @@ func.func @op_outfeed(%arg0: tensor<f32>, %arg1: !stablehlo.token) -> !stablehlo
 // CHECK-LABEL: "op_outfeed"
 
 func.func @op_pad(%arg0: tensor<8xf32>, %arg1: tensor<f32>) -> tensor<16xf32> {
-  //      CHECK: "vhlo.pad"(%arg0, %arg1) {
-  // CHECK-SAME:   edge_padding_high = #vhlo.tensor<dense<4> : tensor<1xi64>>,
-  // CHECK-SAME:   edge_padding_low = #vhlo.tensor<dense<4> : tensor<1xi64>>,
-  // CHECK-SAME:   interior_padding = #vhlo.tensor<dense<0> : tensor<1xi64>>
-  // CHECK-SAME: } : (!vhlo.tensor<8x!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<16x!vhlo.f32>
+  //      CHECK: "vhlo.pad_v1"(%arg0, %arg1) {
+  // CHECK-SAME:   edge_padding_high = #vhlo.tensor_v1<dense<4> : tensor<1xi64>>,
+  // CHECK-SAME:   edge_padding_low = #vhlo.tensor_v1<dense<4> : tensor<1xi64>>,
+  // CHECK-SAME:   interior_padding = #vhlo.tensor_v1<dense<0> : tensor<1xi64>>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<8x!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x!vhlo.f32_v1>
   %0 = "stablehlo.pad"(%arg0, %arg1) {
     edge_padding_high = dense<4> : tensor<1xi64>,
     edge_padding_low = dense<4> : tensor<1xi64>,
@@ -1555,39 +1555,39 @@ func.func @op_pad(%arg0: tensor<8xf32>, %arg1: tensor<f32>) -> tensor<16xf32> {
 // CHECK-LABEL: "op_pad"
 
 func.func @op_popcnt(%arg0: tensor<i32>) -> tensor<i32> {
-  // CHECK: "vhlo.popcnt"(%arg0) : (!vhlo.tensor<!vhlo.i32>) -> !vhlo.tensor<!vhlo.i32>
+  // CHECK: "vhlo.popcnt_v1"(%arg0) : (!vhlo.tensor_v1<!vhlo.i32_v1>) -> !vhlo.tensor_v1<!vhlo.i32_v1>
   %0 = "stablehlo.popcnt"(%arg0) : (tensor<i32>) -> tensor<i32>
   func.return %0 : tensor<i32>
 }
 // CHECK-LABEL: "op_popcnt"
 
 func.func @op_power(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<f32> {
-  // CHECK: "vhlo.power"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
+  // CHECK: "vhlo.power_v1"(%arg0, %arg1) : (!vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.power"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }
 // CHECK-LABEL: "op_power"
 
 func.func @op_real_dynamic_slice(%arg0: tensor<?xf32>, %arg1: tensor<1xindex>, %arg2: tensor<1xindex>, %arg3: tensor<1xindex>) -> tensor<?xf32> {
-  // CHECK: "vhlo.real_dynamic_slice"(%arg0, %arg1, %arg2, %arg3) : (!vhlo.tensor<?x!vhlo.f32>, !vhlo.tensor<1x!vhlo.index>, !vhlo.tensor<1x!vhlo.index>, !vhlo.tensor<1x!vhlo.index>) -> !vhlo.tensor<?x!vhlo.f32>
+  // CHECK: "vhlo.real_dynamic_slice_v1"(%arg0, %arg1, %arg2, %arg3) : (!vhlo.tensor_v1<?x!vhlo.f32_v1>, !vhlo.tensor_v1<1x!vhlo.index_v1>, !vhlo.tensor_v1<1x!vhlo.index_v1>, !vhlo.tensor_v1<1x!vhlo.index_v1>) -> !vhlo.tensor_v1<?x!vhlo.f32_v1>
   %0 = "stablehlo.real_dynamic_slice"(%arg0, %arg1, %arg2, %arg3) : (tensor<?xf32>, tensor<1xindex>, tensor<1xindex>, tensor<1xindex>) -> tensor<?xf32>
   func.return %0 : tensor<?xf32>
 }
 // CHECK-LABEL: "op_real_dynamic_slice"
 
 func.func @op_real(%arg0: tensor<complex<f32>>) -> tensor<f32> {
-  // CHECK: "vhlo.real"(%arg0) : (!vhlo.tensor<!vhlo.complex<!vhlo.f32>>) -> !vhlo.tensor<!vhlo.f32>
+  // CHECK: "vhlo.real_v1"(%arg0) : (!vhlo.tensor_v1<!vhlo.complex_v1<!vhlo.f32_v1>>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.real"(%arg0) : (tensor<complex<f32>>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }
 // CHECK-LABEL: "op_real"
 
 func.func @op_recv(%arg0: !stablehlo.token) -> (tensor<f32>, !stablehlo.token) {
-  //      CHECK: "vhlo.recv"(%arg0) {
-  // CHECK-SAME:   channel_id = #vhlo.integer<0 : i64>,
-  // CHECK-SAME:   channel_type = #vhlo.integer<0 : i64>,
-  // CHECK-SAME:   is_host_transfer = #vhlo.bool<true>
-  // CHECK-SAME: } : (!vhlo.token) -> (!vhlo.tensor<!vhlo.f32>, !vhlo.token)
+  //      CHECK: "vhlo.recv_v1"(%arg0) {
+  // CHECK-SAME:   channel_id = #vhlo.integer_v1<0 : i64>,
+  // CHECK-SAME:   channel_type = #vhlo.integer_v1<0 : i64>,
+  // CHECK-SAME:   is_host_transfer = #vhlo.bool_v1<true>
+  // CHECK-SAME: } : (!vhlo.token_v1) -> (!vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.token_v1)
   %0:2 = "stablehlo.recv"(%arg0) {
     channel_handle = #stablehlo.channel_handle<handle = 0, type = 0>,
     is_host_transfer = true
@@ -1609,10 +1609,10 @@ func.func @op_reduce(%arg0: tensor<16xf32>, %arg1: tensor<f32>) -> tensor<f32> {
 // CHECK-LABEL: "op_reduce"
 
 func.func @op_reduce_precision(%arg0: tensor<f32>) -> tensor<f32> {
-  //      CHECK: "vhlo.reduce_precision"(%arg0) {
-  // CHECK-SAME:   exponent_bits = #vhlo.integer<8 : i32>
-  // CHECK-SAME:   mantissa_bits = #vhlo.integer<10 : i32>
-  // CHECK-SAME: } : (!vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
+  //      CHECK: "vhlo.reduce_precision_v1"(%arg0) {
+  // CHECK-SAME:   exponent_bits = #vhlo.integer_v1<8 : i32>
+  // CHECK-SAME:   mantissa_bits = #vhlo.integer_v1<10 : i32>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.reduce_precision"(%arg0) {
     exponent_bits = 8 : i32,
     mantissa_bits = 10 : i32
@@ -1622,16 +1622,16 @@ func.func @op_reduce_precision(%arg0: tensor<f32>) -> tensor<f32> {
 // CHECK-LABEL: "op_reduce_precision"
 
 func.func @op_reduce_scatter(%arg0: tensor<16xf32>) -> tensor<16xf32> {
-  //               CHECK: "vhlo.reduce_scatter"(%arg0) ({
-  //          CHECK-NEXT:   ^[[BB:bb.*]](%[[ARG1:arg.*]]: !vhlo.tensor<!vhlo.f32>, %[[ARG2:arg.*]]: !vhlo.tensor<!vhlo.f32>):
-  //          CHECK-NEXT:     %[[VAL1:.*]] = "vhlo.add"(%[[ARG1]], %[[ARG2]]) : (!vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
-  //          CHECK-NEXT:     "vhlo.return"(%[[VAL1]]) : (!vhlo.tensor<!vhlo.f32>) -> ()
+  //               CHECK: "vhlo.reduce_scatter_v1"(%arg0) ({
+  //          CHECK-NEXT:   ^[[BB:bb.*]](%[[ARG1:arg.*]]: !vhlo.tensor_v1<!vhlo.f32_v1>, %[[ARG2:arg.*]]: !vhlo.tensor_v1<!vhlo.f32_v1>):
+  //          CHECK-NEXT:     %[[VAL1:.*]] = "vhlo.add_v1"(%[[ARG1]], %[[ARG2]]) : (!vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
+  //          CHECK-NEXT:     "vhlo.return_v1"(%[[VAL1]]) : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> ()
   //          CHECK-NEXT: }) {
-  //          CHECK-SAME:   channel_id = #vhlo.integer<1 : i64>,
-  // CHECK-SAME{LITERAL}:   replica_groups = #vhlo.tensor<dense<[[0], [1]]> : tensor<2x1xi64>>,
-  //          CHECK-SAME:   scatter_dimension = #vhlo.integer<0 : i64>
-  //          CHECK-SAME:   use_global_device_ids = #vhlo.bool<true>
-  //          CHECK-SAME: } : (!vhlo.tensor<16x!vhlo.f32>) -> !vhlo.tensor<16x!vhlo.f32>
+  //          CHECK-SAME:   channel_id = #vhlo.integer_v1<1 : i64>,
+  // CHECK-SAME{LITERAL}:   replica_groups = #vhlo.tensor_v1<dense<[[0], [1]]> : tensor<2x1xi64>>,
+  //          CHECK-SAME:   scatter_dimension = #vhlo.integer_v1<0 : i64>
+  //          CHECK-SAME:   use_global_device_ids = #vhlo.bool_v1<true>
+  //          CHECK-SAME: } : (!vhlo.tensor_v1<16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x!vhlo.f32_v1>
   %0 = "stablehlo.reduce_scatter"(%arg0) ({
     ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
       %1 = "stablehlo.add"(%arg1, %arg2) : (tensor<f32>, tensor<f32>) -> tensor<f32>
@@ -1647,17 +1647,17 @@ func.func @op_reduce_scatter(%arg0: tensor<16xf32>) -> tensor<16xf32> {
 // CHECK-LABEL: "op_reduce_scatter"
 
 func.func @op_reduce_window(%arg0: tensor<2x17x31x7xf32>, %arg1: tensor<f32>) -> tensor<2x9x16x7xf32> {
-  //               CHECK: "vhlo.reduce_window"(%arg0, %arg1) ({
-  //          CHECK-NEXT:   ^[[BB:bb.*]](%[[ARG2:arg.*]]: !vhlo.tensor<!vhlo.f32>, %[[ARG3:arg.*]]: !vhlo.tensor<!vhlo.f32>):
-  //          CHECK-NEXT:     %[[VAL1:.*]] = "vhlo.maximum"(%[[ARG2]], %[[ARG3]]) : (!vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
-  //          CHECK-NEXT:     "vhlo.return"(%[[VAL1]]) : (!vhlo.tensor<!vhlo.f32>) -> ()
+  //               CHECK: "vhlo.reduce_window_v1"(%arg0, %arg1) ({
+  //          CHECK-NEXT:   ^[[BB:bb.*]](%[[ARG2:arg.*]]: !vhlo.tensor_v1<!vhlo.f32_v1>, %[[ARG3:arg.*]]: !vhlo.tensor_v1<!vhlo.f32_v1>):
+  //          CHECK-NEXT:     %[[VAL1:.*]] = "vhlo.maximum_v1"(%[[ARG2]], %[[ARG3]]) : (!vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
+  //          CHECK-NEXT:     "vhlo.return_v1"(%[[VAL1]]) : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> ()
   //          CHECK-NEXT: }) {
-  //          CHECK-SAME:   base_dilations = #vhlo.tensor<dense<[1, 2, 2, 1]> : tensor<4xi64>>,
-  // CHECK-SAME{LITERAL}:   padding = #vhlo.tensor<dense<[[0, 0], [2, 0], [0, 2], [0, 0]]> : tensor<4x2xi64>>,
-  //          CHECK-SAME:   window_dilations = #vhlo.tensor<dense<[1, 2, 2, 1]> : tensor<4xi64>>,
-  //          CHECK-SAME:   window_dimensions = #vhlo.tensor<dense<[1, 2, 2, 1]> : tensor<4xi64>>,
-  //          CHECK-SAME:   window_strides = #vhlo.tensor<dense<[1, 4, 4, 1]> : tensor<4xi64>>
-  //          CHECK-SAME: } : (!vhlo.tensor<2x17x31x7x!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<2x9x16x7x!vhlo.f32>
+  //          CHECK-SAME:   base_dilations = #vhlo.tensor_v1<dense<[1, 2, 2, 1]> : tensor<4xi64>>,
+  // CHECK-SAME{LITERAL}:   padding = #vhlo.tensor_v1<dense<[[0, 0], [2, 0], [0, 2], [0, 0]]> : tensor<4x2xi64>>,
+  //          CHECK-SAME:   window_dilations = #vhlo.tensor_v1<dense<[1, 2, 2, 1]> : tensor<4xi64>>,
+  //          CHECK-SAME:   window_dimensions = #vhlo.tensor_v1<dense<[1, 2, 2, 1]> : tensor<4xi64>>,
+  //          CHECK-SAME:   window_strides = #vhlo.tensor_v1<dense<[1, 4, 4, 1]> : tensor<4xi64>>
+  //          CHECK-SAME: } : (!vhlo.tensor_v1<2x17x31x7x!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<2x9x16x7x!vhlo.f32_v1>
   %0 = "stablehlo.reduce_window"(%arg0, %arg1) ({
     ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
       %1 = "stablehlo.maximum"(%arg2, %arg3) : (tensor<f32>, tensor<f32>) -> tensor<f32>
@@ -1674,37 +1674,37 @@ func.func @op_reduce_window(%arg0: tensor<2x17x31x7xf32>, %arg1: tensor<f32>) ->
 // CHECK-LABEL: "op_reduce_window"
 
 func.func @op_remainder(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<f32> {
-  // CHECK: "vhlo.remainder"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
+  // CHECK: "vhlo.remainder_v1"(%arg0, %arg1) : (!vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.remainder"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }
 // CHECK-LABEL: "op_remainder"
 
 func.func @op_replica_id() -> tensor<ui32> {
-  // CHECK: "vhlo.replica_id"() : () -> !vhlo.tensor<!vhlo.ui32>
+  // CHECK: "vhlo.replica_id_v1"() : () -> !vhlo.tensor_v1<!vhlo.ui32_v1>
   %0 = "stablehlo.replica_id"() : () -> tensor<ui32>
   func.return %0 : tensor<ui32>
 }
 // CHECK-LABEL: "op_replica_id"
 
 func.func @op_partition_id() -> tensor<ui32> {
-  // CHECK: "vhlo.partition_id"() : () -> !vhlo.tensor<!vhlo.ui32>
+  // CHECK: "vhlo.partition_id_v1"() : () -> !vhlo.tensor_v1<!vhlo.ui32_v1>
   %0 = "stablehlo.partition_id"() : () -> tensor<ui32>
   func.return %0 : tensor<ui32>
 }
 // CHECK-LABEL: "op_partition_id"
 
 func.func @op_reshape(%arg0: tensor<16xf32>) -> tensor<4x4xf32> {
-  // CHECK: "vhlo.reshape"(%arg0) : (!vhlo.tensor<16x!vhlo.f32>) -> !vhlo.tensor<4x4x!vhlo.f32>
+  // CHECK: "vhlo.reshape_v1"(%arg0) : (!vhlo.tensor_v1<16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<4x4x!vhlo.f32_v1>
   %0 = "stablehlo.reshape"(%arg0) : (tensor<16xf32>) -> tensor<4x4xf32>
   func.return %0 : tensor<4x4xf32>
 }
 // CHECK-LABEL: "op_reshape"
 
 func.func @op_return(%arg0: tensor<i32>, %arg1: tensor<f32>) -> tensor<f32> {
-  //      CHECK: "vhlo.case"(%arg0) ({
-  // CHECK-NEXT:   "vhlo.return"(%arg1) : (!vhlo.tensor<!vhlo.f32>) -> ()
-  // CHECK-NEXT: }) : (!vhlo.tensor<!vhlo.i32>) -> !vhlo.tensor<!vhlo.f32>
+  //      CHECK: "vhlo.case_v1"(%arg0) ({
+  // CHECK-NEXT:   "vhlo.return_v1"(%arg1) : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> ()
+  // CHECK-NEXT: }) : (!vhlo.tensor_v1<!vhlo.i32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.case"(%arg0) ({
     "stablehlo.return"(%arg1) : (tensor<f32>) -> ()
   }) : (tensor<i32>) -> tensor<f32>
@@ -1713,9 +1713,9 @@ func.func @op_return(%arg0: tensor<i32>, %arg1: tensor<f32>) -> tensor<f32> {
 // CHECK-LABEL: "op_return"
 
 func.func @op_reverse(%arg0: tensor<16xf32>) -> tensor<16xf32> {
-  //      CHECK: "vhlo.reverse"(%arg0) {
-  // CHECK-SAME:   dimensions = #vhlo.tensor<dense<0> : tensor<1xi64>>
-  // CHECK-SAME: } : (!vhlo.tensor<16x!vhlo.f32>) -> !vhlo.tensor<16x!vhlo.f32>
+  //      CHECK: "vhlo.reverse_v1"(%arg0) {
+  // CHECK-SAME:   dimensions = #vhlo.tensor_v1<dense<0> : tensor<1xi64>>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x!vhlo.f32_v1>
   %0 = "stablehlo.reverse"(%arg0) {
     dimensions = dense<0> : tensor<1xi64>
   } : (tensor<16xf32>) -> tensor<16xf32>
@@ -1724,9 +1724,9 @@ func.func @op_reverse(%arg0: tensor<16xf32>) -> tensor<16xf32> {
 // CHECK-LABEL: "op_reverse"
 
 func.func @op_rng_bit_generator(%arg0: tensor<f32>) -> (tensor<f32>, tensor<f32>) {
-  //      CHECK: "vhlo.rng_bit_generator"(%arg0) {
-  // CHECK-SAME:   rng_algorithm = #vhlo<rng_algorithm PHILOX>
-  // CHECK-SAME: } : (!vhlo.tensor<!vhlo.f32>) -> (!vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f32>)
+  //      CHECK: "vhlo.rng_bit_generator_v1"(%arg0) {
+  // CHECK-SAME:   rng_algorithm = #vhlo<rng_algorithm_v1 PHILOX>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> (!vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>)
   %0:2 = "stablehlo.rng_bit_generator"(%arg0) {
     rng_algorithm = #stablehlo<rng_algorithm PHILOX>
   } : (tensor<f32>) -> (tensor<f32>, tensor<f32>)
@@ -1735,9 +1735,9 @@ func.func @op_rng_bit_generator(%arg0: tensor<f32>) -> (tensor<f32>, tensor<f32>
 // CHECK-LABEL: "op_rng_bit_generator"
 
 func.func @op_rng(%arg0: tensor<f32>, %arg1: tensor<f32>, %arg2: tensor<?xindex>) -> tensor<f32> {
-  //      CHECK: "vhlo.rng"(%arg0, %arg1, %arg2) {
-  // CHECK-SAME:   rng_distribution = #vhlo<rng_distribution NORMAL>
-  // CHECK-SAME: } : (!vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f32>, !vhlo.tensor<?x!vhlo.index>) -> !vhlo.tensor<!vhlo.f32>
+  //      CHECK: "vhlo.rng_v1"(%arg0, %arg1, %arg2) {
+  // CHECK-SAME:   rng_distribution = #vhlo<rng_distribution_v1 NORMAL>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.tensor_v1<?x!vhlo.index_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.rng"(%arg0, %arg1, %arg2) {
     rng_distribution = #stablehlo<rng_distribution NORMAL>
   } : (tensor<f32>, tensor<f32>, tensor<?xindex>) -> tensor<f32>
@@ -1746,39 +1746,39 @@ func.func @op_rng(%arg0: tensor<f32>, %arg1: tensor<f32>, %arg2: tensor<?xindex>
 // CHECK-LABEL: "op_rng"
 
 func.func @op_round_nearest_afz(%arg0: tensor<f32>) -> tensor<f32> {
-  // CHECK: "vhlo.round_nearest_afz"(%arg0) : (!vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
+  // CHECK: "vhlo.round_nearest_afz_v1"(%arg0) : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.round_nearest_afz"(%arg0) : (tensor<f32>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }
 // CHECK-LABEL: "op_round_nearest_afz"
 
 func.func @op_round_nearest_even(%arg0: tensor<f32>) -> tensor<f32> {
-  // CHECK: "vhlo.round_nearest_even"(%arg0) : (!vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
+  // CHECK: "vhlo.round_nearest_even_v1"(%arg0) : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.round_nearest_even"(%arg0) : (tensor<f32>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }
 // CHECK-LABEL: "op_round_nearest_even"
 
 func.func @op_rsqrt(%arg0: tensor<f32>) -> tensor<f32> {
-  // CHECK: "vhlo.rsqrt"(%arg0) : (!vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
+  // CHECK: "vhlo.rsqrt_v1"(%arg0) : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.rsqrt"(%arg0) : (tensor<f32>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }
 // CHECK-LABEL: "op_rsqrt"
 
 func.func @op_scatter(%arg0: tensor<200x100x300xf32>, %arg1: tensor<10x2xi32>, %arg2: tensor<10x300xf32>) -> tensor<200x100x300xf32> {
-  //      CHECK: "vhlo.scatter"(%arg0, %arg1, %arg2) ({
-  // CHECK-NEXT:   ^[[BB:bb.*]](%[[ARG3:arg.*]]: !vhlo.tensor<!vhlo.f32>, %[[ARG4:arg.*]]: !vhlo.tensor<!vhlo.f32>):
-  // CHECK-NEXT:     %[[VAL1:.*]] = "vhlo.add"(%[[ARG3]], %[[ARG4]]) : (!vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
-  // CHECK-NEXT:     "vhlo.return"(%[[VAL1]]) : (!vhlo.tensor<!vhlo.f32>) -> ()
+  //      CHECK: "vhlo.scatter_v1"(%arg0, %arg1, %arg2) ({
+  // CHECK-NEXT:   ^[[BB:bb.*]](%[[ARG3:arg.*]]: !vhlo.tensor_v1<!vhlo.f32_v1>, %[[ARG4:arg.*]]: !vhlo.tensor_v1<!vhlo.f32_v1>):
+  // CHECK-NEXT:     %[[VAL1:.*]] = "vhlo.add_v1"(%[[ARG3]], %[[ARG4]]) : (!vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
+  // CHECK-NEXT:     "vhlo.return_v1"(%[[VAL1]]) : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> ()
   // CHECK-NEXT: }) {
-  // CHECK-SAME:   index_vector_dim = #vhlo.integer<1 : i64>,
-  // CHECK-SAME:   indices_are_sorted = #vhlo.bool<true>,
-  // CHECK-SAME:   inserted_window_dims = #vhlo.tensor<dense<[0, 1]> : tensor<2xi64>>,
-  // CHECK-SAME:   scatter_dims_to_operand_dims = #vhlo.tensor<dense<[0, 1]> : tensor<2xi64>>,
-  // CHECK-SAME:   unique_indices = #vhlo.bool<true>,
-  // CHECK-SAME:   update_window_dims = #vhlo.tensor<dense<1> : tensor<1xi64>>
-  // CHECK-SAME: } : (!vhlo.tensor<200x100x300x!vhlo.f32>, !vhlo.tensor<10x2x!vhlo.i32>, !vhlo.tensor<10x300x!vhlo.f32>) -> !vhlo.tensor<200x100x300x!vhlo.f32>
+  // CHECK-SAME:   index_vector_dim = #vhlo.integer_v1<1 : i64>,
+  // CHECK-SAME:   indices_are_sorted = #vhlo.bool_v1<true>,
+  // CHECK-SAME:   inserted_window_dims = #vhlo.tensor_v1<dense<[0, 1]> : tensor<2xi64>>,
+  // CHECK-SAME:   scatter_dims_to_operand_dims = #vhlo.tensor_v1<dense<[0, 1]> : tensor<2xi64>>,
+  // CHECK-SAME:   unique_indices = #vhlo.bool_v1<true>,
+  // CHECK-SAME:   update_window_dims = #vhlo.tensor_v1<dense<1> : tensor<1xi64>>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<200x100x300x!vhlo.f32_v1>, !vhlo.tensor_v1<10x2x!vhlo.i32_v1>, !vhlo.tensor_v1<10x300x!vhlo.f32_v1>) -> !vhlo.tensor_v1<200x100x300x!vhlo.f32_v1>
   %0 = "stablehlo.scatter"(%arg0, %arg1, %arg2) ({
     ^bb0(%arg3: tensor<f32>, %arg4: tensor<f32>):
       %1 = "stablehlo.add"(%arg3, %arg4) : (tensor<f32>, tensor<f32>) -> tensor<f32>
@@ -1798,19 +1798,19 @@ func.func @op_scatter(%arg0: tensor<200x100x300xf32>, %arg1: tensor<10x2xi32>, %
 // CHECK-LABEL: "op_scatter"
 
 func.func @op_select_and_scatter(%arg0: tensor<10x24x24x64xf32>, %arg1: tensor<12x13x13x66xf32>, %arg2: tensor<f32>) -> tensor<10x24x24x64xf32> {
-  //      CHECK: "vhlo.select_and_scatter"(%arg0, %arg1, %arg2) ({
-  // CHECK-NEXT:   ^[[BB:bb.*]](%[[ARG31:arg.*]]: !vhlo.tensor<!vhlo.f32>, %[[ARG41:arg.*]]: !vhlo.tensor<!vhlo.f32>):
-  // CHECK-NEXT:     %[[VAL11:.*]] = "vhlo.compare"(%[[ARG31]], %[[ARG41]]) {compare_type = #vhlo<comparison_type TOTALORDER>, comparison_direction = #vhlo<comparison_direction GE>} : (!vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.bool>
-  // CHECK-NEXT:     "vhlo.return"(%[[VAL11]]) : (!vhlo.tensor<!vhlo.bool>) -> ()
+  //      CHECK: "vhlo.select_and_scatter_v1"(%arg0, %arg1, %arg2) ({
+  // CHECK-NEXT:   ^[[BB:bb.*]](%[[ARG31:arg.*]]: !vhlo.tensor_v1<!vhlo.f32_v1>, %[[ARG41:arg.*]]: !vhlo.tensor_v1<!vhlo.f32_v1>):
+  // CHECK-NEXT:     %[[VAL11:.*]] = "vhlo.compare_v1"(%[[ARG31]], %[[ARG41]]) {compare_type = #vhlo<comparison_type_v1 TOTALORDER>, comparison_direction = #vhlo<comparison_direction_v1 GE>} : (!vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.bool_v1>
+  // CHECK-NEXT:     "vhlo.return_v1"(%[[VAL11]]) : (!vhlo.tensor_v1<!vhlo.bool_v1>) -> ()
   // CHECK-NEXT: }, {
-  // CHECK-NEXT:   ^[[BB:bb.*]](%[[ARG32:arg.*]]: !vhlo.tensor<!vhlo.f32>, %[[ARG42:arg.*]]: !vhlo.tensor<!vhlo.f32>):
-  // CHECK-NEXT:     %[[VAL12:.*]] = "vhlo.add"(%[[ARG32]], %[[ARG42]]) : (!vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
-  // CHECK-NEXT:     "vhlo.return"(%[[VAL12]]) : (!vhlo.tensor<!vhlo.f32>) -> ()
+  // CHECK-NEXT:   ^[[BB:bb.*]](%[[ARG32:arg.*]]: !vhlo.tensor_v1<!vhlo.f32_v1>, %[[ARG42:arg.*]]: !vhlo.tensor_v1<!vhlo.f32_v1>):
+  // CHECK-NEXT:     %[[VAL12:.*]] = "vhlo.add_v1"(%[[ARG32]], %[[ARG42]]) : (!vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
+  // CHECK-NEXT:     "vhlo.return_v1"(%[[VAL12]]) : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> ()
   // CHECK-NEXT: }) {
-  // CHECK-SAME:   padding = #vhlo.tensor<dense<1> : tensor<4x2xi64>>,
-  // CHECK-SAME:   window_dimensions = #vhlo.tensor<dense<[1, 2, 2, 1]> : tensor<4xi64>>,
-  // CHECK-SAME:   window_strides = #vhlo.tensor<dense<[1, 2, 2, 1]> : tensor<4xi64>>
-  // CHECK-SAME: } : (!vhlo.tensor<10x24x24x64x!vhlo.f32>, !vhlo.tensor<12x13x13x66x!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<10x24x24x64x!vhlo.f32>
+  // CHECK-SAME:   padding = #vhlo.tensor_v1<dense<1> : tensor<4x2xi64>>,
+  // CHECK-SAME:   window_dimensions = #vhlo.tensor_v1<dense<[1, 2, 2, 1]> : tensor<4xi64>>,
+  // CHECK-SAME:   window_strides = #vhlo.tensor_v1<dense<[1, 2, 2, 1]> : tensor<4xi64>>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<10x24x24x64x!vhlo.f32_v1>, !vhlo.tensor_v1<12x13x13x66x!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<10x24x24x64x!vhlo.f32_v1>
   %0 = "stablehlo.select_and_scatter"(%arg0, %arg1, %arg2) ({
     ^bb0(%arg3: tensor<f32>, %arg4: tensor<f32>):
       %1 = "stablehlo.compare"(%arg3, %arg4) {compare_type = #stablehlo<comparison_type TOTALORDER>, comparison_direction = #stablehlo<comparison_direction GE>} : (tensor<f32>, tensor<f32>) -> tensor<i1>
@@ -1829,18 +1829,18 @@ func.func @op_select_and_scatter(%arg0: tensor<10x24x24x64xf32>, %arg1: tensor<1
 // CHECK-LABEL: "op_select_and_scatter"
 
 func.func @op_select(%arg0: tensor<i1>, %arg1: tensor<f32>, %arg2: tensor<f32>) -> tensor<f32> {
-  // CHECK: "vhlo.select"(%arg0, %arg1, %arg2) : (!vhlo.tensor<!vhlo.bool>, !vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
+  // CHECK: "vhlo.select_v1"(%arg0, %arg1, %arg2) : (!vhlo.tensor_v1<!vhlo.bool_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.select"(%arg0, %arg1, %arg2) : (tensor<i1>, tensor<f32>, tensor<f32>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }
 // CHECK-LABEL: "op_select"
 
 func.func @op_send(%arg0: tensor<f32>, %arg1: !stablehlo.token) -> !stablehlo.token {
-  //      CHECK: "vhlo.send"(%arg0, %arg1) {
-  // CHECK-SAME:   channel_id = #vhlo.integer<0 : i64>,
-  // CHECK-SAME:   channel_type = #vhlo.integer<0 : i64>,
-  // CHECK-SAME:   is_host_transfer = #vhlo.bool<true>
-  // CHECK-SAME: } : (!vhlo.tensor<!vhlo.f32>, !vhlo.token) -> !vhlo.token
+  //      CHECK: "vhlo.send_v1"(%arg0, %arg1) {
+  // CHECK-SAME:   channel_id = #vhlo.integer_v1<0 : i64>,
+  // CHECK-SAME:   channel_type = #vhlo.integer_v1<0 : i64>,
+  // CHECK-SAME:   is_host_transfer = #vhlo.bool_v1<true>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.token_v1) -> !vhlo.token_v1
   %0 = "stablehlo.send"(%arg0, %arg1) {
     channel_handle = #stablehlo.channel_handle<handle = 0, type = 0>,
     is_host_transfer = true
@@ -1850,9 +1850,9 @@ func.func @op_send(%arg0: tensor<f32>, %arg1: !stablehlo.token) -> !stablehlo.to
 // CHECK-LABEL: "op_send"
 
 func.func @op_set_dimension_size(%arg0: tensor<?xf32>, %arg1: tensor<i32>) -> tensor<16xf32> {
-  //      CHECK: "vhlo.set_dimension_size"(%arg0, %arg1) {
-  // CHECK-SAME:   dimension = #vhlo.integer<0 : i64>
-  // CHECK-SAME: } : (!vhlo.tensor<?x!vhlo.f32>, !vhlo.tensor<!vhlo.i32>) -> !vhlo.tensor<16x!vhlo.f32>
+  //      CHECK: "vhlo.set_dimension_size_v1"(%arg0, %arg1) {
+  // CHECK-SAME:   dimension = #vhlo.integer_v1<0 : i64>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<?x!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.i32_v1>) -> !vhlo.tensor_v1<16x!vhlo.f32_v1>
   %0 = "stablehlo.set_dimension_size"(%arg0, %arg1) {
     dimension = 0 : i64
   } : (tensor<?xf32>, tensor<i32>) -> tensor<16xf32>
@@ -1861,46 +1861,46 @@ func.func @op_set_dimension_size(%arg0: tensor<?xf32>, %arg1: tensor<i32>) -> te
 // CHECK-LABEL: "op_set_dimension_size"
 
 func.func @op_shift_left(%arg0: tensor<i32>, %arg1: tensor<i32>) -> tensor<i32> {
-  // CHECK: "vhlo.shift_left"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.i32>, !vhlo.tensor<!vhlo.i32>) -> !vhlo.tensor<!vhlo.i32>
+  // CHECK: "vhlo.shift_left_v1"(%arg0, %arg1) : (!vhlo.tensor_v1<!vhlo.i32_v1>, !vhlo.tensor_v1<!vhlo.i32_v1>) -> !vhlo.tensor_v1<!vhlo.i32_v1>
   %0 = "stablehlo.shift_left"(%arg0, %arg1) : (tensor<i32>, tensor<i32>) -> tensor<i32>
   func.return %0 : tensor<i32>
 }
 // CHECK-LABEL: "op_shift_left"
 
 func.func @op_shift_right_arithmetic(%arg0: tensor<i32>, %arg1: tensor<i32>) -> tensor<i32> {
-  // CHECK: "vhlo.shift_right_arithmetic"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.i32>, !vhlo.tensor<!vhlo.i32>) -> !vhlo.tensor<!vhlo.i32>
+  // CHECK: "vhlo.shift_right_arithmetic_v1"(%arg0, %arg1) : (!vhlo.tensor_v1<!vhlo.i32_v1>, !vhlo.tensor_v1<!vhlo.i32_v1>) -> !vhlo.tensor_v1<!vhlo.i32_v1>
   %0 = "stablehlo.shift_right_arithmetic"(%arg0, %arg1) : (tensor<i32>, tensor<i32>) -> tensor<i32>
   func.return %0 : tensor<i32>
 }
 // CHECK-LABEL: "op_shift_right_arithmetic"
 
 func.func @op_shift_right_logical(%arg0: tensor<i32>, %arg1: tensor<i32>) -> tensor<i32> {
-  // CHECK: "vhlo.shift_right_logical"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.i32>, !vhlo.tensor<!vhlo.i32>) -> !vhlo.tensor<!vhlo.i32>
+  // CHECK: "vhlo.shift_right_logical_v1"(%arg0, %arg1) : (!vhlo.tensor_v1<!vhlo.i32_v1>, !vhlo.tensor_v1<!vhlo.i32_v1>) -> !vhlo.tensor_v1<!vhlo.i32_v1>
   %0 = "stablehlo.shift_right_logical"(%arg0, %arg1) : (tensor<i32>, tensor<i32>) -> tensor<i32>
   func.return %0 : tensor<i32>
 }
 // CHECK-LABEL: "op_shift_right_logical"
 
 func.func @op_sign(%arg0: tensor<f32>) -> tensor<f32> {
-  // CHECK: "vhlo.sign"(%arg0) : (!vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
+  // CHECK: "vhlo.sign_v1"(%arg0) : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.sign"(%arg0) : (tensor<f32>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }
 // CHECK-LABEL: "op_sign"
 
 func.func @op_sine(%arg0: tensor<f32>) -> tensor<f32> {
-  // CHECK: "vhlo.sine"(%arg0) : (!vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
+  // CHECK: "vhlo.sine_v1"(%arg0) : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.sine"(%arg0) : (tensor<f32>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }
 // CHECK-LABEL: "op_sine"
 
 func.func @op_slice(%arg0: tensor<16xf32>) -> tensor<4xf32> {
-  //      CHECK: "vhlo.slice"(%arg0) {
-  // CHECK-SAME:   limit_indices = #vhlo.tensor<dense<4> : tensor<1xi64>>,
-  // CHECK-SAME:   start_indices = #vhlo.tensor<dense<0> : tensor<1xi64>>,
-  // CHECK-SAME:   strides = #vhlo.tensor<dense<1> : tensor<1xi64>>
-  // CHECK-SAME: } : (!vhlo.tensor<16x!vhlo.f32>) -> !vhlo.tensor<4x!vhlo.f32>
+  //      CHECK: "vhlo.slice_v1"(%arg0) {
+  // CHECK-SAME:   limit_indices = #vhlo.tensor_v1<dense<4> : tensor<1xi64>>,
+  // CHECK-SAME:   start_indices = #vhlo.tensor_v1<dense<0> : tensor<1xi64>>,
+  // CHECK-SAME:   strides = #vhlo.tensor_v1<dense<1> : tensor<1xi64>>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<4x!vhlo.f32_v1>
   %0 = "stablehlo.slice"(%arg0) {
     start_indices = dense<0> : tensor<1xi64>,
     limit_indices = dense<4> : tensor<1xi64>,
@@ -1911,14 +1911,14 @@ func.func @op_slice(%arg0: tensor<16xf32>) -> tensor<4xf32> {
 // CHECK-LABEL: "op_slice"
 
 func.func @op_sort(%arg0: tensor<16xf32>) -> tensor<16xf32> {
-  //      CHECK: "vhlo.sort"(%arg0) ({
-  // CHECK-NEXT:   ^[[BB:bb.*]](%[[ARG1:arg.*]]: !vhlo.tensor<!vhlo.f32>, %[[ARG2:arg.*]]: !vhlo.tensor<!vhlo.f32>):
-  // CHECK-NEXT:     %[[VAL1:.*]] = "vhlo.compare"(%[[ARG1]], %[[ARG2]]) {compare_type = #vhlo<comparison_type FLOAT>, comparison_direction = #vhlo<comparison_direction GT>} : (!vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.bool>
-  // CHECK-NEXT:     "vhlo.return"(%[[VAL1]]) : (!vhlo.tensor<!vhlo.bool>) -> ()
+  //      CHECK: "vhlo.sort_v1"(%arg0) ({
+  // CHECK-NEXT:   ^[[BB:bb.*]](%[[ARG1:arg.*]]: !vhlo.tensor_v1<!vhlo.f32_v1>, %[[ARG2:arg.*]]: !vhlo.tensor_v1<!vhlo.f32_v1>):
+  // CHECK-NEXT:     %[[VAL1:.*]] = "vhlo.compare_v1"(%[[ARG1]], %[[ARG2]]) {compare_type = #vhlo<comparison_type_v1 FLOAT>, comparison_direction = #vhlo<comparison_direction_v1 GT>} : (!vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.bool_v1>
+  // CHECK-NEXT:     "vhlo.return_v1"(%[[VAL1]]) : (!vhlo.tensor_v1<!vhlo.bool_v1>) -> ()
   // CHECK-NEXT: }) {
-  // CHECK-SAME:   dimension = #vhlo.integer<0 : i64>
-  // CHECK-SAME:   is_stable = #vhlo.bool<true>
-  // CHECK-SAME: } : (!vhlo.tensor<16x!vhlo.f32>) -> !vhlo.tensor<16x!vhlo.f32>
+  // CHECK-SAME:   dimension = #vhlo.integer_v1<0 : i64>
+  // CHECK-SAME:   is_stable = #vhlo.bool_v1<true>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x!vhlo.f32_v1>
   %0 = "stablehlo.sort"(%arg0) ({
     ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
       %1 = "stablehlo.compare"(%arg1, %arg2) {compare_type = #stablehlo<comparison_type FLOAT>, comparison_direction = #stablehlo<comparison_direction GT>} : (tensor<f32>, tensor<f32>) -> tensor<i1>
@@ -1932,31 +1932,31 @@ func.func @op_sort(%arg0: tensor<16xf32>) -> tensor<16xf32> {
 // CHECK-LABEL: "op_sort"
 
 func.func @op_sqrt(%arg0: tensor<f32>) -> tensor<f32> {
-  // CHECK: "vhlo.sqrt"(%arg0) : (!vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
+  // CHECK: "vhlo.sqrt_v1"(%arg0) : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.sqrt"(%arg0) : (tensor<f32>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }
 // CHECK-LABEL: "op_sqrt"
 
 func.func @op_subtract(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<f32> {
-  // CHECK: "vhlo.subtract"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
+  // CHECK: "vhlo.subtract_v1"(%arg0, %arg1) : (!vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.subtract"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }
 // CHECK-LABEL: "op_subtract"
 
 func.func @op_tanh(%arg0: tensor<f32>) -> tensor<f32> {
-  // CHECK: "vhlo.tanh"(%arg0) : (!vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
+  // CHECK: "vhlo.tanh_v1"(%arg0) : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.tanh"(%arg0) : (tensor<f32>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }
 // CHECK-LABEL: "op_tanh"
 
 func.func @op_torch_index_select(%arg0: tensor<5x1x5xf32>, %arg1: tensor<2xi32>) ->  tensor<2x1x5xf32> {
-  //      CHECK: "vhlo.torch_index_select"(%arg0, %arg1) {
-  // CHECK-SAME:   batch_dims = #vhlo.integer<0 : i64>
-  // CHECK-SAME:   dim = #vhlo.integer<0 : i64>
-  // CHECK-SAME: } : (!vhlo.tensor<5x1x5x!vhlo.f32>, !vhlo.tensor<2x!vhlo.i32>) -> !vhlo.tensor<2x1x5x!vhlo.f32>
+  //      CHECK: "vhlo.torch_index_select_v1"(%arg0, %arg1) {
+  // CHECK-SAME:   batch_dims = #vhlo.integer_v1<0 : i64>
+  // CHECK-SAME:   dim = #vhlo.integer_v1<0 : i64>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<5x1x5x!vhlo.f32_v1>, !vhlo.tensor_v1<2x!vhlo.i32_v1>) -> !vhlo.tensor_v1<2x1x5x!vhlo.f32_v1>
   %0 = "stablehlo.torch_index_select"(%arg0, %arg1) {
     dim = 0 : i64,
     batch_dims = 0 : i64
@@ -1966,9 +1966,9 @@ func.func @op_torch_index_select(%arg0: tensor<5x1x5xf32>, %arg1: tensor<2xi32>)
 // CHECK-LABEL: "op_torch_index_select"
 
 func.func @op_trace(%arg0: tensor<f32>) {
-  //      CHECK: "vhlo.trace"(%arg0) {
-  // CHECK-SAME:   tag = #vhlo.string<"foo">
-  // CHECK-SAME: } : (!vhlo.tensor<!vhlo.f32>) -> ()
+  //      CHECK: "vhlo.trace_v1"(%arg0) {
+  // CHECK-SAME:   tag = #vhlo.string_v1<"foo">
+  // CHECK-SAME: } : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> ()
   "stablehlo.trace"(%arg0) {
     tag = "foo"
   } : (tensor<f32>) -> ()
@@ -1977,9 +1977,9 @@ func.func @op_trace(%arg0: tensor<f32>) {
 // CHECK-LABEL: "op_trace"
 
 func.func @op_transpose(%arg0: tensor<16x8xf32>) ->  tensor<8x16xf32> {
-  //      CHECK: "vhlo.transpose"(%arg0) {
-  // CHECK-SAME:   permutation = #vhlo.tensor<dense<[1, 0]> : tensor<2xi64>>
-  // CHECK-SAME: } : (!vhlo.tensor<16x8x!vhlo.f32>) -> !vhlo.tensor<8x16x!vhlo.f32>
+  //      CHECK: "vhlo.transpose_v1"(%arg0) {
+  // CHECK-SAME:   permutation = #vhlo.tensor_v1<dense<[1, 0]> : tensor<2xi64>>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<16x8x!vhlo.f32_v1>) -> !vhlo.tensor_v1<8x16x!vhlo.f32_v1>
   %0 = "stablehlo.transpose"(%arg0) {
     permutation = dense<[1, 0]> : tensor<2xi64>
   } : (tensor<16x8xf32>) -> tensor<8x16xf32>
@@ -1988,12 +1988,12 @@ func.func @op_transpose(%arg0: tensor<16x8xf32>) ->  tensor<8x16xf32> {
 // CHECK-LABEL: "op_transpose"
 
 func.func @op_triangular_solve(%arg0: tensor<16x16xf32>, %arg1: tensor<16x16xf32>) ->  tensor<16x16xf32> {
-  //      CHECK: "vhlo.triangular_solve"(%arg0, %arg1) {
-  // CHECK-SAME:   left_side = #vhlo.bool<true>,
-  // CHECK-SAME:   lower = #vhlo.bool<true>,
-  // CHECK-SAME:   transpose_a = #vhlo<transpose NO_TRANSPOSE>,
-  // CHECK-SAME:   unit_diagonal = #vhlo.bool<true>
-  // CHECK-SAME: } : (!vhlo.tensor<16x16x!vhlo.f32>, !vhlo.tensor<16x16x!vhlo.f32>) -> !vhlo.tensor<16x16x!vhlo.f32>
+  //      CHECK: "vhlo.triangular_solve_v1"(%arg0, %arg1) {
+  // CHECK-SAME:   left_side = #vhlo.bool_v1<true>,
+  // CHECK-SAME:   lower = #vhlo.bool_v1<true>,
+  // CHECK-SAME:   transpose_a = #vhlo<transpose_v1 NO_TRANSPOSE>,
+  // CHECK-SAME:   unit_diagonal = #vhlo.bool_v1<true>
+  // CHECK-SAME: } : (!vhlo.tensor_v1<16x16x!vhlo.f32_v1>, !vhlo.tensor_v1<16x16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x16x!vhlo.f32_v1>
   %0 = "stablehlo.triangular_solve"(%arg0, %arg1) {
     left_side = true,
     lower = true,
@@ -2005,16 +2005,16 @@ func.func @op_triangular_solve(%arg0: tensor<16x16xf32>, %arg1: tensor<16x16xf32
 // CHECK-LABEL: "op_triangular_solve"
 
 func.func @op_tuple(%arg0: tensor<f32>) -> tuple<tensor<f32>> {
-  // CHECK: "vhlo.tuple"(%arg0) : (!vhlo.tensor<!vhlo.f32>) -> !vhlo.tuple<!vhlo.tensor<!vhlo.f32>>
+  // CHECK: "vhlo.tuple_v1"(%arg0) : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tuple_v1<!vhlo.tensor_v1<!vhlo.f32_v1>>
   %0 = "stablehlo.tuple"(%arg0) : (tensor<f32>) -> tuple<tensor<f32>>
   func.return %0 : tuple<tensor<f32>>
 }
 // CHECK-LABEL: "op_tuple"
 
 func.func @op_unary_einsum(%arg0: tensor<8x16xf32>) -> tensor<8xf32> {
-  //      CHECK: "vhlo.unary_einsum"(%arg0) {
-  // CHECK-SAME:   einsum_config = #vhlo.string<"ab->a">
-  // CHECK-SAME: } : (!vhlo.tensor<8x16x!vhlo.f32>) -> !vhlo.tensor<8x!vhlo.f32>
+  //      CHECK: "vhlo.unary_einsum_v1"(%arg0) {
+  // CHECK-SAME:   einsum_config = #vhlo.string_v1<"ab->a">
+  // CHECK-SAME: } : (!vhlo.tensor_v1<8x16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<8x!vhlo.f32_v1>
   %0 = "stablehlo.unary_einsum"(%arg0) {
     einsum_config = "ab->a"
   } : (tensor<8x16xf32>) -> tensor<8xf32>
@@ -2023,27 +2023,27 @@ func.func @op_unary_einsum(%arg0: tensor<8x16xf32>) -> tensor<8xf32> {
 // CHECK-LABEL: "op_unary_einsum"
 
 func.func @op_uniform_dequantize(%arg0: tensor<!quant.uniform<i8:f32, 34.0:16>>) -> tensor<f32> {
-  // CHECK: "vhlo.uniform_dequantize"(%arg0) : (!vhlo.tensor<!vhlo.quant<!vhlo.i8:!vhlo.f32, 3.400000e+01:16, -128:127, 1>>) -> !vhlo.tensor<!vhlo.f32>
+  // CHECK: "vhlo.uniform_dequantize_v1"(%arg0) : (!vhlo.tensor_v1<!vhlo.quant_v1<!vhlo.i8_v1:!vhlo.f32_v1, 3.400000e+01:16, -128:127, 1>>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.uniform_dequantize"(%arg0) : (tensor<!quant.uniform<i8:f32, 34.0:16>>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }
 // CHECK-LABEL: "op_uniform_dequantize"
 
 func.func @op_uniform_quantize(%arg0: tensor<f32>) -> tensor<!quant.uniform<i8:f32, 34.0:16>> {
-  // CHECK: "vhlo.uniform_quantize"(%arg0) : (!vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.quant<!vhlo.i8:!vhlo.f32, 3.400000e+01:16, -128:127, 1>>
+  // CHECK: "vhlo.uniform_quantize_v1"(%arg0) : (!vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.quant_v1<!vhlo.i8_v1:!vhlo.f32_v1, 3.400000e+01:16, -128:127, 1>>
   %0 = "stablehlo.uniform_quantize"(%arg0) : (tensor<f32>) -> tensor<!quant.uniform<i8:f32, 34.0:16>>
   func.return %0 : tensor<!quant.uniform<i8:f32, 34.0:16>>
 }
 // CHECK-LABEL: "op_uniform_quantize"
 
 func.func @op_while(%arg0: tensor<i1>) -> tensor<i1> {
-  //      CHECK: "vhlo.while"(%arg0) ({
-  // CHECK-NEXT:   ^[[BB:bb.*]](%[[ARG1:arg.*]]: !vhlo.tensor<!vhlo.bool>):
-  // CHECK-NEXT:     "vhlo.return"(%[[ARG1]]) : (!vhlo.tensor<!vhlo.bool>) -> ()
+  //      CHECK: "vhlo.while_v1"(%arg0) ({
+  // CHECK-NEXT:   ^[[BB:bb.*]](%[[ARG1:arg.*]]: !vhlo.tensor_v1<!vhlo.bool_v1>):
+  // CHECK-NEXT:     "vhlo.return_v1"(%[[ARG1]]) : (!vhlo.tensor_v1<!vhlo.bool_v1>) -> ()
   // CHECK-NEXT:   }, {
-  // CHECK-NEXT:   ^[[BB:bb.*]](%[[ARG1:arg.*]]: !vhlo.tensor<!vhlo.bool>)
-  // CHECK-NEXT:     "vhlo.return"(%[[ARG1]]) : (!vhlo.tensor<!vhlo.bool>) -> ()
-  // CHECK-NEXT: }) : (!vhlo.tensor<!vhlo.bool>) -> !vhlo.tensor<!vhlo.bool>
+  // CHECK-NEXT:   ^[[BB:bb.*]](%[[ARG1:arg.*]]: !vhlo.tensor_v1<!vhlo.bool_v1>)
+  // CHECK-NEXT:     "vhlo.return_v1"(%[[ARG1]]) : (!vhlo.tensor_v1<!vhlo.bool_v1>) -> ()
+  // CHECK-NEXT: }) : (!vhlo.tensor_v1<!vhlo.bool_v1>) -> !vhlo.tensor_v1<!vhlo.bool_v1>
   %0 = "stablehlo.while"(%arg0) ({
     ^bb0(%arg1: tensor<i1>):
       "stablehlo.return"(%arg1) : (tensor<i1>) -> ()
@@ -2056,7 +2056,7 @@ func.func @op_while(%arg0: tensor<i1>) -> tensor<i1> {
 // CHECK-LABEL: "op_while"
 
 func.func @op_xor(%arg0: tensor<i1>, %arg1: tensor<i1>) -> tensor<i1> {
-  // CHECK: "vhlo.xor"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.bool>, !vhlo.tensor<!vhlo.bool>) -> !vhlo.tensor<!vhlo.bool>
+  // CHECK: "vhlo.xor_v1"(%arg0, %arg1) : (!vhlo.tensor_v1<!vhlo.bool_v1>, !vhlo.tensor_v1<!vhlo.bool_v1>) -> !vhlo.tensor_v1<!vhlo.bool_v1>
   %0 = "stablehlo.xor"(%arg0, %arg1) : (tensor<i1>, tensor<i1>) -> tensor<i1>
   func.return %0 : tensor<i1>
 }
@@ -2065,179 +2065,179 @@ func.func @op_xor(%arg0: tensor<i1>, %arg1: tensor<i1>) -> tensor<i1> {
 // ============ TYPES ============
 
 func.func @type_i1(%arg0: tensor<i1>, %arg1: tensor<i1>) -> tensor<i1> {
-  // CHECK: "vhlo.and"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.bool>, !vhlo.tensor<!vhlo.bool>) -> !vhlo.tensor<!vhlo.bool>
+  // CHECK: "vhlo.and_v1"(%arg0, %arg1) : (!vhlo.tensor_v1<!vhlo.bool_v1>, !vhlo.tensor_v1<!vhlo.bool_v1>) -> !vhlo.tensor_v1<!vhlo.bool_v1>
   %0 = "stablehlo.and"(%arg0, %arg1) : (tensor<i1>, tensor<i1>) -> tensor<i1>
   func.return %0 : tensor<i1>
 }
 // CHECK-LABEL: "type_i1"
 
 func.func @type_i4(%arg0: tensor<i4>, %arg1: tensor<i4>) -> tensor<i4> {
-  // CHECK: "vhlo.add"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.i4>, !vhlo.tensor<!vhlo.i4>) -> !vhlo.tensor<!vhlo.i4>
+  // CHECK: "vhlo.add_v1"(%arg0, %arg1) : (!vhlo.tensor_v1<!vhlo.i4_v1>, !vhlo.tensor_v1<!vhlo.i4_v1>) -> !vhlo.tensor_v1<!vhlo.i4_v1>
   %0 = "stablehlo.add"(%arg0, %arg1) : (tensor<i4>, tensor<i4>) -> tensor<i4>
   func.return %0 : tensor<i4>
 }
 // CHECK-LABEL: "type_i4"
 
 func.func @type_i8(%arg0: tensor<i8>, %arg1: tensor<i8>) -> tensor<i8> {
-  // CHECK: "vhlo.add"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.i8>, !vhlo.tensor<!vhlo.i8>) -> !vhlo.tensor<!vhlo.i8>
+  // CHECK: "vhlo.add_v1"(%arg0, %arg1) : (!vhlo.tensor_v1<!vhlo.i8_v1>, !vhlo.tensor_v1<!vhlo.i8_v1>) -> !vhlo.tensor_v1<!vhlo.i8_v1>
   %0 = "stablehlo.add"(%arg0, %arg1) : (tensor<i8>, tensor<i8>) -> tensor<i8>
   func.return %0 : tensor<i8>
 }
 // CHECK-LABEL: "type_i8"
 
 func.func @type_i16(%arg0: tensor<i16>, %arg1: tensor<i16>) -> tensor<i16> {
-  // CHECK: "vhlo.add"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.i16>, !vhlo.tensor<!vhlo.i16>) -> !vhlo.tensor<!vhlo.i16>
+  // CHECK: "vhlo.add_v1"(%arg0, %arg1) : (!vhlo.tensor_v1<!vhlo.i16_v1>, !vhlo.tensor_v1<!vhlo.i16_v1>) -> !vhlo.tensor_v1<!vhlo.i16_v1>
   %0 = "stablehlo.add"(%arg0, %arg1) : (tensor<i16>, tensor<i16>) -> tensor<i16>
   func.return %0 : tensor<i16>
 }
 // CHECK-LABEL: "type_i16"
 
 func.func @type_i32(%arg0: tensor<i32>, %arg1: tensor<i32>) -> tensor<i32> {
-  // CHECK: "vhlo.add"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.i32>, !vhlo.tensor<!vhlo.i32>) -> !vhlo.tensor<!vhlo.i32>
+  // CHECK: "vhlo.add_v1"(%arg0, %arg1) : (!vhlo.tensor_v1<!vhlo.i32_v1>, !vhlo.tensor_v1<!vhlo.i32_v1>) -> !vhlo.tensor_v1<!vhlo.i32_v1>
   %0 = "stablehlo.add"(%arg0, %arg1) : (tensor<i32>, tensor<i32>) -> tensor<i32>
   func.return %0 : tensor<i32>
 }
 // CHECK-LABEL: "type_i32"
 
 func.func @type_i64(%arg0: tensor<i64>, %arg1: tensor<i64>) -> tensor<i64> {
-  // CHECK: "vhlo.add"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.i64>, !vhlo.tensor<!vhlo.i64>) -> !vhlo.tensor<!vhlo.i64>
+  // CHECK: "vhlo.add_v1"(%arg0, %arg1) : (!vhlo.tensor_v1<!vhlo.i64_v1>, !vhlo.tensor_v1<!vhlo.i64_v1>) -> !vhlo.tensor_v1<!vhlo.i64_v1>
   %0 = "stablehlo.add"(%arg0, %arg1) : (tensor<i64>, tensor<i64>) -> tensor<i64>
   func.return %0 : tensor<i64>
 }
 // CHECK-LABEL: "type_i64"
 
 func.func @type_ui4(%arg0: tensor<ui4>, %arg1: tensor<ui4>) -> tensor<ui4> {
-  // CHECK: "vhlo.add"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.ui4>, !vhlo.tensor<!vhlo.ui4>) -> !vhlo.tensor<!vhlo.ui4>
+  // CHECK: "vhlo.add_v1"(%arg0, %arg1) : (!vhlo.tensor_v1<!vhlo.ui4_v1>, !vhlo.tensor_v1<!vhlo.ui4_v1>) -> !vhlo.tensor_v1<!vhlo.ui4_v1>
   %0 = "stablehlo.add"(%arg0, %arg1) : (tensor<ui4>, tensor<ui4>) -> tensor<ui4>
   func.return %0 : tensor<ui4>
 }
 // CHECK-LABEL: "type_ui4"
 
 func.func @type_ui8(%arg0: tensor<ui8>, %arg1: tensor<ui8>) -> tensor<ui8> {
-  // CHECK: "vhlo.add"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.ui8>, !vhlo.tensor<!vhlo.ui8>) -> !vhlo.tensor<!vhlo.ui8>
+  // CHECK: "vhlo.add_v1"(%arg0, %arg1) : (!vhlo.tensor_v1<!vhlo.ui8_v1>, !vhlo.tensor_v1<!vhlo.ui8_v1>) -> !vhlo.tensor_v1<!vhlo.ui8_v1>
   %0 = "stablehlo.add"(%arg0, %arg1) : (tensor<ui8>, tensor<ui8>) -> tensor<ui8>
   func.return %0 : tensor<ui8>
 }
 // CHECK-LABEL: "type_ui8"
 
 func.func @type_ui16(%arg0: tensor<ui16>, %arg1: tensor<ui16>) -> tensor<ui16> {
-  // CHECK: "vhlo.add"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.ui16>, !vhlo.tensor<!vhlo.ui16>) -> !vhlo.tensor<!vhlo.ui16>
+  // CHECK: "vhlo.add_v1"(%arg0, %arg1) : (!vhlo.tensor_v1<!vhlo.ui16_v1>, !vhlo.tensor_v1<!vhlo.ui16_v1>) -> !vhlo.tensor_v1<!vhlo.ui16_v1>
   %0 = "stablehlo.add"(%arg0, %arg1) : (tensor<ui16>, tensor<ui16>) -> tensor<ui16>
   func.return %0 : tensor<ui16>
 }
 // CHECK-LABEL: "type_ui16"
 
 func.func @type_ui32(%arg0: tensor<ui32>, %arg1: tensor<ui32>) -> tensor<ui32> {
-  // CHECK: "vhlo.add"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.ui32>, !vhlo.tensor<!vhlo.ui32>) -> !vhlo.tensor<!vhlo.ui32>
+  // CHECK: "vhlo.add_v1"(%arg0, %arg1) : (!vhlo.tensor_v1<!vhlo.ui32_v1>, !vhlo.tensor_v1<!vhlo.ui32_v1>) -> !vhlo.tensor_v1<!vhlo.ui32_v1>
   %0 = "stablehlo.add"(%arg0, %arg1) : (tensor<ui32>, tensor<ui32>) -> tensor<ui32>
   func.return %0 : tensor<ui32>
 }
 // CHECK-LABEL: "type_ui32"
 
 func.func @type_ui64(%arg0: tensor<ui64>, %arg1: tensor<ui64>) -> tensor<ui64> {
-  // CHECK: "vhlo.add"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.ui64>, !vhlo.tensor<!vhlo.ui64>) -> !vhlo.tensor<!vhlo.ui64>
+  // CHECK: "vhlo.add_v1"(%arg0, %arg1) : (!vhlo.tensor_v1<!vhlo.ui64_v1>, !vhlo.tensor_v1<!vhlo.ui64_v1>) -> !vhlo.tensor_v1<!vhlo.ui64_v1>
   %0 = "stablehlo.add"(%arg0, %arg1) : (tensor<ui64>, tensor<ui64>) -> tensor<ui64>
   func.return %0 : tensor<ui64>
 }
 // CHECK-LABEL: "type_ui64"
 
 func.func @type_f8E4M3FN(%arg0: tensor<f8E4M3FN>, %arg1: tensor<f8E4M3FN>) -> tensor<f8E4M3FN> {
-  // CHECK: "vhlo.add"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.f8E4M3FN>, !vhlo.tensor<!vhlo.f8E4M3FN>) -> !vhlo.tensor<!vhlo.f8E4M3FN>
+  // CHECK: "vhlo.add_v1"(%arg0, %arg1) : (!vhlo.tensor_v1<!vhlo.f8E4M3FN_v1>, !vhlo.tensor_v1<!vhlo.f8E4M3FN_v1>) -> !vhlo.tensor_v1<!vhlo.f8E4M3FN_v1>
   %0 = "stablehlo.add"(%arg0, %arg1) : (tensor<f8E4M3FN>, tensor<f8E4M3FN>) -> tensor<f8E4M3FN>
   func.return %0 : tensor<f8E4M3FN>
 }
 // CHECK-LABEL: "type_f8E4M3FN"
 
 func.func @type_f8E5M2(%arg0: tensor<f8E5M2>, %arg1: tensor<f8E5M2>) -> tensor<f8E5M2> {
-  // CHECK: "vhlo.add"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.f8E5M2>, !vhlo.tensor<!vhlo.f8E5M2>) -> !vhlo.tensor<!vhlo.f8E5M2>
+  // CHECK: "vhlo.add_v1"(%arg0, %arg1) : (!vhlo.tensor_v1<!vhlo.f8E5M2_v1>, !vhlo.tensor_v1<!vhlo.f8E5M2_v1>) -> !vhlo.tensor_v1<!vhlo.f8E5M2_v1>
   %0 = "stablehlo.add"(%arg0, %arg1) : (tensor<f8E5M2>, tensor<f8E5M2>) -> tensor<f8E5M2>
   func.return %0 : tensor<f8E5M2>
 }
 // CHECK-LABEL: "type_f8E5M2"
 
 func.func @type_bf16(%arg0: tensor<bf16>, %arg1: tensor<bf16>) -> tensor<bf16> {
-  // CHECK: "vhlo.add"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.bf16>, !vhlo.tensor<!vhlo.bf16>) -> !vhlo.tensor<!vhlo.bf16>
+  // CHECK: "vhlo.add_v1"(%arg0, %arg1) : (!vhlo.tensor_v1<!vhlo.bf16_v1>, !vhlo.tensor_v1<!vhlo.bf16_v1>) -> !vhlo.tensor_v1<!vhlo.bf16_v1>
   %0 = "stablehlo.add"(%arg0, %arg1) : (tensor<bf16>, tensor<bf16>) -> tensor<bf16>
   func.return %0 : tensor<bf16>
 }
 // CHECK-LABEL: "type_bf16"
 
 func.func @type_f16(%arg0: tensor<f16>, %arg1: tensor<f16>) -> tensor<f16> {
-  // CHECK: "vhlo.add"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.f16>, !vhlo.tensor<!vhlo.f16>) -> !vhlo.tensor<!vhlo.f16>
+  // CHECK: "vhlo.add_v1"(%arg0, %arg1) : (!vhlo.tensor_v1<!vhlo.f16_v1>, !vhlo.tensor_v1<!vhlo.f16_v1>) -> !vhlo.tensor_v1<!vhlo.f16_v1>
   %0 = "stablehlo.add"(%arg0, %arg1) : (tensor<f16>, tensor<f16>) -> tensor<f16>
   func.return %0 : tensor<f16>
 }
 // CHECK-LABEL: "type_f16"
 
 func.func @type_f32(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<f32> {
-  // CHECK: "vhlo.add"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.f32>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
+  // CHECK: "vhlo.add_v1"(%arg0, %arg1) : (!vhlo.tensor_v1<!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.add"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }
 // CHECK-LABEL: "type_f32"
 
 func.func @type_f64(%arg0: tensor<f64>, %arg1: tensor<f64>) -> tensor<f64> {
-  // CHECK: "vhlo.add"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.f64>, !vhlo.tensor<!vhlo.f64>) -> !vhlo.tensor<!vhlo.f64>
+  // CHECK: "vhlo.add_v1"(%arg0, %arg1) : (!vhlo.tensor_v1<!vhlo.f64_v1>, !vhlo.tensor_v1<!vhlo.f64_v1>) -> !vhlo.tensor_v1<!vhlo.f64_v1>
   %0 = "stablehlo.add"(%arg0, %arg1) : (tensor<f64>, tensor<f64>) -> tensor<f64>
   func.return %0 : tensor<f64>
 }
 // CHECK-LABEL: "type_f64"
 
 func.func @type_complex_f32(%arg0: tensor<complex<f32>>, %arg1: tensor<complex<f32>>) -> tensor<complex<f32>> {
-  // CHECK: "vhlo.add"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.complex<!vhlo.f32>>, !vhlo.tensor<!vhlo.complex<!vhlo.f32>>) -> !vhlo.tensor<!vhlo.complex<!vhlo.f32>>
+  // CHECK: "vhlo.add_v1"(%arg0, %arg1) : (!vhlo.tensor_v1<!vhlo.complex_v1<!vhlo.f32_v1>>, !vhlo.tensor_v1<!vhlo.complex_v1<!vhlo.f32_v1>>) -> !vhlo.tensor_v1<!vhlo.complex_v1<!vhlo.f32_v1>>
   %0 = "stablehlo.add"(%arg0, %arg1) : (tensor<complex<f32>>, tensor<complex<f32>>) -> tensor<complex<f32>>
   func.return %0 : tensor<complex<f32>>
 }
 // CHECK-LABEL: "type_complex_f32"
 
 func.func @type_complex_f64(%arg0: tensor<complex<f64>>, %arg1: tensor<complex<f64>>) -> tensor<complex<f64>> {
-  // CHECK: "vhlo.add"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.complex<!vhlo.f64>>, !vhlo.tensor<!vhlo.complex<!vhlo.f64>>) -> !vhlo.tensor<!vhlo.complex<!vhlo.f64>>
+  // CHECK: "vhlo.add_v1"(%arg0, %arg1) : (!vhlo.tensor_v1<!vhlo.complex_v1<!vhlo.f64_v1>>, !vhlo.tensor_v1<!vhlo.complex_v1<!vhlo.f64_v1>>) -> !vhlo.tensor_v1<!vhlo.complex_v1<!vhlo.f64_v1>>
   %0 = "stablehlo.add"(%arg0, %arg1) : (tensor<complex<f64>>, tensor<complex<f64>>) -> tensor<complex<f64>>
   func.return %0 : tensor<complex<f64>>
 }
 // CHECK-LABEL: "type_complex_f64"
 
 func.func @type_dynamism_ranked(%arg0: tensor<?xf32>) -> tensor<?xf32> {
-  // CHECK: "vhlo.abs"(%arg0) : (!vhlo.tensor<?x!vhlo.f32>) -> !vhlo.tensor<?x!vhlo.f32>
+  // CHECK: "vhlo.abs_v1"(%arg0) : (!vhlo.tensor_v1<?x!vhlo.f32_v1>) -> !vhlo.tensor_v1<?x!vhlo.f32_v1>
   %0 = "stablehlo.abs"(%arg0) : (tensor<?xf32>) -> tensor<?xf32>
   func.return %0 : tensor<?xf32>
 }
 // CHECK-LABEL: "type_dynamism_ranked"
 
 func.func @type_dynamism_unranked(%arg0: tensor<*xf32>) -> tensor<*xf32> {
-  // CHECK: "vhlo.abs"(%arg0) : (!vhlo.unranked_tensor<!vhlo.f32>) -> !vhlo.unranked_tensor<!vhlo.f32>
+  // CHECK: "vhlo.abs_v1"(%arg0) : (!vhlo.unranked_tensor_v1<!vhlo.f32_v1>) -> !vhlo.unranked_tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.abs"(%arg0) : (tensor<*xf32>) -> tensor<*xf32>
   func.return %0 : tensor<*xf32>
 }
 // CHECK-LABEL: "type_dynamism_unranked"
 
 func.func @type_quantization(%arg0: tensor<!quant.uniform<i8:f32, 34.0:16>>, %arg1: tensor<f32>) -> tensor<f32> {
-  // CHECK: "vhlo.add"(%arg0, %arg1) : (!vhlo.tensor<!vhlo.quant<!vhlo.i8:!vhlo.f32, 3.400000e+01:16, -128:127, 1>>, !vhlo.tensor<!vhlo.f32>) -> !vhlo.tensor<!vhlo.f32>
+  // CHECK: "vhlo.add_v1"(%arg0, %arg1) : (!vhlo.tensor_v1<!vhlo.quant_v1<!vhlo.i8_v1:!vhlo.f32_v1, 3.400000e+01:16, -128:127, 1>>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>
   %0 = "stablehlo.add"(%arg0, %arg1) : (tensor<!quant.uniform<i8:f32, 34.0:16>>, tensor<f32>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }
 // CHECK-LABEL: "type_quantization"
 
 func.func @type_token_callee(%arg0: !stablehlo.token) -> !stablehlo.token {
-  // CHECK: "vhlo.return"(%arg0) : (!vhlo.token) -> ()
+  // CHECK: "vhlo.return_v1"(%arg0) : (!vhlo.token_v1) -> ()
   return %arg0 : !stablehlo.token
 }
-//       CHECK: function_type = #vhlo.type<!vhlo.func<(!vhlo.token) -> !vhlo.token>>
+//       CHECK: function_type = #vhlo.type_v1<!vhlo.func_v1<(!vhlo.token_v1) -> !vhlo.token_v1>>
 // CHECK-LABEL: "type_token_callee"
 
 func.func @type_token_caller(%arg0: !stablehlo.token) -> !stablehlo.token {
-  // CHECK:      "vhlo.call"(%arg0) {callee = #vhlo.string<"type_token_callee">}
-  // CHECK-SAME: (!vhlo.token) -> !vhlo.token
+  // CHECK:      "vhlo.call_v1"(%arg0) {callee = #vhlo.string_v1<"type_token_callee">}
+  // CHECK-SAME: (!vhlo.token_v1) -> !vhlo.token_v1
   %0 = func.call @type_token_callee(%arg0) : (!stablehlo.token) -> !stablehlo.token
   return %0 : !stablehlo.token
 }
-//       CHECK: function_type = #vhlo.type<!vhlo.func<(!vhlo.token) -> !vhlo.token>>
+//       CHECK: function_type = #vhlo.type_v1<!vhlo.func_v1<(!vhlo.token_v1) -> !vhlo.token_v1>>
 // CHECK-LABEL: "type_token_caller"
 
 func.func @type_tuple(%arg0: tuple<tensor<f32>>) -> tuple<!stablehlo.token> {
   %0 = "stablehlo.custom_call"(%arg0) {
     call_target_name = "foo"
-  // CHECK: (!vhlo.tuple<!vhlo.tensor<!vhlo.f32>>) -> !vhlo.tuple<!vhlo.token>
+  // CHECK: (!vhlo.tuple_v1<!vhlo.tensor_v1<!vhlo.f32_v1>>) -> !vhlo.tuple_v1<!vhlo.token_v1>
   } : (tuple<tensor<f32>>) -> tuple<!stablehlo.token>
   return %0 : tuple<!stablehlo.token>
 }


### PR DESCRIPTION
We've been oscillating on vhlo.foo vs vhlo.foo_v1 in the last few months, but vhlo.foo_v1 has won because of its explicitness - we have encountered quite a few questions along the lines of "if I see vhlo.foo, what version does it have?".

In the current design, VHLO isn't supposed to be manipulated by users directly, so we figured that the downside of increased verbosity is going to be relatively minor in practice. If this ends up not being the case, then this decision isn't going to be set in stone - we will always be able to drop _v1 before the 1.0 release.