### PR TITLE
Implement prettyprinting for dot_general

### DIFF
--- a/stablehlo/dialect/AssemblyFormat.h
+++ b/stablehlo/dialect/AssemblyFormat.h
@@ -20,8 +20,11 @@ limitations under the License.
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "mlir/IR/Attributes.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/DialectImplementation.h"
+#include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/TypeRange.h"
@@ -235,6 +238,90 @@ void printTypeExtensions(BoundedAttrInterface attr, DialectAsmPrinter& os);
 
 Attribute parseTypeExtensions(HloDialectInterface* dialect,
                               DialectAsmParser& parser);
+
+// DotDimensionNumbers - Abbreviated printing using a ConvDimensionNumbers-
+// inspired notation. batching_dims are skipped if empty.
+//
+// Generic:
+//    dot_dimension_numbers = #stablehlo.dot<
+//      lhs_batching_dimensions = [],
+//      lhs_contracting_dimensions = [1],
+//      rhs_batching_dimensions = [],
+//      rhs_contracting_dimensions = [0]
+//    >
+//    dot_dimension_numbers = #stablehlo.dot<
+//      lhs_batching_dimensions = [0],
+//      lhs_contracting_dimensions = [2],
+//      rhs_batching_dimensions = [0],
+//      rhs_contracting_dimensions = [1]
+//    >
+//
+// Custom:
+//    contracting_dims = [1] x [0]
+//    batching_dims = [0] x [0], contracting_dims = [2] x [1]
+template <typename AttrTy>
+void printDotDimensionNumbers(AsmPrinter& p, Operation* op, AttrTy target) {
+  // Print two ArrayRef<int64_t> as `[...] x [...]`
+  auto printLhsRhsDims = [&](ArrayRef<int64_t> lhsDims,
+                             ArrayRef<int64_t> rhsDims) {
+    DenseI64ArrayAttr::get(op->getContext(), lhsDims).print(p);
+    p << " x ";
+    DenseI64ArrayAttr::get(op->getContext(), rhsDims).print(p);
+  };
+
+  // Print the optional `batching_dims = [...] x [...]`.
+  if (!target.getLhsBatchingDimensions().empty() ||
+      !target.getRhsBatchingDimensions().empty()) {
+    p << "batching_dims = ";
+    printLhsRhsDims(target.getLhsBatchingDimensions(),
+                    target.getRhsBatchingDimensions());
+    p << ", ";
+  }
+
+  // Print the required `contracting_dims = [...] x [...]`.
+  p << "contracting_dims = ";
+  printLhsRhsDims(target.getLhsContractingDimensions(),
+                  target.getRhsContractingDimensions());
+}
+
+template <typename AttrTy>
+ParseResult parseDotDimensionNumbers(AsmParser& parser, AttrTy& target) {
+  // Parse `[...] x [...]` into two DenseI64ArrayAttr attributes.
+  auto parseLhsRhsDims = [&](DenseI64ArrayAttr& lhsDims,
+                             DenseI64ArrayAttr& rhsDims) -> ParseResult {
+    lhsDims = DenseI64ArrayAttr::parse(parser, Type{})
+                  .dyn_cast_or_null<DenseI64ArrayAttr>();
+    if (!lhsDims) return failure();
+    if (failed(parser.parseKeyword("x"))) return failure();
+    rhsDims = DenseI64ArrayAttr::parse(parser, Type{})
+                  .dyn_cast_or_null<DenseI64ArrayAttr>();
+    if (!rhsDims) return failure();
+    return success();
+  };
+
+  // Parse the optional `batching_dims = [...] x [...]`.
+  DenseI64ArrayAttr lhsBatchingDims, rhsBatchingDims;
+  if (succeeded(parser.parseOptionalKeyword("batching_dims"))) {
+    if (failed(parser.parseEqual()) ||
+        failed(parseLhsRhsDims(lhsBatchingDims, rhsBatchingDims)) ||
+        failed(parser.parseComma()))
+      return failure();
+  }
+
+  // Parse the required `contracting_dims = [...] x [...]`.
+  DenseI64ArrayAttr lhsContractingDims, rhsContractingDims;
+  if (failed(parser.parseKeyword("contracting_dims")) ||
+      failed(parser.parseEqual()) ||
+      failed(parseLhsRhsDims(lhsContractingDims, rhsContractingDims)))
+    return failure();
+
+  target = AttrTy::get(
+      parser.getBuilder().getContext(),
+      lhsBatchingDims ? lhsBatchingDims.asArrayRef() : ArrayRef<int64_t>{},
+      rhsBatchingDims ? rhsBatchingDims.asArrayRef() : ArrayRef<int64_t>{},
+      lhsContractingDims.asArrayRef(), rhsContractingDims.asArrayRef());
+  return success();
+}
 
 }  // namespace hlo
 }  // namespace mlir

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -2384,6 +2384,7 @@ LogicalResult UniformDequantizeOp::inferReturnTypeComponents(
 using mlir::hlo::parseComplexOpType;
 using mlir::hlo::parseCustomCallTarget;
 using mlir::hlo::parseDenseI64Array;
+using mlir::hlo::parseDotDimensionNumbers;
 using mlir::hlo::parseExponentMantissa;
 using mlir::hlo::parsePairwiseOpType;
 using mlir::hlo::parseSameOperandsAndResultType;
@@ -2394,6 +2395,7 @@ using mlir::hlo::parseVariadicSameOperandsAndResultType;
 using mlir::hlo::printComplexOpType;
 using mlir::hlo::printCustomCallTarget;
 using mlir::hlo::printDenseI64Array;
+using mlir::hlo::printDotDimensionNumbers;
 using mlir::hlo::printExponentMantissa;
 using mlir::hlo::printPairwiseOpType;
 using mlir::hlo::printSameOperandsAndResultType;

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2196,15 +2196,9 @@ def StableHLO_DotGeneralOp: StableHLO_ShapedInterfaceOp<"dot_general", [Pure]> {
 
     Example:
     ```mlir
-    %result = "stablehlo.dot_general"(%lhs, %rhs) {
-      dot_dimension_numbers = #stablehlo.dot<
-        lhs_batching_dimensions = [0],
-        rhs_batching_dimensions = [0],
-        lhs_contracting_dimensions = [2],
-        rhs_contracting_dimensions = [1]
-      >,
-      precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-    } : (tensor<2x2x2xi32>, tensor<2x2x2xi32>) -> tensor<2x2x2xi32>
+    %result = stablehlo.dot_general %lhs, %rhs,
+      batching_dims = [0] x [0], contracting_dims = [2] x [1], precision = [DEFAULT, DEFAULT]
+      : (tensor<2x2x2xi32>, tensor<2x2x2xi32>) -> tensor<2x2x2xi32>
     ```
   }];
   let arguments = (ins
@@ -2216,6 +2210,13 @@ def StableHLO_DotGeneralOp: StableHLO_ShapedInterfaceOp<"dot_general", [Pure]> {
 
   let results = (outs HLO_Tensor);
   let hasVerifier = 1;
+
+  // Use empty `` to prevent extra whitespace before precision config.
+  let assemblyFormat = [{
+    $lhs `,` $rhs `,` custom<DotDimensionNumbers>($dot_dimension_numbers) ``
+    custom<PrecisionConfig>($precision_config) attr-dict
+      `:` functional-type(operands, results)
+  }];
 }
 
 def StableHLO_EinsumOp: StableHLO_Op<"einsum", [Pure]> {

--- a/stablehlo/tests/ops_sparse.mlir
+++ b/stablehlo/tests/ops_sparse.mlir
@@ -207,7 +207,7 @@ func.func @sparse_mul_eltwise2(%arg0: tensor<10x20xf32>,
 // CHECK-LABEL: func @dot1(
 //  CHECK-SAME: %[[A:.*]]: tensor<4xf64, #{{.*}}>,
 //  CHECK-SAME: %[[B:.*]]: tensor<4xf64>) -> tensor<f64> {
-//       CHECK: %[[T:.*]] = "stablehlo.dot_general"(%[[A]], %[[B]]) {{{.*}}} : (tensor<4xf64, #{{.*}}>, tensor<4xf64>) -> tensor<f64>
+//       CHECK: %[[T:.*]] = stablehlo.dot_general %[[A]], %[[B]]{{.*}} : (tensor<4xf64, #{{.*}}>, tensor<4xf64>) -> tensor<f64>
 //       CHECK: return %[[T]] : tensor<f64>
 func.func @dot1(%arg0: tensor<4xf64, #SV>,
                 %arg1: tensor<4xf64>) -> tensor<f64> {
@@ -223,7 +223,7 @@ func.func @dot1(%arg0: tensor<4xf64, #SV>,
 // CHECK-LABEL: func @dot2(
 //  CHECK-SAME: %[[A:.*]]: tensor<4xf64>,
 //  CHECK-SAME: %[[B:.*]]: tensor<4xf64, #{{.*}}>) -> tensor<f64> {
-//       CHECK: %[[T:.*]] = "stablehlo.dot_general"(%[[A]], %[[B]]) {{{.*}}} : (tensor<4xf64>, tensor<4xf64, #{{.*}}>) -> tensor<f64>
+//       CHECK: %[[T:.*]] = stablehlo.dot_general %[[A]], %[[B]]{{.*}} : (tensor<4xf64>, tensor<4xf64, #{{.*}}>) -> tensor<f64>
 //       CHECK: return %[[T]] : tensor<f64>
 func.func @dot2(%arg0: tensor<4xf64>,
                 %arg1: tensor<4xf64, #SV>) -> tensor<f64> {
@@ -239,7 +239,7 @@ func.func @dot2(%arg0: tensor<4xf64>,
 // CHECK-LABEL: func @dot3(
 //  CHECK-SAME: %[[A:.*]]: tensor<4xf64, #{{.*}}>,
 //  CHECK-SAME: %[[B:.*]]: tensor<4xf64, #{{.*}}>) -> tensor<f64> {
-//       CHECK: %[[T:.*]] = "stablehlo.dot_general"(%[[A]], %[[B]]) {{{.*}}} : (tensor<4xf64, #{{.*}}>, tensor<4xf64, #{{.*}}>) -> tensor<f64>
+//       CHECK: %[[T:.*]] = stablehlo.dot_general %[[A]], %[[B]]{{.*}} : (tensor<4xf64, #{{.*}}>, tensor<4xf64, #{{.*}}>) -> tensor<f64>
 //       CHECK: return %[[T]] : tensor<f64>
 func.func @dot3(%arg0: tensor<4xf64, #SV>,
                 %arg1: tensor<4xf64, #SV>) -> tensor<f64> {

--- a/stablehlo/tests/print_stablehlo.mlir
+++ b/stablehlo/tests/print_stablehlo.mlir
@@ -316,3 +316,45 @@ func.func @encodings(%arg0: tensor<10x20xf32, #CSR>,
   %4 = "stablehlo.complex"(%arg0, %arg0) : (tensor<10x20xf32, #CSR>, tensor<10x20xf32, #CSR>) -> tensor<10x20xcomplex<f32>>
   func.return %0 : tensor<10x20xf32>
 }
+
+func.func @dot_general(%arg0: tensor<2x2x2xi8>, %arg1: tensor<2x2x3xi8>, %arg2: tensor<2x2xi8>, %arg3: tensor<2x3xi8>) -> tensor<2x2x3xi32> {
+  //      CHECK: {{%.*}} = stablehlo.dot_general %arg0, %arg1, batching_dims = [0] x [0], contracting_dims = [2] x [1] : (tensor<2x2x2xi8>, tensor<2x2x3xi8>) -> tensor<2x2x3xi32>
+  // CHECK-NEXT: {{%.*}} = stablehlo.dot_general %arg0, %arg1, batching_dims = [0] x [0], contracting_dims = [2] x [1], precision = [DEFAULT, DEFAULT] : (tensor<2x2x2xi8>, tensor<2x2x3xi8>) -> tensor<2x2x3xi32>
+  // CHECK-NEXT: {{%.*}} = stablehlo.dot_general %arg2, %arg3, contracting_dims = [1] x [0] : (tensor<2x2xi8>, tensor<2x3xi8>) -> tensor<2x3xi32>
+  // CHECK-NEXT: {{%.*}} = stablehlo.dot_general %arg2, %arg3, contracting_dims = [1] x [0], precision = [DEFAULT, DEFAULT] : (tensor<2x2xi8>, tensor<2x3xi8>) -> tensor<2x3xi32>
+  %0 = "stablehlo.dot_general"(%arg0, %arg1) {
+    dot_dimension_numbers = #stablehlo.dot<
+      lhs_batching_dimensions = [0],
+      lhs_contracting_dimensions = [2],
+      rhs_batching_dimensions = [0],
+      rhs_contracting_dimensions = [1]
+    >
+  } : (tensor<2x2x2xi8>, tensor<2x2x3xi8>) -> tensor<2x2x3xi32>
+  %1 = "stablehlo.dot_general"(%arg0, %arg1) {
+    dot_dimension_numbers = #stablehlo.dot<
+      lhs_batching_dimensions = [0],
+      lhs_contracting_dimensions = [2],
+      rhs_batching_dimensions = [0],
+      rhs_contracting_dimensions = [1]
+    >,
+    precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+  } : (tensor<2x2x2xi8>, tensor<2x2x3xi8>) -> tensor<2x2x3xi32>
+  %2 = "stablehlo.dot_general"(%arg2, %arg3) {
+    dot_dimension_numbers = #stablehlo.dot<
+      lhs_batching_dimensions = [],
+      lhs_contracting_dimensions = [1],
+      rhs_batching_dimensions = [],
+      rhs_contracting_dimensions = [0]
+    >
+  } : (tensor<2x2xi8>, tensor<2x3xi8>) -> tensor<2x3xi32>
+  %3 = "stablehlo.dot_general"(%arg2, %arg3) {
+    dot_dimension_numbers = #stablehlo.dot<
+      lhs_batching_dimensions = [],
+      lhs_contracting_dimensions = [1],
+      rhs_batching_dimensions = [],
+      rhs_contracting_dimensions = [0]
+    >,
+    precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+  } : (tensor<2x2xi8>, tensor<2x3xi8>) -> tensor<2x3xi32>
+  func.return %0 : tensor<2x2x3xi32>
+}

--- a/stablehlo/tests/stablehlo_refine_shapes.mlir
+++ b/stablehlo/tests/stablehlo_refine_shapes.mlir
@@ -426,7 +426,7 @@ func.func @refine_custom_call(%arg0: tensor<4xf32>) -> (tensor<*xf32>, tensor<*x
 
 // CHECK-LABEL: @refine_dot_general
 func.func @refine_dot_general(%arg0: tensor<2x3x4xf32>, %arg1: tensor<2x3x5xf32>) -> tensor<*xf32> {
-  // CHECK: "stablehlo.dot_general"{{.*}} -> tensor<2x4x5xf32>
+  // CHECK: stablehlo.dot_general{{.*}} -> tensor<2x4x5xf32>
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
       lhs_batching_dimensions = [0],


### PR DESCRIPTION
Before:

```
  %0 = "stablehlo.dot_general"(%arg0, %arg1) {
    dot_dimension_numbers = #stablehlo.dot<
      lhs_batching_dimensions = [0],
      lhs_contracting_dimensions = [2],
      rhs_batching_dimensions = [0],
      rhs_contracting_dimensions = [1]
    >
  } : (tensor<2x2x2xi8>, tensor<2x2x3xi8>) -> tensor<2x2x3xi32>
```

After:

```
  %0 = stablehlo.dot_general %arg0, %arg1,
    batching_dims = [0] x [0], contracting_dims = [2] x [1]
    : (tensor<2x2x2xi8>, tensor<2x2x3xi8>) -> tensor<2x2x3xi32>
```

The batching_dims part is optional and can be dropped if the corresponding dims are empty.