### PR TITLE
Align summaries and descriptions in StableHLO and MHLO dialects

### DIFF
--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -69,7 +69,7 @@ class StableHLO_ShapedInterfaceOp<string mnemonic, list<Trait> traits> :
 
 def StableHLO_ConstantOp : StableHLO_Op<"constant",
     [ConstantLike, Pure, DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
-  let summary = "Constant operator";
+  let summary = "Constant operation";
   let description = [{
     Produces an `output` tensor from a constant `value`.
 
@@ -101,7 +101,7 @@ def StableHLO_ConstantOp : StableHLO_Op<"constant",
 }
 
 def StableHLO_IotaOp : StableHLO_Op<"iota", [Pure]> {
-  let summary = "Iota operator";
+  let summary = "Iota operation";
   let description = [{
     Fills an `output` tensor with values in increasing order starting from zero
     along the `iota_dimension` dimension.
@@ -134,7 +134,6 @@ def StableHLO_DynamicIotaOp: StableHLO_ShapedInterfaceOp<"dynamic_iota", [Pure]>
     https://github.com/openxla/stablehlo/blob/main/docs/spec.md#iota
 
     Example:
-
     ```mlir
     %0 = stablehlo.dynamic_iota %arg0, dim = 0 : (tensor<1xindex>) -> tensor<4xi32>
     ```
@@ -159,7 +158,6 @@ def StableHLO_CreateTokenOp : StableHLO_Op<"create_token", [Pure,
     https://github.com/openxla/stablehlo/blob/main/docs/spec.md#after_all
 
     Example:
-
     ```mlir
     %output = stablehlo.create_token : !stablehlo.token
     ```
@@ -220,7 +218,7 @@ def StableHLO_AbsOp: StableHLO_UnaryElementwiseOp<"abs",
 
 def StableHLO_CbrtOp: StableHLO_UnaryElementwiseOp<"cbrt",
     [Pure, HLO_CompatibleOperandsAndResultType], HLO_FpOrComplexTensor> {
-  let summary = "Cubic root operator";
+  let summary = "Cbrt operation";
   let description = [{
     Performs element-wise cubic root operation on `operand` tensor and produces
     a `result` tensor.
@@ -237,7 +235,7 @@ def StableHLO_CbrtOp: StableHLO_UnaryElementwiseOp<"cbrt",
 
 def StableHLO_CeilOp: StableHLO_UnaryElementwiseOp<"ceil",
     [Pure, HLO_CompatibleOperandsAndResultType], HLO_FpTensor> {
-  let summary = "Ceil operator";
+  let summary = "Ceil operation";
   let description = [{
     Performs element-wise ceil of `operand` tensor and produces a `result` tensor.
 
@@ -253,7 +251,7 @@ def StableHLO_CeilOp: StableHLO_UnaryElementwiseOp<"ceil",
 
 def StableHLO_ConvertOp : StableHLO_UnaryElementwiseOp<"convert",
     [Pure, SameOperandsAndResultShape], HLO_Tensor> {
-  let summary = "Convert operator";
+  let summary = "Convert operation";
   let description = [{
     Performs an element-wise conversion from one element type to another on
     `operand` tensor and produces a `result` tensor.
@@ -272,7 +270,7 @@ def StableHLO_ConvertOp : StableHLO_UnaryElementwiseOp<"convert",
 
 def StableHLO_ClzOp: StableHLO_UnaryElementwiseOp<"count_leading_zeros",
     [Pure, HLO_CompatibleOperandsAndResultType], HLO_IntTensor> {
-  let summary = "Count-leading-zeros (Clz) operator";
+  let summary = "Clz operation";
   let description = [{
     Performs element-wise count of the number of leading zero bits in the
     `operand` tensor and produces a `result` tensor.
@@ -289,7 +287,7 @@ def StableHLO_ClzOp: StableHLO_UnaryElementwiseOp<"count_leading_zeros",
 
 def StableHLO_CosineOp: StableHLO_UnaryElementwiseOp<"cosine",
     [Pure, HLO_CompatibleOperandsAndResultType], HLO_FpOrComplexTensor> {
-  let summary = "Cos operator";
+  let summary = "Cosine operation";
   let description = [{
     Performs element-wise cosine operation on `operand` tensor and produces a
     `result` tensor.
@@ -307,7 +305,7 @@ def StableHLO_CosineOp: StableHLO_UnaryElementwiseOp<"cosine",
 def StableHLO_ExpOp: StableHLO_UnaryElementwiseOp<"exponential",
     [Pure, HLO_CompatibleOperandsAndResultType /*exponential_c1*/],
      HLO_FpOrComplexTensor /*exponential_i1*/> {
-  let summary = "Exponential operation";
+  let summary = "Exp operation";
   let description = [{
     Performs element-wise exponential operation on `operand` tensor and produces
     a `result` tensor.
@@ -324,7 +322,7 @@ def StableHLO_ExpOp: StableHLO_UnaryElementwiseOp<"exponential",
 
 def StableHLO_Expm1Op: StableHLO_UnaryElementwiseOp<"exponential_minus_one",
     [Pure, HLO_CompatibleOperandsAndResultType], HLO_FpOrComplexTensor> {
-  let summary = "Exponential minus one operator";
+  let summary = "Expm1 operation";
   let description = [{
     Performs element-wise exponential minus one operation on `operand` tensor
     and produces a `result` tensor.
@@ -341,7 +339,7 @@ def StableHLO_Expm1Op: StableHLO_UnaryElementwiseOp<"exponential_minus_one",
 
 def StableHLO_FloorOp: StableHLO_UnaryElementwiseOp<"floor",
     [Pure, HLO_CompatibleOperandsAndResultType], HLO_FpTensor> {
-  let summary = "Floor operator";
+  let summary = "Floor operation";
   let description = [{
     Performs element-wise floor of `operand` tensor and produces a `result`
     tensor.
@@ -376,7 +374,7 @@ def StableHLO_ImagOp: StableHLO_UnaryElementwiseOp<"imag",
 
 def StableHLO_IsFiniteOp: StableHLO_UnaryElementwiseOp<"is_finite", [Pure,
     DeclareOpInterfaceMethods<InferTypeOpInterface>], HLO_Tensor> {
-  let summary = "IsFinite operator";
+  let summary = "IsFinite operation";
   let description = [{
     Performs element-wise check whether the value in `x` is finite (i.e. is
     neither +Inf, -Inf, nor NaN) and produces a `y` tensor.
@@ -417,7 +415,7 @@ def StableHLO_LogOp: StableHLO_UnaryElementwiseOp<"log",
 
 def StableHLO_Log1pOp: StableHLO_UnaryElementwiseOp<"log_plus_one",
     [Pure, HLO_CompatibleOperandsAndResultType], HLO_FpOrComplexTensor> {
-  let summary = "Log1p operator";
+  let summary = "Log1p operation";
   let description = [{
     Performs element-wise logarithm plus one operation on `operand` tensor and
     produces a `result` tensor.
@@ -434,7 +432,7 @@ def StableHLO_Log1pOp: StableHLO_UnaryElementwiseOp<"log_plus_one",
 
 def StableHLO_LogisticOp: StableHLO_UnaryElementwiseOp<"logistic",
     [Pure, HLO_CompatibleOperandsAndResultType], HLO_FpOrComplexTensor> {
-  let summary = "Logistic operator";
+  let summary = "Logistic operation";
   let description = [{
     Performs element-wise logistic operation on `operand` tensor and produces a
     `result` tensor.
@@ -451,7 +449,7 @@ def StableHLO_LogisticOp: StableHLO_UnaryElementwiseOp<"logistic",
 
 def StableHLO_NotOp: StableHLO_UnaryElementwiseOp<"not",
     [Pure, HLO_CompatibleOperandsAndResultType], HLO_PredOrIntTensor> {
-  let summary = "Not operator";
+  let summary = "Not operation";
   let description = [{
     Performs element-wise NOT of tensor `operand` of type integer and produces
     a `result` tensor.
@@ -468,7 +466,7 @@ def StableHLO_NotOp: StableHLO_UnaryElementwiseOp<"not",
 
 def StableHLO_NegOp: StableHLO_UnaryElementwiseOp<"negate",
     [Pure, HLO_CompatibleOperandsAndResultType], HLO_IntFpOrComplexTensor> {
-  let summary = "Negation operator";
+  let summary = "Neg operation";
   let description = [{
     Performs element-wise negation of `operand` tensor and produces a `result`
     tensor.
@@ -485,7 +483,7 @@ def StableHLO_NegOp: StableHLO_UnaryElementwiseOp<"negate",
 
 def StableHLO_PopulationCountOp: StableHLO_UnaryElementwiseOp<"popcnt",
     [Pure, HLO_CompatibleOperandsAndResultType], HLO_IntTensor> {
-  let summary = "PopulationCount operator";
+  let summary = "PopulationCount operation";
   let description = [{
     Performs element-wise count of the number of bits set in the `operand`
     tensor and produces a `result` tensor.
@@ -520,7 +518,7 @@ def StableHLO_RealOp: StableHLO_UnaryElementwiseOp<"real",
 
 def StableHLO_RoundOp: StableHLO_UnaryElementwiseOp<"round_nearest_afz",
     [Pure, HLO_CompatibleOperandsAndResultType], HLO_FpTensor> {
-  let summary = "Round operator, ties away from zero";
+  let summary = "Round operation";
   let description = [{
     Performs element-wise rounding towards the nearest integer, breaking ties
     away from zero, on the `operand` tensor and produces a `result` tensor.
@@ -537,7 +535,7 @@ def StableHLO_RoundOp: StableHLO_UnaryElementwiseOp<"round_nearest_afz",
 
 def StableHLO_RoundNearestEvenOp: StableHLO_UnaryElementwiseOp<"round_nearest_even",
     [Pure, HLO_CompatibleOperandsAndResultType], HLO_FpTensor> {
-  let summary = "Round operator, ties to even";
+  let summary = "RoundNearestEven operation";
   let description = [{
     Performs element-wise rounding towards the nearest integer, breaking ties
     towards the even integer, on the `operand` tensor and produces a `result`
@@ -547,7 +545,6 @@ def StableHLO_RoundNearestEvenOp: StableHLO_UnaryElementwiseOp<"round_nearest_ev
     https://github.com/openxla/stablehlo/blob/main/docs/spec.md#round_nearest_even
 
     Example:
-
     ```mlir
     %result = stablehlo.round_nearest_even %operand : tensor<5xf32>
     ```
@@ -576,7 +573,7 @@ def StableHLO_RsqrtOp: StableHLO_UnaryElementwiseOp<"rsqrt", [Pure,
 def StableHLO_SignOp: StableHLO_UnaryElementwiseOp<"sign",
     [Pure, HLO_CompatibleOperandsAndResultType],
     TensorOf<[HLO_SInt, HLO_Float, HLO_Complex]>> {
-  let summary = "Sign operator";
+  let summary = "Sign operation";
   let description = [{
     Returns the sign of the `operand` element-wise and produces a `result`
     tensor.
@@ -593,7 +590,7 @@ def StableHLO_SignOp: StableHLO_UnaryElementwiseOp<"sign",
 
 def StableHLO_SineOp: StableHLO_UnaryElementwiseOp<"sine",
     [Pure, HLO_CompatibleOperandsAndResultType], HLO_FpOrComplexTensor> {
-  let summary = "Sin operator";
+  let summary = "Sine operation";
   let description = [{
     Performs element-wise sine operation on `operand` tensor and produces a
     `result` tensor.
@@ -629,7 +626,7 @@ def StableHLO_SqrtOp: StableHLO_UnaryElementwiseOp<"sqrt", [Pure,
 def StableHLO_TanhOp: StableHLO_UnaryElementwiseOp<"tanh",
     [Pure, HLO_CompatibleOperandsAndResultType],
     HLO_FpOrComplexTensor> {
-  let summary = "Tanh operator";
+  let summary = "Tanh operation";
   let description = [{
     Performs element-wise hyperbolic tangent operation on `operand` tensor and
     produces a `result` tensor.
@@ -681,7 +678,7 @@ class StableHLO_BinaryElementwiseOp<string mnemonic, list<Trait> traits,
 
 def StableHLO_AddOp : StableHLO_BinaryElementwiseOp<"add",
       [Commutative, Pure, HLO_CompatibleOperandsAndResultType]> {
-  let summary = "Addition operator";
+  let summary = "Add operation";
   let description = [{
     Performs element-wise addition of two tensors `lhs` and `rhs` and produces a
     `result` tensor.
@@ -698,7 +695,7 @@ def StableHLO_AddOp : StableHLO_BinaryElementwiseOp<"add",
 
 def StableHLO_Atan2Op : StableHLO_BinaryElementwiseOp<"atan2",
       [Pure, HLO_CompatibleOperandsAndResultType], HLO_FpOrComplexTensor> {
-  let summary = "Atan2 operator";
+  let summary = "Atan2 operation";
   let description = [{
     Performs element-wise atan2 operation on `lhs` and `rhs` tensor and produces
     a `result` tensor.
@@ -716,7 +713,7 @@ def StableHLO_Atan2Op : StableHLO_BinaryElementwiseOp<"atan2",
 def StableHLO_ComplexOp: StableHLO_BinaryElementwiseOp<"complex", [Pure,
     SameOperandsElementType, SameOperandsAndResultShape,
     DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
-  let summary = "Complex operator";
+  let summary = "Complex operation";
   let description = [{
     Performs element-wise conversion to a complex value from a pair of real and
     imaginary values, `lhs` and `rhs`, and produces a `result` tensor.
@@ -741,7 +738,7 @@ def StableHLO_ComplexOp: StableHLO_BinaryElementwiseOp<"complex", [Pure,
 def StableHLO_DivOp : StableHLO_BinaryElementwiseOp<"divide", [Pure,
     HLO_CompatibleOperandsAndResultType /* div_c1 */],
     HLO_IntFpOrComplexTensor /* div_i1, div_i2 */> {
-  let summary = "Divide operation";
+  let summary = "Div operation";
   let description = [{
     Performs element-wise division of dividend `lhs` and divisor `rhs` tensors
     and produces a `result` tensor.
@@ -758,7 +755,7 @@ def StableHLO_DivOp : StableHLO_BinaryElementwiseOp<"divide", [Pure,
 
 def StableHLO_MaxOp : StableHLO_BinaryElementwiseOp<"maximum",
       [Commutative, Pure, HLO_CompatibleOperandsAndResultType]> {
-  let summary = "Maximum operator";
+  let summary = "Max operation";
   let description = [{
     Performs element-wise max operation on tensors `lhs` and `rhs` and produces
     a `result` tensor.
@@ -775,7 +772,7 @@ def StableHLO_MaxOp : StableHLO_BinaryElementwiseOp<"maximum",
 
 def StableHLO_MinOp : StableHLO_BinaryElementwiseOp<"minimum",
       [Commutative, Pure, HLO_CompatibleOperandsAndResultType]> {
-  let summary = "Minimum operator";
+  let summary = "Min operation";
   let description = [{
     Performs element-wise min operation on tensors `lhs` and `rhs` and produces a
     `result` tensor.
@@ -792,7 +789,7 @@ def StableHLO_MinOp : StableHLO_BinaryElementwiseOp<"minimum",
 
 def StableHLO_MulOp : StableHLO_BinaryElementwiseOp<"multiply",
       [Commutative, Pure, HLO_CompatibleOperandsAndResultType]> {
-  let summary = "Multiplication operator";
+  let summary = "Mul operation";
   let description = [{
     Performs element-wise product of two tensors `lhs` and `rhs` and produces a
     `result` tensor.
@@ -809,7 +806,7 @@ def StableHLO_MulOp : StableHLO_BinaryElementwiseOp<"multiply",
 
 def StableHLO_PowOp : StableHLO_BinaryElementwiseOp<"power",
       [Pure, HLO_CompatibleOperandsAndResultType], HLO_IntFpOrComplexTensor> {
-  let summary = "Power operator";
+  let summary = "Pow operation";
   let description = [{
     Performs element-wise exponentiation of `lhs` tensor by `rhs` tensor and
     produces a `result` tensor.
@@ -827,7 +824,7 @@ def StableHLO_PowOp : StableHLO_BinaryElementwiseOp<"power",
 def StableHLO_RemOp : StableHLO_BinaryElementwiseOp<"remainder",
       [Pure, HLO_CompatibleOperandsAndResultType /*remainder_c1*/],
        HLO_IntFpOrComplexTensor /*remainder_i1, remainder_i2*/> {
-  let summary = "Remainder operation";
+  let summary = "Rem operation";
   let description = [{
     Performs element-wise remainder of dividend `lhs` and divisor `rhs` tensors
     and produces a `result` tensor.
@@ -844,7 +841,7 @@ def StableHLO_RemOp : StableHLO_BinaryElementwiseOp<"remainder",
 
 def StableHLO_ShiftLeftOp : StableHLO_BinaryElementwiseOp<"shift_left",
       [Pure, HLO_CompatibleOperandsAndResultType], HLO_IntTensor> {
-  let summary = "Shift Left operator";
+  let summary = "ShiftLeft operation";
   let description = [{
     Performs element-wise left-shift operation on the `lhs` tensor by `rhs`
     number of bits and produces a `result` tensor.
@@ -861,7 +858,7 @@ def StableHLO_ShiftLeftOp : StableHLO_BinaryElementwiseOp<"shift_left",
 
 def StableHLO_ShiftRightArithmeticOp : StableHLO_BinaryElementwiseOp<"shift_right_arithmetic",
       [Pure, HLO_CompatibleOperandsAndResultType], HLO_IntTensor> {
-  let summary = "Shift right arithmetic operator";
+  let summary = "ShiftRightArithmetic operation";
   let description = [{
     Performs element-wise arithmetic right-shift operation on the `lhs` tensor
     by `rhs` number of bits and produces a `result` tensor.
@@ -878,7 +875,7 @@ def StableHLO_ShiftRightArithmeticOp : StableHLO_BinaryElementwiseOp<"shift_righ
 
 def StableHLO_ShiftRightLogicalOp : StableHLO_BinaryElementwiseOp<"shift_right_logical",
       [Pure, HLO_CompatibleOperandsAndResultType], HLO_IntTensor> {
-  let summary = "Shift right logical operator";
+  let summary = "ShiftRightLogical operation";
   let description = [{
     Performs element-wise logical right-shift operation on the `lhs` tensor by
     `rhs` number of bits and produces a `result` tensor.
@@ -895,7 +892,7 @@ def StableHLO_ShiftRightLogicalOp : StableHLO_BinaryElementwiseOp<"shift_right_l
 
 def StableHLO_SubtractOp : StableHLO_BinaryElementwiseOp<"subtract",
       [Pure, HLO_CompatibleOperandsAndResultType], HLO_IntFpOrComplexTensor> {
-  let summary = "Subtraction operator";
+  let summary = "Subtract operation";
   let description = [{
     Performs element-wise subtraction of two tensors `lhs` and `rhs` and
     produces a `result` tensor.
@@ -925,7 +922,7 @@ class StableHLO_BinaryBiwiseOrLogicalElementwiseOp<string mnemonic> :
 }
 
 def StableHLO_AndOp: StableHLO_BinaryBiwiseOrLogicalElementwiseOp<"and"> {
-  let summary = "And operator";
+  let summary = "And operation";
   let description = [{
     Performs element-wise AND of two tensors `lhs` and `rhs` and produces a
     `result` tensor
@@ -941,7 +938,7 @@ def StableHLO_AndOp: StableHLO_BinaryBiwiseOrLogicalElementwiseOp<"and"> {
 }
 
 def StableHLO_OrOp: StableHLO_BinaryBiwiseOrLogicalElementwiseOp<"or"> {
-  let summary = "Or operator";
+  let summary = "Or operation";
   let description = [{
     Performs element-wise OR of two tensors `lhs` and `rhs` and produces a
     `result` tensor.
@@ -957,7 +954,7 @@ def StableHLO_OrOp: StableHLO_BinaryBiwiseOrLogicalElementwiseOp<"or"> {
 }
 
 def StableHLO_XorOp : StableHLO_BinaryBiwiseOrLogicalElementwiseOp<"xor"> {
-  let summary = "Xor operator";
+  let summary = "Xor operation";
   let description = [{
     Performs element-wise XOR of two tensors `lhs` and `rhs` and produces a
     `result` tensor.
@@ -977,9 +974,7 @@ def StableHLO_XorOp : StableHLO_BinaryBiwiseOrLogicalElementwiseOp<"xor"> {
 //===----------------------------------------------------------------------===//
 
 def StableHLO_InfeedOp : StableHLO_Op<"infeed", []> {
-
-  let summary = "Infeed operator";
-
+  let summary = "Infeed operation";
   let description = [{
     Reads data from the infeed and produces `results`.
 
@@ -1005,9 +1000,7 @@ def StableHLO_InfeedOp : StableHLO_Op<"infeed", []> {
 
 def StableHLO_OutfeedOp : StableHLO_Op<"outfeed",
     [DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
-
-  let summary = "Outfeed operator";
-
+  let summary = "Outfeed operation";
   let description = [{
     Writes `inputs` to the outfeed and produces a `result` token.
 
@@ -1032,9 +1025,7 @@ def StableHLO_OutfeedOp : StableHLO_Op<"outfeed",
 
 def StableHLO_SendOp : StableHLO_Op<"send",
     [DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
-
-  let summary = "Send operator";
-
+  let summary = "Send operation";
   let description = [{
     Sends `inputs` to a channel `channel_id` and produces a `result` token.
 
@@ -1063,9 +1054,7 @@ def StableHLO_SendOp : StableHLO_Op<"send",
 }
 
 def StableHLO_RecvOp : StableHLO_Op<"recv", []> {
-
-  let summary = "Recv operator";
-
+  let summary = "Recv operation";
   let description = [{
     Receives data from a channel with `channel_id` and produces `results`.
 
@@ -1099,7 +1088,7 @@ def StableHLO_RecvOp : StableHLO_Op<"recv", []> {
 
 def StableHLO_ReplicaIdOp : StableHLO_Op<"replica_id", [Pure,
     DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
-  let summary = "ReplicaId operator";
+  let summary = "ReplicaId operation";
   let description = [{
     Produces `replica_id` of the current process.
 
@@ -1118,7 +1107,7 @@ def StableHLO_ReplicaIdOp : StableHLO_Op<"replica_id", [Pure,
 
 def StableHLO_PartitionIdOp : StableHLO_Op<"partition_id", [Pure,
     DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
-  let summary = "PartitionId operator";
+  let summary = "PartitionId operation";
   let description = [{
     Produces `partition_id` of the current process.
 
@@ -1141,9 +1130,7 @@ def StableHLO_PartitionIdOp : StableHLO_Op<"partition_id", [Pure,
 
 def StableHLO_AfterAllOp : StableHLO_Op<"after_all", [Pure,
     DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
-
-  let summary = "AfterAll operator";
-
+  let summary = "AfterAll operation";
   let description = [{
     Ensures that the operations producing the `inputs` are executed before any
     operations that depend on `result`.
@@ -1152,7 +1139,6 @@ def StableHLO_AfterAllOp : StableHLO_Op<"after_all", [Pure,
     https://github.com/openxla/stablehlo/blob/main/docs/spec.md#after_all
 
     Example:
-
     ```mlir
     %result = stablehlo.after_all %input0, %input1 : !stablehlo.token
     ```
@@ -1175,7 +1161,6 @@ def StableHLO_IfOp: StableHLO_Op<"if", [
     SingleBlockImplicitTerminator<"ReturnOp">,
     DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
   let summary = "If operation";
-
   let description = [{
     Produces the output from executing exactly one branch from `true_branch` or
     `false_branch` depending on the value of `pred`.
@@ -1243,7 +1228,7 @@ def StableHLO_WhileOp: StableHLO_Op<"while", [
       DeclareOpInterfaceMethods<InferTypeOpInterface>,
       OpAsmOpInterface
     ]> {
-  let summary = "While operator";
+  let summary = "While operation";
   let description = [{
     Produces the output from executing `body` function 0 or more times while the
     `cond` function outputs `true`.
@@ -1252,6 +1237,7 @@ def StableHLO_WhileOp: StableHLO_Op<"while", [
     https://github.com/openxla/stablehlo/blob/main/docs/spec.md#while
 
     Example:
+    ```mlir
     %results0, %results1 = "stablehlo.while"(%operand0, %operand1) ({
       ^bb0(%arg0: tensor<i32>, %arg1: tensor<i32>):
         %0 = "stablehlo.compare"(%arg0, %arg1) {
@@ -1263,6 +1249,7 @@ def StableHLO_WhileOp: StableHLO_Op<"while", [
         %0 = "stablehlo.add"(%arg0, %constant0) : (tensor<i32>, tensor<i32>) -> tensor<i32>
         "stablehlo.return"(%0, %arg1) : (tensor<i32>, tensor<i32>) -> ()
     }) : (tensor<i32>, tensor<i32>) -> (tensor<i32>, tensor<i32>)
+    ```
   }];
   let arguments = (ins Variadic<HLO_TensorOrToken>:$operand);
 
@@ -1292,11 +1279,9 @@ def StableHLO_WhileOp: StableHLO_Op<"while", [
 }
 
 def StableHLO_AllGatherOp : StableHLO_Op<"all_gather", [SameOperandsAndResultElementType]> {
-
-  string summary = "AllGather operator";
-
+  string summary = "AllGather operation";
   string description = [{
-    Within each process group in the StableHLO grid, concatenates the values of the
+    Within each process group in the process grid, concatenates the values of the
     `operand` tensor from each process along `all_gather_dim` and produces a
     `result` tensor.
 
@@ -1328,9 +1313,9 @@ def StableHLO_AllGatherOp : StableHLO_Op<"all_gather", [SameOperandsAndResultEle
 
 def StableHLO_AllReduceOp : StableHLO_Op<"all_reduce",
     [HLO_CompatibleOperandsAndResultType]> {
-  let summary = "AllReduce operator";
+  let summary = "AllReduce operation";
   let description = [{
-    Within each process group in the StableHLO grid, applies a reduction function
+    Within each process group in the process grid, applies a reduction function
     `computation` to the values of the `operand` tensor from each process and
     produces a `result` tensor.
 
@@ -1365,9 +1350,9 @@ def StableHLO_AllReduceOp : StableHLO_Op<"all_reduce",
 
 def StableHLO_ReduceScatterOp : StableHLO_Op<"reduce_scatter",
     [SameOperandsAndResultElementType]> {
-  let summary = "ReduceScatter operator";
+  let summary = "ReduceScatter operation";
   let description = [{
-     Within each process group in the StableHLO grid, performs reduction, using
+     Within each process group in the process grid, performs reduction, using
      `computations`, over the values of the `operand` tensor from each process,
      splits the reduction result along `scatter_dimension` into parts, and
      scatters the split parts between the processes to produce the `result`.
@@ -1405,9 +1390,9 @@ def StableHLO_ReduceScatterOp : StableHLO_Op<"reduce_scatter",
 
 def StableHLO_AllToAllOp : StableHLO_Op<"all_to_all",
     [SameOperandsAndResultElementType, InferTensorType]> {
-  let summary = "AllToAll operator";
+  let summary = "AllToAll operation";
   let description = [{
-    Within each process group in the StableHLO grid, splits the values of the
+    Within each process group in the process grid, splits the values of the
     `operand` tensor along `split_dimension` into parts, scatters the split parts
     between the processes, concatenates the scattered parts along `concat_dimension`
     and produces a `result` tensor.
@@ -1453,7 +1438,7 @@ def StableHLO_ReduceOp: StableHLO_ShapedInterfaceOp<"reduce", [
       InferTensorTypeWithReify,
       SingleBlockImplicitTerminator<"ReturnOp">
     ]> {
-  let summary = "Reduce operator";
+  let summary = "Reduce operation";
   let description = [{
     Applies a reduction function `body` to `inputs` and `init_values` along the
     `dimensions` and produces a `result` tensor.
@@ -1494,7 +1479,7 @@ def StableHLO_ReduceOp: StableHLO_ShapedInterfaceOp<"reduce", [
 //===----------------------------------------------------------------------===//
 def StableHLO_GetTupleElementOp: StableHLO_Op<"get_tuple_element", [Pure,
      DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
-  let summary = "GetTupleElement operator";
+  let summary = "GetTupleElement operation";
   let description = [{
     Extracts element at `index` position of the `operand` tuple and produces a
     `result`.
@@ -1521,7 +1506,7 @@ def StableHLO_GetTupleElementOp: StableHLO_Op<"get_tuple_element", [Pure,
 
 def StableHLO_TupleOp : StableHLO_Op<"tuple", [Pure,
      DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
-  let summary = "XLA's tuple op";
+  let summary = "Tuple operation";
   let description = [{
     Produces a `result` tuple from values `val`.
 
@@ -1544,7 +1529,7 @@ def StableHLO_TupleOp : StableHLO_Op<"tuple", [Pure,
 
 def StableHLO_CompareOp: StableHLO_Op<"compare", [Pure, SameOperandsElementType,
     SameOperandsAndResultShape, Elementwise, InferTensorTypeWithReify]> {
-  let summary = "Comparison operator";
+  let summary = "Compare operation";
   let description = [{
     Performs element-wise comparison of `lhs` and `rhs` tensors according to
     `comparison_direction` and `compare_type`, and produces a `result` tensor.
@@ -1683,7 +1668,7 @@ def StableHLO_DynamicUpdateSliceOp: StableHLO_Op<"dynamic_update_slice",
 def StableHLO_BatchNormGradOp : StableHLO_Op<"batch_norm_grad", [Pure,
     AllElementTypesMatch<["operand", "grad_operand", "grad_scale", "grad_offset"]>,
     InferTensorType]> {
-  let summary = "Batch Normalization Gradient";
+  let summary = "BatchNormGrad operation";
   let description = [{
     Computes gradients of several inputs of BatchNormTrainingOp backpropagating
     from `grad_output`, and produces `grad_operand`, `grad_scale` and
@@ -1721,7 +1706,7 @@ def StableHLO_BatchNormGradOp : StableHLO_Op<"batch_norm_grad", [Pure,
 
 def StableHLO_BatchNormInferenceOp : StableHLO_Op<"batch_norm_inference",
     [Pure, AllElementTypesMatch<["operand", "result"]>, InferTensorType]> {
-  let summary = "Batch Normalization for Inference";
+  let summary = "BatchNormInference operation";
   let description = [{
     Normalizes the `operand` tensor across all dimensions except for the
     `feature_index` dimension and produces a `result` tensor.
@@ -1754,7 +1739,7 @@ def StableHLO_BatchNormInferenceOp : StableHLO_Op<"batch_norm_inference",
 def StableHLO_BatchNormTrainingOp : StableHLO_Op<"batch_norm_training",
     [Pure, AllElementTypesMatch<["operand", "output", "batch_mean", "batch_var"]>,
     InferTensorType]> {
-  let summary = "Batch Normalization for Training";
+  let summary = "BatchNormTraining operation";
   let description = [{
     Computes mean and variance across batch and spatial dimensions and
     normalizes the `operand` tensor, for each feature in the `feature_index`
@@ -1788,7 +1773,7 @@ def StableHLO_BatchNormTrainingOp : StableHLO_Op<"batch_norm_training",
 
 def StableHLO_BitcastConvertOp : StableHLO_ShapedInterfaceOp<"bitcast_convert",
     [Pure]> {
-  let summary = "BitcastConvert operator";
+  let summary = "BitcastConvert operation";
   let description = [{
     Performs a bitcast operation on `operand` tensor and produces a `result`
     tensor where the bits of the entire `operand` tensor are reinterpreted using
@@ -1821,7 +1806,6 @@ def StableHLO_BroadcastOp : StableHLO_ShapedInterfaceOp<"broadcast",
     https://www.tensorflow.org/xla/operation_semantics#broadcast
 
     Example:
-
     ```mlir
     %result = stablehlo.broadcast %operand, sizes = [1, 2] : (tensor<3xi32>) -> tensor<1x2x3xi32>
     ```
@@ -1850,7 +1834,6 @@ def StableHLO_BroadcastInDimOp : StableHLO_Op<"broadcast_in_dim",
     https://github.com/openxla/stablehlo/blob/main/docs/spec.md#broadcast_in_dim
 
     Example:
-
     ```mlir
     %result = stablehlo.broadcast_in_dim %operand, dims = [2, 1] : (tensor<1x3xi32>) -> tensor<2x3x2xi32>
     ```
@@ -1921,7 +1904,7 @@ def StableHLO_DynamicBroadcastInDimOp : StableHLO_ShapedInterfaceOp<
 
 def StableHLO_CholeskyOp : StableHLO_Op<"cholesky",
       [Pure, SameOperandsAndResultElementType, InferTensorType]> {
-  let summary = "Cholesky operator";
+  let summary = "Cholesky operation";
   let description = [{
     Computes the Cholesky decomposition of a batch of matrices.
 
@@ -1991,7 +1974,7 @@ def StableHLO_ConcatenateOp : StableHLO_ShapedInterfaceOp<"concatenate",
     ```mlir
     %result = stablehlo.concatenate %input0, %input1, dim = 0 : (tensor<3x2xi64>, tensor<1x2xi64>) -> tensor<4x2xi64>
     ```
-   }];
+  }];
 
   let arguments = (ins
     Variadic<HLO_Tensor>:$inputs /*concatenate_i1*/,
@@ -2007,9 +1990,9 @@ def StableHLO_ConcatenateOp : StableHLO_ShapedInterfaceOp<"concatenate",
 
 def StableHLO_CollectivePermuteOp: StableHLO_Op<"collective_permute",
     [HLO_CompatibleOperandsAndResultType]> {
-  let summary = "CollectivePermute operator";
+  let summary = "CollectivePermute operation";
   let description = [{
-    Within each process group in the StableHLO grid, sends the value of the
+    Within each process group in the process grid, sends the value of the
     `operand` tensor from the source process to the target process and produces
     a `result` tensor.
 
@@ -2024,7 +2007,6 @@ def StableHLO_CollectivePermuteOp: StableHLO_Op<"collective_permute",
       channel_handle = #stablehlo.channel_handle<handle = 0, type = 0>
     } : (tensor<4x2xf32>) -> tensor<4x2xf32>
     ```
-
   }];
 
   let arguments = (ins
@@ -2043,7 +2025,7 @@ def StableHLO_CollectivePermuteOp: StableHLO_Op<"collective_permute",
 }
 
 def StableHLO_ConvolutionOp : StableHLO_Op<"convolution", [Pure]> {
-  let summary = "Convolution operator";
+  let summary = "Convolution operation";
   let description = [{
     Computes dot products between windows of `lhs` and slices of `rhs` and
     produces `result`.
@@ -2106,7 +2088,6 @@ def StableHLO_CrossReplicaSumOp : StableHLO_Op<"cross-replica-sum",
     https://github.com/openxla/stablehlo/blob/main/docs/spec.md#all_reduce
 
     Example:
-
     ```mlir
     %result = "stablehlo.cross-replica-sum"(%operand) {
       replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>
@@ -2124,7 +2105,7 @@ def StableHLO_CrossReplicaSumOp : StableHLO_Op<"cross-replica-sum",
 
 def StableHLO_CustomCallOp: StableHLO_Op<"custom_call",
     [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
-  let summary = "CustomCall operator";
+  let summary = "CustomCall operation";
   let description = [{
     Encapsulates an implementation-defined operation `call_target_name` that
     takes `inputs` and `called_computations` and produces `results`.
@@ -2183,7 +2164,6 @@ def StableHLO_DotOp: StableHLO_Op<"dot", [Pure]> {
     https://www.tensorflow.org/xla/operation_semantics#dot
 
     Example:
-
     ```mlir
     %0 = stablehlo.dot %arg0, %arg1 : (tensor<1x2xi32>, tensor<2x1xi32>) -> tensor<1x1xi32>
     ```
@@ -2204,7 +2184,7 @@ def StableHLO_DotOp: StableHLO_Op<"dot", [Pure]> {
 }
 
 def StableHLO_DotGeneralOp: StableHLO_ShapedInterfaceOp<"dot_general", [Pure]> {
-  let summary = "General Dot operator";
+  let summary = "DotGeneral operation";
   let description = [{
     Computes dot products between slices of `lhs` and slices of `rhs` and
     produces a `result` tensor.
@@ -2246,7 +2226,6 @@ def StableHLO_EinsumOp: StableHLO_Op<"einsum", [Pure]> {
     https://www.tensorflow.org/api_docs/python/tf/einsum
 
     Example:
-
     ```mlir
     %result = "stablehlo.einsum"(%lhs, %rhs) {
       einsum_config = "ab,bc->ac"
@@ -2277,7 +2256,6 @@ def StableHLO_UnaryEinsumOp: StableHLO_Op<"unary_einsum", [Pure]> {
     https://www.tensorflow.org/api_docs/python/tf/einsum
 
     Example:
-
     ```mlir
     %result = "stablehlo.unary_einsum"(%operand) {
       einsum_config = "ab->a"
@@ -2298,7 +2276,7 @@ def StableHLO_UnaryEinsumOp: StableHLO_Op<"unary_einsum", [Pure]> {
 }
 
 def StableHLO_FftOp: StableHLO_Op<"fft", [InferTensorType, Pure]> {
-  let summary = "Fast fourier transform operator";
+  let summary = "Fft operation";
   let description = [{
     Performs the forward and inverse Fourier transforms for real and complex
     inputs/outputs.
@@ -2326,7 +2304,7 @@ def StableHLO_FftOp: StableHLO_Op<"fft", [InferTensorType, Pure]> {
 }
 
 def StableHLO_GatherOp: StableHLO_Op<"gather", [InferTensorTypeWithReify, Pure]> {
-  let summary = "Gather operator";
+  let summary = "Gather operation";
   let description = [{
     Gathers slices from `operand` tensor from offsets specified in
     `start_indices` and produces a `result` tensor.
@@ -2361,7 +2339,7 @@ def StableHLO_GatherOp: StableHLO_Op<"gather", [InferTensorTypeWithReify, Pure]>
 
 def StableHLO_GetDimensionSizeOp: StableHLO_Op<"get_dimension_size",
       [Pure, InferTensorType]> {
-  let summary = "GetDimensionSize operator";
+  let summary = "GetDimensionSize operation";
   let description = [{
     Produces the size of the given `dimension` of the `operand`.
 
@@ -2369,7 +2347,6 @@ def StableHLO_GetDimensionSizeOp: StableHLO_Op<"get_dimension_size",
     https://github.com/openxla/stablehlo/blob/main/docs/spec.md#get_dimension_size
 
     Example:
-
     ```mlir
     %result = stablehlo.get_dimension_size %operand, dim = 1 : (tensor<2x3xf32>) -> tensor<i32>
     ```
@@ -2391,7 +2368,7 @@ def StableHLO_GetDimensionSizeOp: StableHLO_Op<"get_dimension_size",
 def StableHLO_MapOp: StableHLO_ShapedInterfaceOp<"map",
       [RecursiveMemoryEffects, SameOperandsAndResultShape,
        SingleBlockImplicitTerminator<"ReturnOp">, InferTensorTypeWithReify]> {
-  let summary = "Map operator";
+  let summary = "Map operation";
   let description = [{
     Applies a map function `computation` to `inputs` along the `dimensions` and
     produces a `result` tensor.
@@ -2408,7 +2385,7 @@ def StableHLO_MapOp: StableHLO_ShapedInterfaceOp<"map",
     }) {
       dimensions = dense<[0, 1]> : tensor<2xi64>
     } : (tensor<2x2xi32>, tensor<2x2xi32>) -> tensor<2x2xi32>
-  ```
+    ```
   }];
   let arguments = (ins
     Variadic<HLO_Tensor>:$inputs,
@@ -2420,7 +2397,7 @@ def StableHLO_MapOp: StableHLO_ShapedInterfaceOp<"map",
 
 def StableHLO_ReshapeOp: StableHLO_Op<"reshape",
       [Pure, SameOperandsAndResultElementType]> {
-  let summary = "Reshape operator";
+  let summary = "Reshape operation";
   let description = [{
     Performs reshape of `operand` tensor to a `result` tensor.
 
@@ -2452,7 +2429,6 @@ def StableHLO_DynamicReshapeOp: StableHLO_ShapedInterfaceOp<"dynamic_reshape", [
     https://github.com/openxla/stablehlo/blob/main/docs/spec.md#reshape
 
     Example:
-
     ```mlir
     %0 = stablehlo.dynamic_reshape %arg0, %shape : (tensor<?xf32>, tensor<2xindex>) -> tensor<?x?xf32>
     ```
@@ -2469,7 +2445,7 @@ def StableHLO_DynamicReshapeOp: StableHLO_ShapedInterfaceOp<"dynamic_reshape", [
 def StableHLO_ScatterOp: StableHLO_Op<"scatter",
       [SameVariadicOperandSize, RecursiveMemoryEffects,
       DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
-  let summary = "Scatter operator";
+  let summary = "Scatter operation";
   let description = [{
     Produces `results` tensors which are equal to `inputs` tensors except that
     several slices specified by `scatter_indices` are updated with the values
@@ -2495,7 +2471,6 @@ def StableHLO_ScatterOp: StableHLO_Op<"scatter",
      unique_indices = false
    } : (tensor<3x4x2xi32>, tensor<2x3x2xi64>, tensor<2x3x2x2xi32>) -> tensor<3x4x2xi32>
    ```
-
   }];
   let arguments = (ins
     Variadic<HLO_Tensor>:$inputs,
@@ -2544,7 +2519,7 @@ def StableHLO_SelectOp: StableHLO_Op<"select", [Pure, HLO_BroadcastingElementwis
 
 def StableHLO_SelectAndScatterOp: StableHLO_Op<"select_and_scatter",
       [RecursiveMemoryEffects, DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
-  let summary = "SelectAndScatter operator";
+  let summary = "SelectAndScatter operation";
   let description = [{
     Scatters the values from the `source` tensor using `scatter` based on the
     outcome of `reduce_window` of the `input` tensor using `select` and produces
@@ -2599,7 +2574,6 @@ def StableHLO_SetDimensionSizeOp: StableHLO_Op<"set_dimension_size", [Pure,
     https://www.tensorflow.org/xla/operation_semantics#setdimensionsize
 
     Example:
-
     ```mlir
     %0 = stablehlo.set_dimension_size %arg0, %arg1, dim = 1 : (tensor<4x2xf32>, tensor<i32>) -> tensor<4x2xf32>
     ```
@@ -2619,7 +2593,7 @@ def StableHLO_SetDimensionSizeOp: StableHLO_Op<"set_dimension_size", [Pure,
 
 def StableHLO_SortOp : StableHLO_Op<"sort",
       [RecursiveMemoryEffects, SameOperandsAndResultShape, InferTensorType]> {
-  let summary = "Sort operator";
+  let summary = "Sort operation";
   let description = [{
     Sorts a variadic number of tensors in `inputs` together, according to a
     custom `comparator`, along the given `dimension` and produces a variadic
@@ -2629,6 +2603,7 @@ def StableHLO_SortOp : StableHLO_Op<"sort",
     https://github.com/openxla/stablehlo/blob/main/docs/spec.md#sort
 
     Example:
+    ```mlir
     %result0, %result1 = "stablehlo.sort"(%input0, %input1) ({
       ^bb0(%arg0: tensor<i32>, %arg1: tensor<i32>, %arg2: tensor<i32>, %arg3: tensor<i32>):
         %predicate = "stablehlo.compare"(%arg0, %arg1) {
@@ -2639,6 +2614,7 @@ def StableHLO_SortOp : StableHLO_Op<"sort",
       dimension = 0 : i64,
       is_stable = true
     } : (tensor<2x3xi32>, tensor<2x3xi32>) -> (tensor<2x3xi32>, tensor<2x3xi32>)
+    ```
   }];
   let arguments = (ins
     Variadic<HLO_Tensor>:$inputs,
@@ -2736,7 +2712,6 @@ def StableHLO_TraceOp: StableHLO_Op<"trace", []> {
     first place. With that in mind, its semantics will not be documented here.
 
     Example:
-
     ```mlir
     stablehlo.trace %arg0, "In test code." : tensor<5x1x5xi32>
     ```
@@ -2751,7 +2726,7 @@ def StableHLO_TraceOp: StableHLO_Op<"trace", []> {
 def StableHLO_TransposeOp: StableHLO_ShapedInterfaceOp<"transpose",
       [Pure, SameOperandsAndResultElementType,
       DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
-  let summary = "Transpose operator";
+  let summary = "Transpose operation";
   let description = [{
     Permutes the dimensions of `operand` tensor using `permutation` and produces
     a `result` tensor.
@@ -2778,7 +2753,7 @@ def StableHLO_TransposeOp: StableHLO_ShapedInterfaceOp<"transpose",
 
 def StableHLO_TriangularSolveOp: StableHLO_Op<"triangular_solve",
     [Pure, SameOperandsAndResultElementType, InferTensorType]> {
-  let summary = "TriangularSolve operator";
+  let summary = "TriangularSolve operation";
   let description = [{
     Solves batches of systems of linear equations with lower or upper triangular
     coefficient matrices.
@@ -2813,7 +2788,7 @@ def StableHLO_ReduceWindowOp: StableHLO_Op<"reduce_window", [
       SingleBlockImplicitTerminator<"ReturnOp">,
       InferTensorType,
     ]> {
-  let summary = "ReduceWindow operator";
+  let summary = "ReduceWindow operation";
   let description = [{
     Applies a reduction function `body` to windows of `inputs` and `init_values`
     and produces `results`.
@@ -2928,7 +2903,6 @@ def StableHLO_TorchIndexSelectOp : StableHLO_Op<"torch_index_select", [Pure]> {
     the index.
 
     Example:
-
     ```mlir
     %result = "stablehlo.torch_index_select"(%operand, %index) {
       dim = 2 : i64,
@@ -2950,11 +2924,7 @@ def StableHLO_TorchIndexSelectOp : StableHLO_Op<"torch_index_select", [Pure]> {
 def StableHLO_OptimizationBarrierOp : StableHLO_Op<"optimization_barrier",
       [Pure, HLO_PairwiseSameOperandAndResultType,
       DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
-  let summary = [{
-    The `stablehlo.optimization_barrier` op blocks optimizations.
-
-  }];
-
+  let summary = "OptimizationBarrier operation";
   let description = [{
     Ensures that the operations that produce the `operand` are executed before any
     operations that depend on the `result` and prevents compiler transformations
@@ -2987,11 +2957,11 @@ def StableHLO_OptimizationBarrierOp : StableHLO_Op<"optimization_barrier",
 }
 
 //===----------------------------------------------------------------------===//
-// StableHLO RNG Operators.
+// StableHLO RNG operations.
 //===----------------------------------------------------------------------===//
 
 def StableHLO_RngOp : StableHLO_Op<"rng", [InferTensorTypeWithReify, AllElementTypesMatch<["a", "b", "result"]>]> {
-  let summary = "RNG operator with uniform or normal distribution.";
+  let summary = "Rng operation";
   let description = [{
     Generates random numbers using the `rng_distribution` algorithm and produces
     a `result` tensor of a given shape `shape`.
@@ -3020,7 +2990,7 @@ def StableHLO_RngOp : StableHLO_Op<"rng", [InferTensorTypeWithReify, AllElementT
 }
 
 def StableHLO_RngBitGeneratorOp : StableHLO_Op<"rng_bit_generator", [Pure]> {
-  let summary = "Uniform pseudo random number generator operator";
+  let summary = "RngBitGenerator operation";
   let description = [{
     Returns an `output` filled with uniform random data and an updated output
     state `output_state` given an initial state `initial_state` using the
@@ -3053,14 +3023,14 @@ def StableHLO_RngBitGeneratorOp : StableHLO_Op<"rng_bit_generator", [Pure]> {
 }
 
 //===----------------------------------------------------------------------===//
-// StableHLO Quantize Operator.
+// StableHLO Quantize operation.
 //===----------------------------------------------------------------------===//
 
 // TODO(b/230662142): Implement unknown scales/zero_point cases.
 def StableHLO_UniformQuantizeOp : StableHLO_UnaryElementwiseOp<"uniform_quantize",
       [Pure], TensorOf<[F32, BF16, HLO_QuantizedInt]>,
       HLO_QuantizedIntTensor> {
-  let summary = "UniformQuantize operator";
+  let summary = "UniformQuantize operation";
   let description = [{
     This operation is a work in progress, so it is not yet included in
     the StableHLO specification: https://github.com/openxla/stablehlo/issues/588.
@@ -3070,7 +3040,6 @@ def StableHLO_UniformQuantizeOp : StableHLO_UnaryElementwiseOp<"uniform_quantize
     parameters defined by the result type.
 
     Example:
-
     ```mlir
     %result = stablehlo.uniform_quantize %operand : (tensor<16x16xf32>) -> tensor<16x16x!quant.uniform<ui8:f32, 34.0:16>>
     ```
@@ -3089,7 +3058,6 @@ def StableHLO_UniformDequantizeOp : StableHLO_UnaryElementwiseOp<"uniform_dequan
     operand type.
 
     Example:
-
     ```mlir
     %result = stablehlo.uniform_dequantize %operand : (tensor<16x16x!quant.uniform<i8:f32, 34.0:16>>) -> tensor<16x16xf32>
     ```
@@ -3098,7 +3066,7 @@ def StableHLO_UniformDequantizeOp : StableHLO_UnaryElementwiseOp<"uniform_dequan
 
 def StableHLO_ReducePrecisionOp :
     StableHLO_Op<"reduce_precision", [HLO_CompatibleOperandsAndResultType, Pure]> {
-  let summary = "Reduce precision operator";
+  let summary = "ReducePrecision operation";
   let description = [{
     Performs element-wise conversion of `operand` to another floating-point type
     that uses `exponent_bits` and `mantissa_bits` and back to the original
@@ -3140,7 +3108,6 @@ def StableHLO_RealDynamicSliceOp: StableHLO_ShapedInterfaceOp<
     https://github.com/openxla/stablehlo/blob/main/docs/spec.md#slice
 
     Example:
-
     ```mlir
     %result = stablehlo.real_dynamic_slice %operand,
                 %start_indices, %limit_indices, %strides
@@ -3173,7 +3140,6 @@ def StableHLO_DynamicPadOp: StableHLO_ShapedInterfaceOp<"dynamic_pad",
     https://github.com/openxla/stablehlo/blob/main/docs/spec.md#pad
 
     Example:
-
     ```mlir
     %result = stablehlo.dynamic_pad %operand, %padding_value,
                 %edge_padding_low, %edge_padding_high, %interior_padding
@@ -3209,7 +3175,6 @@ def StableHLO_DynamicGatherOp: StableHLO_Op<"dynamic_gather",
     https://github.com/openxla/stablehlo/blob/main/docs/spec.md#gather
 
     Example:
-
     ```mlir
     %result = "stablehlo.dynamic_gather"(%operand, %start_indices, %slice_sizes) {
       dimension_numbers = #stablehlo.gather<
@@ -3284,7 +3249,6 @@ def StableHLO_ComputeReshapeShapeOp :
     multiple -1 values in dimensions), this leads to undefined behavior.
 
     Example:
-
     ```mlir
     %result = stablehlo.compute_reshape_shape %num_elements, %dynamic_shape
            : (index, tensor<2xi32>) -> tensor<2xi32>
@@ -3308,7 +3272,6 @@ def StableHLO_CstrReshapableOp :
     ComputeReshapeShape would succeed with the provided operands.
 
     Example:
-
     ```mlir
     %result = stablehlo.cstr_reshapable %num_elements, %dynamic_shape
            : (index, tensor<3xi32>) -> !shape.witness


### PR DESCRIPTION
Align MHLO documentation with StableHLO documentation, which features a comprehensive spec for 94 statically-shaped ops from MHLO/HLO.

based on tensorflow@7f8ce6692c507eb6275b78c00f734a63c5e9af58