### PR TITLE
Update signature of `inferPadOp` function for re-usability

### DIFF
--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -1876,8 +1876,9 @@ LogicalResult PadOp::inferReturnTypes(
     DictionaryAttr attributes, RegionRange regions,
     SmallVectorImpl<Type>& inferredReturnTypes) {
   PadOp::Adaptor adaptor(operands, attributes, regions);
-  return hlo::inferPadOp(location, adaptor.getOperand(),
-                         adaptor.getPaddingValue(), adaptor.getEdgePaddingLow(),
+  return hlo::inferPadOp(location, adaptor.getOperand().getType(),
+                         adaptor.getPaddingValue().getType(),
+                         adaptor.getEdgePaddingLow(),
                          adaptor.getEdgePaddingHigh(),
                          adaptor.getInteriorPadding(), inferredReturnTypes);
 }

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2461,14 +2461,14 @@ LogicalResult inferOutfeedOp(Dialect* dialect, std::optional<Location> location,
   return success();
 }
 
-LogicalResult inferPadOp(std::optional<Location> location, Value operand,
-                         Value paddingValue,
+LogicalResult inferPadOp(std::optional<Location> location, Type operandType,
+                         Type paddingValueType,
                          DenseIntElementsAttr edgePaddingLow,
                          DenseIntElementsAttr edgePaddingHigh,
                          DenseIntElementsAttr interiorPadding,
                          SmallVectorImpl<Type>& inferredReturnTypes) {
-  auto inputType = operand.getType().cast<RankedTensorType>();
-  auto padType = paddingValue.getType().cast<RankedTensorType>();
+  auto inputType = operandType.cast<RankedTensorType>();
+  auto padType = paddingValueType.cast<RankedTensorType>();
 
   // pad_i2
   if (padType.getRank() != 0)

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -258,8 +258,8 @@ LogicalResult inferOptimizationBarrierOp(
 LogicalResult inferOutfeedOp(Dialect* dialect, std::optional<Location> location,
                              SmallVectorImpl<Type>& inferredReturnTypes);
 
-LogicalResult inferPadOp(std::optional<Location> location, Value operand,
-                         Value paddingValue,
+LogicalResult inferPadOp(std::optional<Location> location, Type operandType,
+                         Type paddingValueType,
                          DenseIntElementsAttr edgePaddingLow,
                          DenseIntElementsAttr edgePaddingHigh,
                          DenseIntElementsAttr interiorPadding,

--- a/stablehlo/transforms/StablehloRefineShapes.cpp
+++ b/stablehlo/transforms/StablehloRefineShapes.cpp
@@ -754,7 +754,8 @@ struct RefineDynamicPadOpPattern : public OpRewritePattern<DynamicPadOp> {
 
     SmallVector<Type> inferredReturnTypes;
     if (failed(hlo::inferPadOp(
-            /*location=*/{}, op.getOperand(), op.getPaddingValue(),
+            /*location=*/{}, op.getOperand().getType(),
+            op.getPaddingValue().getType(),
             rewriter.getI64TensorAttr(edgePaddingLow),
             rewriter.getI64TensorAttr(edgePaddingHigh),
             rewriter.getI64TensorAttr(interiorPadding), inferredReturnTypes)))


### PR DESCRIPTION
This is a follow up PR to #1019 that partially addresses the proposal in #1000 and #1028. This PR enables ConvolutionOp to share PadOp's shape inference code.