### PR TITLE
Add interpreter for LogisticOp

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3149,13 +3149,11 @@ Performs element-wise logistic operation on `operand` tensor and produces a
 
 ```mlir
 // %operand: [[0.0, 1.0], [2.0, 3.0]]
-%result = "stablehlo.logistic"(%operand) : (tensor<2x2xf32>) -> tensor<2x2xf32>
+%result = "stablehlo.logistic"(%operand) : (tensor<2x2xf64>) -> tensor<2x2xf64>
 // %result: [[0.5, 0.73105858], [0.88079708, 0.95257413]]
-
-// %operand: (1.0, 2.0)
-%result = "stablehlo.logistic"(%operand) : (tensor<complex<f32>>) -> tensor<complex<f32>>
-// %result: (1.02141536, 0.40343871)
 ```
+
+&nbsp;[More Examples](../stablehlo/tests/interpret_logistic.mlir)
 
 ### map
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -101,7 +101,7 @@ one of the following tracking labels.
 | is_finite                | yes           | yes          | yes            | yes             | no          |
 | log                      | yes           | yes          | yes            | yes             | yes         |
 | log_plus_one             | yes           | yes          | yes            | yes             | no          |
-| logistic                 | yes           | yes          | yes            | yes             | no          |
+| logistic                 | yes           | yes          | yes            | yes             | yes         |
 | map                      | yes           | revisit      | yes            | no              | no          |
 | maximum                  | yes           | yes          | yes            | yes             | yes         |
 | minimum                  | yes           | yes          | yes            | yes             | yes         |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -431,8 +431,9 @@ def StableHLO_Log1pOp: StableHLO_UnaryElementwiseOp<"log_plus_one",
 }
 
 def StableHLO_LogisticOp: StableHLO_UnaryElementwiseOp<"logistic",
