### PR TITLE
Improve newcomer experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Here's how to build the StableHLO repo on Linux or macOS:
 
    ```sh
    # On Linux
-   sudo apt install cmake ninja lld
+   sudo apt install cmake ninja-build lld
 
    # On macOS
    brew install cmake ninja

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Here's how to build the StableHLO repo on Linux or macOS:
    recommend setting it to `ON` on Linux and to `OFF` on macOS.
 
    ```sh
-   [[ uname != "Darwin" ]] && LLVM_ENABLE_LLD="ON" || LLVM_ENABLE_LLD="OFF"
+   [[ "$(uname)" != "Darwin" ]] && LLVM_ENABLE_LLD="ON" || LLVM_ENABLE_LLD="OFF"
    ```
 
 3. Clone the StableHLO repo and the LLVM repository:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ specification](https://github.com/openxla/stablehlo/blob/main/docs/spec.md)
 along with an MLIR-based implementation in C++ and Python, which you can use to
 define StableHLO programs for consumption by compilers such as XLA and IREE.
 
-## Build instruction
+## Build instructions
 
 Here's how to build the StableHLO repo on Linux or macOS:
 
@@ -33,7 +33,11 @@ Here's how to build the StableHLO repo on Linux or macOS:
    and hardware configurations.
 
    ```sh
+   # On Linux
    sudo apt install cmake ninja lld
+
+   # On macOS
+   brew install cmake ninja
    ```
 
 2. Set the `LLVM_ENABLE_LLD` shell variable depending on your preferences. We

--- a/README.md
+++ b/README.md
@@ -21,17 +21,29 @@ specification](https://github.com/openxla/stablehlo/blob/main/docs/spec.md)
 along with an MLIR-based implementation in C++ and Python, which you can use to
 define StableHLO programs for consumption by compilers such as XLA and IREE.
 
-## Build steps
+## Build instruction
 
-Here's how to build the StableHLO repo:
+Here's how to build the StableHLO repo on Linux or macOS:
 
-1. Make sure you have the LLVM-based linker `lld` installed:
+1. CMake is our primary build tool, so before you begin make sure that
+   you have CMake and Ninja installed.
+
+   If you're using Linux, we recommend installing `lld` as well - we have
+   observed it to be noticeably faster than alternatives on our typical software
+   and hardware configurations.
 
    ```sh
-   sudo apt update && sudo apt install lld
+   sudo apt install cmake ninja lld
    ```
 
-2. Clone this repo and the LLVM git repository:
+2. Set the `LLVM_ENABLE_LLD` shell variable depending on your preferences. We
+   recommend setting it to `ON` on Linux and to `OFF` on macOS.
+
+   ```sh
+   [[ uname != "Darwin" ]] && LLVM_ENABLE_LLD="ON" || LLVM_ENABLE_LLD="OFF"
+   ```
+
+3. Clone the StableHLO repo and the LLVM repository:
 
    ```sh
    git clone https://github.com/openxla/stablehlo
@@ -41,7 +53,9 @@ Here's how to build the StableHLO repo:
    cd stablehlo && git clone https://github.com/llvm/llvm-project.git
    ```
 
-3. Make sure you check out the correct commit in the LLVM repository:
+   Cloning the LLVM repository may take a few minutes.
+
+4. Make sure you check out the correct commit in the LLVM repository:
 
    ```sh
    (cd llvm-project && git fetch && git checkout $(cat ../build_tools/llvm_version.txt))
@@ -49,32 +63,34 @@ Here's how to build the StableHLO repo:
 
    You need to do this every time `llvm_version.txt` changes.
 
-4. Configure and build MLIR:
+5. Configure and build MLIR:
 
    ```sh
    build_tools/build_mlir.sh ${PWD}/llvm-project/ ${PWD}/llvm-build
    ```
 
-   This will take several minutes.
+   This will take a considerable amount of time. For example, on a MacBook Pro
+   with an M1 Pro chip, building MLIR took around 10 minutes at the moment
+   of writing.
 
    Again, you need to do this every time `llvm_version.txt` changes.
 
-5. Build StableHLO as a standalone library:
+6. Build StableHLO as a standalone library:
 
    ```sh
    mkdir -p build && cd build
 
    cmake .. -GNinja \
-     -DLLVM_ENABLE_LLD=ON \
+     -DLLVM_ENABLE_LLD="$LLVM_ENABLE_LLD" \
      -DCMAKE_BUILD_TYPE=Release \
      -DLLVM_ENABLE_ASSERTIONS=On \
      -DMLIR_DIR=${PWD}/../llvm-build/lib/cmake/mlir
    ```
 
-6. Now you can make sure it works by running some tests:
+7. Now you can make sure it works by running some tests:
 
    ```sh
-   ninja check-stablehlo
+   ninja check-stablehlo-tests
    ```
 
    You should see results like this:

--- a/build_tools/build_mlir.sh
+++ b/build_tools/build_mlir.sh
@@ -37,11 +37,12 @@ mkdir -p "$build_dir"
 echo "Beginning build (commands will echo)"
 set -x
 
+[[ uname != "Darwin" ]] && LLVM_ENABLE_LLD="ON" || LLVM_ENABLE_LLD="OFF"
 cmake -GNinja \
   "-H$LLVM_SRC_DIR/llvm" \
   "-B$build_dir" \
   -DLLVM_INSTALL_UTILS=ON \
-  -DLLVM_ENABLE_LLD=ON \
+  -DLLVM_ENABLE_LLD="$LLVM_ENABLE_LLD" \
   -DLLVM_ENABLE_PROJECTS=mlir \
   -DLLVM_TARGETS_TO_BUILD="X86;NVPTX;AMDGPU" \
   -DLLVM_INCLUDE_TOOLS=ON \
