### PR TITLE
Update signature of `inferReverseOp` function for re-usability

### DIFF
--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -185,7 +185,6 @@ INFER_RETURN_TYPE_COMPONENTS_FROM_OPERANDS(PopulationCountOp)
 INFER_RETURN_TYPE_COMPONENTS_FROM_OPERANDS(PowOp)
 INFER_RETURN_TYPE_COMPONENTS_FROM_OPERANDS(ReducePrecisionOp)
 INFER_RETURN_TYPE_COMPONENTS_FROM_OPERANDS(RemOp)
-INFER_RETURN_TYPE_COMPONENTS_FROM_OPERANDS(ReverseOp)
 INFER_RETURN_TYPE_COMPONENTS_FROM_OPERANDS(RoundNearestEvenOp)
 INFER_RETURN_TYPE_COMPONENTS_FROM_OPERANDS(RoundOp)
 INFER_RETURN_TYPE_COMPONENTS_FROM_OPERANDS(RsqrtOp)
@@ -1795,6 +1794,15 @@ LogicalResult OptimizationBarrierOp::inferReturnTypes(
 //===----------------------------------------------------------------------===//
 LogicalResult ReverseOp::verify() {
   return hlo::verifyReverseOp(getLoc(), getOperand(), getDimensions());
+}
+
+LogicalResult ReverseOp::inferReturnTypeComponents(
+    MLIRContext* context, std::optional<Location> location,
+    ValueShapeRange operands, DictionaryAttr attributes, RegionRange regions,
+    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
+  ReverseOp::Adaptor adaptor(operands, attributes, regions);
+  return hlo::inferReverseOp(location, adaptor.getOperand().getType(),
+                             inferredReturnShapes);
 }
 
 //===----------------------------------------------------------------------===//

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2631,6 +2631,16 @@ LogicalResult inferReplicaIdOp(MLIRContext* context, std::optional<Location>,
   return success();
 }
 
+LogicalResult inferReverseOp(
+    std::optional<Location> location, Type operandType,
+    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
+  SmallVector<Type> inferredReturnTypes;
+  auto inferredTypeOrErr = hlo::inferMostSpecificType(location, operandType);
+  if (failed(inferredTypeOrErr)) return failure();
+  inferredReturnShapes.emplace_back((*inferredTypeOrErr).cast<ShapedType>());
+  return success();
+}
+
 LogicalResult inferRngOp(
     std::optional<Location> location, Value a, Value b, Value shape,
     bool isRngDistributionUniform,

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2634,11 +2634,8 @@ LogicalResult inferReplicaIdOp(MLIRContext* context, std::optional<Location>,
 LogicalResult inferReverseOp(
     std::optional<Location> location, Type operandType,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
-  SmallVector<Type> inferredReturnTypes;
-  auto inferredTypeOrErr = hlo::inferMostSpecificType(location, operandType);
-  if (failed(inferredTypeOrErr)) return failure();
-  inferredReturnShapes.emplace_back((*inferredTypeOrErr).cast<ShapedType>());
-  return success();
+  return hlo::inferMostSpecificTypeComponents(location, operandType,
+                                              inferredReturnShapes);
 }
 
 LogicalResult inferRngOp(

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -289,6 +289,10 @@ LogicalResult inferReduceWindowOp(
 LogicalResult inferReplicaIdOp(MLIRContext* context, std::optional<Location>,
                                SmallVectorImpl<Type>& inferredReturnTypes);
 
+LogicalResult inferReverseOp(
+    std::optional<Location> location, Type operands,
+    SmallVectorImpl<ShapedTypeComponents>& inferredReturnTypes);
+
 LogicalResult inferRngOp(
     std::optional<Location> location, Value a, Value b, Value shape,
     bool isRngDistributionUniform,


### PR DESCRIPTION
This is a follow up PR to #1019 that partially addresses the proposal in #1000 and #1028. This PR enables ConvolutionOp to share ReverseOp's shape inference code.