### PR TITLE
Remove unnecessary include

### DIFF
--- a/stablehlo/dialect/Serialization.cpp
+++ b/stablehlo/dialect/Serialization.cpp
@@ -24,7 +24,6 @@ limitations under the License.
 #include "mlir/Parser/Parser.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Support/LogicalResult.h"
-#include "stablehlo/dialect/Version.h"
 #include "stablehlo/dialect/VhloOps.h"
 #include "stablehlo/transforms/Passes.h"
 


### PR DESCRIPTION
Found during integrate, we don't have a bazel dependency for this include file because it is unused.