### PR TITLE
Fix compilation error on macOS

### DIFF
--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -577,7 +577,7 @@ Element power(const Element &e1, const Element &e2) {
       if (base.abs().isOne())
         exponent = exponent.abs();
       else
-        return Element(type, 0l);
+        return Element(type, static_cast<int64_t>(0));
     }
     APInt result(base.getBitWidth(), 1, isSigned);
     while (!exponent.isZero()) {


### PR DESCRIPTION
Just `0l` is ambiguous between multiple Element::Element constructors, including the ones that take int64_t, double and bool.