### PR TITLE
Only lint whitespace for changed files

### DIFF
--- a/build_tools/github_actions/lint_whitespace_checks.sh
+++ b/build_tools/github_actions/lint_whitespace_checks.sh
@@ -17,9 +17,11 @@ print_usage() {
 }
 
 FORMAT_MODE='validate'
-while getopts 'f' flag; do
+BASE_BRANCH="$(git merge-base HEAD origin/main)"
+while getopts 'fb:' flag; do
   case "${flag}" in
     f) FORMAT_MODE="fix" ;;
+    b) BASE_BRANCH="$OPTARG" ;;
     *) print_usage
        exit 1 ;;
   esac
@@ -32,8 +34,10 @@ if [[ $# -ne 0 ]] ; then
 fi
 
 get_source_files() {
-  find . -iname '*.h' -o -iname '*.cpp' -o -iname '*.td' -o -iname '*.md' -o -iname '*.txt' -o -iname '*.mlir' -o -iname '*.yml'
+  git diff $BASE_BRANCH HEAD --name-only --diff-filter=d | grep '.*\.cpp\|.*\.h\|.*\.md\|.*\.mlir\|.*\.sh\|.*\.td\|.*\.txt\|.*\.yml\|.*\.yaml' | xargs
 }
+echo "Checking whitespace:"
+echo "  $(get_source_files)"
 
 files_without_eof_newline() {
   get_source_files | xargs -L1 bash -c 'test "$(tail -c 1 "$0")" && echo "$0"'
@@ -67,7 +71,7 @@ else
     echo $TRAIL_WS
     echo
     echo "Auto-fix using:"
-    echo "  $ lint_whitespace_checks.sh -f"
+    echo "  $ ./build_tools/github_actions/lint_whitespace_checks.sh -f"
     exit 1
   else
     echo "No whitespace issues found."


### PR DESCRIPTION
Now that we have a bunch of test files, it saves a lot of time to only lint changed files.

Granted we will likely be shedding most of these test files soon (reorganizing, trimming, changing where they are stored, or something else), this is still a worthwhile change to make.

Also updated the fix link so that it is copy-pastable. This tool is only runnable from the root directory as it is, so including full relative path is probably best.