### PR TITLE
Use std::optional instead of llvm::Optional

### DIFF
--- a/stablehlo/dialect/Base.cpp
+++ b/stablehlo/dialect/Base.cpp
@@ -16,6 +16,8 @@ limitations under the License.
 
 #include "stablehlo/dialect/Base.h"
 
+#include <optional>
+
 #include "llvm/ADT/TypeSwitch.h"
 #include "mlir/Dialect/Quant/QuantTypes.h"
 #include "mlir/Dialect/Shape/IR/Shape.h"
@@ -228,7 +230,7 @@ std::pair<int64_t, int64_t> inferConcatenatedDimAndBound(int64_t leftSize,
 //  c5:  ?              ?, B            ?, B
 //  c6:  ?, B           ?, C            ?, min(B, C)
 FailureOr<std::pair<int64_t, int64_t>> inferMostSpecificDimAndBound(
-    Optional<Location> location, int64_t dim, int64_t leftSize,
+    std::optional<Location> location, int64_t dim, int64_t leftSize,
     int64_t rightSize, int64_t leftBound, int64_t rightBound) {
   bool isLeftStaticDim = !isDynamicDimSize(leftSize);
   bool isRightStaticDim = !isDynamicDimSize(rightSize);
@@ -268,7 +270,7 @@ FailureOr<std::pair<int64_t, int64_t>> inferMostSpecificDimAndBound(
 //  c4:  ?              ?, B            ?
 //  c5:  ?, B           ?, C            ?, max(B, C)
 FailureOr<std::pair<int64_t, int64_t>> inferLeastSpecificDimAndBound(
-    Optional<Location> location, int64_t dim, int64_t leftSize,
+    std::optional<Location> location, int64_t dim, int64_t leftSize,
     int64_t rightSize, int64_t leftBound, int64_t rightBound) {
   bool isLeftStaticDim = !isDynamicDimSize(leftSize);
   bool isRightStaticDim = !isDynamicDimSize(rightSize);
@@ -295,9 +297,9 @@ FailureOr<std::pair<int64_t, int64_t>> inferLeastSpecificDimAndBound(
 }
 
 FailureOr<TensorType> inferTypeWithCustomFn(
-    Optional<Location> location, SmallVector<RankedTensorType> rankedTypes,
+    std::optional<Location> location, SmallVector<RankedTensorType> rankedTypes,
     std::function<FailureOr<std::pair<int64_t, int64_t>>(
-        Optional<Location>, int64_t, int64_t, int64_t, int64_t, int64_t)>
+        std::optional<Location>, int64_t, int64_t, int64_t, int64_t, int64_t)>
         inferDimAndBoundFn) {
   auto rank = rankedTypes[0].getRank();
   SmallVector<int64_t> inferredSizes = to_vector(rankedTypes[0].getShape());
@@ -331,7 +333,7 @@ FailureOr<TensorType> inferTypeWithCustomFn(
           anyInputHaveBounds ? inferredBounds : ArrayRef<int64_t>({})));
 }
 
-FailureOr<Type> inferLeastSpecificType(Optional<Location> location,
+FailureOr<Type> inferLeastSpecificType(std::optional<Location> location,
                                        TypeRange inputTypes) {
   SmallVector<RankedTensorType> rankedTypes;
   for (auto inputType : inputTypes)
@@ -343,7 +345,7 @@ FailureOr<Type> inferLeastSpecificType(Optional<Location> location,
                                inferLeastSpecificDimAndBound);
 }
 
-FailureOr<Type> inferMostSpecificType(Optional<Location> location,
+FailureOr<Type> inferMostSpecificType(std::optional<Location> location,
                                       TypeRange inputTypes) {
   SmallVector<RankedTensorType> rankedTypes;
   for (auto inputType : inputTypes)

--- a/stablehlo/dialect/Base.h
+++ b/stablehlo/dialect/Base.h
@@ -75,25 +75,25 @@ std::pair<int64_t, int64_t> inferConcatenatedDimAndBound(int64_t leftSize,
                                                          int64_t rightBound);
 
 FailureOr<std::pair<int64_t, int64_t>> inferMostSpecificDimAndBound(
-    Optional<Location> location, int64_t dim, int64_t leftSize,
+    std::optional<Location> location, int64_t dim, int64_t leftSize,
     int64_t rightSize, int64_t leftBound, int64_t rightBound);
 
 FailureOr<std::pair<int64_t, int64_t>> inferLeastSpecificDimAndBound(
-    Optional<Location> location, int64_t dim, int64_t leftSize,
+    std::optional<Location> location, int64_t dim, int64_t leftSize,
     int64_t rightSize, int64_t leftBound, int64_t rightBound);
 
 // Infer single least specific return type from inputTypes with support for
 // bounds. (Size, bound) of each dimension of the return type will be merged
 // from corresponding dimensions of every inputType by extracting the least
 // specific one. Return unranked tensor if any input is unranked.
-FailureOr<Type> inferLeastSpecificType(Optional<Location> location,
+FailureOr<Type> inferLeastSpecificType(std::optional<Location> location,
                                        TypeRange inputTypes);
 
 // Infer single most specific return type from inputTypes with support for
 // bounds. (Size, bound) of each dimension of the return type will be merged
 // from corresponding dimensions of every inputType by extracting the most
 // specific one. Return unranked tensor if all inputs are unranked.
-FailureOr<Type> inferMostSpecificType(Optional<Location> location,
+FailureOr<Type> inferMostSpecificType(std::optional<Location> location,
                                       TypeRange inputTypes);
 
 LogicalResult inferMostSpecificTypeComponents(

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -25,6 +25,7 @@ limitations under the License.
 #include <cstdint>
 #include <functional>
 #include <numeric>
+#include <optional>
 #include <set>
 #include <unordered_map>
 #include <utility>
@@ -217,7 +218,7 @@ LogicalResult verifyPairwiseCompatibleShapes(TypeRange values) {
   return success();
 }
 
-LogicalResult verifyBatchNorm(Optional<Location> location,
+LogicalResult verifyBatchNorm(std::optional<Location> location,
                               ValueRange multiDimOperands,
                               ValueRange singleDimOperands,
                               int64_t featureIndex) {
@@ -261,7 +262,7 @@ LogicalResult verifyBatchNorm(Optional<Location> location,
 }
 
 LogicalResult inferBatchNormOp(
-    Optional<Location> location, ValueRange multiDimOperands,
+    std::optional<Location> location, ValueRange multiDimOperands,
     ValueRange singleDimOperands, int64_t featureIndex,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes,
     bool is_inference) {
@@ -1236,8 +1237,8 @@ void reifyGatherDimSizes(int64_t resultRank,
 //  P1. Verify 0 <= offset_dims[i] < output_shape_rank, for every i.
 //      (output_shape_rank = size(offset_dims) + rank(start_indices) -1)
 static LogicalResult inferGatherReturnTypeComponents(
-    Optional<Location> location, ShapeAdaptor operandShape, Value startIndices,
-    llvm::function_ref<int64_t(int64_t)> getSliceDim,
+    std::optional<Location> location, ShapeAdaptor operandShape,
+    Value startIndices, llvm::function_ref<int64_t(int64_t)> getSliceDim,
     ArrayRef<int64_t> offsetDims, ArrayRef<int64_t> collapsedSliceDims,
     ArrayRef<int64_t> startIndexMap, int64_t indexVectorDim,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
@@ -1301,8 +1302,8 @@ static LogicalResult inferGatherReturnTypeComponents(
 }
 
 // Used by IfOp and CaseOp
-LogicalResult inferConditionalOp(Optional<Location> location, Value operand,
-                                 RegionRange branches,
+LogicalResult inferConditionalOp(std::optional<Location> location,
+                                 Value operand, RegionRange branches,
                                  SmallVectorImpl<Type>& inferredReturnTypes) {
   // case_i1, if_i1
   auto operandRankedTy = operand.getType().dyn_cast<RankedTensorType>();
@@ -1461,7 +1462,7 @@ LogicalResult inferAllToAllOp(
 }
 
 LogicalResult inferBatchNormGradOp(
-    Optional<Location> location, Value operand, Value scale, Value mean,
+    std::optional<Location> location, Value operand, Value scale, Value mean,
     Value variance, Value gradOutput, int64_t featureIndex,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   return inferBatchNormOp(location, {operand, gradOutput},
@@ -1470,7 +1471,7 @@ LogicalResult inferBatchNormGradOp(
 }
 
 LogicalResult inferBatchNormInferenceOp(
-    Optional<Location> location, Value operand, Value scale, Value offset,
+    std::optional<Location> location, Value operand, Value scale, Value offset,
     Value mean, Value variance, int64_t featureIndex,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   return inferBatchNormOp(location, {operand}, {scale, offset, mean, variance},
@@ -1479,7 +1480,7 @@ LogicalResult inferBatchNormInferenceOp(
 }
 
 LogicalResult inferBatchNormTrainingOp(
-    Optional<Location> location, Value operand, Value scale, Value offset,
+    std::optional<Location> location, Value operand, Value scale, Value offset,
     int64_t featureIndex,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   return inferBatchNormOp(location, {operand}, {scale, offset}, featureIndex,
@@ -1510,7 +1511,7 @@ LogicalResult inferBroadcastOp(
   return success();
 }
 
-LogicalResult inferCaseOp(Optional<Location> location, Value index,
+LogicalResult inferCaseOp(std::optional<Location> location, Value index,
                           RegionRange branches,
                           SmallVectorImpl<Type>& inferredReturnTypes) {
   return inferConditionalOp(location, index, branches, inferredReturnTypes);

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -115,17 +115,17 @@ LogicalResult inferAllToAllOp(
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferBatchNormGradOp(
-    Optional<Location> location, Value operand, Value scale, Value mean,
+    std::optional<Location> location, Value operand, Value scale, Value mean,
     Value variance, Value gradOutput, int64_t featureIndex,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferBatchNormInferenceOp(
-    Optional<Location> location, Value operand, Value scale, Value offset,
+    std::optional<Location> location, Value operand, Value scale, Value offset,
     Value mean, Value variance, int64_t featureIndex,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferBatchNormTrainingOp(
-    Optional<Location> location, Value operand, Value scale, Value offset,
+    std::optional<Location> location, Value operand, Value scale, Value offset,
     int64_t featureIndex,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 


### PR DESCRIPTION
Note that llvm::Optional is just an alias for std::optional these days and have since been deprecated upstream in favor of std::optional.

based on tensorflow@515b5d867bb901fd1c37911d7dfe6118ee3cc925