### PR TITLE
Two minor bugs fixes in lint whitespace check

### DIFF
--- a/build_tools/github_actions/lint_whitespace_checks.sh
+++ b/build_tools/github_actions/lint_whitespace_checks.sh
@@ -34,13 +34,13 @@ if [[ $# -ne 0 ]] ; then
 fi
 
 get_source_files() {
-  git diff $BASE_BRANCH HEAD --name-only --diff-filter=d | grep '.*\.cpp\|.*\.h\|.*\.md\|.*\.mlir\|.*\.sh\|.*\.td\|.*\.txt\|.*\.yml\|.*\.yaml' | xargs
+  git diff $BASE_BRANCH HEAD --name-only --diff-filter=d | grep '.*\.cpp$\|.*\.h$\|.*\.md$\|.*\.mlir$\|.*\.sh$\|.*\.td$\|.*\.txt$\|.*\.yml$\|.*\.yaml$' | xargs
 }
 echo "Checking whitespace:"
 echo "  $(get_source_files)"
 
 files_without_eof_newline() {
-  get_source_files | xargs -L1 bash -c 'test "$(tail -c 1 "$0")" && echo "$0"'
+  [[ -z $(get_source_files) ]] || get_source_files | xargs -L1 bash -c 'test "$(tail -c 1 "$0")" && echo "$0"'
 }
 
 files_with_trailing_whitespace() {


### PR DESCRIPTION
1. Pass if file list to lint is empty.
2. Enforce extension checking at end of file (was checking .mlir.bc files)

Given the pipe into bash using $0:

```
get_source_files | xargs -L1 bash -c 'test "$(tail -c 1 "$0")"
```

This requires the output of get_source_files to be non-empty. Added a `-z` check before calling this command. This is odd, but I can't find a better way to go about this check.