### PR TITLE
Retire the link to GitHub Discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,6 @@ requires collaboration across the whole ML industry, so we're happy to have
 your help on the StableHLO project.
 
 We're using GitHub issues / pull requests to organize development and
-[GitHub discussions](https://github.com/orgs/openxla/discussions/categories/stablehlo)
+[openxla-discuss](https://groups.google.com/a/openxla.org/g/openxla-discuss/)
 to have longer discussions. We also have a `#stablehlo`
 channel on [the OpenXLA Discord server](https://discord.gg/PeWUTaecrA).


### PR DESCRIPTION
Following https://github.com/openxla/community/commit/62833d737ed5fc6756e0cc1b10aa44d9979b5790, this PR replaces the link to GitHub Discussions with a link to openxla-discuss@.