### PR TITLE
[RFC] Increase backward compatibility guarantees to 6 months

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -16,10 +16,10 @@ Future work section for more details.
 
 ## Guarantees
 
-**1 month of backward compatibility:** Portable artifacts serialized by an old
+**6 months of backward compatibility:** Portable artifacts serialized by an old
 version of libStablehlo have the same semantics* when deserialized by a new
 version of libStablehlo if these versions are built from openxla/stablehlo
-commits which are less than 1 month apart.
+commits which are less than 6 months apart.
 
 **1 month of forward compatibility:** Portable artifacts serialized by a new
 version of libStablehlo have the same semantics* when deserialized by an old

--- a/rfcs/20220912-compatibility.md
+++ b/rfcs/20220912-compatibility.md
@@ -5,6 +5,7 @@ Initial version: 9/12/2022<br/>
 Last updated: 3/9/2022
 
 Version log
+
 * 9/12/2022: Initial version.
 * 11/9/2022: Major updates based on a prototype implementation and conversations
              with OpenXLA and MLIR communities.

--- a/rfcs/20220912-compatibility.md
+++ b/rfcs/20220912-compatibility.md
@@ -4,7 +4,7 @@ Status: Approved<br/>
 Initial version: 9/12/2022<br/>
 Last updated: 3/9/2022
 
-Version log
+## Version log
 
 * 9/12/2022: Initial version.
 * 11/9/2022: Major updates based on a prototype implementation and conversations

--- a/rfcs/20220912-compatibility.md
+++ b/rfcs/20220912-compatibility.md
@@ -2,7 +2,16 @@
 
 Status: Approved<br/>
 Initial version: 9/12/2022<br/>
-Last updated: 12/13/2022
+Last updated: 3/9/2022
+
+Version log
+* 9/12/2022: Initial version.
+* 11/9/2022: Major updates based on a prototype implementation and conversations
+             with OpenXLA and MLIR communities.
+* 12/13/2022: Approved.
+* 3/9/2023: Extend backward compatibility guarantees from 1 month to 6 months.
+
+## Introduction
 
 Based on discussions held over the past two months, and new use cases and
 feedback left in comments on the first revision of this RFC, we propose the
@@ -106,8 +115,9 @@ and we can have a discussion about supporting it.
 
 **(G4) Version 0.x.x:** There will be some stability guarantees while in major
 version 0. There is not stability guaranteed within the major version, but we
-will provide 1 month of forward and backward compatibility between minor
-versions. This approach is chosen to allow dialect evolution and cleanup in
+will provide 6 months of backward and 1 month of forward compatibility
+guarantees between minor versions.
+This approach is chosen to allow dialect evolution and cleanup in
 the early days, as well as refine compatibility procedures while meeting the
 requirements of early adopters. Stability within major version will begin
 with version `1.x.x` and will happen in 2023.


### PR DESCRIPTION
We have recently had the first official release of StableHLO, which fully implemented the compatibility guarantees established by the compatibility RFC accepted in December.

These guarantees ended up being more compelling than we anticipated in the RFC discussions, and there are stakeholders who are interested in using them in production right away. To enable that, we have received a request to bump up the backward compatibility guarantees to 6 months (from 1 month for the 0.x.x series, as established by the original RFC).

I would like to proposes to fulfil this request to further strengthen the practical usefulness of the StableHLO opset, given that the additional maintenance cost looks acceptable (5 extra months of maintaining backward-compatible VHLO ops).

This RFC does not affect the long-term compatibility guarantees established for the 1.x.x series and onwards, which remain at 5 years of forward and backward compatibility.