### PR TITLE
Change sym_visibility default from "public" to ""

### DIFF
--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.mlir
@@ -553,7 +553,7 @@ func.func @default_func(%arg0: tensor<f32>) -> tensor<f32> {
   // CHECK-SAME:   function_type = #vhlo.type_v1<!vhlo.func_v1<(!vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<!vhlo.f32_v1>>>,
   // CHECK-SAME:   res_attrs = #vhlo.array_v1<[]>,
   // CHECK-SAME:   sym_name = #vhlo.string_v1<"default_func">,
-  // CHECK-SAME:   sym_visibility = #vhlo.string_v1<"public">
+  // CHECK-SAME:   sym_visibility = #vhlo.string_v1<"">
   // CHECK-SAME: } : () -> ()
   func.return %arg0 : tensor<f32>
 }

--- a/stablehlo/transforms/StablehloLegalizeToVhlo.cpp
+++ b/stablehlo/transforms/StablehloLegalizeToVhlo.cpp
@@ -564,7 +564,7 @@ LogicalResult addDefaults(const OpConversionPattern<StablehloOpTy>& pattern,
   if constexpr (std::is_same<StablehloOpTy, func::FuncOp>::value) {
     if (!stablehloOp.getSymVisibilityAttr())
       addDefaultAttr("sym_visibility",
-                     StringAttr::get(pattern.getContext(), "public"));
+                     StringAttr::get(pattern.getContext(), ""));
     if (!stablehloOp.getArgAttrsAttr())
       addDefaultAttr("arg_attrs", ArrayAttr::get(pattern.getContext(), {}));
     if (!stablehloOp.getResAttrsAttr())

--- a/stablehlo/transforms/VhloLegalizeToStablehlo.cpp
+++ b/stablehlo/transforms/VhloLegalizeToStablehlo.cpp
@@ -528,7 +528,7 @@ LogicalResult removeDefaults(const OpConversionPattern<VhloOpTy>& pattern,
                              VhloOpTy vhloOp,
                              SmallVector<NamedAttribute>& vhloAttrs) {
   if constexpr (std::is_same<VhloOpTy, vhlo::FuncOpV1>::value) {
-    if (isString(vhloOp.getSymVisibilityAttr(), "public"))
+    if (isString(vhloOp.getSymVisibilityAttr(), ""))
       eraseAttrs(vhloAttrs, "sym_visibility");
     if (isEmptyArray(vhloOp.getArgAttrsAttr()))
       eraseAttrs(vhloAttrs, "arg_attrs");


### PR DESCRIPTION
When removing default values from VHLO, I used "public" as the default value for vhlo::FuncOp's sym_visibility argument. That was a mistake because func::FuncOp doesn't say anything about "public" being the default.