-    [Pure, HLO_CompatibleOperandsAndResultType], HLO_FpOrComplexTensor> {
-  let summary = "Logistic operation";
+    [Pure, HLO_CompatibleOperandsAndResultType /*logistic_c1*/],
+    HLO_FpOrComplexTensor /*logistic_i1*/> { /*logistic_c1*/
+  let summary = "Logistic operator";
   let description = [{
     Performs element-wise logistic operation on `operand` tensor and produces a
     `result` tensor.
@@ -442,7 +443,7 @@ def StableHLO_LogisticOp: StableHLO_UnaryElementwiseOp<"logistic",
 
     Example:
     ```mlir
-    %result = stablehlo.logistic %operand : tensor<2x2xf32>
+    %result = stablehlo.logistic %operand : tensor<2x2xf64>
     ```
   }];
 }

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -433,7 +433,7 @@ def StableHLO_Log1pOp: StableHLO_UnaryElementwiseOp<"log_plus_one",
 def StableHLO_LogisticOp: StableHLO_UnaryElementwiseOp<"logistic",
     [Pure, HLO_CompatibleOperandsAndResultType /*logistic_c1*/],
     HLO_FpOrComplexTensor /*logistic_i1*/> { /*logistic_c1*/
-  let summary = "Logistic operator";
+  let summary = "Logistic operation";
   let description = [{
     Performs element-wise logistic operation on `operand` tensor and produces a
     `result` tensor.

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -530,6 +530,14 @@ Element log(const Element &el) {
       [](std::complex<double> e) { return std::log(e); });
 }
 
+Element logistic(const Element &el) {
+  Element one;
+  if (isSupportedFloatType(el.getType())) one = Element(el.getType(), 1.0);
+  if (isSupportedComplexType(el.getType()))
+    one = Element(el.getType(), std::complex<double>(1.0));
+  return one / (one + exponential(-el));
+}
+
 Element max(const Element &e1, const Element &e2) {
   return map(
       e1, e2,

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -190,9 +190,6 @@ Element::Element(Type type, bool value) : type_(type), value_(value) {}
 
 Element::Element(Type type, APFloat value) : type_(type), value_(value) {}
 
-// The double `value` can be used to construct two types: floating-point or
-// complex element types. By specifying a double value for complex element type,
-// the real part is set to `value`, and the imaginary part is zero.
 Element::Element(Type type, double value) {
   if (isSupportedFloatType(type)) {
     APFloat floatVal(value);

--- a/stablehlo/reference/Element.h
+++ b/stablehlo/reference/Element.h
@@ -42,7 +42,6 @@ class Element {
   Element(Type type, std::complex<APFloat> value);
   Element(Type type, std::complex<double> value);
   Element(const Element &other) = default;
-  Element() = default;
   /// @}
 
   /// Assignment operator.

--- a/stablehlo/reference/Element.h
+++ b/stablehlo/reference/Element.h
@@ -42,6 +42,7 @@ class Element {
   Element(Type type, std::complex<APFloat> value);
   Element(Type type, std::complex<double> value);
   Element(const Element &other) = default;
+  Element() = default;
   /// @}
 
   /// Assignment operator.
@@ -137,6 +138,9 @@ Element imag(const Element &el);
 
 /// Returns log of Element object.
 Element log(const Element &el);
+
+/// Returns logistic of Element object.
+Element logistic(const Element &el);
 
 /// Returns the maximum between two Element objects.
 Element max(const Element &e1, const Element &e2);

--- a/stablehlo/reference/Element.h
+++ b/stablehlo/reference/Element.h
@@ -35,12 +35,22 @@ class Element {
   /// \name Constructors
   /// @{
   Element(Type type, APInt value);
+
   Element(Type type, int64_t value);
+
   Element(Type type, bool value);
+
   Element(Type type, APFloat value);
+
+  /// The double `value` can be used to construct two types: floating-point or
+  /// complex element types. By specifying a double value for complex element
+  /// type, the real part is set to `value`, and the imaginary part is zero.
   Element(Type type, double value);
+
   Element(Type type, std::complex<APFloat> value);
+
   Element(Type type, std::complex<double> value);
+
   Element(const Element &other) = default;
   /// @}
 

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -231,6 +231,13 @@ Tensor evalLogOp(const Tensor &operand, TensorType resultType) {
   return result;
 }
 
+Tensor evalLogisticOp(const Tensor &operand, TensorType resultType) {
+  Tensor result(resultType);
+  for (auto it = result.index_begin(); it != result.index_end(); ++it)
+    result.set(*it, logistic(operand.get(*it)));
+  return result;
+}
+
 Tensor evalMaxOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
@@ -545,6 +552,11 @@ SmallVector<Tensor> eval(
     } else if (auto logOp = dyn_cast<LogOp>(op)) {
       Tensor runtimeOperand = scope.find(logOp.getOperand());
       Tensor runtimeResult = evalLogOp(runtimeOperand, logOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto logisticOp = dyn_cast<LogisticOp>(op)) {
+      Tensor runtimeOperand = scope.find(logisticOp.getOperand());
+      Tensor runtimeResult =
+          evalLogisticOp(runtimeOperand, logisticOp.getType());
       scope.add(op.getResults(), {runtimeResult});
     } else if (auto maxOp = dyn_cast<MaxOp>(op)) {
       Tensor runtimeLhs = scope.find(maxOp.getLhs());

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -56,6 +56,7 @@ SmallVector<Tensor> evalIfOp(const Tensor &pred, Region &trueBranch,
 Tensor evalImagOp(const Tensor &operand, TensorType resultType);
 Tensor evalIotaOp(Axis iotaDimension, TensorType resultType);
 Tensor evalLogOp(const Tensor &operand, TensorType resultType);
+Tensor evalLogisticOp(const Tensor &operand, TensorType resultType);
 Tensor evalMaxOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType);
 Tensor evalMinOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType);
 Tensor evalMultiplyOp(const Tensor &lhs, const Tensor &rhs,

--- a/stablehlo/tests/interpret_logistic.mlir
+++ b/stablehlo/tests/interpret_logistic.mlir
@@ -1,0 +1,18 @@
+// RUN: stablehlo-interpreter --interpret -split-input-file %s
+
+func.func @logistic_op_test_i64() {
+  %operand = stablehlo.constant dense<[[1.0, 2.0], [3.0, 4.0]]> : tensor<2x2xf64>
+  %result = stablehlo.logistic %operand : tensor<2x2xf64>
+  check.almost_eq %result, dense<[[0.73105857863000488, 0.88079707797788244],
+                                  [0.95257412682243322, 0.98201379003790844]]> : tensor<2x2xf64>
+  func.return
+}
+
+// -----
+
+func.func @logistic_op_test_c128() {
+  %operand = stablehlo.constant dense<(1.0, 2.0)> : tensor<complex<f64>>
+  %result = stablehlo.logistic %operand : tensor<complex<f64>>
+  check.almost_eq %result, dense<(1.02141536417218054, 0.40343870608154248)> : tensor<complex<f64>>
+  func.return
+}

--- a/stablehlo/tests/interpret_logistic.mlir
+++ b/stablehlo/tests/interpret_logistic.mlir
@@ -1,6 +1,6 @@
-// RUN: stablehlo-interpreter --interpret -split-input-file %s
+// RUN: stablehlo-translate --interpret -split-input-file %s
 
-func.func @logistic_op_test_i64() {
+func.func @logistic_op_test_f64() {
   %operand = stablehlo.constant dense<[[1.0, 2.0], [3.0, 4.0]]> : tensor<2x2xf64>
   %result = stablehlo.logistic %operand : tensor<2x2xf64>
   check.expect_almost_eq_const %result,

--- a/stablehlo/tests/interpret_logistic.mlir
+++ b/stablehlo/tests/interpret_logistic.mlir
@@ -3,8 +3,9 @@
 func.func @logistic_op_test_i64() {
   %operand = stablehlo.constant dense<[[1.0, 2.0], [3.0, 4.0]]> : tensor<2x2xf64>
   %result = stablehlo.logistic %operand : tensor<2x2xf64>
-  check.almost_eq %result, dense<[[0.73105857863000488, 0.88079707797788244],
-                                  [0.95257412682243322, 0.98201379003790844]]> : tensor<2x2xf64>
+  check.expect_almost_eq_const %result,
+      dense<[[0.73105857863000488, 0.88079707797788244],
+             [0.95257412682243322, 0.98201379003790844]]> : tensor<2x2xf64>
   func.return
 }
 
@@ -13,6 +14,7 @@ func.func @logistic_op_test_i64() {
 func.func @logistic_op_test_c128() {
   %operand = stablehlo.constant dense<(1.0, 2.0)> : tensor<complex<f64>>
   %result = stablehlo.logistic %operand : tensor<complex<f64>>
-  check.almost_eq %result, dense<(1.02141536417218054, 0.40343870608154248)> : tensor<complex<f64>>
+  check.expect_almost_eq_const %result,
+      dense<(1.02141536417218054, 0.40343870608154248)> : tensor<complex<f64>>
   func.return
 }


### PR DESCRIPTION
Here are the following constraints:
```
(I1) operand is a tensor of floating-point or complex type. (Covered by ODS).
(C1) `operand` and `result` have the same type. (Covered by ODS).
```

No additional tests are needed as all constraints and shape inference is covered by ODS.

closes #978