### PR TITLE
Streamline the on: part of all GitHub workflows

### DIFF
--- a/.github/workflows/buildAndTestCMake.yml
+++ b/.github/workflows/buildAndTestCMake.yml
@@ -17,10 +17,8 @@ name: CMake Build
 on:
   pull_request:
     branches: [ main ]
-    paths-ignore: ['**.md', 'docs/**']
   push:
     branches: [ main ]
-    paths-ignore: ['**.md', 'docs/**']
   schedule:
     # Run once a day
     - cron:  '0 12 * * *'

--- a/.github/workflows/buildBazel.yml
+++ b/.github/workflows/buildBazel.yml
@@ -17,10 +17,8 @@ name: Bazel Build
 on:
   pull_request:
     branches: [ main ]
-    paths-ignore: ['**.md', 'docs/**']
   push:
     branches: [ main ]
-    paths-ignore: ['**.md', 'docs/**']
   schedule:
     # Run once a day
     - cron:  '0 12 * * *'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,13 @@ name: Lint
 
 on:
   pull_request:
-    paths-ignore: ['**.md', 'docs/**']
+    branches: [ main ]
+  push:
+    branches: [ main ]
+  schedule:
+    # Run once a day
+    - cron:  '0 12 * * *'
+  workflow_dispatch:
 
 jobs:
   clang-format:

--- a/.github/workflows/markdown_lint.yml
+++ b/.github/workflows/markdown_lint.yml
@@ -15,10 +15,14 @@
 name: Markdown Lint
 
 on:
-  workflow_dispatch:
   pull_request:
-    paths:
-      - '**.md'
+    branches: [ main ]
+  push:
+    branches: [ main ]
+  schedule:
+    # Run once a day
+    - cron:  '0 12 * * *'
+  workflow_dispatch:
 
 jobs:
   markdown-lint:


### PR DESCRIPTION
I was looking to fix the long-standing issue with checks being skipped by paths/paths-ignore, leading to: 1) spuriously blocked merges if the checks are required, 2) weird "in progress" dots next to PRs.

I discovered that there is no easy solution to this, but there is a workaround: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks.

This solution works, but it's quite fiddly. Defining a shadow workflow, making sure that its paths/paths-ignore are an exact negation of the real workflow - this got old pretty fast.

Then I realized that we don't have to suffer through this. We can just enable all our workflows on all pull requests. Now that we have fast CI runners, waiting for unnecessary builds when we only update docs would take a few minutes at most, and I think it's a worthy tradeoff for getting rid of awkwardness.

So I went and removed all paths/path-ignore from all our workflows. When doing that, I noticed that their on: parts are different between one another, so I went ahead and unified that too. If we're running builds on pushes, we might as well run lints on pushes too.