### PR TITLE
Update build to remove traces of conformance

### DIFF
--- a/stablehlo/testdata/CMakeLists.txt
+++ b/stablehlo/testdata/CMakeLists.txt
@@ -24,12 +24,12 @@ set(STABLEHLO_TEST_DEPENDS
         stablehlo-opt
         stablehlo-interpreter
 )
-add_lit_testsuite(check-stablehlo-conformance-lit "Running the StableHLO compatibility tests"
+add_lit_testsuite(check-stablehlo-compatibility-lit "Running the StableHLO compatibility tests"
         ${CMAKE_CURRENT_BINARY_DIR}
         DEPENDS ${STABLEHLO_TEST_DEPENDS}
         )
-set_target_properties(check-stablehlo-conformance-lit PROPERTIES FOLDER "Tests")
+set_target_properties(check-stablehlo-compatibility-lit PROPERTIES FOLDER "Tests")
 add_lit_testsuites(STABLEHLO_SUITE ${CMAKE_CURRENT_SOURCE_DIR} DEPENDS ${STABLEHLO_TEST_DEPENDS})
 
-add_dependencies(check-stablehlo check-stablehlo-conformance-lit)
+add_dependencies(check-stablehlo check-stablehlo-compatibility-lit)
 


### PR DESCRIPTION
PR #1221 renamed stablehlo/conformance to stablehlo/testdata because we're not ready to call it a conformance suite, and this PR cleans up the remaining traces of the original name in the build file.