### PR TITLE
Update signature of `inferConvolutionOp` function for re-usability

### DIFF
--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -807,8 +807,8 @@ LogicalResult CollectivePermuteOp::verify() {
 
 LogicalResult ConvolutionOp::verify() {
   return hlo::verifyConvolutionOp(
-      getLoc(), getLhs(), getRhs(), getWindowStrides(), getPadding(),
-      getLhsDilation(), getRhsDilation(), getWindowReversal(),
+      getLoc(), getLhs().getType(), getRhs().getType(), getWindowStrides(),
+      getPadding(), getLhsDilation(), getRhsDilation(), getWindowReversal(),
       getDimensionNumbers().getInputBatchDimension(),
       getDimensionNumbers().getInputFeatureDimension(),
       getDimensionNumbers().getInputSpatialDimensions(),
@@ -819,7 +819,7 @@ LogicalResult ConvolutionOp::verify() {
       getDimensionNumbers().getOutputFeatureDimension(),
       getDimensionNumbers().getOutputSpatialDimensions(),
       getFeatureGroupCount(), getBatchGroupCount(), getPrecisionConfig(),
-      getResult());
+      getResult().getType());
 }
 
 //===----------------------------------------------------------------------===//

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -165,7 +165,7 @@ LogicalResult inferConvertOp(
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferConvolutionOp(
-    std::optional<Location> location, Value lhs, Value rhs,
+    std::optional<Location> location, Type lhsType, Type rhsType,
     std::optional<DenseIntElementsAttr> windowStrides,
     std::optional<DenseIntElementsAttr> padding,
     std::optional<DenseIntElementsAttr> lhsDilation,
@@ -372,7 +372,7 @@ LogicalResult verifyCollectivePermuteOp(std::optional<Location> location,
                                         DenseIntElementsAttr sourceTargetPairs);
 
 LogicalResult verifyConvolutionOp(
-    std::optional<Location> location, Value lhs, Value rhs,
+    std::optional<Location> location, Type lhsType, Type rhsType,
     std::optional<DenseIntElementsAttr> windowStrides,
     std::optional<DenseIntElementsAttr> padding,
     std::optional<DenseIntElementsAttr> lhsDilation,
@@ -384,7 +384,7 @@ LogicalResult verifyConvolutionOp(
     ArrayRef<int64_t> kernelSpatialDimensions, int64_t outputBatchDimension,
     int64_t outputFeatureDimension, ArrayRef<int64_t> outputSpatialDimensions,
     int64_t featureGroupCount, int64_t batchGroupCount,
-    std::optional<ArrayAttr> precisionConfig, Value result);
+    std::optional<ArrayAttr> precisionConfig, Type resultType);
 
 LogicalResult verifyDotOp(std::optional<Location> location, Value lhs,
                           Value rhs, std::optional<ArrayAttr> precisionConfig,

--- a/stablehlo/transforms/StablehloRefineShapes.cpp
+++ b/stablehlo/transforms/StablehloRefineShapes.cpp
@@ -621,9 +621,9 @@ struct RefineConvolutionOpPattern : public OpRewritePattern<ConvolutionOp> {
                                 PatternRewriter& rewriter) const override {
     SmallVector<ShapedTypeComponents> inferredReturnShapes;
     if (failed(hlo::inferConvolutionOp(
-            /*location=*/{}, op.getLhs(), op.getRhs(), op.getWindowStrides(),
-            op.getPadding(), op.getLhsDilation(), op.getRhsDilation(),
-            op.getWindowReversal(),
+            /*location=*/{}, op.getLhs().getType(), op.getRhs().getType(),
+            op.getWindowStrides(), op.getPadding(), op.getLhsDilation(),
+            op.getRhsDilation(), op.getWindowReversal(),
             op.getDimensionNumbers().getInputBatchDimension(),
             op.getDimensionNumbers().getInputFeatureDimension(),
             op.getDimensionNumbers().getInputSpatialDimensions(),
@@ -707,9 +707,9 @@ struct RefineDynamicConvOpPattern : public OpRewritePattern<DynamicConvOp> {
 
     SmallVector<ShapedTypeComponents> inferredReturnShapes;
     if (failed(hlo::inferConvolutionOp(
-            /*location=*/{}, op.getLhs(), op.getRhs(), op.getWindowStrides(),
-            paddingAttr, op.getLhsDilation(), op.getRhsDilation(),
-            op.getWindowReversal(),
+            /*location=*/{}, op.getLhs().getType(), op.getRhs().getType(),
+            op.getWindowStrides(), paddingAttr, op.getLhsDilation(),
+            op.getRhsDilation(), op.getWindowReversal(),
             op.getDimensionNumbers().getInputBatchDimension(),
             op.getDimensionNumbers().getInputFeatureDimension(),
             op.getDimensionNumbers().getInputSpatialDimensions(),


### PR DESCRIPTION
This is a follow up PR to #1019 that partially addresses the proposal in #1000 and #1028. This PR enables ConvolutionOp to 
 use its shape inference code in the interpreter as well. The signature of `verifyConvolutionOp` is also updated as well.