@@ -51,4 +52,4 @@ cmake -GNinja \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \
   -DLLVM_ENABLE_ASSERTIONS=On
 
-cmake --build "$build_dir" --target all --target mlir-cpu-runner
+cmake --build "$build_dir" --target all

--- a/build_tools/build_mlir.sh
+++ b/build_tools/build_mlir.sh
@@ -37,7 +37,7 @@ mkdir -p "$build_dir"
 echo "Beginning build (commands will echo)"
 set -x
 
-[[ uname != "Darwin" ]] && LLVM_ENABLE_LLD="ON" || LLVM_ENABLE_LLD="OFF"
+[[ "$(uname)" != "Darwin" ]] && LLVM_ENABLE_LLD="ON" || LLVM_ENABLE_LLD="OFF"
 cmake -GNinja \
   "-H$LLVM_SRC_DIR/llvm" \
   "-B$build_dir" \

--- a/stablehlo/testdata/CMakeLists.txt
+++ b/stablehlo/testdata/CMakeLists.txt
@@ -24,12 +24,12 @@ set(STABLEHLO_TEST_DEPENDS
         stablehlo-opt
         stablehlo-interpreter
 )
-add_lit_testsuite(check-stablehlo-compatibility-lit "Running the StableHLO compatibility tests"
+add_lit_testsuite(check-stablehlo-testdata "Running the testdata/ suite"
         ${CMAKE_CURRENT_BINARY_DIR}
         DEPENDS ${STABLEHLO_TEST_DEPENDS}
         )
-set_target_properties(check-stablehlo-compatibility-lit PROPERTIES FOLDER "Tests")
-add_lit_testsuites(STABLEHLO_SUITE ${CMAKE_CURRENT_SOURCE_DIR} DEPENDS ${STABLEHLO_TEST_DEPENDS})
+set_target_properties(check-stablehlo-testdata PROPERTIES FOLDER "Tests")
+add_lit_testsuites(STABLEHLO_TESTDATA_SUITE ${CMAKE_CURRENT_SOURCE_DIR} DEPENDS ${STABLEHLO_TEST_DEPENDS})
 
-add_dependencies(check-stablehlo check-stablehlo-compatibility-lit)
+add_dependencies(check-stablehlo check-stablehlo-testdata)
 

--- a/stablehlo/testdata/lit.cfg.py
+++ b/stablehlo/testdata/lit.cfg.py
@@ -25,7 +25,7 @@ import lit.util
 # Configuration file for the 'lit' test runner.
 
 # name: The name of this test suite.
-config.name = 'STABLEHLO_SUITE'
+config.name = 'STABLEHLO_TESTDATA_SUITE'
 
 config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
 
@@ -65,7 +65,6 @@ tool_dirs = [
 tools = [
     'stablehlo-opt',
     'stablehlo-interpreter',
-    'mlir-cpu-runner',
 ]
 
 llvm_config.add_tool_substitutions(tools, tool_dirs)

--- a/stablehlo/tests/CMakeLists.txt
+++ b/stablehlo/tests/CMakeLists.txt
@@ -25,14 +25,14 @@ set(STABLEHLO_TEST_DEPENDS
         stablehlo-opt
         stablehlo-interpreter
 )
-add_lit_testsuite(check-stablehlo-lit "Running the StableHLO regression tests"
+add_lit_testsuite(check-stablehlo-tests "Running the tests/ suite"
         ${CMAKE_CURRENT_BINARY_DIR}
         DEPENDS ${STABLEHLO_TEST_DEPENDS}
         )
-set_target_properties(check-stablehlo-lit PROPERTIES FOLDER "Tests")
-add_lit_testsuites(STABLEHLO_SUITE ${CMAKE_CURRENT_SOURCE_DIR} DEPENDS ${STABLEHLO_TEST_DEPENDS})
+set_target_properties(check-stablehlo-tests PROPERTIES FOLDER "Tests")
+add_lit_testsuites(STABLEHLO_TESTS_SUITE ${CMAKE_CURRENT_SOURCE_DIR} DEPENDS ${STABLEHLO_TEST_DEPENDS})
 
-add_dependencies(check-stablehlo check-stablehlo-lit)
+add_dependencies(check-stablehlo check-stablehlo-tests)
 
 set(LLVM_TARGET_DEFINITIONS TestUtils.td)
 mlir_tablegen(TestUtils.h.inc -gen-pass-decls -name HloTest)

--- a/stablehlo/tests/lit.cfg.py
+++ b/stablehlo/tests/lit.cfg.py
@@ -25,7 +25,7 @@ import lit.util
 # Configuration file for the 'lit' test runner.
 
 # name: The name of this test suite.
-config.name = 'STABLEHLO_SUITE'
+config.name = 'STABLEHLO_TESTS_SUITE'
 
 config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
 
@@ -65,7 +65,6 @@ tool_dirs = [
 tools = [
     'stablehlo-opt',
     'stablehlo-interpreter',
-    'mlir-cpu-runner',
 ]
 
 llvm_config.add_tool_substitutions(tools, tool_dirs)


### PR DESCRIPTION
I've tried to follow our build instructions on my personal macbook to see how smooth the experience is and how onerous it is to run the testdata/ suite on a reasonably mainstream machine.

Turns out that our instructions don't really work on macOS, and predictably checking the entire testdata/ takes a considerable amount of time (20+ seconds on a 2021 M1 Pro macbook).

This PR fixes the build instructions to work on macOS and updates the CMake target called out in the readme to only check the tests/ suite.