### PR TITLE
Add interpreter for ConvolutionOp

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2179,8 +2179,8 @@ For quantized types, performs `dequantize_op_quantize(
   // "i" is input feature dimension, "o" is output feature dimension,
   // "0/1/etc" are spatial dimensions.
   dimension_numbers = #stablehlo.conv<[b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f]>,
-  feature_group_count = 1 : i64,
   batch_group_count = 1 : i64,
+  feature_group_count = 1 : i64,
   precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
 } : (tensor<1x4x4x1xi64>, tensor<3x3x1x1xi64>) -> tensor<1x2x2x1xi64>
 // %result: [[

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2182,12 +2182,14 @@ For quantized types, performs `dequantize_op_quantize(
   feature_group_count = 1 : i64,
   batch_group_count = 1 : i64,
   precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-} : (tensor<1x4x4x1xi32>, tensor<3x3x1x1xi32>) -> tensor<1x2x2x1xi32>
+} : (tensor<1x4x4x1xi64>, tensor<3x3x1x1xi64>) -> tensor<1x2x2x1xi64>
 // %result: [[
 //            [[10], [26]],
 //            [[46], [62]]
 //          ]]
 ```
+
+&nbsp;[More Examples](../stablehlo/tests/interpret_convolution.mlir)
 
 ### cosine
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -68,7 +68,7 @@ one of the following tracking labels.
 | concatenate              | yes           | yes          | yes            | yes             | yes         |
 | constant                 | yes           | yes          | yes            | yes             | yes         |
 | convert                  | yes           | yes          | infeasible     | yes             | yes         |
-| convolution              | yes           | yes          | infeasible     | revisit         | no          |
+| convolution              | yes           | yes          | infeasible     | revisit         | yes         |
 | cosine                   | yes           | yes          | yes            | yes             | yes         |
 | count_leading_zeros      | yes           | yes          | yes            | yes             | yes         |
 | create_token             | no            | yes\*        | yes\*          | yes             | revisit     |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2073,10 +2073,10 @@ def StableHLO_ConvolutionOp : StableHLO_Op<"convolution", [Pure]> {
         pad = [[0, 0], [0, 0]],
         lhs_dilate = [2, 2],
         rhs_dilate = [1, 1],
-        reverse = [false, false]
+        reverse = [0, 0]
       } {
-        feature_group_count = 1 : i64,
         batch_group_count = 1 : i64,
+        feature_group_count = 1 : i64,
         precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
       } :
     (tensor<1x4x4x1xi64>, tensor<3x3x1x1xi64>) -> tensor<1x2x2x1xi64>

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2066,24 +2066,32 @@ def StableHLO_ConvolutionOp : StableHLO_Op<"convolution", [Pure]> {
 
     Example:
     ```mlir
-    %result = "stablehlo.convolution"(%lhs, %rhs) {
-      window_strides = dense<4> : tensor<2xi64>,
-      padding = dense<0> : tensor<2x2xi64>,
-      lhs_dilation = dense<2> : tensor<2xi64>,
-      rhs_dilation = dense<1> : tensor<2xi64>,
-      window_reversal = dense<false> : tensor<2xi1>,
-      dimension_numbers = #stablehlo.conv<[b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f]>,
-      feature_group_count = 1 : i64,
-      batch_group_count = 1 : i64,
-      precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-    } : (tensor<1x4x4x1xi32>, tensor<3x3x1x1xi32>) -> tensor<1x2x2x1xi32>
+    %result = stablehlo.convolution(%lhs, %rhs)
+      dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+      window = {
+        stride = [4, 4],
+        pad = [[0, 0], [0, 0]],
+        lhs_dilate = [2, 2],
+        rhs_dilate = [1, 1],
+        reverse = [false, false]
+      } {
+        feature_group_count = 1 : i64,
+        batch_group_count = 1 : i64,
+        precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+      } :
+    (tensor<1x4x4x1xi64>, tensor<3x3x1x1xi64>) -> tensor<1x2x2x1xi64>
     ```
   }];
   let arguments = !con(
     (ins
-       HLO_Tensor:$lhs,
-       HLO_Tensor:$rhs),
-    StableHLO_ConvolutionAttributes.attributes);
+       HLO_Tensor:$lhs, /*convolution_i1*/
+       HLO_Tensor:$rhs), /*convolution_i2*/
+    StableHLO_ConvolutionAttributes.attributes /*convolution_i3, convolution_i4,
+    convolution_i5, convolution_i6, convolution_i7, convolution_i8,
+    convolution_i9, convolution_i10, convolution_i11, convolution_i12,
+    convolution_i13, convolution_i14, convolution_i15, convolution_i16,
+    convolution_i17, convolution_i18, convolution_i19*/
+  );
 
   let results = (outs HLO_Tensor);
   let hasVerifier = 1;

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -318,26 +318,30 @@ verifyWindowAttributesAndInferWindowDimensions(
         " to have same dimension-size as size of window dimensions (",
         windowDimensions.size(), "), but got: ", attrSize, ".");
   };
-  // convolution_c3, reduce_window_c6, select_and_scatter_c6
+  // convolution_c2, reduce_window_c6, select_and_scatter_c6
   if (failed(verifySize(windowStrides.size(), "window-strides")))
     return failure();
-  // convolution_c6, reduce_window_c8
+
+  // convolution_c5, reduce_window_c8
   if (failed(verifySize(lhsDilation.size(), "base-dilation factors")))
     return failure();
-  // convolution_c8, reduce_window_c10
+
+  // convolution_c7, reduce_window_c10
   if (failed(verifySize(rhsDilation.size(), "window-dilation factors")))
     return failure();
-  // convolution_c5, reduce_window_c12
+
+  // convolution_c4, reduce_window_c12
   if (failed(verifySize(padding.size(), "padding-entries"))) return failure();
-  // convolution_c10
+
+  // convolution_c9
   if (failed(verifySize(windowReversal.size(), "window-reversal")))
     return failure();
 
   SmallVector<WindowDimension> window(windowDimensions.size());
   for (size_t i = 0; i < windowDimensions.size(); i++) {
     WindowDimension& dim = window[i];
-
     dim.size = windowDimensions[i];
+
     // reduce_window_c5, select_and_scatter_c5
     if (!isDynamicDimSize(dim.size) && dim.size <= 0)
       return emitOptionalError(loc,
@@ -345,21 +349,24 @@ verifyWindowAttributesAndInferWindowDimensions(
                                "-th window dimension, but got ", dim.size, ".");
 
     if (!windowStrides.empty()) dim.stride = windowStrides[i];
-    // convolution_c4, reduce_window_c7, select_and_scatter_c7
+
+    // convolution_c3, reduce_window_c7, select_and_scatter_c7
     if (dim.stride <= 0)
       return emitOptionalError(
           loc, "expects window to have positive stride for ", i,
           "-th window dimension, but got ", dim.stride, ".");
 
     if (!lhsDilation.empty()) dim.baseDilation = lhsDilation[i];
-    // convolution_c7, reduce_window_c9
+
+    // convolution_c6, reduce_window_c9
     if (dim.baseDilation <= 0)
       return emitOptionalError(
           loc, "expects window to have positive base dilation factor for ", i,
           "-th window dimension, but got ", dim.baseDilation, ".");
 
     if (!rhsDilation.empty()) dim.windowDilation = rhsDilation[i];
-    // convolution_c9, reduce_window_c11
+
+    // convolution_c8, reduce_window_c11
     if (dim.windowDilation <= 0)
       return emitOptionalError(
           loc, "expects window to have positive window dilation factor for ", i,
@@ -757,7 +764,7 @@ LogicalResult isSpatialDimensionsValid(
     int64_t outputFeatureDimension, ArrayRef<int64_t> outputSpatialDimensions,
     std::optional<Location> location) {
   uint64_t spatialDimNum = inputSpatialDimensions.size();
-  // convolution_c18, convolution_c20
+  // convolution_c17, convolution_c19
   if ((spatialDimNum != kernelSpatialDimensions.size()) ||
       (spatialDimNum != outputSpatialDimensions.size()))
     return emitOptionalError(location,
@@ -787,7 +794,7 @@ LogicalResult isSpatialDimensionsValid(
 
   auto numDims = lhsType.cast<RankedTensorType>().getRank();
   const auto inRange = [numDims](int64_t i) { return 0 <= i && i < numDims; };
-  // convolution_c14, convolution_c19, convolution_c21
+  // convolution_c13, convolution_c18, convolution_c20
   if (!llvm::all_of(inputDimNums, inRange) ||
       !llvm::all_of(windowDimNums, inRange) ||
       !llvm::all_of(outputDimNums, inRange))
@@ -795,17 +802,20 @@ LogicalResult isSpatialDimensionsValid(
                              "expects input, kernel, and output "
                              "dimension-numbers to be in-range [0, ",
                              numDims, ").");
-  // convolution_c14
+
+  // convolution_c13
   if (hasDuplicates(inputDimNums))
     return emitOptionalError(
         location, "expects input dimension-numbers to be unique, got {",
         inputDimNums, "}.");
-  // convolution_c19
+
+  // convolution_c18
   if (hasDuplicates(windowDimNums))
     return emitOptionalError(
         location, "expects kernel dimension-numbers to be unique, got {",
         windowDimNums, "}.");
-  // convolution_c21
+
+  // convolution_c20
   if (hasDuplicates(outputDimNums))
     return emitOptionalError(
         location, "expects output dimension-numbers to be unique, got {",
@@ -844,17 +854,19 @@ LogicalResult verifyConvolutionAttributes(
           location)))
     return failure();
 
-  // convolution_c22
+  // convolution_c21
   if (featureGroupCount <= 0)
     return emitOptionalError(
         location, "expects feature_group_count to be a positive number, got ",
         featureGroupCount, ".");
-  // convolution_c23
+
+  // convolution_c22
   if (batchGroupCount <= 0)
     return emitOptionalError(
         location, "expects batch_group_count to be a positive number, got ",
         batchGroupCount, ".");
-  // convolution_c24
+
+  // convolution_c23
   if (batchGroupCount > 1 && featureGroupCount > 1)
     return emitOptionalError(
         location,
@@ -872,22 +884,24 @@ LogicalResult verifyConvolutionAttributes(
   const int64_t kernelOutputFeatures =
       rankedRhsType.getShape()[kernelOutputFeatureDimension];
 
-  // convolution_c11
+  // convolution_c10
   if (!isDynamicDimSize(inputBatch) && inputBatch % batchGroupCount != 0)
     return emitOptionalError(location, "expects input batch dimension (",
                              inputBatch,
                              ") to be divisible by "
                              "batch_group_count. Got batch_group_count = ",
                              batchGroupCount, ".");
+
   if (!isDynamicDimSize(inputFeatures)) {
-    // convolution_c12
+    // convolution_c11
     if (inputFeatures % featureGroupCount != 0)
       return emitOptionalError(location, "expects input feature dimension (",
                                inputFeatures,
                                ") to be a multiple of feature_group_count. Got "
                                "feature_group_count = ",
                                featureGroupCount, ".");
-    // convolution_c15
+
+    // convolution_c14
     if (!isDynamicDimSize(kernelInputFeatures) &&
         inputFeatures / featureGroupCount != kernelInputFeatures)
       return emitOptionalError(
@@ -897,15 +911,17 @@ LogicalResult verifyConvolutionAttributes(
           kernelInputFeatures,
           "). Got feature_group_count = ", featureGroupCount, ".");
   }
+
   if (!isDynamicDimSize(kernelOutputFeatures)) {
-    // convolution_c16
+    // convolution_c15
     if (kernelOutputFeatures % batchGroupCount != 0)
       return emitOptionalError(
           location, "expects output feature dimension size (",
           kernelOutputFeatures,
           ") to be a multiple of batch_group_count. Got batch_group_count = ",
           batchGroupCount, ".");
-    // convolution_c17
+
+    // convolution_c16
     if (kernelOutputFeatures % featureGroupCount != 0)
       return emitOptionalError(location,
                                "expects kernel output feature dimension (",
@@ -915,7 +931,7 @@ LogicalResult verifyConvolutionAttributes(
                                featureGroupCount, ".");
   }
 
-  // convolution_c25
+  // convolution_c24
   if (failed(verifyPrecisionConfig(location, precisionConfig)))
     return failure();
 
@@ -1714,20 +1730,22 @@ LogicalResult inferConvolutionOp(
     return success();
   }
 
-  // convolution_c14
+  // convolution_c13
   int numDims = rankedLhsType.getRank();
   if (numDims < 2)
     return emitOptionalError(
         location,
         "expects convolution arguments to have >= 2 dimensions. Got: ",
         rankedLhsType, " and ", rankedRhsType, ".");
+
   // convolution_c1
   if (numDims != rankedRhsType.getRank())
     return emitOptionalError(location,
                              "expects convolution arguments to have same "
                              "number of dimensions. Got: ",
                              rankedLhsType, " and ", rankedRhsType, ".");
-  // convolution_c2
+
+  // convolution_c27
   if (!isCompatibleForHloTypeInference(rankedLhsType.getElementType(),
                                        rankedRhsType.getElementType()))
     return emitOptionalError(
@@ -1743,7 +1761,8 @@ LogicalResult inferConvolutionOp(
           outputSpatialDimensions, featureGroupCount, batchGroupCount,
           precisionConfig)))
     return failure();
-  // convolution_c13
+
+  // convolution_c12
   if ((size_t)numDims != inputSpatialDimensions.size() + 2)
     return emitOptionalError(location, "expects convolution arguments to have ",
                              inputSpatialDimensions.size() + 2,
@@ -1753,7 +1772,7 @@ LogicalResult inferConvolutionOp(
   for (size_t i = 0; i < windowDimensions.size(); i++)
     windowDimensions[i] = rankedRhsType.getShape()[kernelSpatialDimensions[i]];
 
-  // convolution_c5, convolution_i4
+  // convolution_c4, convolution_i4
   auto paddingOrErr = convertPaddingAttribute(padding, location);
   if (failed(paddingOrErr)) return failure();
 
@@ -1761,14 +1780,17 @@ LogicalResult inferConvolutionOp(
   auto windowStridesOrErr =
       convert1DAttribute(windowStrides, location, "window_strides");
   if (failed(windowStridesOrErr)) return failure();
+
   // convolution_i5
   auto lhsDilationOrErr =
       convert1DAttribute(lhsDilation, location, "lhs_dilation");
   if (failed(lhsDilationOrErr)) return failure();
+
   // convolution_i6
   auto rhsDilationOrErr =
       convert1DAttribute(rhsDilation, location, "rhs_dilation");
   if (failed(rhsDilationOrErr)) return failure();
+
   // convolution_i7
   auto windowReversalOrErr = convertWindowReversalAttribute(
       windowReversal, location, "window_reversal");
@@ -1779,7 +1801,7 @@ LogicalResult inferConvolutionOp(
       *rhsDilationOrErr, *windowReversalOrErr, location);
   if (failed(windowOrErr)) return failure();
 
-  // convolution_c26
+  // convolution_c25, convolution_c26
   SmallVector<int64_t> outputDimensions(rankedLhsType.getShape().size(),
                                         ShapedType::kDynamic);
   auto numSpatialDims = inputSpatialDimensions.size();
@@ -3326,7 +3348,7 @@ LogicalResult verifyConvolutionOp(
 
   auto inferredShape = inferredReturnShapes[0];
   auto shapedResultType = resultType.cast<ShapedType>();
-  // convolution_c26
+  // convolution_c25
   if (inferredShape.hasRank() && shapedResultType.hasRank() &&
       failed(verifyCompatibleShape(inferredShape.getDims(),
                                    shapedResultType.getShape())))

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -318,18 +318,18 @@ verifyWindowAttributesAndInferWindowDimensions(
         " to have same dimension-size as size of window dimensions (",
         windowDimensions.size(), "), but got: ", attrSize, ".");
   };
-  // convolution_c4, reduce_window_c6, select_and_scatter_c6
+  // convolution_c3, reduce_window_c6, select_and_scatter_c6
   if (failed(verifySize(windowStrides.size(), "window-strides")))
     return failure();
-  // convolution_c7, reduce_window_c8
+  // convolution_c6, reduce_window_c8
   if (failed(verifySize(lhsDilation.size(), "base-dilation factors")))
     return failure();
-  // convolution_c9, reduce_window_c10
+  // convolution_c8, reduce_window_c10
   if (failed(verifySize(rhsDilation.size(), "window-dilation factors")))
     return failure();
-  // convolution_c6, reduce_window_c12
+  // convolution_c5, reduce_window_c12
   if (failed(verifySize(padding.size(), "padding-entries"))) return failure();
-  // convolution_c11
+  // convolution_c10
   if (failed(verifySize(windowReversal.size(), "window-reversal")))
     return failure();
 
@@ -345,21 +345,21 @@ verifyWindowAttributesAndInferWindowDimensions(
                                "-th window dimension, but got ", dim.size, ".");
 
     if (!windowStrides.empty()) dim.stride = windowStrides[i];
-    // convolution_c5, reduce_window_c7, select_and_scatter_c7
+    // convolution_c4, reduce_window_c7, select_and_scatter_c7
     if (dim.stride <= 0)
       return emitOptionalError(
           loc, "expects window to have positive stride for ", i,
           "-th window dimension, but got ", dim.stride, ".");
 
     if (!lhsDilation.empty()) dim.baseDilation = lhsDilation[i];
-    // convolution_c8, reduce_window_c9
+    // convolution_c7, reduce_window_c9
     if (dim.baseDilation <= 0)
       return emitOptionalError(
           loc, "expects window to have positive base dilation factor for ", i,
           "-th window dimension, but got ", dim.baseDilation, ".");
 
     if (!rhsDilation.empty()) dim.windowDilation = rhsDilation[i];
-    // convolution_c10, reduce_window_c11
+    // convolution_c9, reduce_window_c11
     if (dim.windowDilation <= 0)
       return emitOptionalError(
           loc, "expects window to have positive window dilation factor for ", i,
@@ -757,7 +757,7 @@ LogicalResult isSpatialDimensionsValid(
     int64_t outputFeatureDimension, ArrayRef<int64_t> outputSpatialDimensions,
     std::optional<Location> location) {
   uint64_t spatialDimNum = inputSpatialDimensions.size();
-  // convolution_c19, convolution_c21
+  // convolution_c18, convolution_c20
   if ((spatialDimNum != kernelSpatialDimensions.size()) ||
       (spatialDimNum != outputSpatialDimensions.size()))
     return emitOptionalError(location,
@@ -787,7 +787,7 @@ LogicalResult isSpatialDimensionsValid(
 
   auto numDims = lhsType.cast<RankedTensorType>().getRank();
   const auto inRange = [numDims](int64_t i) { return 0 <= i && i < numDims; };
-  // convolution_c15, convolution_c20, convolution_c22
+  // convolution_c14, convolution_c19, convolution_c21
   if (!llvm::all_of(inputDimNums, inRange) ||
       !llvm::all_of(windowDimNums, inRange) ||
       !llvm::all_of(outputDimNums, inRange))
@@ -795,17 +795,17 @@ LogicalResult isSpatialDimensionsValid(
                              "expects input, kernel, and output "
                              "dimension-numbers to be in-range [0, ",
                              numDims, ").");
-  // convolution_c15
+  // convolution_c14
   if (hasDuplicates(inputDimNums))
     return emitOptionalError(
         location, "expects input dimension-numbers to be unique, got {",
         inputDimNums, "}.");
-  // convolution_c20
+  // convolution_c19
   if (hasDuplicates(windowDimNums))
     return emitOptionalError(
         location, "expects kernel dimension-numbers to be unique, got {",
         windowDimNums, "}.");
-  // convolution_c22
+  // convolution_c21
   if (hasDuplicates(outputDimNums))
     return emitOptionalError(
         location, "expects output dimension-numbers to be unique, got {",
@@ -844,17 +844,17 @@ LogicalResult verifyConvolutionAttributes(
           location)))
     return failure();
 
-  // convolution_c23
+  // convolution_c22
   if (featureGroupCount <= 0)
     return emitOptionalError(
         location, "expects feature_group_count to be a positive number, got ",
         featureGroupCount, ".");
-  // convolution_c24
+  // convolution_c23
   if (batchGroupCount <= 0)
     return emitOptionalError(
         location, "expects batch_group_count to be a positive number, got ",
         batchGroupCount, ".");
-  // convolution_c25
+  // convolution_c24
   if (batchGroupCount > 1 && featureGroupCount > 1)
     return emitOptionalError(
         location,
@@ -872,7 +872,7 @@ LogicalResult verifyConvolutionAttributes(
   const int64_t kernelOutputFeatures =
       rankedRhsType.getShape()[kernelOutputFeatureDimension];
 
-  // convolution_c12
+  // convolution_c11
   if (!isDynamicDimSize(inputBatch) && inputBatch % batchGroupCount != 0)
     return emitOptionalError(location, "expects input batch dimension (",
                              inputBatch,
@@ -880,14 +880,14 @@ LogicalResult verifyConvolutionAttributes(
                              "batch_group_count. Got batch_group_count = ",
                              batchGroupCount, ".");
   if (!isDynamicDimSize(inputFeatures)) {
-    // convolution_c13
+    // convolution_c12
     if (inputFeatures % featureGroupCount != 0)
       return emitOptionalError(location, "expects input feature dimension (",
                                inputFeatures,
                                ") to be a multiple of feature_group_count. Got "
                                "feature_group_count = ",
                                featureGroupCount, ".");
-    // convolution_c16
+    // convolution_c15
     if (!isDynamicDimSize(kernelInputFeatures) &&
         inputFeatures / featureGroupCount != kernelInputFeatures)
       return emitOptionalError(
@@ -898,14 +898,14 @@ LogicalResult verifyConvolutionAttributes(
           "). Got feature_group_count = ", featureGroupCount, ".");
   }
   if (!isDynamicDimSize(kernelOutputFeatures)) {
-    // convolution_c17
+    // convolution_c16
     if (kernelOutputFeatures % batchGroupCount != 0)
       return emitOptionalError(
           location, "expects output feature dimension size (",
           kernelOutputFeatures,
           ") to be a multiple of batch_group_count. Got batch_group_count = ",
           batchGroupCount, ".");
-    // convolution_c18
+    // convolution_c17
     if (kernelOutputFeatures % featureGroupCount != 0)
       return emitOptionalError(location,
                                "expects kernel output feature dimension (",
@@ -915,7 +915,7 @@ LogicalResult verifyConvolutionAttributes(
                                featureGroupCount, ".");
   }
 
-  // convolution_c26
+  // convolution_c25
   if (failed(verifyPrecisionConfig(location, precisionConfig)))
     return failure();
 
@@ -1692,7 +1692,6 @@ LogicalResult inferConvertOp(
   return success();
 }
 
-// TODO(b/232574102): Verify the element-type of return-value.
 LogicalResult inferConvolutionOp(
     std::optional<Location> location, Type lhsType, Type rhsType,
     std::optional<DenseIntElementsAttr> windowStrides,
@@ -1715,20 +1714,20 @@ LogicalResult inferConvolutionOp(
     return success();
   }
 
-  // convolution_c1
+  // convolution_c14
   int numDims = rankedLhsType.getRank();
   if (numDims < 2)
     return emitOptionalError(
         location,
         "expects convolution arguments to have >= 2 dimensions. Got: ",
         rankedLhsType, " and ", rankedRhsType, ".");
-  // convolution_c2
+  // convolution_c1
   if (numDims != rankedRhsType.getRank())
     return emitOptionalError(location,
                              "expects convolution arguments to have same "
                              "number of dimensions. Got: ",
                              rankedLhsType, " and ", rankedRhsType, ".");
-  // convolution_c3
+  // convolution_c2
   if (!isCompatibleForHloTypeInference(rankedLhsType.getElementType(),
                                        rankedRhsType.getElementType()))
     return emitOptionalError(
@@ -1744,7 +1743,7 @@ LogicalResult inferConvolutionOp(
           outputSpatialDimensions, featureGroupCount, batchGroupCount,
           precisionConfig)))
     return failure();
-  // convolution_c14
+  // convolution_c13
   if ((size_t)numDims != inputSpatialDimensions.size() + 2)
     return emitOptionalError(location, "expects convolution arguments to have ",
                              inputSpatialDimensions.size() + 2,
@@ -1754,7 +1753,7 @@ LogicalResult inferConvolutionOp(
   for (size_t i = 0; i < windowDimensions.size(); i++)
     windowDimensions[i] = rankedRhsType.getShape()[kernelSpatialDimensions[i]];
 
-  // convolution_c6, convolution_i4
+  // convolution_c5, convolution_i4
   auto paddingOrErr = convertPaddingAttribute(padding, location);
   if (failed(paddingOrErr)) return failure();
 
@@ -1780,10 +1779,9 @@ LogicalResult inferConvolutionOp(
       *rhsDilationOrErr, *windowReversalOrErr, location);
   if (failed(windowOrErr)) return failure();
 
+  // convolution_c26
   SmallVector<int64_t> outputDimensions(rankedLhsType.getShape().size(),
                                         ShapedType::kDynamic);
-
-  // Infer the output spatial dimensions.
   auto numSpatialDims = inputSpatialDimensions.size();
   SmallVector<int64_t> inputSpatialDimVals(numSpatialDims);
   for (int64_t i = 0; i < static_cast<int64_t>(numSpatialDims); ++i)
@@ -1795,7 +1793,6 @@ LogicalResult inferConvolutionOp(
   for (int64_t i = 0; i < static_cast<int64_t>(windowOrErr->size()); ++i)
     outputDimensions[outputSpatialDimensions[i]] = windowOutputShape[i];
 
-  // Infer the output-batch-dimension and output-feature-dimension.
   const int64_t inputBatch = rankedLhsType.getShape()[inputBatchDimension];
   const int64_t kernelOutputFeatures =
       rankedRhsType.getShape()[kernelOutputFeatureDimension];
@@ -3329,7 +3326,7 @@ LogicalResult verifyConvolutionOp(
 
   auto inferredShape = inferredReturnShapes[0];
   auto shapedResultType = resultType.cast<ShapedType>();
-  // convolution_c27
+  // convolution_c26
   if (inferredShape.hasRank() && shapedResultType.hasRank() &&
       failed(verifyCompatibleShape(inferredShape.getDims(),
                                    shapedResultType.getShape())))

--- a/stablehlo/reference/Element.h
+++ b/stablehlo/reference/Element.h
@@ -51,6 +51,7 @@ class Element {
   Element(Type type, std::complex<APFloat> value);
 
   Element(const Element &other) = default;
+  Element() = default;
   /// @}
 
   /// Assignment operator.

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -75,14 +75,14 @@ Tensor evalConstantOp(ElementsAttr value);
 Tensor evalConvertOp(const Tensor &operand, ShapedType resultType);
 Tensor evalConvolutionOp(
     const Tensor &lhs, const Tensor &rhs, ArrayRef<int64_t> windowStrides,
-    SmallVector<SmallVector<int64_t>> padding, ArrayRef<int64_t> lhsDilation,
-    ArrayRef<int64_t> rhsDilation, ArrayRef<bool> windowReversal,
-    Axis inputBatchDimension, Axis inputFeatureDimension,
-    Axes inputSpatialDimensions, Axis kernelInputFeatureDimension,
-    Axis kernelOutputFeatureDimension, Axes kernelSpatialDimensions,
-    Axis outputBatchDimension, Axis outputFeatureDimension,
-    Axes outputSpatialDimensions, int64_t featureGroupCount,
-    int64_t batchGroupCount, ShapedType resultType);
+    ArrayRef<std::pair<int64_t, int64_t>> padding,
+    ArrayRef<int64_t> lhsDilation, ArrayRef<int64_t> rhsDilation,
+    ArrayRef<bool> windowReversal, Axis inputBatchDimension,
+    Axis inputFeatureDimension, Axes inputSpatialDimensions,
+    Axis kernelInputFeatureDimension, Axis kernelOutputFeatureDimension,
+    Axes kernelSpatialDimensions, Axis outputBatchDimension,
+    Axis outputFeatureDimension, Axes outputSpatialDimensions,
+    int64_t featureGroupCount, int64_t batchGroupCount, ShapedType resultType);
 Tensor evalCosineOp(const Tensor &operand, ShapedType resultType);
 Tensor evalDivideOp(const Tensor &lhs, const Tensor &rhs,
                     ShapedType resultType);

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -78,10 +78,10 @@ Tensor evalConvolutionOp(
     ArrayRef<std::pair<int64_t, int64_t>> padding,
     ArrayRef<int64_t> lhsDilation, ArrayRef<int64_t> rhsDilation,
     ArrayRef<bool> windowReversal, Axis inputBatchDimension,
-    Axis inputFeatureDimension, Axes inputSpatialDimensions,
+    Axis inputFeatureDimension, const Axes &inputSpatialDimensions,
     Axis kernelInputFeatureDimension, Axis kernelOutputFeatureDimension,
-    Axes kernelSpatialDimensions, Axis outputBatchDimension,
-    Axis outputFeatureDimension, Axes outputSpatialDimensions,
+    const Axes &kernelSpatialDimensions, Axis outputBatchDimension,
+    Axis outputFeatureDimension, const Axes &outputSpatialDimensions,
     int64_t featureGroupCount, int64_t batchGroupCount, ShapedType resultType);
 Tensor evalCosineOp(const Tensor &operand, ShapedType resultType);
 Tensor evalDivideOp(const Tensor &lhs, const Tensor &rhs,

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -73,6 +73,16 @@ Tensor evalConcatenateOp(ArrayRef<Tensor> inputs, Axis dimension,
                          ShapedType resultType);
 Tensor evalConstantOp(ElementsAttr value);
 Tensor evalConvertOp(const Tensor &operand, ShapedType resultType);
+Tensor evalConvolutionOp(
+    const Tensor &lhs, const Tensor &rhs, ArrayRef<int64_t> windowStrides,
+    SmallVector<SmallVector<int64_t>> padding, ArrayRef<int64_t> lhsDilation,
+    ArrayRef<int64_t> rhsDilation, ArrayRef<bool> windowReversal,
+    Axis inputBatchDimension, Axis inputFeatureDimension,
+    Axes inputSpatialDimensions, Axis kernelInputFeatureDimension,
+    Axis kernelOutputFeatureDimension, Axes kernelSpatialDimensions,
+    Axis outputBatchDimension, Axis outputFeatureDimension,
+    Axes outputSpatialDimensions, int64_t featureGroupCount,
+    int64_t batchGroupCount, ShapedType resultType);
 Tensor evalCosineOp(const Tensor &operand, ShapedType resultType);
 Tensor evalDivideOp(const Tensor &lhs, const Tensor &rhs,
                     ShapedType resultType);

--- a/stablehlo/testdata/conv_general_dilated_conv1d_lhs_float32_2_3_10__rhs_float32_3_3_5__windowstrides__1___padding___0_0_3336387849681708224.mlir
+++ b/stablehlo/testdata/conv_general_dilated_conv1d_lhs_float32_2_3_10__rhs_float32_3_3_5__windowstrides__1___padding___0_0_3336387849681708224.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_conv_tranpose1d_same_padding_lhs_float32_1_16_2__rhs_float32_3_2_2__windowstrid-2801039169040378295.mlir
+++ b/stablehlo/testdata/conv_general_dilated_conv_tranpose1d_same_padding_lhs_float32_1_16_2__rhs_float32_3_2_2__windowstrid-2801039169040378295.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_conv_tranpose1d_valid_padding_lhs_float32_1_16_2__rhs_float32_3_2_2__windowstri-8415303397313720110.mlir
+++ b/stablehlo/testdata/conv_general_dilated_conv_tranpose1d_valid_padding_lhs_float32_1_16_2__rhs_float32_3_2_2__windowstri-8415303397313720110.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_conv_tranpose2d_same_padding_lhs_float32_1_16_16_2__rhs_float32_2_3_2_2__window-296817466026258822.mlir
+++ b/stablehlo/testdata/conv_general_dilated_conv_tranpose2d_same_padding_lhs_float32_1_16_16_2__rhs_float32_2_3_2_2__window-296817466026258822.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_conv_tranpose2d_valid_padding_lhs_float32_1_16_16_2__rhs_float32_2_3_2_2__windo216554503587864094.mlir
+++ b/stablehlo/testdata/conv_general_dilated_conv_tranpose2d_valid_padding_lhs_float32_1_16_16_2__rhs_float32_2_3_2_2__windo216554503587864094.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_depthwise1d_dilated_lhs_float32_2_3_9__rhs_float32_12_1_3__windowstrides__1___p4726467912149865720.mlir
+++ b/stablehlo/testdata/conv_general_dilated_depthwise1d_dilated_lhs_float32_2_3_9__rhs_float32_12_1_3__windowstrides__1___p4726467912149865720.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_depthwise1d_lhs_float32_2_3_9__rhs_float32_12_1_3__windowstrides__1___padding__2025442285785167829.mlir
+++ b/stablehlo/testdata/conv_general_dilated_depthwise1d_lhs_float32_2_3_9__rhs_float32_12_1_3__windowstrides__1___padding__2025442285785167829.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_depthwise2d_dilated_lhs_float32_2_3_9_9__rhs_float32_12_1_3_3__windowstrides__1-5299255563318388077.mlir
+++ b/stablehlo/testdata/conv_general_dilated_depthwise2d_dilated_lhs_float32_2_3_9_9__rhs_float32_12_1_3_3__windowstrides__1-5299255563318388077.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_depthwise2d_lhs_float32_2_3_9_9__rhs_float32_12_1_3_3__windowstrides__1_1__padd-5494580149111736437.mlir
+++ b/stablehlo/testdata/conv_general_dilated_depthwise2d_lhs_float32_2_3_9_9__rhs_float32_12_1_3_3__windowstrides__1_1__padd-5494580149111736437.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_dilations_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__paddin-940783895638600378.mlir
+++ b/stablehlo/testdata/conv_general_dilated_dilations_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__paddin-940783895638600378.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_dilations_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__paddin7803468828575064957.mlir
+++ b/stablehlo/testdata/conv_general_dilated_dilations_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__paddin7803468828575064957.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_dilations_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__paddin8362069580368565836.mlir
+++ b/stablehlo/testdata/conv_general_dilated_dilations_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__paddin8362069580368565836.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_dimension_numbers_lhs_float32_2_3_9_10__rhs_float32_4_5_3_3__windowstrides__1_1-8327739261064575227.mlir
+++ b/stablehlo/testdata/conv_general_dilated_dimension_numbers_lhs_float32_2_3_9_10__rhs_float32_4_5_3_3__windowstrides__1_1-8327739261064575227.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_dimension_numbers_lhs_float32_2_9_10_3__rhs_float32_4_5_3_3__windowstrides__1_1-6479296361709234045.mlir
+++ b/stablehlo/testdata/conv_general_dilated_dimension_numbers_lhs_float32_2_9_10_3__rhs_float32_4_5_3_3__windowstrides__1_1-6479296361709234045.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_dtype_precision_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__-1572008590406220780.mlir
+++ b/stablehlo/testdata/conv_general_dilated_dtype_precision_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__-1572008590406220780.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_dtype_precision_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__-4848375839726769119.mlir
+++ b/stablehlo/testdata/conv_general_dilated_dtype_precision_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__-4848375839726769119.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_dtype_precision_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__-6463715315589295392.mlir
+++ b/stablehlo/testdata/conv_general_dilated_dtype_precision_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__-6463715315589295392.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_dtype_precision_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__-7128650963837464321.mlir
+++ b/stablehlo/testdata/conv_general_dilated_dtype_precision_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__-7128650963837464321.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_group_counts_lhs_float32_2_6_9_10__rhs_float32_6_3_4_5__windowstrides__1_1__pad-2212136815070163245.mlir
+++ b/stablehlo/testdata/conv_general_dilated_group_counts_lhs_float32_2_6_9_10__rhs_float32_6_3_4_5__windowstrides__1_1__pad-2212136815070163245.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_group_counts_lhs_float32_4_3_9_10__rhs_float32_6_3_4_5__windowstrides__1_1__pad2141518546713332984.mlir
+++ b/stablehlo/testdata/conv_general_dilated_group_counts_lhs_float32_4_3_9_10__rhs_float32_6_3_4_5__windowstrides__1_1__pad2141518546713332984.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_padding_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__padding_-5318452038191342786.mlir
+++ b/stablehlo/testdata/conv_general_dilated_padding_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__padding_-5318452038191342786.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_padding_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__padding_5050050053143756869.mlir
+++ b/stablehlo/testdata/conv_general_dilated_padding_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__padding_5050050053143756869.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_preferred_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__paddin-8230831430534381289.mlir
+++ b/stablehlo/testdata/conv_general_dilated_preferred_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__paddin-8230831430534381289.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_preferred_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__paddin2430556623423240398.mlir
+++ b/stablehlo/testdata/conv_general_dilated_preferred_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__paddin2430556623423240398.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_preferred_lhs_int32_2_3_9_10__rhs_int32_3_3_4_5__windowstrides__1_1__padding___-7077764382968112509.mlir
+++ b/stablehlo/testdata/conv_general_dilated_preferred_lhs_int32_2_3_9_10__rhs_int32_3_3_4_5__windowstrides__1_1__padding___-7077764382968112509.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_preferred_lhs_int32_2_3_9_10__rhs_int32_3_3_4_5__windowstrides__1_1__padding___8425439145703732762.mlir
+++ b/stablehlo/testdata/conv_general_dilated_preferred_lhs_int32_2_3_9_10__rhs_int32_3_3_4_5__windowstrides__1_1__padding___8425439145703732762.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_rhs_oob_after_dilation_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides2604570134889024577.mlir
+++ b/stablehlo/testdata/conv_general_dilated_rhs_oob_after_dilation_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides2604570134889024577.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_rhs_oob_after_pading_lhs_float32_1_3_2_2__rhs_float32_64_3_7_7__windowstrides__5476883256254674781.mlir
+++ b/stablehlo/testdata/conv_general_dilated_rhs_oob_after_pading_lhs_float32_1_3_2_2__rhs_float32_64_3_7_7__windowstrides__5476883256254674781.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_rhs_oob_lhs_float32_2_3_9_10__rhs_float32_3_3_10_5__windowstrides__1_1__padding-7028470013130116023.mlir
+++ b/stablehlo/testdata/conv_general_dilated_rhs_oob_lhs_float32_2_3_9_10__rhs_float32_3_3_10_5__windowstrides__1_1__padding-7028470013130116023.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_rhs_oob_same_padding_lhs_float32_1_1_16_1__rhs_float32_4_1_1_2__windowstrides__-5378230060959849233.mlir
+++ b/stablehlo/testdata/conv_general_dilated_rhs_oob_same_padding_lhs_float32_1_1_16_1__rhs_float32_4_1_1_2__windowstrides__-5378230060959849233.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_tf_conversion_path_1d_lhs_float32_1_28_1__rhs_float32_3_1_16__windowstrides__1_-3327288011231887622.mlir
+++ b/stablehlo/testdata/conv_general_dilated_tf_conversion_path_1d_lhs_float32_1_28_1__rhs_float32_3_1_16__windowstrides__1_-3327288011231887622.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_tf_conversion_path_1d_lhs_float32_1_28_1__rhs_float32_3_1_16__windowstrides__1_-3622729120410096886.mlir
+++ b/stablehlo/testdata/conv_general_dilated_tf_conversion_path_1d_lhs_float32_1_28_1__rhs_float32_3_1_16__windowstrides__1_-3622729120410096886.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_tf_conversion_path_1d_lhs_float32_1_28_1__rhs_float32_3_1_16__windowstrides__1_-6986955039250405512.mlir
+++ b/stablehlo/testdata/conv_general_dilated_tf_conversion_path_1d_lhs_float32_1_28_1__rhs_float32_3_1_16__windowstrides__1_-6986955039250405512.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_tf_conversion_path_1d_lhs_float32_1_28_1__rhs_float32_3_1_16__windowstrides__1_-9029857704645127306.mlir
+++ b/stablehlo/testdata/conv_general_dilated_tf_conversion_path_1d_lhs_float32_1_28_1__rhs_float32_3_1_16__windowstrides__1_-9029857704645127306.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_tf_conversion_path_2d_lhs_float32_1_1_28_28__rhs_float32_3_3_1_16__windowstride-2949258448720886117.mlir
+++ b/stablehlo/testdata/conv_general_dilated_tf_conversion_path_2d_lhs_float32_1_1_28_28__rhs_float32_3_3_1_16__windowstride-2949258448720886117.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_tf_conversion_path_2d_lhs_float32_1_1_28_28__rhs_float32_3_3_1_16__windowstride-3150713558304940791.mlir
+++ b/stablehlo/testdata/conv_general_dilated_tf_conversion_path_2d_lhs_float32_1_1_28_28__rhs_float32_3_3_1_16__windowstride-3150713558304940791.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_tf_conversion_path_2d_lhs_float32_1_1_28_28__rhs_float32_3_3_1_16__windowstride-4268834939663085007.mlir
+++ b/stablehlo/testdata/conv_general_dilated_tf_conversion_path_2d_lhs_float32_1_1_28_28__rhs_float32_3_3_1_16__windowstride-4268834939663085007.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_tf_conversion_path_2d_lhs_float32_1_1_28_28__rhs_float32_3_3_1_16__windowstride-4823547473556881342.mlir
+++ b/stablehlo/testdata/conv_general_dilated_tf_conversion_path_2d_lhs_float32_1_1_28_28__rhs_float32_3_3_1_16__windowstride-4823547473556881342.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_tf_conversion_path_2d_lhs_float32_1_1_28_28__rhs_float32_3_3_1_16__windowstride6887804375295982821.mlir
+++ b/stablehlo/testdata/conv_general_dilated_tf_conversion_path_2d_lhs_float32_1_1_28_28__rhs_float32_3_3_1_16__windowstride6887804375295982821.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_tf_conversion_path_2d_lhs_float32_1_28_28_1__rhs_float32_3_3_1_16__windowstride-5370080226275098061.mlir
+++ b/stablehlo/testdata/conv_general_dilated_tf_conversion_path_2d_lhs_float32_1_28_28_1__rhs_float32_3_3_1_16__windowstride-5370080226275098061.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_tf_conversion_path_2d_lhs_float32_1_28_28_1__rhs_float32_3_3_1_16__windowstride3500806609840728678.mlir
+++ b/stablehlo/testdata/conv_general_dilated_tf_conversion_path_2d_lhs_float32_1_28_28_1__rhs_float32_3_3_1_16__windowstride3500806609840728678.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_tf_conversion_path_2d_lhs_float32_1_28_28_1__rhs_float32_3_3_1_16__windowstride5787494791845602941.mlir
+++ b/stablehlo/testdata/conv_general_dilated_tf_conversion_path_2d_lhs_float32_1_28_28_1__rhs_float32_3_3_1_16__windowstride5787494791845602941.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_tf_conversion_path_2d_lhs_float32_1_28_28_1__rhs_float32_3_3_1_16__windowstride6312536791243051545.mlir
+++ b/stablehlo/testdata/conv_general_dilated_tf_conversion_path_2d_lhs_float32_1_28_28_1__rhs_float32_3_3_1_16__windowstride6312536791243051545.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_tf_conversion_path_2d_lhs_float32_1_28_28_1__rhs_float32_3_3_1_16__windowstride8472832706066243053.mlir
+++ b/stablehlo/testdata/conv_general_dilated_tf_conversion_path_2d_lhs_float32_1_28_28_1__rhs_float32_3_3_1_16__windowstride8472832706066243053.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_tf_conversion_path_3d_lhs_float32_1_4_28_28_1__rhs_float32_2_3_3_1_16__windowst-8282934958224398022.mlir
+++ b/stablehlo/testdata/conv_general_dilated_tf_conversion_path_3d_lhs_float32_1_4_28_28_1__rhs_float32_2_3_3_1_16__windowst-8282934958224398022.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_tf_conversion_path_3d_lhs_float32_1_4_28_28_1__rhs_float32_2_3_3_1_16__windowst3167308923230843499.mlir
+++ b/stablehlo/testdata/conv_general_dilated_tf_conversion_path_3d_lhs_float32_1_4_28_28_1__rhs_float32_2_3_3_1_16__windowst3167308923230843499.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_tf_conversion_path_3d_lhs_float32_1_4_28_28_1__rhs_float32_2_3_3_1_16__windowst6072174321640638276.mlir
+++ b/stablehlo/testdata/conv_general_dilated_tf_conversion_path_3d_lhs_float32_1_4_28_28_1__rhs_float32_2_3_3_1_16__windowst6072174321640638276.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_tf_conversion_path_3d_lhs_float32_1_4_28_28_1__rhs_float32_2_3_3_1_16__windowst8524424959485066052.mlir
+++ b/stablehlo/testdata/conv_general_dilated_tf_conversion_path_3d_lhs_float32_1_4_28_28_1__rhs_float32_2_3_3_1_16__windowst8524424959485066052.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/testdata/conv_general_dilated_window_strides_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__2_3__p-3051008093469972974.mlir
+++ b/stablehlo/testdata/conv_general_dilated_window_strides_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__2_3__p-3051008093469972974.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -142,6 +142,19 @@ func.func @abs(%arg0: tensor<1x2xf32>) -> tensor<1x2xindex> {
 
 // -----
 
+// CHECK-LABEL: func @collective_permute_c5
+func.func @collective_permute_c5(%arg0: tensor<2x2xi64>) -> tensor<2x2xindex> {
+  %0 = "stablehlo.collective_permute"(%arg0) {
+    source_target_pairs = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>,
+    channel_handle = #stablehlo.channel_handle<handle = 0, type = 0>
+  } : (tensor<2x2xi64>) -> tensor<2x2xi64>
+  // CHECK: types0 = tensor<2x2xi64>
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<2x2xi64>) -> tensor<2x2xindex>
+  func.return %1 : tensor<2x2xindex>
+}
+
+// -----
+
 // CHECK-LABEL: @concat
 func.func @concat(%arg0: tensor<1xi32>, %arg1: tensor<2xi32>)  -> tensor<3xindex> {
   %0 = "stablehlo.concatenate"(%arg0, %arg1) { dimension = 0 : i64 } : (tensor<1xi32>, tensor<2xi32>) -> tensor<3xi32>
@@ -152,15 +165,182 @@ func.func @concat(%arg0: tensor<1xi32>, %arg1: tensor<2xi32>)  -> tensor<3xindex
 
 // -----
 
-// CHECK-LABEL: func @collective_permute_c5
-func.func @collective_permute_c5(%arg0: tensor<2x2xi64>) -> tensor<2x2xindex> {
-  %0 = "stablehlo.collective_permute"(%arg0) {
-    source_target_pairs = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>,
-    channel_handle = #stablehlo.channel_handle<handle = 0, type = 0>
-  } : (tensor<2x2xi64>) -> tensor<2x2xi64>
-  // CHECK: types0 = tensor<2x2xi64>
-  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<2x2xi64>) -> tensor<2x2xindex>
-  func.return %1 : tensor<2x2xindex>
+// Invalid rank of output-type.
+
+func.func @invalid_conv_return_type(%arg0: tensor<1x8x8x207xf32>,
+    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x16xf32> {
+  // expected-error @+1 {{inferred shape '[1, 8, 8, 16]' is incompatible with return type of operation 'tensor<1x8x16xf32>'}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
+           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
+         {
+           batch_group_count = 1 : i64,
+           feature_group_count = 1 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+         } :
+       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x16xf32>
+  func.return %0 : tensor<1x8x16xf32>
+}
+
+// -----
+
+// Invalid batch dimension in output-type. Should be equal to
+// input-batch-dimension / batch_group_count.
+
+func.func @invalid_conv_return_type(%arg0: tensor<1x8x8x207xf32>,
+    %arg1: tensor<3x3x207x16xf32>) -> tensor<2x8x8x16xf32> {
+  // expected-error@+1 {{inferred shape '[1, 8, 8, 16]' is incompatible with return type of operation 'tensor<2x8x8x16xf32>'}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+         window = {stride = [1, 1], pad = [[1, 1], [1,1]],
+           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
+         {
+           batch_group_count = 1 : i64,
+           feature_group_count = 1 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+         } :
+       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<2x8x8x16xf32>
+  func.return %0 : tensor<2x8x8x16xf32>
+}
+
+// -----
+
+// Invalid feature dimension in output-type. Should be equal to
+// kernel_output_feature_dimension.
+
+func.func @invalid_conv_return_type(%arg0: tensor<1x8x8x207xf32>,
+    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x32xf32> {
+  // expected-error@+1 {{inferred shape '[1, 8, 8, 16]' is incompatible with return type of operation 'tensor<1x8x8x32xf32>'}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+         window = {stride = [1, 1], pad = [[1, 1], [1,1]],
+           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
+         {
+           batch_group_count = 1 : i64,
+           feature_group_count = 1 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+         } :
+       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x32xf32>
+  func.return %0 : tensor<1x8x8x32xf32>
+}
+
+// -----
+
+// The following tests checks the inferred output-type of ConvolutionOp. We
+// deliberately put an invalid output-type in these tests so that the
+// inffered-type can be highlighted in the error message.
+
+// Dynamic input-batch-dimension
+func.func @invalid_conv_dynamic_shapes(%arg0: tensor<?x8x8x207xf32>,
+    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x1x1x1xf32> {
+  // expected-error@+1 {{inferred shape '[?, 8, 8, 16]' is incompatible with return type of operation 'tensor<1x1x1x1xf32>'}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+         window = {stride = [1, 1], pad = [[1, 1], [1,1]],
+           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
+         {
+           batch_group_count = 1 : i64,
+           feature_group_count = 1 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+         } :
+       (tensor<?x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x1x1x1xf32>
+  func.return %0 : tensor<1x1x1x1xf32>
+}
+
+// -----
+
+// Dynamic input-feature-dimension: No effect on output dimensions.
+func.func @invalid_conv_dynamic_shapes(%arg0: tensor<1x8x8x?xf32>,
+    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x1x1x1xf32> {
+  // expected-error@+1 {{inferred shape '[1, 8, 8, 16]' is incompatible with return type of operation 'tensor<1x1x1x1xf32>'}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+         window = {stride = [1, 1], pad = [[1, 1], [1,1]],
+           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
+         {
+           batch_group_count = 1 : i64,
+           feature_group_count = 1 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+         } :
+       (tensor<1x8x8x?xf32>, tensor<3x3x207x16xf32>) -> tensor<1x1x1x1xf32>
+  func.return %0 : tensor<1x1x1x1xf32>
+}
+
+// -----
+
+// Dynamic input-spatial-dimension
+func.func @invalid_conv_dynamic_shapes(%arg0: tensor<1x?x8x207xf32>,
+    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x1x1x1xf32> {
+  // expected-error@+1 {{inferred shape '[1, ?, 8, 16]' is incompatible with return type of operation 'tensor<1x1x1x1xf32>'}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+         window = {stride = [1, 1], pad = [[1, 1], [1,1]],
+           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
+         {
+           batch_group_count = 1 : i64,
+           feature_group_count = 1 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+         } :
+       (tensor<1x?x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x1x1x1xf32>
+  func.return %0 : tensor<1x1x1x1xf32>
+}
+
+// -----
+
+// Dynamic kernel-input-feature-dimension: No effect on output dimensions.
+func.func @invalid_conv_dynamic_shapes(%arg0: tensor<1x8x8x207xf32>,
+    %arg1: tensor<3x3x?x16xf32>) -> tensor<1x1x1x1xf32> {
+  // expected-error@+1 {{inferred shape '[1, 8, 8, 16]' is incompatible with return type of operation 'tensor<1x1x1x1xf32>'}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+         window = {stride = [1, 1], pad = [[1, 1], [1,1]],
+           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
+         {
+           batch_group_count = 1 : i64,
+           feature_group_count = 1 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+         } :
+       (tensor<1x8x8x207xf32>, tensor<3x3x?x16xf32>) -> tensor<1x1x1x1xf32>
+  func.return %0 : tensor<1x1x1x1xf32>
+}
+
+// -----
+
+// Dynamic kernel-output-feature-dimension
+func.func @check_inferred_type_with_dynamic_input_dims(%arg0: tensor<1x8x8x207xf32>,
+    %arg1: tensor<3x3x207x?xf32>) -> tensor<1x1x1x1xf32> {
+  // expected-error@+1 {{inferred shape '[1, 8, 8, ?]' is incompatible with return type of operation 'tensor<1x1x1x1xf32>'}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+         window = {stride = [1, 1], pad = [[1, 1], [1,1]],
+           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
+         {
+           batch_group_count = 1 : i64,
+           feature_group_count = 1 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+         } :
+       (tensor<1x8x8x207xf32>, tensor<3x3x207x?xf32>) -> tensor<1x1x1x1xf32>
+  func.return %0 : tensor<1x1x1x1xf32>
+}
+
+// -----
+
+// Dynamic kernel-spatial-dimension
+func.func @check_inferred_type_with_dynamic_input_dims(%arg0: tensor<1x8x8x207xf32>,
+    %arg1: tensor<3x?x207x16xf32>) -> tensor<1x1x1x1xf32> {
+  // expected-error@+1 {{inferred shape '[1, 8, ?, 16]' is incompatible with return type of operation 'tensor<1x1x1x1xf32>'}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+         window = {stride = [1, 1], pad = [[1, 1], [1,1]],
+           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
+         {
+           batch_group_count = 1 : i64,
+           feature_group_count = 1 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+         } :
+       (tensor<1x8x8x207xf32>, tensor<3x?x207x16xf32>) -> tensor<1x1x1x1xf32>
+  func.return %0 : tensor<1x1x1x1xf32>
 }
 
 // -----

--- a/stablehlo/tests/interpret_convolution.mlir
+++ b/stablehlo/tests/interpret_convolution.mlir
@@ -1,0 +1,38 @@
+// RUN: stablehlo-translate --interpret -split-input-file %s
+
+func.func @convolution() {
+  %lhs = stablehlo.constant dense<[[
+                                    [[1], [2], [5], [6]],
+                                    [[3], [4], [7], [8]],
+                                    [[10], [11], [14], [15]],
+                                    [[12], [13], [16], [17]]
+                                  ]]> : tensor<1x4x4x1xi64>
+  %rhs = stablehlo.constant dense<[[[[1]],
+                                    [[1]],
+                                    [[1]]],
+                                    [[[1]],
+                                    [[1]],
+                                    [[1]]],
+                                    [[[1]],
+                                    [[1]],
+                                    [[1]]]]> : tensor<3x3x1x1xi64>
+  %result = stablehlo.convolution(%lhs, %rhs)
+    dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+    window = {
+      stride = [4, 4],
+      pad = [[0, 0], [0, 0]],
+      lhs_dilate = [2, 2],
+      rhs_dilate = [1, 1],
+      reverse = [false, false]
+    } {
+      feature_group_count = 1 : i64,
+      batch_group_count = 1 : i64,
+      precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+    }
+  : (tensor<1x4x4x1xi64>, tensor<3x3x1x1xi64>) -> tensor<1x2x2x1xi64>
+  check.expect_eq_const %result, dense<[[
+                                          [[10], [26]],
+                                          [[46], [62]]
+                                        ]]> : tensor<1x2x2x1xi64>
+  func.return
+}

--- a/stablehlo/tests/interpret_convolution.mlir
+++ b/stablehlo/tests/interpret_convolution.mlir
@@ -1,32 +1,21 @@
 // RUN: stablehlo-translate --interpret -split-input-file %s
 
-func.func @convolution() {
+func.func @convolution_op_test_si64() {
   %lhs = stablehlo.constant dense<[[
                                     [[1], [2], [5], [6]],
                                     [[3], [4], [7], [8]],
                                     [[10], [11], [14], [15]],
                                     [[12], [13], [16], [17]]
                                   ]]> : tensor<1x4x4x1xi64>
-  %rhs = stablehlo.constant dense<[[[[1]],
-                                    [[1]],
-                                    [[1]]],
-                                    [[[1]],
-                                    [[1]],
-                                    [[1]]],
-                                    [[[1]],
-                                    [[1]],
-                                    [[1]]]]> : tensor<3x3x1x1xi64>
+  %rhs = stablehlo.constant dense<1> : tensor<3x3x1x1xi64>
   %result = stablehlo.convolution(%lhs, %rhs)
     dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
     window = {
       stride = [4, 4],
-      pad = [[0, 0], [0, 0]],
-      lhs_dilate = [2, 2],
-      rhs_dilate = [1, 1],
-      reverse = [false, false]
+      lhs_dilate = [2, 2]
     } {
-      feature_group_count = 1 : i64,
       batch_group_count = 1 : i64,
+      feature_group_count = 1 : i64,
       precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
     }
   : (tensor<1x4x4x1xi64>, tensor<3x3x1x1xi64>) -> tensor<1x2x2x1xi64>
@@ -34,5 +23,57 @@ func.func @convolution() {
                                           [[10], [26]],
                                           [[46], [62]]
                                         ]]> : tensor<1x2x2x1xi64>
+  func.return
+}
+
+// -----
+
+func.func @convolution_batch_group_count_4() {
+  %lhs = stablehlo.constant dense<[[
+                                    [[1], [2], [5], [6]],
+                                    [[3], [4], [7], [8]],
+                                    [[10], [11], [14], [15]],
+                                    [[12], [13], [16], [17]]
+                                  ]]> : tensor<1x4x4x1xi64>
+  %rhs = stablehlo.constant dense<1> : tensor<1x2x1x4xi64>
+  %result = stablehlo.convolution(%lhs, %rhs)
+    dim_numbers = [0, b, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+    window = {
+      stride = [4, 4],
+      lhs_dilate = [2, 2]
+    } {
+      batch_group_count = 4 : i64,
+      feature_group_count = 1 : i64,
+      precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+    }
+  : (tensor<1x4x4x1xi64>, tensor<1x2x1x4xi64>) -> tensor<1x1x2x4xi64>
+  check.expect_eq_const %result, dense<[[[[1, 3, 10, 12],
+                                          [5, 7, 14, 16]]]]> : tensor<1x1x2x4xi64>
+  func.return
+}
+
+// -----
+
+func.func @convolution_feature_group_count_4() {
+  %lhs = stablehlo.constant dense<[[
+                                    [[1], [2], [5], [6]],
+                                    [[3], [4], [7], [8]],
+                                    [[10], [11], [14], [15]],
+                                    [[12], [13], [16], [17]]
+                                  ]]> : tensor<1x4x4x1xi64>
+  %rhs = stablehlo.constant dense<1> : tensor<1x2x1x4xi64>
+  %result = stablehlo.convolution(%lhs, %rhs)
+    dim_numbers = [b, 0, f, 1]x[0, i, 1, o]->[b, 0, 1, f],
+    window = {
+      stride = [4, 4],
+      lhs_dilate = [2, 2]
+    } {
+      batch_group_count = 1 : i64,
+      feature_group_count = 2 : i64,
+      precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+    }
+  : (tensor<1x4x4x1xi64>, tensor<1x2x1x4xi64>) -> tensor<1x2x1x4xi64>
+  check.expect_eq_const %result, dense<[[[[3, 3, 11, 11]],
+                                         [[21, 21, 29, 29]]]]> : tensor<1x2x1x4xi64>
   func.return
 }

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -4967,8 +4967,8 @@ func.func @eltwise_static_and_dynamic_type(%arg0: tensor<10x10xf32>, %arg1: tens
 
 // -----
 
-// CHECK-LABEL: func @conv_i4
-func.func @conv_i4(%arg0: tensor<64x8x8x8xi4>, %arg1: tensor<4x4x8x32xi4>) -> tensor<64x3x3x32xi8> {
+// CHECK-LABEL: func @convolution_operand_element_type_i4
+func.func @convolution_operand_element_type_i4(%arg0: tensor<64x8x8x8xi4>, %arg1: tensor<4x4x8x32xi4>) -> tensor<64x3x3x32xi8> {
   // Note: This has been lowered and adapted from:
   // %0 = "tf.Conv2D"(%arg0, %arg1) {
   //        data_format = "NHWC",
@@ -4987,11 +4987,11 @@ func.func @conv_i4(%arg0: tensor<64x8x8x8xi4>, %arg1: tensor<4x4x8x32xi4>) -> te
 
 // -----
 
-// CHECK: func @quantized_conv2d
+// CHECK: func @convolution_quantized_conv2d
 // CHECK: stablehlo.convolution
 // CHECK-SAME: dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f]
 // CHECK-SAME{LITERAL}: window = {stride = [1, 1], pad = [[1, 1], [1, 1]], lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
-func.func @quantized_conv2d(%arg0: tensor<1x8x8x207x!quant.uniform<i8:f32, 2.0:15>>, %arg1: tensor<3x3x207x16x!quant.uniform<i8:f32, 5.0:20>>) -> tensor<1x8x8x16x!quant.uniform<i8:f32, 10.0:50>> {
+func.func @convolution_quantized_conv2d(%arg0: tensor<1x8x8x207x!quant.uniform<i8:f32, 2.0:15>>, %arg1: tensor<3x3x207x16x!quant.uniform<i8:f32, 5.0:20>>) -> tensor<1x8x8x16x!quant.uniform<i8:f32, 10.0:50>> {
   %0 = stablehlo.convolution(%arg0, %arg1)
          dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
          window = {stride = [1, 1], pad = [[1, 1], [1, 1]], lhs_dilate = [1, 1], rhs_dilate = [1, 1]}

--- a/stablehlo/tests/verify_conv.mlir
+++ b/stablehlo/tests/verify_conv.mlir
@@ -1,9 +1,30 @@
 // RUN: stablehlo-opt %s -verify-diagnostics -split-input-file | FileCheck %s
 
-// Valid: Generic convolution
+// CHECK: func @conv_empty_spatial_dimensions
+// CHECK: stablehlo.convolution
+// CHECK-SAME: dim_numbers = [b, f]x[i, o]->[b, f]
+// CHECK-SAME: window = {stride = [], pad = [], lhs_dilate = [],
+// CHECK-SAME: rhs_dilate = [], reverse = []}
+func.func @conv_empty_spatial_dimensions(%arg0: tensor<3x2xf16>,
+    %arg1: tensor<2x2xf16>) -> tuple<tensor<3x2xf16>> {
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, f]x[i, o]->[b, f],
+         window = {stride = [], pad = [], lhs_dilate = [], rhs_dilate = [],
+           reverse = []}
+         {
+           batch_group_count = 1 : i64,
+           feature_group_count = 1 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+         }
+       : (tensor<3x2xf16>, tensor<2x2xf16>) -> tensor<3x2xf16>
+  %1 = "stablehlo.tuple"(%0) : (tensor<3x2xf16>) -> tuple<tensor<3x2xf16>>
+  func.return %1 : tuple<tensor<3x2xf16>>
+}
 
-// CHECK-LABEL: func @main
-func.func @main(%arg0 : tensor<100x26x26x32xf32>, %arg1 : tensor<3x3x1x32xf32>) ->
+// -----
+
+// CHECK-LABEL: func @convolution
+func.func @convolution(%arg0 : tensor<100x26x26x32xf32>, %arg1 : tensor<3x3x1x32xf32>) ->
     tensor<100x28x28x1xf32> {
   %result = "stablehlo.convolution"(%arg0, %arg1) {
     batch_group_count = 1 : i64,
@@ -29,8 +50,6 @@ func.func @main(%arg0 : tensor<100x26x26x32xf32>, %arg1 : tensor<3x3x1x32xf32>) 
 }
 
 // -----
-
-// Valid: Test convolution i8xi8 -> i32.
 
 // CHECK-LABEL: func @convolution_upcast
 func.func @convolution_upcast(%arg0 : tensor<100x26x26x32xi8>,
@@ -59,51 +78,151 @@ func.func @convolution_upcast(%arg0 : tensor<100x26x26x32xi8>,
 
 // -----
 
-// Valid: Empty spatial dimensions
-
-// CHECK: func @conv_empty_spatial_dimensions
-// CHECK: stablehlo.convolution
-// CHECK-SAME: dim_numbers = [b, f]x[i, o]->[b, f]
-// CHECK-SAME: window = {stride = [], pad = [], lhs_dilate = [],
-// CHECK-SAME: rhs_dilate = [], reverse = []}
-func.func @conv_empty_spatial_dimensions(%arg0: tensor<3x2xf16>,
-    %arg1: tensor<2x2xf16>) -> tuple<tensor<3x2xf16>> {
+func.func @convolution(%arg0: tensor<2x2x3x4xf32>, %arg1: tensor<3x5x5x3xf32>) -> tensor<3x5x5x4xf32> {
+  // expected-error@+3{{Unexpected keyword stide}}
   %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, f]x[i, o]->[b, f],
-         window = {stride = [], pad = [], lhs_dilate = [], rhs_dilate = [],
-           reverse = []}
-         {
-           batch_group_count = 1 : i64,
-           feature_group_count = 1 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-         }
-       : (tensor<3x2xf16>, tensor<2x2xf16>) -> tensor<3x2xf16>
-  %1 = "stablehlo.tuple"(%0) : (tensor<3x2xf16>) -> tuple<tensor<3x2xf16>>
-  func.return %1 : tuple<tensor<3x2xf16>>
+     dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+     window = {stide = [2, 1], pad = [[0, 1], [0, 1]], rhs_dilate = [1, 2]}
+     { batch_group_count = 1 : i64, feature_group_count = 1 : i64}
+  : (tensor<2x2x3x4xf32>, tensor<3x5x5x3xf32>) -> tensor<3x5x5x4xf32>
+  func.return %0 : tensor<3x5x5x4xf32>
 }
 
 // -----
 
-func.func @invalid_conv_dimensions(%arg0: tensor<2x4x5x2xf32>,
-                     %arg1: tensor<2x2x1x6xf32>) -> tensor<2x3x4x6xf32> {
-  // expected-error@+1 {{expects input dimension-numbers to be unique, got {0, 0}.}}
-  %1 = "stablehlo.convolution"(%arg0, %arg1) {
+func.func @convolution(%arg0: tensor<2x2x3x4xf32>, %arg1: tensor<3x5x5x3xf32>) -> tensor<3x5x5x4xf32> {
+  // expected-error@+3{{expected integer value}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+     dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+     window = {stride = [2, b], pad = [[0, 1], [0, 1]], rhs_dilate = [1, 2]}
+     { batch_group_count = 1 : i64, feature_group_count = 1 : i64}
+  : (tensor<2x2x3x4xf32>, tensor<3x5x5x3xf32>) -> tensor<3x5x5x4xf32>
+  func.return %0 : tensor<3x5x5x4xf32>
+}
+
+// -----
+
+func.func @convolution(%arg0: tensor<2x2x3x4xf32>, %arg1: tensor<3x5x5x3xf32>) -> tensor<3x5x5x4xf32> {
+  // expected-error@+3{{Unexpected keyword stride}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+     dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+     window = {stride = [2, 1], pad = [[0, 1], [0, 1]], rhs_dilate = [1, 2], stride=[2,1]}
+     { batch_group_count = 1 : i64, feature_group_count = 1 : i64}
+  : (tensor<2x2x3x4xf32>, tensor<3x5x5x3xf32>) -> tensor<3x5x5x4xf32>
+  func.return %0 : tensor<3x5x5x4xf32>
+}
+
+// -----
+
+func.func @convolution_i3(%arg0: tensor<1x4x4x1xi64>,
+    %arg1: tensor<3x3x1x1xi64>) -> tensor<1x2x2x1xi64> {
+  // expected-error@+1 {{expects the shape of window_strides attribute to be 1-D, but got {2, 2}.}}
+  %0 = "stablehlo.convolution"(%arg0, %arg1) {
+    window_strides = dense<4> : tensor<2x2xi64>,
+    padding = dense<0> : tensor<2x2xi64>,
+    lhs_dilation = dense<2> : tensor<2xi64>,
+    rhs_dilation = dense<1> : tensor<2xi64>,
+    window_reversal = dense<false> : tensor<2xi1>,
+    dimension_numbers = #stablehlo.conv<[b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f]>,
+    feature_group_count = 1 : i64,
     batch_group_count = 1 : i64,
-    dimension_numbers = #stablehlo.conv<raw
-      kernel_input_feature_dimension = 2,
-      kernel_output_feature_dimension = 3,
-      output_batch_dimension = 0,
-      output_feature_dimension = 3,
-    >,
-    feature_group_count = 2 : i64,
-    someattr} : (tensor<2x4x5x2xf32>, tensor<2x2x1x6xf32>) ->
-      tensor<2x3x4x6xf32>
-  func.return %1 : tensor<2x3x4x6xf32>
+    precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+  } : (tensor<1x4x4x1xi64>, tensor<3x3x1x1xi64>) -> tensor<1x2x2x1xi64>
+  func.return %0 : tensor<1x2x2x1xi64>
 }
 
 // -----
 
-func.func @invalid_conv_dimensions(%arg0: tensor<1x8x8x207xf32>,
+func.func @convolution_i4(%arg0: tensor<1x4x4x1xi64>,
+    %arg1: tensor<3x3x1x1xi64>) -> tensor<1x2x2x1xi64> {
+  // expected-error@+1 {{expects the shape of padding-attribute to be {N, 2}, but got {2}.}}
+  %0 = "stablehlo.convolution"(%arg0, %arg1) {
+    window_strides = dense<4> : tensor<2xi64>,
+    padding = dense<0> : tensor<2xi64>,
+    lhs_dilation = dense<2> : tensor<2xi64>,
+    rhs_dilation = dense<1> : tensor<2xi64>,
+    window_reversal = dense<false> : tensor<2xi1>,
+    dimension_numbers = #stablehlo.conv<[b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f]>,
+    feature_group_count = 1 : i64,
+    batch_group_count = 1 : i64,
+    precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+  } : (tensor<1x4x4x1xi64>, tensor<3x3x1x1xi64>) -> tensor<1x2x2x1xi64>
+  func.return %0 : tensor<1x2x2x1xi64>
+}
+
+// -----
+
+func.func @convolution_i5(%arg0: tensor<1x4x4x1xi64>,
+    %arg1: tensor<3x3x1x1xi64>) -> tensor<1x2x2x1xi64> {
+  // expected-error@+1 {{expects the shape of lhs_dilation attribute to be 1-D, but got {2, 2}.}}
+  %0 = "stablehlo.convolution"(%arg0, %arg1) {
+    window_strides = dense<4> : tensor<2xi64>,
+    padding = dense<0> : tensor<2x2xi64>,
+    lhs_dilation = dense<2> : tensor<2x2xi64>,
+    rhs_dilation = dense<1> : tensor<2xi64>,
+    window_reversal = dense<false> : tensor<2xi1>,
+    dimension_numbers = #stablehlo.conv<[b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f]>,
+    feature_group_count = 1 : i64,
+    batch_group_count = 1 : i64,
+    precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+  } : (tensor<1x4x4x1xi64>, tensor<3x3x1x1xi64>) -> tensor<1x2x2x1xi64>
+  func.return %0 : tensor<1x2x2x1xi64>
+}
+
+// -----
+
+func.func @convolution_i6(%arg0: tensor<1x4x4x1xi64>,
+    %arg1: tensor<3x3x1x1xi64>) -> tensor<1x2x2x1xi64> {
+  // expected-error@+1 {{expects the shape of rhs_dilation attribute to be 1-D, but got {2, 2}.}}
+  %0 = "stablehlo.convolution"(%arg0, %arg1) {
+    window_strides = dense<4> : tensor<2xi64>,
+    padding = dense<0> : tensor<2x2xi64>,
+    lhs_dilation = dense<2> : tensor<2xi64>,
+    rhs_dilation = dense<1> : tensor<2x2xi64>,
+    window_reversal = dense<false> : tensor<2xi1>,
+    dimension_numbers = #stablehlo.conv<[b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f]>,
+    feature_group_count = 1 : i64,
+    batch_group_count = 1 : i64,
+    precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+  } : (tensor<1x4x4x1xi64>, tensor<3x3x1x1xi64>) -> tensor<1x2x2x1xi64>
+  func.return %0 : tensor<1x2x2x1xi64>
+}
+
+// -----
+
+func.func @convolution_i7(%arg0: tensor<1x4x4x1xi64>,
+    %arg1: tensor<3x3x1x1xi64>) -> tensor<1x2x2x1xi64> {
+  // expected-error@+1 {{expects the shape of window_reversal attribute to be 1-D, but got {2, 2}.}}
+  %0 = "stablehlo.convolution"(%arg0, %arg1) {
+    window_strides = dense<4> : tensor<2xi64>,
+    padding = dense<0> : tensor<2x2xi64>,
+    lhs_dilation = dense<2> : tensor<2xi64>,
+    rhs_dilation = dense<1> : tensor<2xi64>,
+    window_reversal = dense<false> : tensor<2x2xi1>,
+    dimension_numbers = #stablehlo.conv<[b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f]>,
+    feature_group_count = 1 : i64,
+    batch_group_count = 1 : i64,
+    precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+  } : (tensor<1x4x4x1xi64>, tensor<3x3x1x1xi64>) -> tensor<1x2x2x1xi64>
+  func.return %0 : tensor<1x2x2x1xi64>
+}
+
+// -----
+
+func.func @convolution_c1(%arg0: tensor<1xi64>,
+    %arg1: tensor<1xi64>) -> tensor<1xi64> {
+  // expected-error@+1 {{expects convolution arguments to have >= 2 dimensions. Got: 'tensor<1xi64>' and 'tensor<1xi64>'.}}
+  %0 = "stablehlo.convolution"(%arg0, %arg1) {
+    dimension_numbers = #stablehlo.conv<[b, f]x[i, o]->[b, f]>,
+    feature_group_count = 1 : i64,
+    batch_group_count = 1 : i64
+  } : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
+  func.return %0 : tensor<1xi64>
+}
+
+// -----
+
+func.func @convolution_c2(%arg0: tensor<1x8x8x207xf32>,
     %arg1: tensor<3x3x207xf32>) -> tensor<1x8x8x16xf32> {
   // expected-error@+1 {{expects convolution arguments to have same number of dimensions. Got: 'tensor<1x8x8x207xf32>' and 'tensor<3x3x207xf32>'.}}
   %0 = stablehlo.convolution(%arg0, %arg1)
@@ -121,306 +240,26 @@ func.func @invalid_conv_dimensions(%arg0: tensor<1x8x8x207xf32>,
 
 // -----
 
-func.func @invalid_conv_dimensions(%arg0: tensor<1xf32>, %arg1: tensor<3xf32>)
-    -> tensor<1x8x8x16xf32> {
-  // expected-error@+1 {{expects convolution arguments to have >= 2 dimensions. Got: 'tensor<1xf32>' and 'tensor<3xf32>'.}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
-           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
-         {
-           batch_group_count = 1 : i64,
-           feature_group_count = 1 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-         } :
-       (tensor<1xf32>, tensor<3xf32>) -> tensor<1x8x8x16xf32>
-  func.return %0 : tensor<1x8x8x16xf32>
-}
-
-// -----
-
-func.func @invalid_conv_dimensions(%arg0: tensor<1x8x8x207xf32>,
-    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
-  // expected-error@+1 {{expects the same size for input, kernel and output spatial-dimensions, but got 3, 2, and 2 resp.}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, 2, f]x[0, 1, i, o]->[b, 0, 1, f],
-         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
-           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
-         {
-           batch_group_count = 1 : i64,
-           feature_group_count = 1 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]} :
-       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
-  func.return %0 : tensor<1x8x8x16xf32>
-}
-
-// -----
-
-func.func @invalid_conv_dimensions(%arg0: tensor<1x8x8x207xf32>,
-    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
-  // expected-error@+1 {{expects the same size for input, kernel and output spatial-dimensions, but got 2, 3, and 2 resp.}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, f]x[0, 1, 2, i, o]->[b, 0, 1, f],
-         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
-           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
-         {
-           batch_group_count = 1 : i64,
-           feature_group_count = 1 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-         } :
-       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
-  func.return %0 : tensor<1x8x8x16xf32>
-}
-
-// -----
-
-func.func @invalid_conv_dimensions(%arg0: tensor<1x8x8x207xf32>,
-    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
-  // expected-error@+1 {{expects the same size for input, kernel and output spatial-dimensions, but got 2, 2, and 3 resp.}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, 2, f],
-         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
-           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
-         {
-           batch_group_count = 1 : i64,
-           feature_group_count = 1 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-         } :
-       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
-  func.return %0 : tensor<1x8x8x16xf32>
-}
-
-// -----
-
-func.func @invalid_conv_dimensions(%arg0 : tensor<100x26x26x32xf32>,
-    %arg1 : tensor<3x3x1x32xf32>) -> tensor<100x28x28x1xf32> {
-  // expected-error@+1 {{expects input, kernel, and output dimension-numbers to be in-range [0, 4).}}
-  %result = "stablehlo.convolution"(%arg0, %arg1) {
-    batch_group_count = 1 : i64,
-    dimension_numbers = #stablehlo.conv<raw
-      input_batch_dimension = 0,
-      input_feature_dimension = 3,
-      input_spatial_dimensions = [1, 4],
-      kernel_input_feature_dimension = 3,
-      kernel_output_feature_dimension = 2,
-      kernel_spatial_dimensions = [0, 1],
-      output_batch_dimension = 0,
-      output_feature_dimension = 3,
-      output_spatial_dimensions = [1, 2]
-    >,
-    feature_group_count = 1 : i64,
-    lhs_dilation = dense<1> : tensor<2xi64>,
-    padding = dense<2> : tensor<2x2xi64>,
+func.func @convolution_c3(%arg0: tensor<1x4x4x1xi64>,
+    %arg1: tensor<3x3x1x1xi32>) -> tensor<1x2x2x1xi64> {
+  // expected-error@+1 {{expects lhs and rhs to have compatible element type. Got: 'i64' and 'i32'}}
+    %0 = "stablehlo.convolution"(%arg0, %arg1) {
+    window_strides = dense<4> : tensor<2xi64>,
+    padding = dense<0> : tensor<2x2xi64>,
+    lhs_dilation = dense<2> : tensor<2xi64>,
     rhs_dilation = dense<1> : tensor<2xi64>,
-    window_strides = dense<1> : tensor<2xi64>
-  } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>) ->
-    tensor<100x28x28x1xf32>
-  func.return %result : tensor<100x28x28x1xf32>
-}
-
-// -----
-
-func.func @invalid_conv_dimensions(%arg0 : tensor<100x26x26x32xf32>,
-    %arg1 : tensor<3x3x1x32xf32>) -> tensor<100x28x28x1xf32> {
-  // expected-error@+1 {{expects kernel dimension-numbers to be unique, got {3, 2, 0, 0}.}}
-  %result = "stablehlo.convolution"(%arg0, %arg1) {
-    batch_group_count = 1 : i64,
-    dimension_numbers = #stablehlo.conv<raw
-      input_batch_dimension = 0,
-      input_feature_dimension = 3,
-      input_spatial_dimensions = [1, 2],
-      kernel_input_feature_dimension = 3,
-      kernel_output_feature_dimension = 2,
-      kernel_spatial_dimensions = [0, 0],
-      output_batch_dimension = 0,
-      output_feature_dimension = 3,
-      output_spatial_dimensions = [1, 2]
-    >,
+    window_reversal = dense<false> : tensor<2xi1>,
+    dimension_numbers = #stablehlo.conv<[b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f]>,
     feature_group_count = 1 : i64,
-    lhs_dilation = dense<1> : tensor<2xi64>,
-    padding = dense<2> : tensor<2x2xi64>,
-    rhs_dilation = dense<1> : tensor<2xi64>,
-    window_strides = dense<1> : tensor<2xi64>
-  } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>) ->
-    tensor<100x28x28x1xf32>
-  func.return %result : tensor<100x28x28x1xf32>
-}
-
-// -----
-
-func.func @invalid_conv_dimensions(%arg0 : tensor<100x26x26x32xf32>,
-    %arg1 : tensor<3x3x1x32xf32>) -> tensor<100x28x28x1xf32> {
-  // expected-error@+1 {{expects output dimension-numbers to be unique, got {0, 3, 0, 3}.}}
-  %result = "stablehlo.convolution"(%arg0, %arg1) {
     batch_group_count = 1 : i64,
-    dimension_numbers = #stablehlo.conv<raw
-      input_batch_dimension = 0,
-      input_feature_dimension = 3,
-      input_spatial_dimensions = [1, 2],
-      kernel_input_feature_dimension = 3,
-      kernel_output_feature_dimension = 2,
-      kernel_spatial_dimensions = [0, 1],
-      output_batch_dimension = 0,
-      output_feature_dimension = 3,
-      output_spatial_dimensions = [0, 3]
-    >,
-    feature_group_count = 1 : i64,
-    lhs_dilation = dense<1> : tensor<2xi64>,
-    padding = dense<2> : tensor<2x2xi64>,
-    rhs_dilation = dense<1> : tensor<2xi64>,
-    window_strides = dense<1> : tensor<2xi64>
-  } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>) ->
-    tensor<100x28x28x1xf32>
-  func.return %result : tensor<100x28x28x1xf32>
+    precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+  } : (tensor<1x4x4x1xi64>, tensor<3x3x1x1xi32>) -> tensor<1x2x2x1xi64>
+  func.return %0 : tensor<1x2x2x1xi64>
 }
 
 // -----
 
-func.func @invalid_conv_dimensions(%arg0: tensor<1x8x8x207xf32>,
-    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
-  // expected-error@+1 {{expects batch_group_count to be a positive number, got 0.}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
-           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
-         {
-           batch_group_count = 0 : i64,
-           feature_group_count = 1 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-         } :
-       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
-  func.return %0 : tensor<1x8x8x16xf32>
-}
-
-// -----
-
-func.func @invalid_conv_dimensions(%arg0: tensor<1x8x8x207xf32>,
-    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
-  // expected-error@+1 {{expects feature_group_count to be a positive number, got 0.}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
-           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
-         {
-           batch_group_count = 1 : i64,
-           feature_group_count = 0 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-         } :
-       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
-  func.return %0 : tensor<1x8x8x16xf32>
-}
-
-// -----
-
-func.func @invalid_conv_dimensions(%arg0: tensor<1x8x8x207xf32>,
-    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
-  // expected-error@+1 {{expects batch_group_count and feature_group_count not to be both greater than 1. Got 2 and 2 resp.}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
-           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
-         {
-           batch_group_count = 2 : i64,
-           feature_group_count = 2 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-         } :
-       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
-  func.return %0 : tensor<1x8x8x16xf32>
-}
-
-// -----
-
-func.func @invalid_conv_dimensions(%arg0: tensor<1x8x8x207xf32>,
-    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
-  // expected-error@+1 {{expects output feature dimension size (16) to be a multiple of batch_group_count. Got batch_group_count = 3.}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
-           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
-         {
-           batch_group_count = 3 : i64,
-           feature_group_count = 1 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-         } :
-       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
-  func.return %0 : tensor<1x8x8x16xf32>
-}
-
-// -----
-
-func.func @invalid_conv_dimensions(%arg0: tensor<1x8x8x207xf32>,
-    %arg1: tensor<3x3x20x16xf32>) -> tensor<1x8x8x16xf32> {
-  // expected-error@+1 {{expects input feature dimension (207) to be a multiple of feature_group_count. Got feature_group_count = 2.}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
-           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
-         {
-           batch_group_count = 1 : i64,
-           feature_group_count = 2 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-         } :
-       (tensor<1x8x8x207xf32>, tensor<3x3x20x16xf32>) -> tensor<1x8x8x16xf32>
-  func.return %0 : tensor<1x8x8x16xf32>
-}
-
-// -----
-
-func.func @invalid_conv_dimensions(%arg0: tensor<1x8x8x207xf32>,
-    %arg1: tensor<3x3x20x16xf32>) -> tensor<1x8x8x16xf32> {
-  // expected-error@+1 {{expects input feature dimension (207) / feature_group_count = kernel input feature dimension (20). Got feature_group_count = 1.}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
-           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
-         {
-           batch_group_count = 1 : i64,
-           feature_group_count = 1 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-         } :
-       (tensor<1x8x8x207xf32>, tensor<3x3x20x16xf32>) -> tensor<1x8x8x16xf32>
-  func.return %0 : tensor<1x8x8x16xf32>
-}
-
-// -----
-
-func.func @invalid_conv_dimensions(%arg0: tensor<1x8x8x207xf32>,
-    %arg1: tensor<3x3x69x16xf32>) -> tensor<1x8x8x16xf32> {
-  // expected-error@+1 {{expects kernel output feature dimension (16) to be divisible by feature_group_count. For feature_group_count = 3.}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
-           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
-         {
-           batch_group_count = 1 : i64,
-           feature_group_count = 3 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-         } :
-       (tensor<1x8x8x207xf32>, tensor<3x3x69x16xf32>) -> tensor<1x8x8x16xf32>
-  func.return %0 : tensor<1x8x8x16xf32>
-}
-
-// -----
-
-func.func @invalid_conv_dimensions(%arg0: tensor<5x8x8x207xf32>,
-    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
-  // expected-error@+1 {{expects input batch dimension (5) to be divisible by batch_group_count. Got batch_group_count = 2.}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
-           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
-         {
-           batch_group_count = 2 : i64,
-           feature_group_count = 1 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-         } :
-       (tensor<5x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
-  func.return %0 : tensor<1x8x8x16xf32>
-}
-
-// -----
-
-func.func @invalid_conv_window_attributes(%arg0: tensor<1x8x8x207xf32>,
+func.func @convolution_c4(%arg0: tensor<1x8x8x207xf32>,
     %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
   // expected-error@+1 {{expects window-strides to have same dimension-size as size of window dimensions (2), but got: 1.}}
   %0 = stablehlo.convolution(%arg0, %arg1)
@@ -438,63 +277,12 @@ func.func @invalid_conv_window_attributes(%arg0: tensor<1x8x8x207xf32>,
 
 // -----
 
-func.func @invalid_conv_window_attributes(%arg0: tensor<1x8x8x207xf32>,
+func.func @convolution_c5(%arg0: tensor<1x8x8x207xf32>,
     %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
-  // expected-error@+1 {{expects base-dilation factors to have same dimension-size as size of window dimensions (2), but got: 1.}}
+  // expected-error@+1 {{expects window to have positive stride for 1-th window dimension, but got 0.}}
   %0 = stablehlo.convolution(%arg0, %arg1)
          dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
-           lhs_dilate = [1], rhs_dilate = [1, 1]}
-         {
-           batch_group_count = 1 : i64,
-           feature_group_count = 1 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]} :
-       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
-  func.return %0 : tensor<1x8x8x16xf32>
-}
-
-// -----
-
-func.func @invalid_conv_window_attributes(%arg0: tensor<1x8x8x207xf32>,
-    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
-  // expected-error@+1 {{expects window-dilation factors to have same dimension-size as size of window dimensions (2), but got: 1.}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
-           lhs_dilate = [1, 1], rhs_dilate = [1]}
-         {
-           batch_group_count = 1 : i64,
-           feature_group_count = 1 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]} :
-       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
-  func.return %0 : tensor<1x8x8x16xf32>
-}
-
-// -----
-
-func.func @invalid_conv_window_attributes(%arg0: tensor<1x8x8x207xf32>,
-    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
-  // expected-error@+1 {{expects window-reversal to have same dimension-size as size of window dimensions (2), but got: 1.}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
-           lhs_dilate = [1, 1], rhs_dilate = [1, 1], reverse = [false]}
-         {
-           batch_group_count = 1 : i64,
-           feature_group_count = 1 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]} :
-       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
-  func.return %0 : tensor<1x8x8x16xf32>
-}
-
-// -----
-
-func.func @invalid_conv_window_attributes(%arg0: tensor<1x8x8x207xf32>,
-    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
-  // expected-error@+1 {{expects padding-entries to have same dimension-size as size of window dimensions (2), but got: 1.}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-         window = {stride = [1, 1], pad = [[1, 1]],
+         window = {stride = [1, 0], pad = [[1, 1], [1,1]],
            lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
          {
            batch_group_count = 1 : i64,
@@ -506,25 +294,7 @@ func.func @invalid_conv_window_attributes(%arg0: tensor<1x8x8x207xf32>,
 
 // -----
 
-func.func @invalid_conv_dimensions(%arg0: tensor<1x8x8x207xf32>,
-    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-         // expected-error@+1 {{Expected array with 2 elements, got 4 elements instead}}
-         window = {stride = [1, 1], pad = [[1, 1, 1, 1]],
-           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
-         {
-           batch_group_count = 1 : i64,
-           feature_group_count = 1 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-         } :
-       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
-  func.return %0 : tensor<1x8x8x16xf32>
-}
-
-// -----
-
-func.func @invalid_conv_dimensions(%arg0 : tensor<100x26x26x32xf32>, %arg1 : tensor<3x3x1x32xf32>) ->
+func.func @convolution_c6(%arg0 : tensor<100x26x26x32xf32>, %arg1 : tensor<3x3x1x32xf32>) ->
     tensor<100x28x28x1xf32> {
   // expected-error@+1 {{expects padding-entries to have same dimension-size as size of window dimensions (2), but got: 3.}}
   %result = "stablehlo.convolution"(%arg0, %arg1) {
@@ -552,30 +322,50 @@ func.func @invalid_conv_dimensions(%arg0 : tensor<100x26x26x32xf32>, %arg1 : ten
 
 // -----
 
-func.func @invalid_conv_window_attributes(%arg0: tensor<1x8x8x207xf32>,
-    %arg1: tensor<0x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
-  // expected-error@+1 {{expects window to have positive value for 0-th window dimension, but got 0.}}
+func.func @convolution_c6(%arg0: tensor<1x4x4x1xi64>,
+    %arg1: tensor<3x3x1x1xi64>) -> tensor<1x2x2x1xi64> {
+  // expected-error@+1 {{expects the shape of padding-attribute to be {N, 2}, but got {2, 3}.}}
+  %0 = "stablehlo.convolution"(%arg0, %arg1) {
+    window_strides = dense<4> : tensor<2xi64>,
+    padding = dense<0> : tensor<2x3xi64>,
+    lhs_dilation = dense<2> : tensor<2xi64>,
+    rhs_dilation = dense<1> : tensor<2xi64>,
+    window_reversal = dense<false> : tensor<2xi1>,
+    dimension_numbers = #stablehlo.conv<[b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f]>,
+    feature_group_count = 1 : i64,
+    batch_group_count = 1 : i64,
+    precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+  } : (tensor<1x4x4x1xi64>, tensor<3x3x1x1xi64>) -> tensor<1x2x2x1xi64>
+  func.return %0 : tensor<1x2x2x1xi64>
+}
+
+// -----
+
+func.func @convolution_c6(%arg0: tensor<1x8x8x207xf32>,
+    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
   %0 = stablehlo.convolution(%arg0, %arg1)
          dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-         window = {stride = [1, 1], pad = [[1, 1], [1,1]],
+         // expected-error@+1 {{Expected array with 2 elements, got 4 elements instead}}
+         window = {stride = [1, 1], pad = [[1, 1, 1, 1]],
            lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
          {
            batch_group_count = 1 : i64,
            feature_group_count = 1 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]} :
-       (tensor<1x8x8x207xf32>, tensor<0x3x207x16xf32>) -> tensor<1x8x8x16xf32>
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+         } :
+       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
   func.return %0 : tensor<1x8x8x16xf32>
 }
 
 // -----
 
-func.func @invalid_conv_window_attributes(%arg0: tensor<1x8x8x207xf32>,
+func.func @convolution_c7(%arg0: tensor<1x8x8x207xf32>,
     %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
-  // expected-error@+1 {{expects window to have positive stride for 1-th window dimension, but got 0.}}
+  // expected-error@+1 {{expects base-dilation factors to have same dimension-size as size of window dimensions (2), but got: 1.}}
   %0 = stablehlo.convolution(%arg0, %arg1)
          dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-         window = {stride = [1, 0], pad = [[1, 1], [1,1]],
-           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
+         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
+           lhs_dilate = [1], rhs_dilate = [1, 1]}
          {
            batch_group_count = 1 : i64,
            feature_group_count = 1 : i64,
@@ -586,7 +376,7 @@ func.func @invalid_conv_window_attributes(%arg0: tensor<1x8x8x207xf32>,
 
 // -----
 
-func.func @invalid_conv_window_attributes(%arg0: tensor<1x8x8x207xf32>,
+func.func @convolution_c8(%arg0: tensor<1x8x8x207xf32>,
     %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
   // expected-error@+1 {{expects window to have positive base dilation factor for 0-th window dimension, but got 0.}}
   %0 = stablehlo.convolution(%arg0, %arg1)
@@ -604,7 +394,24 @@ func.func @invalid_conv_window_attributes(%arg0: tensor<1x8x8x207xf32>,
 
 // -----
 
-func.func @invalid_conv_window_attributes(%arg0: tensor<1x8x8x207xf32>,
+func.func @convolution_c9(%arg0: tensor<1x8x8x207xf32>,
+    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
+  // expected-error@+1 {{expects window-dilation factors to have same dimension-size as size of window dimensions (2), but got: 1.}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
+           lhs_dilate = [1, 1], rhs_dilate = [1]}
+         {
+           batch_group_count = 1 : i64,
+           feature_group_count = 1 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]} :
+       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
+  func.return %0 : tensor<1x8x8x16xf32>
+}
+
+// -----
+
+func.func @convolution_c10(%arg0: tensor<1x8x8x207xf32>,
     %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
   // expected-error@+1 {{expects window to have positive window dilation factor for 0-th window dimension, but got 0.}}
   %0 = stablehlo.convolution(%arg0, %arg1)
@@ -622,182 +429,55 @@ func.func @invalid_conv_window_attributes(%arg0: tensor<1x8x8x207xf32>,
 
 // -----
 
-// Invalid rank of output-type.
+func.func @convolution_c11(%arg0: tensor<1x8x8x207xf32>,
+    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
+  // expected-error@+1 {{expects window-reversal to have same dimension-size as size of window dimensions (2), but got: 1.}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
+           lhs_dilate = [1, 1], rhs_dilate = [1, 1], reverse = [false]}
+         {
+           batch_group_count = 1 : i64,
+           feature_group_count = 1 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]} :
+       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
+  func.return %0 : tensor<1x8x8x16xf32>
+}
 
-func.func @invalid_conv_return_type(%arg0: tensor<1x8x8x207xf32>,
-    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x16xf32> {
-  // expected-error @+1 {{inferred shape '[1, 8, 8, 16]' is incompatible with return type of operation 'tensor<1x8x16xf32>'}}
+// -----
+
+func.func @convolution_c12(%arg0: tensor<5x8x8x207xf32>,
+    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
+  // expected-error@+1 {{expects input batch dimension (5) to be divisible by batch_group_count. Got batch_group_count = 2.}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
+           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
+         {
+           batch_group_count = 2 : i64,
+           feature_group_count = 1 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+         } :
+       (tensor<5x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
+  func.return %0 : tensor<1x8x8x16xf32>
+}
+
+// -----
+
+func.func @convolution_c13(%arg0: tensor<1x8x8x207xf32>,
+    %arg1: tensor<3x3x20x16xf32>) -> tensor<1x8x8x16xf32> {
+  // expected-error@+1 {{expects input feature dimension (207) to be a multiple of feature_group_count. Got feature_group_count = 2.}}
   %0 = stablehlo.convolution(%arg0, %arg1)
          dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
          window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
            lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
          {
            batch_group_count = 1 : i64,
-           feature_group_count = 1 : i64,
+           feature_group_count = 2 : i64,
            precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
          } :
-       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x16xf32>
-  func.return %0 : tensor<1x8x16xf32>
-}
-
-// -----
-
-// Invalid batch dimension in output-type. Should be equal to
-// input-batch-dimension / batch_group_count.
-
-func.func @invalid_conv_return_type(%arg0: tensor<1x8x8x207xf32>,
-    %arg1: tensor<3x3x207x16xf32>) -> tensor<2x8x8x16xf32> {
-  // expected-error@+1 {{inferred shape '[1, 8, 8, 16]' is incompatible with return type of operation 'tensor<2x8x8x16xf32>'}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-         window = {stride = [1, 1], pad = [[1, 1], [1,1]],
-           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
-         {
-           batch_group_count = 1 : i64,
-           feature_group_count = 1 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-         } :
-       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<2x8x8x16xf32>
-  func.return %0 : tensor<2x8x8x16xf32>
-}
-
-// -----
-
-// Invalid feature dimension in output-type. Should be equal to
-// kernel_output_feature_dimension.
-
-func.func @invalid_conv_return_type(%arg0: tensor<1x8x8x207xf32>,
-    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x32xf32> {
-  // expected-error@+1 {{inferred shape '[1, 8, 8, 16]' is incompatible with return type of operation 'tensor<1x8x8x32xf32>'}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-         window = {stride = [1, 1], pad = [[1, 1], [1,1]],
-           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
-         {
-           batch_group_count = 1 : i64,
-           feature_group_count = 1 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-         } :
-       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x32xf32>
-  func.return %0 : tensor<1x8x8x32xf32>
-}
-
-// -----
-
-// The following tests checks the inferred output-type of ConvolutionOp. We
-// deliberately put an invalid output-type in these tests so that the
-// inffered-type can be highlighted in the error message.
-
-// Dynamic input-batch-dimension
-func.func @invalid_conv_dynamic_shapes(%arg0: tensor<?x8x8x207xf32>,
-    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x1x1x1xf32> {
-  // expected-error@+1 {{inferred shape '[?, 8, 8, 16]' is incompatible with return type of operation 'tensor<1x1x1x1xf32>'}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-         window = {stride = [1, 1], pad = [[1, 1], [1,1]],
-           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
-         {
-           batch_group_count = 1 : i64,
-           feature_group_count = 1 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-         } :
-       (tensor<?x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x1x1x1xf32>
-  func.return %0 : tensor<1x1x1x1xf32>
-}
-
-// -----
-
-// Dynamic input-feature-dimension: No effect on output dimensions.
-func.func @invalid_conv_dynamic_shapes(%arg0: tensor<1x8x8x?xf32>,
-    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x1x1x1xf32> {
-  // expected-error@+1 {{inferred shape '[1, 8, 8, 16]' is incompatible with return type of operation 'tensor<1x1x1x1xf32>'}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-         window = {stride = [1, 1], pad = [[1, 1], [1,1]],
-           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
-         {
-           batch_group_count = 1 : i64,
-           feature_group_count = 1 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-         } :
-       (tensor<1x8x8x?xf32>, tensor<3x3x207x16xf32>) -> tensor<1x1x1x1xf32>
-  func.return %0 : tensor<1x1x1x1xf32>
-}
-
-// -----
-
-// Dynamic input-spatial-dimension
-func.func @invalid_conv_dynamic_shapes(%arg0: tensor<1x?x8x207xf32>,
-    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x1x1x1xf32> {
-  // expected-error@+1 {{inferred shape '[1, ?, 8, 16]' is incompatible with return type of operation 'tensor<1x1x1x1xf32>'}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-         window = {stride = [1, 1], pad = [[1, 1], [1,1]],
-           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
-         {
-           batch_group_count = 1 : i64,
-           feature_group_count = 1 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-         } :
-       (tensor<1x?x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x1x1x1xf32>
-  func.return %0 : tensor<1x1x1x1xf32>
-}
-
-// -----
-
-// Dynamic kernel-input-feature-dimension: No effect on output dimensions.
-func.func @invalid_conv_dynamic_shapes(%arg0: tensor<1x8x8x207xf32>,
-    %arg1: tensor<3x3x?x16xf32>) -> tensor<1x1x1x1xf32> {
-  // expected-error@+1 {{inferred shape '[1, 8, 8, 16]' is incompatible with return type of operation 'tensor<1x1x1x1xf32>'}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-         window = {stride = [1, 1], pad = [[1, 1], [1,1]],
-           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
-         {
-           batch_group_count = 1 : i64,
-           feature_group_count = 1 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-         } :
-       (tensor<1x8x8x207xf32>, tensor<3x3x?x16xf32>) -> tensor<1x1x1x1xf32>
-  func.return %0 : tensor<1x1x1x1xf32>
-}
-
-// -----
-
-// Dynamic kernel-output-feature-dimension
-func.func @check_inferred_type_with_dynamic_input_dims(%arg0: tensor<1x8x8x207xf32>,
-    %arg1: tensor<3x3x207x?xf32>) -> tensor<1x1x1x1xf32> {
-  // expected-error@+1 {{inferred shape '[1, 8, 8, ?]' is incompatible with return type of operation 'tensor<1x1x1x1xf32>'}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-         window = {stride = [1, 1], pad = [[1, 1], [1,1]],
-           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
-         {
-           batch_group_count = 1 : i64,
-           feature_group_count = 1 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-         } :
-       (tensor<1x8x8x207xf32>, tensor<3x3x207x?xf32>) -> tensor<1x1x1x1xf32>
-  func.return %0 : tensor<1x1x1x1xf32>
-}
-
-// -----
-
-// Dynamic kernel-spatial-dimension
-func.func @check_inferred_type_with_dynamic_input_dims(%arg0: tensor<1x8x8x207xf32>,
-    %arg1: tensor<3x?x207x16xf32>) -> tensor<1x1x1x1xf32> {
-  // expected-error@+1 {{inferred shape '[1, 8, ?, 16]' is incompatible with return type of operation 'tensor<1x1x1x1xf32>'}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-         window = {stride = [1, 1], pad = [[1, 1], [1,1]],
-           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
-         {
-           batch_group_count = 1 : i64,
-           feature_group_count = 1 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-         } :
-       (tensor<1x8x8x207xf32>, tensor<3x?x207x16xf32>) -> tensor<1x1x1x1xf32>
-  func.return %0 : tensor<1x1x1x1xf32>
+       (tensor<1x8x8x207xf32>, tensor<3x3x20x16xf32>) -> tensor<1x8x8x16xf32>
+  func.return %0 : tensor<1x8x8x16xf32>
 }
 
 // -----
@@ -807,7 +487,7 @@ func.func @check_inferred_type_with_dynamic_input_dims(%arg0: tensor<1x8x8x207xf
 // but negative here: stablehlo.convolution does no support unknown dimenstion
 // dim_numbers = [b, 0, 1, ?, f]x[0, 1, ?, i, o]->[?, b, 0, 1, f]
 // window = {stride = [1, 1], pad = [[1, 1], [1, 1]], lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
-func.func @conv2d_generic(%arg0: tensor<1x8x8x32x207xf32>, %arg1: tensor<3x3x32x207x16xf32>) -> tensor<32x1x8x8x16xf32> {
+func.func @convolution_c14(%arg0: tensor<1x8x8x32x207xf32>, %arg1: tensor<3x3x32x207x16xf32>) -> tensor<32x1x8x8x16xf32> {
   // expected-error@+1{{expects convolution arguments to have 4 dimensions. Got: 5}}
   %0 = "stablehlo.convolution"(%arg0, %arg1) {batch_group_count = 1 : i64,
     dimension_numbers = #stablehlo.conv<raw
@@ -827,20 +507,440 @@ func.func @conv2d_generic(%arg0: tensor<1x8x8x32x207xf32>, %arg1: tensor<3x3x32x
 
 // -----
 
-func.func @conv2d(%arg0: tensor<1x8x8x207xf32>, %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
-  // expected-error @+3 {{'stablehlo.convolution' Expected array with 2 elements, got 3 elements instead}}
+func.func @convolution_c15(%arg0 : tensor<100x26x26x32xf32>,
+    %arg1 : tensor<3x3x1x32xf32>) -> tensor<100x28x28x1xf32> {
+  // expected-error@+1 {{expects input dimension-numbers to be unique, got {0, 0, 1, 2}.}}
+  %result = "stablehlo.convolution"(%arg0, %arg1) {
+    batch_group_count = 1 : i64,
+    dimension_numbers = #stablehlo.conv<raw
+      input_batch_dimension = 0,
+      input_feature_dimension = 0,
+      input_spatial_dimensions = [1, 2],
+      kernel_input_feature_dimension = 3,
+      kernel_output_feature_dimension = 2,
+      kernel_spatial_dimensions = [0, 1],
+      output_batch_dimension = 0,
+      output_feature_dimension = 3,
+      output_spatial_dimensions = [1, 2]
+    >,
+    feature_group_count = 1 : i64,
+    lhs_dilation = dense<1> : tensor<2xi64>,
+    padding = dense<2> : tensor<2x2xi64>,
+    rhs_dilation = dense<1> : tensor<2xi64>,
+    window_strides = dense<1> : tensor<2xi64>
+  } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>) ->
+    tensor<100x28x28x1xf32>
+  func.return %result : tensor<100x28x28x1xf32>
+}
+
+// -----
+
+func.func @convolution_c15(%arg0 : tensor<100x26x26x32xf32>,
+    %arg1 : tensor<3x3x1x32xf32>) -> tensor<100x28x28x1xf32> {
+  // expected-error@+1 {{expects input, kernel, and output dimension-numbers to be in-range [0, 4).}}
+  %result = "stablehlo.convolution"(%arg0, %arg1) {
+    batch_group_count = 1 : i64,
+    dimension_numbers = #stablehlo.conv<raw
+      input_batch_dimension = -1,
+      input_feature_dimension = 3,
+      input_spatial_dimensions = [1, 2],
+      kernel_input_feature_dimension = 3,
+      kernel_output_feature_dimension = 2,
+      kernel_spatial_dimensions = [0, 1],
+      output_batch_dimension = 0,
+      output_feature_dimension = 3,
+      output_spatial_dimensions = [1, 2]
+    >,
+    feature_group_count = 1 : i64,
+    lhs_dilation = dense<1> : tensor<2xi64>,
+    padding = dense<2> : tensor<2x2xi64>,
+    rhs_dilation = dense<1> : tensor<2xi64>,
+    window_strides = dense<1> : tensor<2xi64>
+  } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>) ->
+    tensor<100x28x28x1xf32>
+  func.return %result : tensor<100x28x28x1xf32>
+}
+
+// -----
+
+func.func @convolution_c15(%arg0 : tensor<100x26x26x32xf32>,
+    %arg1 : tensor<3x3x1x32xf32>) -> tensor<100x28x28x1xf32> {
+  // expected-error@+1 {{expects input, kernel, and output dimension-numbers to be in-range [0, 4).}}
+  %result = "stablehlo.convolution"(%arg0, %arg1) {
+    batch_group_count = 1 : i64,
+    dimension_numbers = #stablehlo.conv<raw
+      input_batch_dimension = 4,
+      input_feature_dimension = 3,
+      input_spatial_dimensions = [1, 2],
+      kernel_input_feature_dimension = 3,
+      kernel_output_feature_dimension = 2,
+      kernel_spatial_dimensions = [0, 1],
+      output_batch_dimension = 0,
+      output_feature_dimension = 3,
+      output_spatial_dimensions = [1, 2]
+    >,
+    feature_group_count = 1 : i64,
+    lhs_dilation = dense<1> : tensor<2xi64>,
+    padding = dense<2> : tensor<2x2xi64>,
+    rhs_dilation = dense<1> : tensor<2xi64>,
+    window_strides = dense<1> : tensor<2xi64>
+  } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>) ->
+    tensor<100x28x28x1xf32>
+  func.return %result : tensor<100x28x28x1xf32>
+}
+
+// -----
+
+func.func @convolution_c16(%arg0: tensor<1x8x8x207xf32>,
+    %arg1: tensor<3x3x20x16xf32>) -> tensor<1x8x8x16xf32> {
+  // expected-error@+1 {{expects input feature dimension (207) / feature_group_count = kernel input feature dimension (20). Got feature_group_count = 1.}}
   %0 = stablehlo.convolution(%arg0, %arg1)
          dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-         window = {stride = [1, 1], pad = [[1, 1, 1], [1, 1, 1]], lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
-         {batch_group_count = 1 : i64, feature_group_count = 1 : i64, precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]} :
+         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
+           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
+         {
+           batch_group_count = 1 : i64,
+           feature_group_count = 1 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+         } :
+       (tensor<1x8x8x207xf32>, tensor<3x3x20x16xf32>) -> tensor<1x8x8x16xf32>
+  func.return %0 : tensor<1x8x8x16xf32>
+}
+
+// -----
+
+func.func @convolution_c17(%arg0: tensor<3x8x8x207xf32>,
+    %arg1: tensor<3x3x207x16xf32>) -> tensor<3x8x8x16xf32> {
+  // expected-error@+1 {{expects output feature dimension size (16) to be a multiple of batch_group_count. Got batch_group_count = 3.}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
+           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
+         {
+           batch_group_count = 3 : i64,
+           feature_group_count = 1 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+         } :
+       (tensor<3x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<3x8x8x16xf32>
+  func.return %0 : tensor<3x8x8x16xf32>
+}
+
+// -----
+
+func.func @convolution_c18(%arg0: tensor<1x8x8x207xf32>,
+    %arg1: tensor<3x3x69x16xf32>) -> tensor<1x8x8x16xf32> {
+  // expected-error@+1 {{expects kernel output feature dimension (16) to be divisible by feature_group_count. For feature_group_count = 3.}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
+           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
+         {
+           batch_group_count = 1 : i64,
+           feature_group_count = 3 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+         } :
+       (tensor<1x8x8x207xf32>, tensor<3x3x69x16xf32>) -> tensor<1x8x8x16xf32>
+  func.return %0 : tensor<1x8x8x16xf32>
+}
+
+// -----
+
+func.func @convolution_c19(%arg0: tensor<1x8x8x207xf32>,
+    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
+  // expected-error@+1 {{expects the same size for input, kernel and output spatial-dimensions, but got 2, 3, and 2 resp.}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, 0, 1, f]x[0, 1, 2, i, o]->[b, 0, 1, f],
+         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
+           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
+         {
+           batch_group_count = 1 : i64,
+           feature_group_count = 1 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+         } :
        (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
   func.return %0 : tensor<1x8x8x16xf32>
 }
 
 // -----
 
+func.func @convolution_c20(%arg0 : tensor<100x26x26x32xf32>,
+    %arg1 : tensor<3x3x1x32xf32>) -> tensor<100x28x28x1xf32> {
+  // expected-error@+1 {{expects kernel dimension-numbers to be unique, got {3, 2, 0, 0}.}}
+  %result = "stablehlo.convolution"(%arg0, %arg1) {
+    batch_group_count = 1 : i64,
+    dimension_numbers = #stablehlo.conv<raw
+      input_batch_dimension = 0,
+      input_feature_dimension = 3,
+      input_spatial_dimensions = [1, 2],
+      kernel_input_feature_dimension = 3,
+      kernel_output_feature_dimension = 2,
+      kernel_spatial_dimensions = [0, 0],
+      output_batch_dimension = 0,
+      output_feature_dimension = 3,
+      output_spatial_dimensions = [1, 2]
+    >,
+    feature_group_count = 1 : i64,
+    lhs_dilation = dense<1> : tensor<2xi64>,
+    padding = dense<2> : tensor<2x2xi64>,
+    rhs_dilation = dense<1> : tensor<2xi64>,
+    window_strides = dense<1> : tensor<2xi64>
+  } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>) ->
+    tensor<100x28x28x1xf32>
+  func.return %result : tensor<100x28x28x1xf32>
+}
+
+// -----
+
+func.func @convolution_c20(%arg0 : tensor<100x26x26x32xf32>,
+    %arg1 : tensor<3x3x1x32xf32>) -> tensor<100x28x28x1xf32> {
+  // expected-error@+1 {{expects input, kernel, and output dimension-numbers to be in-range [0, 4).}}
+  %result = "stablehlo.convolution"(%arg0, %arg1) {
+    batch_group_count = 1 : i64,
+    dimension_numbers = #stablehlo.conv<raw
+      input_batch_dimension = 0,
+      input_feature_dimension = 3,
+      input_spatial_dimensions = [1, 2],
+      kernel_input_feature_dimension = -1,
+      kernel_output_feature_dimension = 2,
+      kernel_spatial_dimensions = [0, 1],
+      output_batch_dimension = 0,
+      output_feature_dimension = 3,
+      output_spatial_dimensions = [1, 2]
+    >,
+    feature_group_count = 1 : i64,
+    lhs_dilation = dense<1> : tensor<2xi64>,
+    padding = dense<2> : tensor<2x2xi64>,
+    rhs_dilation = dense<1> : tensor<2xi64>,
+    window_strides = dense<1> : tensor<2xi64>
+  } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>) ->
+    tensor<100x28x28x1xf32>
+  func.return %result : tensor<100x28x28x1xf32>
+}
+
+// -----
+
+func.func @convolution_c20(%arg0 : tensor<100x26x26x32xf32>,
+    %arg1 : tensor<3x3x1x32xf32>) -> tensor<100x28x28x1xf32> {
+  // expected-error@+1 {{expects input, kernel, and output dimension-numbers to be in-range [0, 4).}}
+  %result = "stablehlo.convolution"(%arg0, %arg1) {
+    batch_group_count = 1 : i64,
+    dimension_numbers = #stablehlo.conv<raw
+      input_batch_dimension = 0,
+      input_feature_dimension = 3,
+      input_spatial_dimensions = [1, 2],
+      kernel_input_feature_dimension = 4,
+      kernel_output_feature_dimension = 2,
+      kernel_spatial_dimensions = [0, 1],
+      output_batch_dimension = 0,
+      output_feature_dimension = 3,
+      output_spatial_dimensions = [1, 2]
+    >,
+    feature_group_count = 1 : i64,
+    lhs_dilation = dense<1> : tensor<2xi64>,
+    padding = dense<2> : tensor<2x2xi64>,
+    rhs_dilation = dense<1> : tensor<2xi64>,
+    window_strides = dense<1> : tensor<2xi64>
+  } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>) ->
+    tensor<100x28x28x1xf32>
+  func.return %result : tensor<100x28x28x1xf32>
+}
+
+// -----
+
+func.func @convolution_c21(%arg0: tensor<1x8x8x207xf32>,
+    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
+  // expected-error@+1 {{expects the same size for input, kernel and output spatial-dimensions, but got 2, 2, and 3 resp.}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, 2, f],
+         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
+           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
+         {
+           batch_group_count = 1 : i64,
+           feature_group_count = 1 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+         } :
+       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
+  func.return %0 : tensor<1x8x8x16xf32>
+}
+
+// -----
+
+func.func @convolution_c22(%arg0 : tensor<100x26x26x32xf32>,
+    %arg1 : tensor<3x3x1x32xf32>) -> tensor<100x28x28x1xf32> {
+  // expected-error@+1 {{expects output dimension-numbers to be unique, got {0, 3, 0, 3}.}}
+  %result = "stablehlo.convolution"(%arg0, %arg1) {
+    batch_group_count = 1 : i64,
+    dimension_numbers = #stablehlo.conv<raw
+      input_batch_dimension = 0,
+      input_feature_dimension = 3,
+      input_spatial_dimensions = [1, 2],
+      kernel_input_feature_dimension = 3,
+      kernel_output_feature_dimension = 2,
+      kernel_spatial_dimensions = [0, 1],
+      output_batch_dimension = 0,
+      output_feature_dimension = 3,
+      output_spatial_dimensions = [0, 3]
+    >,
+    feature_group_count = 1 : i64,
+    lhs_dilation = dense<1> : tensor<2xi64>,
+    padding = dense<2> : tensor<2x2xi64>,
+    rhs_dilation = dense<1> : tensor<2xi64>,
+    window_strides = dense<1> : tensor<2xi64>
+  } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>) ->
+    tensor<100x28x28x1xf32>
+  func.return %result : tensor<100x28x28x1xf32>
+}
+
+// -----
+
+func.func @convolution_c22(%arg0 : tensor<100x26x26x32xf32>,
+    %arg1 : tensor<3x3x1x32xf32>) -> tensor<100x28x28x1xf32> {
+  // expected-error@+1 {{expects input, kernel, and output dimension-numbers to be in-range [0, 4).}}
+  %result = "stablehlo.convolution"(%arg0, %arg1) {
+    batch_group_count = 1 : i64,
+    dimension_numbers = #stablehlo.conv<raw
+      input_batch_dimension = 0,
+      input_feature_dimension = 3,
+      input_spatial_dimensions = [1, 2],
+      kernel_input_feature_dimension = 3,
+      kernel_output_feature_dimension = 2,
+      kernel_spatial_dimensions = [0, 1],
+      output_batch_dimension = -1,
+      output_feature_dimension = 3,
+      output_spatial_dimensions = [1, 2]
+    >,
+    feature_group_count = 1 : i64,
+    lhs_dilation = dense<1> : tensor<2xi64>,
+    padding = dense<2> : tensor<2x2xi64>,
+    rhs_dilation = dense<1> : tensor<2xi64>,
+    window_strides = dense<1> : tensor<2xi64>
+  } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>) ->
+    tensor<100x28x28x1xf32>
+  func.return %result : tensor<100x28x28x1xf32>
+}
+
+// -----
+
+func.func @convolution_c22(%arg0 : tensor<100x26x26x32xf32>,
+    %arg1 : tensor<3x3x1x32xf32>) -> tensor<100x28x28x1xf32> {
+  // expected-error@+1 {{expects input, kernel, and output dimension-numbers to be in-range [0, 4).}}
+  %result = "stablehlo.convolution"(%arg0, %arg1) {
+    batch_group_count = 1 : i64,
+    dimension_numbers = #stablehlo.conv<raw
+      input_batch_dimension = 0,
+      input_feature_dimension = 3,
+      input_spatial_dimensions = [1, 2],
+      kernel_input_feature_dimension = 3,
+      kernel_output_feature_dimension = 2,
+      kernel_spatial_dimensions = [0, 1],
+      output_batch_dimension = 4,
+      output_feature_dimension = 3,
+      output_spatial_dimensions = [1, 2]
+    >,
+    feature_group_count = 1 : i64,
+    lhs_dilation = dense<1> : tensor<2xi64>,
+    padding = dense<2> : tensor<2x2xi64>,
+    rhs_dilation = dense<1> : tensor<2xi64>,
+    window_strides = dense<1> : tensor<2xi64>
+  } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>) ->
+    tensor<100x28x28x1xf32>
+  func.return %result : tensor<100x28x28x1xf32>
+}
+
+// -----
+
+func.func @convolution_c23(%arg0: tensor<1x8x8x207xf32>,
+    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
+  // expected-error@+1 {{expects feature_group_count to be a positive number, got 0.}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
+           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
+         {
+           batch_group_count = 1 : i64,
+           feature_group_count = 0 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+         } :
+       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
+  func.return %0 : tensor<1x8x8x16xf32>
+}
+
+// -----
+
+func.func @convolution_c24(%arg0: tensor<1x8x8x207xf32>,
+    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
+  // expected-error@+1 {{expects batch_group_count to be a positive number, got 0.}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
+           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
+         {
+           batch_group_count = 0 : i64,
+           feature_group_count = 1 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+         } :
+       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
+  func.return %0 : tensor<1x8x8x16xf32>
+}
+
+// -----
+
+func.func @convolution_c25(%arg0: tensor<1x8x8x207xf32>,
+    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
+  // expected-error@+1 {{expects batch_group_count and feature_group_count not to be both greater than 1. Got 2 and 2 resp.}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
+           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
+         {
+           batch_group_count = 2 : i64,
+           feature_group_count = 2 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+         } :
+       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
+  func.return %0 : tensor<1x8x8x16xf32>
+}
+
+// -----
+
+func.func @convolution_c26(%arg0: tensor<3x2xf16>,
+    %arg1: tensor<2x2xf16>) -> tuple<tensor<3x2xf16>> {
+  // expected-error@+1{{expects precision config to be empty or have <= 2 elements}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, f]x[i, o]->[b, f],
+         window = {stride = [], pad = [], lhs_dilate = [], rhs_dilate = [],
+           reverse = []}
+         {
+           batch_group_count = 1 : i64,
+           feature_group_count = 1 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+         }
+       : (tensor<3x2xf16>, tensor<2x2xf16>) -> tensor<3x2xf16>
+  %1 = "stablehlo.tuple"(%0) : (tensor<3x2xf16>) -> tuple<tensor<3x2xf16>>
+  func.return %1 : tuple<tensor<3x2xf16>>
+}
+
+// -----
+
+func.func @invalid_conv_window_attributes(%arg0: tensor<1x8x8x207xf32>,
+    %arg1: tensor<0x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
+  // expected-error@+1 {{expects window to have positive value for 0-th window dimension, but got 0.}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+         window = {stride = [1, 1], pad = [[1, 1], [1,1]],
+           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
+         {
+           batch_group_count = 1 : i64,
+           feature_group_count = 1 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]} :
+       (tensor<1x8x8x207xf32>, tensor<0x3x207x16xf32>) -> tensor<1x8x8x16xf32>
+  func.return %0 : tensor<1x8x8x16xf32>
+}
+
+// -----
+
 // CHECK: module
-// CHECK-SAME: stablehlo.conv = #stablehlo.conv<[b, 0, 1, f]x[0, 1, i, o]->[b, 1, 0, f]>
+// CHECK: stablehlo.conv = #stablehlo.conv<[b, 0, 1, f]x[0, 1, i, o]->[b, 1, 0, f]>
 module attributes { stablehlo.conv = #stablehlo.conv<raw
       input_batch_dimension = 0,
       input_feature_dimension = 3,
@@ -922,58 +1022,3 @@ module attributes {
   // expected-error@+1{{Unexpected dimension -2}}
   stablehlo.conv = #stablehlo.conv<[b, f, 1, -2]x[o, 0, 1, i]->[f, b, 0, 1]>
 } {}
-
-// -----
-
-func.func @convolution(%arg0: tensor<2x2x3x4xf32>, %arg1: tensor<3x5x5x3xf32>) -> tensor<3x5x5x4xf32> {
-  // expected-error@+3{{Unexpected keyword stide}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-     dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-     window = {stide = [2, 1], pad = [[0, 1], [0, 1]], rhs_dilate = [1, 2]}
-     { batch_group_count = 1 : i64, feature_group_count = 1 : i64}
-  : (tensor<2x2x3x4xf32>, tensor<3x5x5x3xf32>) -> tensor<3x5x5x4xf32>
-  func.return %0 : tensor<3x5x5x4xf32>
-}
-
-// -----
-
-func.func @convolution(%arg0: tensor<2x2x3x4xf32>, %arg1: tensor<3x5x5x3xf32>) -> tensor<3x5x5x4xf32> {
-  // expected-error@+3{{expected integer value}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-     dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-     window = {stride = [2, b], pad = [[0, 1], [0, 1]], rhs_dilate = [1, 2]}
-     { batch_group_count = 1 : i64, feature_group_count = 1 : i64}
-  : (tensor<2x2x3x4xf32>, tensor<3x5x5x3xf32>) -> tensor<3x5x5x4xf32>
-  func.return %0 : tensor<3x5x5x4xf32>
-}
-
-// -----
-
-func.func @convolution(%arg0: tensor<2x2x3x4xf32>, %arg1: tensor<3x5x5x3xf32>) -> tensor<3x5x5x4xf32> {
-  // expected-error@+3{{Unexpected keyword stride}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-     dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-     window = {stride = [2, 1], pad = [[0, 1], [0, 1]], rhs_dilate = [1, 2], stride=[2,1]}
-     { batch_group_count = 1 : i64, feature_group_count = 1 : i64}
-  : (tensor<2x2x3x4xf32>, tensor<3x5x5x3xf32>) -> tensor<3x5x5x4xf32>
-  func.return %0 : tensor<3x5x5x4xf32>
-}
-
-// -----
-
-func.func @conv_invalid_precision_config(%arg0: tensor<3x2xf16>,
-    %arg1: tensor<2x2xf16>) -> tuple<tensor<3x2xf16>> {
-  // expected-error@+1{{expects precision config to be empty or have <= 2 elements}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, f]x[i, o]->[b, f],
-         window = {stride = [], pad = [], lhs_dilate = [], rhs_dilate = [],
-           reverse = []}
-         {
-           batch_group_count = 1 : i64,
-           feature_group_count = 1 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-         }
-       : (tensor<3x2xf16>, tensor<2x2xf16>) -> tensor<3x2xf16>
-  %1 = "stablehlo.tuple"(%0) : (tensor<3x2xf16>) -> tuple<tensor<3x2xf16>>
-  func.return %1 : tuple<tensor<3x2xf16>>
-}

--- a/stablehlo/tests/verify_convolution.mlir
+++ b/stablehlo/tests/verify_convolution.mlir
@@ -1,28 +1,5 @@
 // RUN: stablehlo-opt %s -verify-diagnostics -split-input-file | FileCheck %s
 
-// CHECK: func @conv_empty_spatial_dimensions
-// CHECK: stablehlo.convolution
-// CHECK-SAME: dim_numbers = [b, f]x[i, o]->[b, f]
-// CHECK-SAME: window = {stride = [], pad = [], lhs_dilate = [],
-// CHECK-SAME: rhs_dilate = [], reverse = []}
-func.func @conv_empty_spatial_dimensions(%arg0: tensor<3x2xf16>,
-    %arg1: tensor<2x2xf16>) -> tuple<tensor<3x2xf16>> {
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, f]x[i, o]->[b, f],
-         window = {stride = [], pad = [], lhs_dilate = [], rhs_dilate = [],
-           reverse = []}
-         {
-           batch_group_count = 1 : i64,
-           feature_group_count = 1 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-         }
-       : (tensor<3x2xf16>, tensor<2x2xf16>) -> tensor<3x2xf16>
-  %1 = "stablehlo.tuple"(%0) : (tensor<3x2xf16>) -> tuple<tensor<3x2xf16>>
-  func.return %1 : tuple<tensor<3x2xf16>>
-}
-
-// -----
-
 // CHECK-LABEL: func @convolution
 func.func @convolution(%arg0 : tensor<100x26x26x32xf32>, %arg1 : tensor<3x3x1x32xf32>) ->
     tensor<100x28x28x1xf32> {
@@ -47,6 +24,29 @@ func.func @convolution(%arg0 : tensor<100x26x26x32xf32>, %arg1 : tensor<3x3x1x32
   } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>) ->
     tensor<100x28x28x1xf32>
   func.return %result : tensor<100x28x28x1xf32>
+}
+
+// -----
+
+// CHECK: func @convolution_empty_spatial_dimensions
+// CHECK: stablehlo.convolution
+// CHECK-SAME: dim_numbers = [b, f]x[i, o]->[b, f]
+// CHECK-SAME: window = {stride = [], pad = [], lhs_dilate = [],
+// CHECK-SAME: rhs_dilate = [], reverse = []}
+func.func @convolution_empty_spatial_dimensions(%arg0: tensor<3x2xf16>,
+    %arg1: tensor<2x2xf16>) -> tuple<tensor<3x2xf16>> {
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, f]x[i, o]->[b, f],
+         window = {stride = [], pad = [], lhs_dilate = [], rhs_dilate = [],
+           reverse = []}
+         {
+           batch_group_count = 1 : i64,
+           feature_group_count = 1 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+         }
+       : (tensor<3x2xf16>, tensor<2x2xf16>) -> tensor<3x2xf16>
+  %1 = "stablehlo.tuple"(%0) : (tensor<3x2xf16>) -> tuple<tensor<3x2xf16>>
+  func.return %1 : tuple<tensor<3x2xf16>>
 }
 
 // -----
@@ -110,6 +110,725 @@ func.func @convolution(%arg0: tensor<2x2x3x4xf32>, %arg1: tensor<3x5x5x3xf32>) -
      { batch_group_count = 1 : i64, feature_group_count = 1 : i64}
   : (tensor<2x2x3x4xf32>, tensor<3x5x5x3xf32>) -> tensor<3x5x5x4xf32>
   func.return %0 : tensor<3x5x5x4xf32>
+}
+
+// -----
+
+func.func @convolution_c1(%arg0: tensor<1x8x8x207xf32>,
+    %arg1: tensor<3x3x207xf32>) -> tensor<1x8x8x16xf32> {
+  // expected-error@+1 {{expects convolution arguments to have same number of dimensions. Got: 'tensor<1x8x8x207xf32>' and 'tensor<3x3x207xf32>'.}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
+           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
+         {
+           batch_group_count = 1 : i64,
+           feature_group_count = 1 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+         } :
+       (tensor<1x8x8x207xf32>, tensor<3x3x207xf32>) -> tensor<1x8x8x16xf32>
+  func.return %0 : tensor<1x8x8x16xf32>
+}
+
+// -----
+
+func.func @convolution_c2(%arg0: tensor<1x4x4x1xi64>,
+    %arg1: tensor<3x3x1x1xi32>) -> tensor<1x2x2x1xi64> {
+  // expected-error@+1 {{expects lhs and rhs to have compatible element type. Got: 'i64' and 'i32'}}
+    %0 = "stablehlo.convolution"(%arg0, %arg1) {
+    window_strides = dense<4> : tensor<2xi64>,
+    padding = dense<0> : tensor<2x2xi64>,
+    lhs_dilation = dense<2> : tensor<2xi64>,
+    rhs_dilation = dense<1> : tensor<2xi64>,
+    window_reversal = dense<false> : tensor<2xi1>,
+    dimension_numbers = #stablehlo.conv<[b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f]>,
+    feature_group_count = 1 : i64,
+    batch_group_count = 1 : i64,
+    precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+  } : (tensor<1x4x4x1xi64>, tensor<3x3x1x1xi32>) -> tensor<1x2x2x1xi64>
+  func.return %0 : tensor<1x2x2x1xi64>
+}
+
+// -----
+
+func.func @convolution_c3(%arg0: tensor<1x8x8x207xf32>,
+    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
+  // expected-error@+1 {{expects window-strides to have same dimension-size as size of window dimensions (2), but got: 1.}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+         window = {stride = [1], pad = [[1, 1], [1, 1]],
+           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
+         {
+           batch_group_count = 1 : i64,
+           feature_group_count = 1 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+         } :
+       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
+  func.return %0 : tensor<1x8x8x16xf32>
+}
+
+// -----
+
+func.func @convolution_c4(%arg0: tensor<1x8x8x207xf32>,
+    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
+  // expected-error@+1 {{expects window to have positive stride for 1-th window dimension, but got 0.}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+         window = {stride = [1, 0], pad = [[1, 1], [1,1]],
+           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
+         {
+           batch_group_count = 1 : i64,
+           feature_group_count = 1 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]} :
+       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
+  func.return %0 : tensor<1x8x8x16xf32>
+}
+
+// -----
+
+func.func @convolution_c5(%arg0 : tensor<100x26x26x32xf32>, %arg1 : tensor<3x3x1x32xf32>) ->
+    tensor<100x28x28x1xf32> {
+  // expected-error@+1 {{expects padding-entries to have same dimension-size as size of window dimensions (2), but got: 3.}}
+  %result = "stablehlo.convolution"(%arg0, %arg1) {
+    batch_group_count = 1 : i64,
+    dimension_numbers = #stablehlo.conv<raw
+      input_batch_dimension = 0,
+      input_feature_dimension = 3,
+      input_spatial_dimensions = [1, 2],
+      kernel_input_feature_dimension = 3,
+      kernel_output_feature_dimension = 2,
+      kernel_spatial_dimensions = [0, 1],
+      output_batch_dimension = 0,
+      output_feature_dimension = 3,
+      output_spatial_dimensions = [1, 2]
+    >,
+    feature_group_count = 1 : i64,
+    lhs_dilation = dense<1> : tensor<2xi64>,
+    padding = dense<2> : tensor<3x2xi64>,
+    rhs_dilation = dense<1> : tensor<2xi64>,
+    window_strides = dense<1> : tensor<2xi64>
+  } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>) ->
+    tensor<100x28x28x1xf32>
+  func.return %result : tensor<100x28x28x1xf32>
+}
+
+// -----
+
+func.func @convolution_c5(%arg0: tensor<1x4x4x1xi64>,
+    %arg1: tensor<3x3x1x1xi64>) -> tensor<1x2x2x1xi64> {
+  // expected-error@+1 {{expects the shape of padding-attribute to be {N, 2}, but got {2, 3}.}}
+  %0 = "stablehlo.convolution"(%arg0, %arg1) {
+    window_strides = dense<4> : tensor<2xi64>,
+    padding = dense<0> : tensor<2x3xi64>,
+    lhs_dilation = dense<2> : tensor<2xi64>,
+    rhs_dilation = dense<1> : tensor<2xi64>,
+    window_reversal = dense<false> : tensor<2xi1>,
+    dimension_numbers = #stablehlo.conv<[b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f]>,
+    feature_group_count = 1 : i64,
+    batch_group_count = 1 : i64,
+    precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+  } : (tensor<1x4x4x1xi64>, tensor<3x3x1x1xi64>) -> tensor<1x2x2x1xi64>
+  func.return %0 : tensor<1x2x2x1xi64>
+}
+
+// -----
+
+func.func @convolution_c5(%arg0: tensor<1x8x8x207xf32>,
+    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+         // expected-error@+1 {{Expected array with 2 elements, got 4 elements instead}}
+         window = {stride = [1, 1], pad = [[1, 1, 1, 1]],
+           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
+         {
+           batch_group_count = 1 : i64,
+           feature_group_count = 1 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+         } :
+       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
+  func.return %0 : tensor<1x8x8x16xf32>
+}
+
+// -----
+
+func.func @convolution_c6(%arg0: tensor<1x8x8x207xf32>,
+    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
+  // expected-error@+1 {{expects base-dilation factors to have same dimension-size as size of window dimensions (2), but got: 1.}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
+           lhs_dilate = [1], rhs_dilate = [1, 1]}
+         {
+           batch_group_count = 1 : i64,
+           feature_group_count = 1 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]} :
+       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
+  func.return %0 : tensor<1x8x8x16xf32>
+}
+
+// -----
+
+func.func @convolution_c7(%arg0: tensor<1x8x8x207xf32>,
+    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
+  // expected-error@+1 {{expects window to have positive base dilation factor for 0-th window dimension, but got 0.}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+         window = {stride = [1, 1], pad = [[1, 1], [1,1]],
+           lhs_dilate = [0, 1], rhs_dilate = [1, 1]}
+         {
+           batch_group_count = 1 : i64,
+           feature_group_count = 1 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+         } :
+       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
+  func.return %0 : tensor<1x8x8x16xf32>
+}
+
+// -----
+
+func.func @convolution_c8(%arg0: tensor<1x8x8x207xf32>,
+    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
+  // expected-error@+1 {{expects window-dilation factors to have same dimension-size as size of window dimensions (2), but got: 1.}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
+           lhs_dilate = [1, 1], rhs_dilate = [1]}
+         {
+           batch_group_count = 1 : i64,
+           feature_group_count = 1 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]} :
+       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
+  func.return %0 : tensor<1x8x8x16xf32>
+}
+
+// -----
+
+func.func @convolution_c9(%arg0: tensor<1x8x8x207xf32>,
+    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
+  // expected-error@+1 {{expects window to have positive window dilation factor for 0-th window dimension, but got 0.}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+         window = {stride = [1, 1], pad = [[1, 1], [1,1]],
+           lhs_dilate = [1, 1], rhs_dilate = [0, 1]}
+         {
+           batch_group_count = 1 : i64,
+           feature_group_count = 1 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+         } :
+       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
+  func.return %0 : tensor<1x8x8x16xf32>
+}
+
+// -----
+
+func.func @convolution_c10(%arg0: tensor<1x8x8x207xf32>,
+    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
+  // expected-error@+1 {{expects window-reversal to have same dimension-size as size of window dimensions (2), but got: 1.}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
+           lhs_dilate = [1, 1], rhs_dilate = [1, 1], reverse = [false]}
+         {
+           batch_group_count = 1 : i64,
+           feature_group_count = 1 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]} :
+       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
+  func.return %0 : tensor<1x8x8x16xf32>
+}
+
+// -----
+
+func.func @convolution_c11(%arg0: tensor<5x8x8x207xf32>,
+    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
+  // expected-error@+1 {{expects input batch dimension (5) to be divisible by batch_group_count. Got batch_group_count = 2.}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
+           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
+         {
+           batch_group_count = 2 : i64,
+           feature_group_count = 1 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+         } :
+       (tensor<5x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
+  func.return %0 : tensor<1x8x8x16xf32>
+}
+
+// -----
+
+func.func @convolution_c12(%arg0: tensor<1x8x8x207xf32>,
+    %arg1: tensor<3x3x20x16xf32>) -> tensor<1x8x8x16xf32> {
+  // expected-error@+1 {{expects input feature dimension (207) to be a multiple of feature_group_count. Got feature_group_count = 2.}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
+           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
+         {
+           batch_group_count = 1 : i64,
+           feature_group_count = 2 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+         } :
+       (tensor<1x8x8x207xf32>, tensor<3x3x20x16xf32>) -> tensor<1x8x8x16xf32>
+  func.return %0 : tensor<1x8x8x16xf32>
+}
+
+// -----
+
+// This is an positive test in MLIR-HLO:
+// https://github.com/tensorflow/mlir-hlo/blob/master/tests/Dialect/mhlo/ops.mlir#L3829
+// but negative here: stablehlo.convolution does no support unknown dimenstion
+// dim_numbers = [b, 0, 1, ?, f]x[0, 1, ?, i, o]->[?, b, 0, 1, f]
+// window = {stride = [1, 1], pad = [[1, 1], [1, 1]], lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
+func.func @convolution_c13(%arg0: tensor<1x8x8x32x207xf32>, %arg1: tensor<3x3x32x207x16xf32>) -> tensor<32x1x8x8x16xf32> {
+  // expected-error@+1{{expects convolution arguments to have 4 dimensions. Got: 5}}
+  %0 = "stablehlo.convolution"(%arg0, %arg1) {batch_group_count = 1 : i64,
+    dimension_numbers = #stablehlo.conv<raw
+      input_batch_dimension = 0,
+      input_feature_dimension = 4,
+      input_spatial_dimensions = [1, 2],
+      kernel_input_feature_dimension = 3,
+      kernel_output_feature_dimension = 4,
+      kernel_spatial_dimensions = [0, 1],
+      output_batch_dimension = 1,
+      output_feature_dimension = 4,
+      output_spatial_dimensions = [2, 3]
+    >, feature_group_count = 1 : i64, lhs_dilation = dense<1> : tensor<2xi64>, padding = dense<1> : tensor<2x2xi64>, precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>], rhs_dilation = dense<1> : tensor<2xi64>, window_strides = dense<1> : tensor<2xi64>} :
+       (tensor<1x8x8x32x207xf32>, tensor<3x3x32x207x16xf32>) -> tensor<32x1x8x8x16xf32>
+  func.return %0 : tensor<32x1x8x8x16xf32>
+}
+
+// -----
+
+func.func @convolution_c14(%arg0: tensor<1xf32>, %arg1: tensor<3xf32>)
+    -> tensor<1x8x8x16xf32> {
+  // expected-error@+1 {{expects convolution arguments to have >= 2 dimensions. Got: 'tensor<1xf32>' and 'tensor<3xf32>'.}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
+           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
+         {
+           batch_group_count = 1 : i64,
+           feature_group_count = 1 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+         } :
+       (tensor<1xf32>, tensor<3xf32>) -> tensor<1x8x8x16xf32>
+  func.return %0 : tensor<1x8x8x16xf32>
+}
+
+
+// -----
+
+func.func @convolution_c14(%arg0 : tensor<100x26x26x32xf32>,
+    %arg1 : tensor<3x3x1x32xf32>) -> tensor<100x28x28x1xf32> {
+  // expected-error@+1 {{expects input dimension-numbers to be unique, got {0, 0, 1, 2}.}}
+  %result = "stablehlo.convolution"(%arg0, %arg1) {
+    batch_group_count = 1 : i64,
+    dimension_numbers = #stablehlo.conv<raw
+      input_batch_dimension = 0,
+      input_feature_dimension = 0,
+      input_spatial_dimensions = [1, 2],
+      kernel_input_feature_dimension = 3,
+      kernel_output_feature_dimension = 2,
+      kernel_spatial_dimensions = [0, 1],
+      output_batch_dimension = 0,
+      output_feature_dimension = 3,
+      output_spatial_dimensions = [1, 2]
+    >,
+    feature_group_count = 1 : i64,
+    lhs_dilation = dense<1> : tensor<2xi64>,
+    padding = dense<2> : tensor<2x2xi64>,
+    rhs_dilation = dense<1> : tensor<2xi64>,
+    window_strides = dense<1> : tensor<2xi64>
+  } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>) ->
+    tensor<100x28x28x1xf32>
+  func.return %result : tensor<100x28x28x1xf32>
+}
+
+// -----
+
+func.func @convolution_c14(%arg0 : tensor<100x26x26x32xf32>,
+    %arg1 : tensor<3x3x1x32xf32>) -> tensor<100x28x28x1xf32> {
+  // expected-error@+1 {{expects input, kernel, and output dimension-numbers to be in-range [0, 4).}}
+  %result = "stablehlo.convolution"(%arg0, %arg1) {
+    batch_group_count = 1 : i64,
+    dimension_numbers = #stablehlo.conv<raw
+      input_batch_dimension = -1,
+      input_feature_dimension = 3,
+      input_spatial_dimensions = [1, 2],
+      kernel_input_feature_dimension = 3,
+      kernel_output_feature_dimension = 2,
+      kernel_spatial_dimensions = [0, 1],
+      output_batch_dimension = 0,
+      output_feature_dimension = 3,
+      output_spatial_dimensions = [1, 2]
+    >,
+    feature_group_count = 1 : i64,
+    lhs_dilation = dense<1> : tensor<2xi64>,
+    padding = dense<2> : tensor<2x2xi64>,
+    rhs_dilation = dense<1> : tensor<2xi64>,
+    window_strides = dense<1> : tensor<2xi64>
+  } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>) ->
+    tensor<100x28x28x1xf32>
+  func.return %result : tensor<100x28x28x1xf32>
+}
+
+// -----
+
+func.func @convolution_c14(%arg0 : tensor<100x26x26x32xf32>,
+    %arg1 : tensor<3x3x1x32xf32>) -> tensor<100x28x28x1xf32> {
+  // expected-error@+1 {{expects input, kernel, and output dimension-numbers to be in-range [0, 4).}}
+  %result = "stablehlo.convolution"(%arg0, %arg1) {
+    batch_group_count = 1 : i64,
+    dimension_numbers = #stablehlo.conv<raw
+      input_batch_dimension = 4,
+      input_feature_dimension = 3,
+      input_spatial_dimensions = [1, 2],
+      kernel_input_feature_dimension = 3,
+      kernel_output_feature_dimension = 2,
+      kernel_spatial_dimensions = [0, 1],
+      output_batch_dimension = 0,
+      output_feature_dimension = 3,
+      output_spatial_dimensions = [1, 2]
+    >,
+    feature_group_count = 1 : i64,
+    lhs_dilation = dense<1> : tensor<2xi64>,
+    padding = dense<2> : tensor<2x2xi64>,
+    rhs_dilation = dense<1> : tensor<2xi64>,
+    window_strides = dense<1> : tensor<2xi64>
+  } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>) ->
+    tensor<100x28x28x1xf32>
+  func.return %result : tensor<100x28x28x1xf32>
+}
+
+// -----
+
+func.func @convolution_c15(%arg0: tensor<1x8x8x207xf32>,
+    %arg1: tensor<3x3x20x16xf32>) -> tensor<1x8x8x16xf32> {
+  // expected-error@+1 {{expects input feature dimension (207) / feature_group_count = kernel input feature dimension (20). Got feature_group_count = 1.}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
+           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
+         {
+           batch_group_count = 1 : i64,
+           feature_group_count = 1 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+         } :
+       (tensor<1x8x8x207xf32>, tensor<3x3x20x16xf32>) -> tensor<1x8x8x16xf32>
+  func.return %0 : tensor<1x8x8x16xf32>
+}
+
+// -----
+
+func.func @convolution_c16(%arg0: tensor<3x8x8x207xf32>,
+    %arg1: tensor<3x3x207x16xf32>) -> tensor<3x8x8x16xf32> {
+  // expected-error@+1 {{expects output feature dimension size (16) to be a multiple of batch_group_count. Got batch_group_count = 3.}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
+           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
+         {
+           batch_group_count = 3 : i64,
+           feature_group_count = 1 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+         } :
+       (tensor<3x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<3x8x8x16xf32>
+  func.return %0 : tensor<3x8x8x16xf32>
+}
+
+// -----
+
+func.func @convolution_c17(%arg0: tensor<1x8x8x207xf32>,
+    %arg1: tensor<3x3x69x16xf32>) -> tensor<1x8x8x16xf32> {
+  // expected-error@+1 {{expects kernel output feature dimension (16) to be divisible by feature_group_count. For feature_group_count = 3.}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
+           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
+         {
+           batch_group_count = 1 : i64,
+           feature_group_count = 3 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+         } :
+       (tensor<1x8x8x207xf32>, tensor<3x3x69x16xf32>) -> tensor<1x8x8x16xf32>
+  func.return %0 : tensor<1x8x8x16xf32>
+}
+
+// -----
+
+func.func @convolution_c18(%arg0: tensor<1x8x8x207xf32>,
+    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
+  // expected-error@+1 {{expects the same size for input, kernel and output spatial-dimensions, but got 2, 3, and 2 resp.}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, 0, 1, f]x[0, 1, 2, i, o]->[b, 0, 1, f],
+         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
+           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
+         {
+           batch_group_count = 1 : i64,
+           feature_group_count = 1 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+         } :
+       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
+  func.return %0 : tensor<1x8x8x16xf32>
+}
+
+// -----
+
+func.func @convolution_c19(%arg0 : tensor<100x26x26x32xf32>,
+    %arg1 : tensor<3x3x1x32xf32>) -> tensor<100x28x28x1xf32> {
+  // expected-error@+1 {{expects kernel dimension-numbers to be unique, got {3, 2, 0, 0}.}}
+  %result = "stablehlo.convolution"(%arg0, %arg1) {
+    batch_group_count = 1 : i64,
+    dimension_numbers = #stablehlo.conv<raw
+      input_batch_dimension = 0,
+      input_feature_dimension = 3,
+      input_spatial_dimensions = [1, 2],
+      kernel_input_feature_dimension = 3,
+      kernel_output_feature_dimension = 2,
+      kernel_spatial_dimensions = [0, 0],
+      output_batch_dimension = 0,
+      output_feature_dimension = 3,
+      output_spatial_dimensions = [1, 2]
+    >,
+    feature_group_count = 1 : i64,
+    lhs_dilation = dense<1> : tensor<2xi64>,
+    padding = dense<2> : tensor<2x2xi64>,
+    rhs_dilation = dense<1> : tensor<2xi64>,
+    window_strides = dense<1> : tensor<2xi64>
+  } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>) ->
+    tensor<100x28x28x1xf32>
+  func.return %result : tensor<100x28x28x1xf32>
+}
+
+// -----
+
+func.func @convolution_c19(%arg0 : tensor<100x26x26x32xf32>,
+    %arg1 : tensor<3x3x1x32xf32>) -> tensor<100x28x28x1xf32> {
+  // expected-error@+1 {{expects input, kernel, and output dimension-numbers to be in-range [0, 4).}}
+  %result = "stablehlo.convolution"(%arg0, %arg1) {
+    batch_group_count = 1 : i64,
+    dimension_numbers = #stablehlo.conv<raw
+      input_batch_dimension = 0,
+      input_feature_dimension = 3,
+      input_spatial_dimensions = [1, 2],
+      kernel_input_feature_dimension = -1,
+      kernel_output_feature_dimension = 2,
+      kernel_spatial_dimensions = [0, 1],
+      output_batch_dimension = 0,
+      output_feature_dimension = 3,
+      output_spatial_dimensions = [1, 2]
+    >,
+    feature_group_count = 1 : i64,
+    lhs_dilation = dense<1> : tensor<2xi64>,
+    padding = dense<2> : tensor<2x2xi64>,
+    rhs_dilation = dense<1> : tensor<2xi64>,
+    window_strides = dense<1> : tensor<2xi64>
+  } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>) ->
+    tensor<100x28x28x1xf32>
+  func.return %result : tensor<100x28x28x1xf32>
+}
+
+// -----
+
+func.func @convolution_c19(%arg0 : tensor<100x26x26x32xf32>,
+    %arg1 : tensor<3x3x1x32xf32>) -> tensor<100x28x28x1xf32> {
+  // expected-error@+1 {{expects input, kernel, and output dimension-numbers to be in-range [0, 4).}}
+  %result = "stablehlo.convolution"(%arg0, %arg1) {
+    batch_group_count = 1 : i64,
+    dimension_numbers = #stablehlo.conv<raw
+      input_batch_dimension = 0,
+      input_feature_dimension = 3,
+      input_spatial_dimensions = [1, 2],
+      kernel_input_feature_dimension = 4,
+      kernel_output_feature_dimension = 2,
+      kernel_spatial_dimensions = [0, 1],
+      output_batch_dimension = 0,
+      output_feature_dimension = 3,
+      output_spatial_dimensions = [1, 2]
+    >,
+    feature_group_count = 1 : i64,
+    lhs_dilation = dense<1> : tensor<2xi64>,
+    padding = dense<2> : tensor<2x2xi64>,
+    rhs_dilation = dense<1> : tensor<2xi64>,
+    window_strides = dense<1> : tensor<2xi64>
+  } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>) ->
+    tensor<100x28x28x1xf32>
+  func.return %result : tensor<100x28x28x1xf32>
+}
+
+// -----
+
+func.func @convolution_c20(%arg0: tensor<1x8x8x207xf32>,
+    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
+  // expected-error@+1 {{expects the same size for input, kernel and output spatial-dimensions, but got 2, 2, and 3 resp.}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, 2, f],
+         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
+           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
+         {
+           batch_group_count = 1 : i64,
+           feature_group_count = 1 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+         } :
+       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
+  func.return %0 : tensor<1x8x8x16xf32>
+}
+
+// -----
+
+func.func @convolution_c21(%arg0 : tensor<100x26x26x32xf32>,
+    %arg1 : tensor<3x3x1x32xf32>) -> tensor<100x28x28x1xf32> {
+  // expected-error@+1 {{expects output dimension-numbers to be unique, got {0, 3, 0, 3}.}}
+  %result = "stablehlo.convolution"(%arg0, %arg1) {
+    batch_group_count = 1 : i64,
+    dimension_numbers = #stablehlo.conv<raw
+      input_batch_dimension = 0,
+      input_feature_dimension = 3,
+      input_spatial_dimensions = [1, 2],
+      kernel_input_feature_dimension = 3,
+      kernel_output_feature_dimension = 2,
+      kernel_spatial_dimensions = [0, 1],
+      output_batch_dimension = 0,
+      output_feature_dimension = 3,
+      output_spatial_dimensions = [0, 3]
+    >,
+    feature_group_count = 1 : i64,
+    lhs_dilation = dense<1> : tensor<2xi64>,
+    padding = dense<2> : tensor<2x2xi64>,
+    rhs_dilation = dense<1> : tensor<2xi64>,
+    window_strides = dense<1> : tensor<2xi64>
+  } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>) ->
+    tensor<100x28x28x1xf32>
+  func.return %result : tensor<100x28x28x1xf32>
+}
+
+// -----
+
+func.func @convolution_c21(%arg0 : tensor<100x26x26x32xf32>,
+    %arg1 : tensor<3x3x1x32xf32>) -> tensor<100x28x28x1xf32> {
+  // expected-error@+1 {{expects input, kernel, and output dimension-numbers to be in-range [0, 4).}}
+  %result = "stablehlo.convolution"(%arg0, %arg1) {
+    batch_group_count = 1 : i64,
+    dimension_numbers = #stablehlo.conv<raw
+      input_batch_dimension = 0,
+      input_feature_dimension = 3,
+      input_spatial_dimensions = [1, 2],
+      kernel_input_feature_dimension = 3,
+      kernel_output_feature_dimension = 2,
+      kernel_spatial_dimensions = [0, 1],
+      output_batch_dimension = -1,
+      output_feature_dimension = 3,
+      output_spatial_dimensions = [1, 2]
+    >,
+    feature_group_count = 1 : i64,
+    lhs_dilation = dense<1> : tensor<2xi64>,
+    padding = dense<2> : tensor<2x2xi64>,
+    rhs_dilation = dense<1> : tensor<2xi64>,
+    window_strides = dense<1> : tensor<2xi64>
+  } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>) ->
+    tensor<100x28x28x1xf32>
+  func.return %result : tensor<100x28x28x1xf32>
+}
+
+// -----
+
+func.func @convolution_c21(%arg0 : tensor<100x26x26x32xf32>,
+    %arg1 : tensor<3x3x1x32xf32>) -> tensor<100x28x28x1xf32> {
+  // expected-error@+1 {{expects input, kernel, and output dimension-numbers to be in-range [0, 4).}}
+  %result = "stablehlo.convolution"(%arg0, %arg1) {
+    batch_group_count = 1 : i64,
+    dimension_numbers = #stablehlo.conv<raw
+      input_batch_dimension = 0,
+      input_feature_dimension = 3,
+      input_spatial_dimensions = [1, 2],
+      kernel_input_feature_dimension = 3,
+      kernel_output_feature_dimension = 2,
+      kernel_spatial_dimensions = [0, 1],
+      output_batch_dimension = 4,
+      output_feature_dimension = 3,
+      output_spatial_dimensions = [1, 2]
+    >,
+    feature_group_count = 1 : i64,
+    lhs_dilation = dense<1> : tensor<2xi64>,
+    padding = dense<2> : tensor<2x2xi64>,
+    rhs_dilation = dense<1> : tensor<2xi64>,
+    window_strides = dense<1> : tensor<2xi64>
+  } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>) ->
+    tensor<100x28x28x1xf32>
+  func.return %result : tensor<100x28x28x1xf32>
+}
+
+// -----
+
+func.func @convolution_c22(%arg0: tensor<1x8x8x207xf32>,
+    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
+  // expected-error@+1 {{expects feature_group_count to be a positive number, got 0.}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
+           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
+         {
+           batch_group_count = 1 : i64,
+           feature_group_count = 0 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+         } :
+       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
+  func.return %0 : tensor<1x8x8x16xf32>
+}
+
+// -----
+
+func.func @convolution_c23(%arg0: tensor<1x8x8x207xf32>,
+    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
+  // expected-error@+1 {{expects batch_group_count to be a positive number, got 0.}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
+           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
+         {
+           batch_group_count = 0 : i64,
+           feature_group_count = 1 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+         } :
+       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
+  func.return %0 : tensor<1x8x8x16xf32>
+}
+
+// -----
+
+func.func @convolution_c24(%arg0: tensor<1x8x8x207xf32>,
+    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
+  // expected-error@+1 {{expects batch_group_count and feature_group_count not to be both greater than 1. Got 2 and 2 resp.}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
+           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
+         {
+           batch_group_count = 2 : i64,
+           feature_group_count = 2 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+         } :
+       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
+  func.return %0 : tensor<1x8x8x16xf32>
+}
+
+// -----
+
+func.func @convolution_c25(%arg0: tensor<3x2xf16>,
+    %arg1: tensor<2x2xf16>) -> tuple<tensor<3x2xf16>> {
+  // expected-error@+1{{expects precision config to be empty or have <= 2 elements}}
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, f]x[i, o]->[b, f],
+         window = {stride = [], pad = [], lhs_dilate = [], rhs_dilate = [],
+           reverse = []}
+         {
+           batch_group_count = 1 : i64,
+           feature_group_count = 1 : i64,
+           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+         }
+       : (tensor<3x2xf16>, tensor<2x2xf16>) -> tensor<3x2xf16>
+  %1 = "stablehlo.tuple"(%0) : (tensor<3x2xf16>) -> tuple<tensor<3x2xf16>>
+  func.return %1 : tuple<tensor<3x2xf16>>
 }
 
 // -----
@@ -209,720 +928,7 @@ func.func @convolution_i7(%arg0: tensor<1x4x4x1xi64>,
 
 // -----
 
-func.func @convolution_c1(%arg0: tensor<1xi64>,
-    %arg1: tensor<1xi64>) -> tensor<1xi64> {
-  // expected-error@+1 {{expects convolution arguments to have >= 2 dimensions. Got: 'tensor<1xi64>' and 'tensor<1xi64>'.}}
-  %0 = "stablehlo.convolution"(%arg0, %arg1) {
-    dimension_numbers = #stablehlo.conv<[b, f]x[i, o]->[b, f]>,
-    feature_group_count = 1 : i64,
-    batch_group_count = 1 : i64
-  } : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
-  func.return %0 : tensor<1xi64>
-}
-
-// -----
-
-func.func @convolution_c2(%arg0: tensor<1x8x8x207xf32>,
-    %arg1: tensor<3x3x207xf32>) -> tensor<1x8x8x16xf32> {
-  // expected-error@+1 {{expects convolution arguments to have same number of dimensions. Got: 'tensor<1x8x8x207xf32>' and 'tensor<3x3x207xf32>'.}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
-           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
-         {
-           batch_group_count = 1 : i64,
-           feature_group_count = 1 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-         } :
-       (tensor<1x8x8x207xf32>, tensor<3x3x207xf32>) -> tensor<1x8x8x16xf32>
-  func.return %0 : tensor<1x8x8x16xf32>
-}
-
-// -----
-
-func.func @convolution_c3(%arg0: tensor<1x4x4x1xi64>,
-    %arg1: tensor<3x3x1x1xi32>) -> tensor<1x2x2x1xi64> {
-  // expected-error@+1 {{expects lhs and rhs to have compatible element type. Got: 'i64' and 'i32'}}
-    %0 = "stablehlo.convolution"(%arg0, %arg1) {
-    window_strides = dense<4> : tensor<2xi64>,
-    padding = dense<0> : tensor<2x2xi64>,
-    lhs_dilation = dense<2> : tensor<2xi64>,
-    rhs_dilation = dense<1> : tensor<2xi64>,
-    window_reversal = dense<false> : tensor<2xi1>,
-    dimension_numbers = #stablehlo.conv<[b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f]>,
-    feature_group_count = 1 : i64,
-    batch_group_count = 1 : i64,
-    precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-  } : (tensor<1x4x4x1xi64>, tensor<3x3x1x1xi32>) -> tensor<1x2x2x1xi64>
-  func.return %0 : tensor<1x2x2x1xi64>
-}
-
-// -----
-
-func.func @convolution_c4(%arg0: tensor<1x8x8x207xf32>,
-    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
-  // expected-error@+1 {{expects window-strides to have same dimension-size as size of window dimensions (2), but got: 1.}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-         window = {stride = [1], pad = [[1, 1], [1, 1]],
-           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
-         {
-           batch_group_count = 1 : i64,
-           feature_group_count = 1 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-         } :
-       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
-  func.return %0 : tensor<1x8x8x16xf32>
-}
-
-// -----
-
-func.func @convolution_c5(%arg0: tensor<1x8x8x207xf32>,
-    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
-  // expected-error@+1 {{expects window to have positive stride for 1-th window dimension, but got 0.}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-         window = {stride = [1, 0], pad = [[1, 1], [1,1]],
-           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
-         {
-           batch_group_count = 1 : i64,
-           feature_group_count = 1 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]} :
-       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
-  func.return %0 : tensor<1x8x8x16xf32>
-}
-
-// -----
-
-func.func @convolution_c6(%arg0 : tensor<100x26x26x32xf32>, %arg1 : tensor<3x3x1x32xf32>) ->
-    tensor<100x28x28x1xf32> {
-  // expected-error@+1 {{expects padding-entries to have same dimension-size as size of window dimensions (2), but got: 3.}}
-  %result = "stablehlo.convolution"(%arg0, %arg1) {
-    batch_group_count = 1 : i64,
-    dimension_numbers = #stablehlo.conv<raw
-      input_batch_dimension = 0,
-      input_feature_dimension = 3,
-      input_spatial_dimensions = [1, 2],
-      kernel_input_feature_dimension = 3,
-      kernel_output_feature_dimension = 2,
-      kernel_spatial_dimensions = [0, 1],
-      output_batch_dimension = 0,
-      output_feature_dimension = 3,
-      output_spatial_dimensions = [1, 2]
-    >,
-    feature_group_count = 1 : i64,
-    lhs_dilation = dense<1> : tensor<2xi64>,
-    padding = dense<2> : tensor<3x2xi64>,
-    rhs_dilation = dense<1> : tensor<2xi64>,
-    window_strides = dense<1> : tensor<2xi64>
-  } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>) ->
-    tensor<100x28x28x1xf32>
-  func.return %result : tensor<100x28x28x1xf32>
-}
-
-// -----
-
-func.func @convolution_c6(%arg0: tensor<1x4x4x1xi64>,
-    %arg1: tensor<3x3x1x1xi64>) -> tensor<1x2x2x1xi64> {
-  // expected-error@+1 {{expects the shape of padding-attribute to be {N, 2}, but got {2, 3}.}}
-  %0 = "stablehlo.convolution"(%arg0, %arg1) {
-    window_strides = dense<4> : tensor<2xi64>,
-    padding = dense<0> : tensor<2x3xi64>,
-    lhs_dilation = dense<2> : tensor<2xi64>,
-    rhs_dilation = dense<1> : tensor<2xi64>,
-    window_reversal = dense<false> : tensor<2xi1>,
-    dimension_numbers = #stablehlo.conv<[b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f]>,
-    feature_group_count = 1 : i64,
-    batch_group_count = 1 : i64,
-    precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-  } : (tensor<1x4x4x1xi64>, tensor<3x3x1x1xi64>) -> tensor<1x2x2x1xi64>
-  func.return %0 : tensor<1x2x2x1xi64>
-}
-
-// -----
-
-func.func @convolution_c6(%arg0: tensor<1x8x8x207xf32>,
-    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-         // expected-error@+1 {{Expected array with 2 elements, got 4 elements instead}}
-         window = {stride = [1, 1], pad = [[1, 1, 1, 1]],
-           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
-         {
-           batch_group_count = 1 : i64,
-           feature_group_count = 1 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-         } :
-       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
-  func.return %0 : tensor<1x8x8x16xf32>
-}
-
-// -----
-
-func.func @convolution_c7(%arg0: tensor<1x8x8x207xf32>,
-    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
-  // expected-error@+1 {{expects base-dilation factors to have same dimension-size as size of window dimensions (2), but got: 1.}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
-           lhs_dilate = [1], rhs_dilate = [1, 1]}
-         {
-           batch_group_count = 1 : i64,
-           feature_group_count = 1 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]} :
-       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
-  func.return %0 : tensor<1x8x8x16xf32>
-}
-
-// -----
-
-func.func @convolution_c8(%arg0: tensor<1x8x8x207xf32>,
-    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
-  // expected-error@+1 {{expects window to have positive base dilation factor for 0-th window dimension, but got 0.}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-         window = {stride = [1, 1], pad = [[1, 1], [1,1]],
-           lhs_dilate = [0, 1], rhs_dilate = [1, 1]}
-         {
-           batch_group_count = 1 : i64,
-           feature_group_count = 1 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-         } :
-       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
-  func.return %0 : tensor<1x8x8x16xf32>
-}
-
-// -----
-
-func.func @convolution_c9(%arg0: tensor<1x8x8x207xf32>,
-    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
-  // expected-error@+1 {{expects window-dilation factors to have same dimension-size as size of window dimensions (2), but got: 1.}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
-           lhs_dilate = [1, 1], rhs_dilate = [1]}
-         {
-           batch_group_count = 1 : i64,
-           feature_group_count = 1 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]} :
-       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
-  func.return %0 : tensor<1x8x8x16xf32>
-}
-
-// -----
-
-func.func @convolution_c10(%arg0: tensor<1x8x8x207xf32>,
-    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
-  // expected-error@+1 {{expects window to have positive window dilation factor for 0-th window dimension, but got 0.}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-         window = {stride = [1, 1], pad = [[1, 1], [1,1]],
-           lhs_dilate = [1, 1], rhs_dilate = [0, 1]}
-         {
-           batch_group_count = 1 : i64,
-           feature_group_count = 1 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-         } :
-       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
-  func.return %0 : tensor<1x8x8x16xf32>
-}
-
-// -----
-
-func.func @convolution_c11(%arg0: tensor<1x8x8x207xf32>,
-    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
-  // expected-error@+1 {{expects window-reversal to have same dimension-size as size of window dimensions (2), but got: 1.}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
-           lhs_dilate = [1, 1], rhs_dilate = [1, 1], reverse = [false]}
-         {
-           batch_group_count = 1 : i64,
-           feature_group_count = 1 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]} :
-       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
-  func.return %0 : tensor<1x8x8x16xf32>
-}
-
-// -----
-
-func.func @convolution_c12(%arg0: tensor<5x8x8x207xf32>,
-    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
-  // expected-error@+1 {{expects input batch dimension (5) to be divisible by batch_group_count. Got batch_group_count = 2.}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
-           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
-         {
-           batch_group_count = 2 : i64,
-           feature_group_count = 1 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-         } :
-       (tensor<5x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
-  func.return %0 : tensor<1x8x8x16xf32>
-}
-
-// -----
-
-func.func @convolution_c13(%arg0: tensor<1x8x8x207xf32>,
-    %arg1: tensor<3x3x20x16xf32>) -> tensor<1x8x8x16xf32> {
-  // expected-error@+1 {{expects input feature dimension (207) to be a multiple of feature_group_count. Got feature_group_count = 2.}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
-           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
-         {
-           batch_group_count = 1 : i64,
-           feature_group_count = 2 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-         } :
-       (tensor<1x8x8x207xf32>, tensor<3x3x20x16xf32>) -> tensor<1x8x8x16xf32>
-  func.return %0 : tensor<1x8x8x16xf32>
-}
-
-// -----
-
-// This is an positive test in MLIR-HLO:
-// https://github.com/tensorflow/mlir-hlo/blob/master/tests/Dialect/mhlo/ops.mlir#L3829
-// but negative here: stablehlo.convolution does no support unknown dimenstion
-// dim_numbers = [b, 0, 1, ?, f]x[0, 1, ?, i, o]->[?, b, 0, 1, f]
-// window = {stride = [1, 1], pad = [[1, 1], [1, 1]], lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
-func.func @convolution_c14(%arg0: tensor<1x8x8x32x207xf32>, %arg1: tensor<3x3x32x207x16xf32>) -> tensor<32x1x8x8x16xf32> {
-  // expected-error@+1{{expects convolution arguments to have 4 dimensions. Got: 5}}
-  %0 = "stablehlo.convolution"(%arg0, %arg1) {batch_group_count = 1 : i64,
-    dimension_numbers = #stablehlo.conv<raw
-      input_batch_dimension = 0,
-      input_feature_dimension = 4,
-      input_spatial_dimensions = [1, 2],
-      kernel_input_feature_dimension = 3,
-      kernel_output_feature_dimension = 4,
-      kernel_spatial_dimensions = [0, 1],
-      output_batch_dimension = 1,
-      output_feature_dimension = 4,
-      output_spatial_dimensions = [2, 3]
-    >, feature_group_count = 1 : i64, lhs_dilation = dense<1> : tensor<2xi64>, padding = dense<1> : tensor<2x2xi64>, precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>], rhs_dilation = dense<1> : tensor<2xi64>, window_strides = dense<1> : tensor<2xi64>} :
-       (tensor<1x8x8x32x207xf32>, tensor<3x3x32x207x16xf32>) -> tensor<32x1x8x8x16xf32>
-  func.return %0 : tensor<32x1x8x8x16xf32>
-}
-
-// -----
-
-func.func @convolution_c15(%arg0 : tensor<100x26x26x32xf32>,
-    %arg1 : tensor<3x3x1x32xf32>) -> tensor<100x28x28x1xf32> {
-  // expected-error@+1 {{expects input dimension-numbers to be unique, got {0, 0, 1, 2}.}}
-  %result = "stablehlo.convolution"(%arg0, %arg1) {
-    batch_group_count = 1 : i64,
-    dimension_numbers = #stablehlo.conv<raw
-      input_batch_dimension = 0,
-      input_feature_dimension = 0,
-      input_spatial_dimensions = [1, 2],
-      kernel_input_feature_dimension = 3,
-      kernel_output_feature_dimension = 2,
-      kernel_spatial_dimensions = [0, 1],
-      output_batch_dimension = 0,
-      output_feature_dimension = 3,
-      output_spatial_dimensions = [1, 2]
-    >,
-    feature_group_count = 1 : i64,
-    lhs_dilation = dense<1> : tensor<2xi64>,
-    padding = dense<2> : tensor<2x2xi64>,
-    rhs_dilation = dense<1> : tensor<2xi64>,
-    window_strides = dense<1> : tensor<2xi64>
-  } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>) ->
-    tensor<100x28x28x1xf32>
-  func.return %result : tensor<100x28x28x1xf32>
-}
-
-// -----
-
-func.func @convolution_c15(%arg0 : tensor<100x26x26x32xf32>,
-    %arg1 : tensor<3x3x1x32xf32>) -> tensor<100x28x28x1xf32> {
-  // expected-error@+1 {{expects input, kernel, and output dimension-numbers to be in-range [0, 4).}}
-  %result = "stablehlo.convolution"(%arg0, %arg1) {
-    batch_group_count = 1 : i64,
-    dimension_numbers = #stablehlo.conv<raw
-      input_batch_dimension = -1,
-      input_feature_dimension = 3,
-      input_spatial_dimensions = [1, 2],
-      kernel_input_feature_dimension = 3,
-      kernel_output_feature_dimension = 2,
-      kernel_spatial_dimensions = [0, 1],
-      output_batch_dimension = 0,
-      output_feature_dimension = 3,
-      output_spatial_dimensions = [1, 2]
-    >,
-    feature_group_count = 1 : i64,
-    lhs_dilation = dense<1> : tensor<2xi64>,
-    padding = dense<2> : tensor<2x2xi64>,
-    rhs_dilation = dense<1> : tensor<2xi64>,
-    window_strides = dense<1> : tensor<2xi64>
-  } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>) ->
-    tensor<100x28x28x1xf32>
-  func.return %result : tensor<100x28x28x1xf32>
-}
-
-// -----
-
-func.func @convolution_c15(%arg0 : tensor<100x26x26x32xf32>,
-    %arg1 : tensor<3x3x1x32xf32>) -> tensor<100x28x28x1xf32> {
-  // expected-error@+1 {{expects input, kernel, and output dimension-numbers to be in-range [0, 4).}}
-  %result = "stablehlo.convolution"(%arg0, %arg1) {
-    batch_group_count = 1 : i64,
-    dimension_numbers = #stablehlo.conv<raw
-      input_batch_dimension = 4,
-      input_feature_dimension = 3,
-      input_spatial_dimensions = [1, 2],
-      kernel_input_feature_dimension = 3,
-      kernel_output_feature_dimension = 2,
-      kernel_spatial_dimensions = [0, 1],
-      output_batch_dimension = 0,
-      output_feature_dimension = 3,
-      output_spatial_dimensions = [1, 2]
-    >,
-    feature_group_count = 1 : i64,
-    lhs_dilation = dense<1> : tensor<2xi64>,
-    padding = dense<2> : tensor<2x2xi64>,
-    rhs_dilation = dense<1> : tensor<2xi64>,
-    window_strides = dense<1> : tensor<2xi64>
-  } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>) ->
-    tensor<100x28x28x1xf32>
-  func.return %result : tensor<100x28x28x1xf32>
-}
-
-// -----
-
-func.func @convolution_c16(%arg0: tensor<1x8x8x207xf32>,
-    %arg1: tensor<3x3x20x16xf32>) -> tensor<1x8x8x16xf32> {
-  // expected-error@+1 {{expects input feature dimension (207) / feature_group_count = kernel input feature dimension (20). Got feature_group_count = 1.}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
-           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
-         {
-           batch_group_count = 1 : i64,
-           feature_group_count = 1 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-         } :
-       (tensor<1x8x8x207xf32>, tensor<3x3x20x16xf32>) -> tensor<1x8x8x16xf32>
-  func.return %0 : tensor<1x8x8x16xf32>
-}
-
-// -----
-
-func.func @convolution_c17(%arg0: tensor<3x8x8x207xf32>,
-    %arg1: tensor<3x3x207x16xf32>) -> tensor<3x8x8x16xf32> {
-  // expected-error@+1 {{expects output feature dimension size (16) to be a multiple of batch_group_count. Got batch_group_count = 3.}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
-           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
-         {
-           batch_group_count = 3 : i64,
-           feature_group_count = 1 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-         } :
-       (tensor<3x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<3x8x8x16xf32>
-  func.return %0 : tensor<3x8x8x16xf32>
-}
-
-// -----
-
-func.func @convolution_c18(%arg0: tensor<1x8x8x207xf32>,
-    %arg1: tensor<3x3x69x16xf32>) -> tensor<1x8x8x16xf32> {
-  // expected-error@+1 {{expects kernel output feature dimension (16) to be divisible by feature_group_count. For feature_group_count = 3.}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
-           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
-         {
-           batch_group_count = 1 : i64,
-           feature_group_count = 3 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-         } :
-       (tensor<1x8x8x207xf32>, tensor<3x3x69x16xf32>) -> tensor<1x8x8x16xf32>
-  func.return %0 : tensor<1x8x8x16xf32>
-}
-
-// -----
-
-func.func @convolution_c19(%arg0: tensor<1x8x8x207xf32>,
-    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
-  // expected-error@+1 {{expects the same size for input, kernel and output spatial-dimensions, but got 2, 3, and 2 resp.}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, f]x[0, 1, 2, i, o]->[b, 0, 1, f],
-         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
-           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
-         {
-           batch_group_count = 1 : i64,
-           feature_group_count = 1 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-         } :
-       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
-  func.return %0 : tensor<1x8x8x16xf32>
-}
-
-// -----
-
-func.func @convolution_c20(%arg0 : tensor<100x26x26x32xf32>,
-    %arg1 : tensor<3x3x1x32xf32>) -> tensor<100x28x28x1xf32> {
-  // expected-error@+1 {{expects kernel dimension-numbers to be unique, got {3, 2, 0, 0}.}}
-  %result = "stablehlo.convolution"(%arg0, %arg1) {
-    batch_group_count = 1 : i64,
-    dimension_numbers = #stablehlo.conv<raw
-      input_batch_dimension = 0,
-      input_feature_dimension = 3,
-      input_spatial_dimensions = [1, 2],
-      kernel_input_feature_dimension = 3,
-      kernel_output_feature_dimension = 2,
-      kernel_spatial_dimensions = [0, 0],
-      output_batch_dimension = 0,
-      output_feature_dimension = 3,
-      output_spatial_dimensions = [1, 2]
-    >,
-    feature_group_count = 1 : i64,
-    lhs_dilation = dense<1> : tensor<2xi64>,
-    padding = dense<2> : tensor<2x2xi64>,
-    rhs_dilation = dense<1> : tensor<2xi64>,
-    window_strides = dense<1> : tensor<2xi64>
-  } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>) ->
-    tensor<100x28x28x1xf32>
-  func.return %result : tensor<100x28x28x1xf32>
-}
-
-// -----
-
-func.func @convolution_c20(%arg0 : tensor<100x26x26x32xf32>,
-    %arg1 : tensor<3x3x1x32xf32>) -> tensor<100x28x28x1xf32> {
-  // expected-error@+1 {{expects input, kernel, and output dimension-numbers to be in-range [0, 4).}}
-  %result = "stablehlo.convolution"(%arg0, %arg1) {
-    batch_group_count = 1 : i64,
-    dimension_numbers = #stablehlo.conv<raw
-      input_batch_dimension = 0,
-      input_feature_dimension = 3,
-      input_spatial_dimensions = [1, 2],
-      kernel_input_feature_dimension = -1,
-      kernel_output_feature_dimension = 2,
-      kernel_spatial_dimensions = [0, 1],
-      output_batch_dimension = 0,
-      output_feature_dimension = 3,
-      output_spatial_dimensions = [1, 2]
-    >,
-    feature_group_count = 1 : i64,
-    lhs_dilation = dense<1> : tensor<2xi64>,
-    padding = dense<2> : tensor<2x2xi64>,
-    rhs_dilation = dense<1> : tensor<2xi64>,
-    window_strides = dense<1> : tensor<2xi64>
-  } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>) ->
-    tensor<100x28x28x1xf32>
-  func.return %result : tensor<100x28x28x1xf32>
-}
-
-// -----
-
-func.func @convolution_c20(%arg0 : tensor<100x26x26x32xf32>,
-    %arg1 : tensor<3x3x1x32xf32>) -> tensor<100x28x28x1xf32> {
-  // expected-error@+1 {{expects input, kernel, and output dimension-numbers to be in-range [0, 4).}}
-  %result = "stablehlo.convolution"(%arg0, %arg1) {
-    batch_group_count = 1 : i64,
-    dimension_numbers = #stablehlo.conv<raw
-      input_batch_dimension = 0,
-      input_feature_dimension = 3,
-      input_spatial_dimensions = [1, 2],
-      kernel_input_feature_dimension = 4,
-      kernel_output_feature_dimension = 2,
-      kernel_spatial_dimensions = [0, 1],
-      output_batch_dimension = 0,
-      output_feature_dimension = 3,
-      output_spatial_dimensions = [1, 2]
-    >,
-    feature_group_count = 1 : i64,
-    lhs_dilation = dense<1> : tensor<2xi64>,
-    padding = dense<2> : tensor<2x2xi64>,
-    rhs_dilation = dense<1> : tensor<2xi64>,
-    window_strides = dense<1> : tensor<2xi64>
-  } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>) ->
-    tensor<100x28x28x1xf32>
-  func.return %result : tensor<100x28x28x1xf32>
-}
-
-// -----
-
-func.func @convolution_c21(%arg0: tensor<1x8x8x207xf32>,
-    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
-  // expected-error@+1 {{expects the same size for input, kernel and output spatial-dimensions, but got 2, 2, and 3 resp.}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, 2, f],
-         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
-           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
-         {
-           batch_group_count = 1 : i64,
-           feature_group_count = 1 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-         } :
-       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
-  func.return %0 : tensor<1x8x8x16xf32>
-}
-
-// -----
-
-func.func @convolution_c22(%arg0 : tensor<100x26x26x32xf32>,
-    %arg1 : tensor<3x3x1x32xf32>) -> tensor<100x28x28x1xf32> {
-  // expected-error@+1 {{expects output dimension-numbers to be unique, got {0, 3, 0, 3}.}}
-  %result = "stablehlo.convolution"(%arg0, %arg1) {
-    batch_group_count = 1 : i64,
-    dimension_numbers = #stablehlo.conv<raw
-      input_batch_dimension = 0,
-      input_feature_dimension = 3,
-      input_spatial_dimensions = [1, 2],
-      kernel_input_feature_dimension = 3,
-      kernel_output_feature_dimension = 2,
-      kernel_spatial_dimensions = [0, 1],
-      output_batch_dimension = 0,
-      output_feature_dimension = 3,
-      output_spatial_dimensions = [0, 3]
-    >,
-    feature_group_count = 1 : i64,
-    lhs_dilation = dense<1> : tensor<2xi64>,
-    padding = dense<2> : tensor<2x2xi64>,
-    rhs_dilation = dense<1> : tensor<2xi64>,
-    window_strides = dense<1> : tensor<2xi64>
-  } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>) ->
-    tensor<100x28x28x1xf32>
-  func.return %result : tensor<100x28x28x1xf32>
-}
-
-// -----
-
-func.func @convolution_c22(%arg0 : tensor<100x26x26x32xf32>,
-    %arg1 : tensor<3x3x1x32xf32>) -> tensor<100x28x28x1xf32> {
-  // expected-error@+1 {{expects input, kernel, and output dimension-numbers to be in-range [0, 4).}}
-  %result = "stablehlo.convolution"(%arg0, %arg1) {
-    batch_group_count = 1 : i64,
-    dimension_numbers = #stablehlo.conv<raw
-      input_batch_dimension = 0,
-      input_feature_dimension = 3,
-      input_spatial_dimensions = [1, 2],
-      kernel_input_feature_dimension = 3,
-      kernel_output_feature_dimension = 2,
-      kernel_spatial_dimensions = [0, 1],
-      output_batch_dimension = -1,
-      output_feature_dimension = 3,
-      output_spatial_dimensions = [1, 2]
-    >,
-    feature_group_count = 1 : i64,
-    lhs_dilation = dense<1> : tensor<2xi64>,
-    padding = dense<2> : tensor<2x2xi64>,
-    rhs_dilation = dense<1> : tensor<2xi64>,
-    window_strides = dense<1> : tensor<2xi64>
-  } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>) ->
-    tensor<100x28x28x1xf32>
-  func.return %result : tensor<100x28x28x1xf32>
-}
-
-// -----
-
-func.func @convolution_c22(%arg0 : tensor<100x26x26x32xf32>,
-    %arg1 : tensor<3x3x1x32xf32>) -> tensor<100x28x28x1xf32> {
-  // expected-error@+1 {{expects input, kernel, and output dimension-numbers to be in-range [0, 4).}}
-  %result = "stablehlo.convolution"(%arg0, %arg1) {
-    batch_group_count = 1 : i64,
-    dimension_numbers = #stablehlo.conv<raw
-      input_batch_dimension = 0,
-      input_feature_dimension = 3,
-      input_spatial_dimensions = [1, 2],
-      kernel_input_feature_dimension = 3,
-      kernel_output_feature_dimension = 2,
-      kernel_spatial_dimensions = [0, 1],
-      output_batch_dimension = 4,
-      output_feature_dimension = 3,
-      output_spatial_dimensions = [1, 2]
-    >,
-    feature_group_count = 1 : i64,
-    lhs_dilation = dense<1> : tensor<2xi64>,
-    padding = dense<2> : tensor<2x2xi64>,
-    rhs_dilation = dense<1> : tensor<2xi64>,
-    window_strides = dense<1> : tensor<2xi64>
-  } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>) ->
-    tensor<100x28x28x1xf32>
-  func.return %result : tensor<100x28x28x1xf32>
-}
-
-// -----
-
-func.func @convolution_c23(%arg0: tensor<1x8x8x207xf32>,
-    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
-  // expected-error@+1 {{expects feature_group_count to be a positive number, got 0.}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
-           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
-         {
-           batch_group_count = 1 : i64,
-           feature_group_count = 0 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-         } :
-       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
-  func.return %0 : tensor<1x8x8x16xf32>
-}
-
-// -----
-
-func.func @convolution_c24(%arg0: tensor<1x8x8x207xf32>,
-    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
-  // expected-error@+1 {{expects batch_group_count to be a positive number, got 0.}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
-           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
-         {
-           batch_group_count = 0 : i64,
-           feature_group_count = 1 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-         } :
-       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
-  func.return %0 : tensor<1x8x8x16xf32>
-}
-
-// -----
-
-func.func @convolution_c25(%arg0: tensor<1x8x8x207xf32>,
-    %arg1: tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
-  // expected-error@+1 {{expects batch_group_count and feature_group_count not to be both greater than 1. Got 2 and 2 resp.}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
-         window = {stride = [1, 1], pad = [[1, 1], [1, 1]],
-           lhs_dilate = [1, 1], rhs_dilate = [1, 1]}
-         {
-           batch_group_count = 2 : i64,
-           feature_group_count = 2 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-         } :
-       (tensor<1x8x8x207xf32>, tensor<3x3x207x16xf32>) -> tensor<1x8x8x16xf32>
-  func.return %0 : tensor<1x8x8x16xf32>
-}
-
-// -----
-
-func.func @convolution_c26(%arg0: tensor<3x2xf16>,
-    %arg1: tensor<2x2xf16>) -> tuple<tensor<3x2xf16>> {
-  // expected-error@+1{{expects precision config to be empty or have <= 2 elements}}
-  %0 = stablehlo.convolution(%arg0, %arg1)
-         dim_numbers = [b, f]x[i, o]->[b, f],
-         window = {stride = [], pad = [], lhs_dilate = [], rhs_dilate = [],
-           reverse = []}
-         {
-           batch_group_count = 1 : i64,
-           feature_group_count = 1 : i64,
-           precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-         }
-       : (tensor<3x2xf16>, tensor<2x2xf16>) -> tensor<3x2xf16>
-  %1 = "stablehlo.tuple"(%0) : (tensor<3x2xf16>) -> tuple<tensor<3x2xf16>>
-  func.return %1 : tuple<tensor<3x2xf16>>
-}
-
-// -----
-
-func.func @invalid_conv_window_attributes(%arg0: tensor<1x8x8x207xf32>,
+func.func @convolution_invalid_window_attributes(%arg0: tensor<1x8x8x207xf32>,
     %arg1: tensor<0x3x207x16xf32>) -> tensor<1x8x8x16xf32> {
   // expected-error@+1 {{expects window to have positive value for 0-th window dimension, but got 0.}}
   %0 = stablehlo.convolution(%arg0, %arg1)


### PR DESCRIPTION
We have the following constraints in the spec (excluding quantization-related constraints C28-C33):

```
(I1) `lhs` tensor.
(I2) `rhs` tensor.
(I3) `window_strides` 1-dimensional tensor constant of type `si64`.
(I4) `padding` 2-dimensional tensor constant of type `si64`.
(I5) `lhs_dilation` 1-dimensional tensor constant of type `si64`.
(I6) `rhs_dilation` 1-dimensional tensor constant of type `si64`.
(I7) `window_reversal` 1-dimensional tensor constant of type `i1`.
(I8) `input_batch_dimension` constant of type `si64`.
(I9) `input_feature_dimension` constant of type `si64`.
(I10) `input_spatial_dimensions` 1-dimensional tensor constant of type `si64`.
(I11) `kernel_input_feature_dimension` constant of type `si64`.
(I12) `kernel_output_feature_dimension` constant of type `si64`.
(I13) `kernel_spatial_dimensions` 1-dimensional tensor constant of type `si64`.
(I14) `output_batch_dimension` constant of type `si64`.
(I15) `output_feature_dimension` constant of type `si64`.
(I16) `output_spatial_dimensions` 1-dimensional tensor constant of type `si64`.
(I17) `feature_group_count` constant of type `si64`.
(I18) `batch_group_count` constant of type `si64`.
(I19) `precision_config` variadic number of enums of `DEFAULT`, `HIGH`, and `HIGHEST`.
(C1) `N = rank(lhs) = rank(rhs)`.
(C2) `size(window_strides) = N - 2`.
(C3) `0 < window_strides`.
(C4) `shape(padding) = [N - 2, 2]`.
(C5) `size(lhs_dilation) = N - 2`.
(C6) `0 < lhs_dilation`.
(C7) `size(rhs_dilation) = N - 2`.
(C8) `0 < rhs_dilation`.
(C9) `size(window_reversal) = N - 2`.
(C10) `dim(lhs, input_batch_dimension) % batch_group_count = 0`.
(C11) `dim(lhs, input_feature_dimension) % feature_group_count = 0`.
(C12) `size(input_spatial_dimensions) = N - 2`.
(C13) Given `input_dimensions = [input_batch_dimension] +
     input_spatial_dimensions + [input_feature_dimension]`:
* `is_unique(input_dimensions)`.
* `0 <= input_dimensions < N`.
(C14) `dim(rhs, kernel_input_feature_dimension = dim(lhs, input_feature_dimension) / feature_group_count`.
(C15) `dim(rhs, kernel_output_feature_dimension) % batch_group_count = 0`.
(C16) `dim(rhs, kernel_output_feature_dimension) % feature_group_count = 0`.
(C17) `size(kernel_spatial_dimensions) = N - 2`.
(C18) Given `kernel_dimensions = kernel_spatial_dimensions +
      [kernel_input_feature_dimension] + [kernel_output_feature_dimension]`:
* `is_unique(kernel_dimensions)`.
* `0 <= kernel_dimensions < N`.
(C19) `size(output_spatial_dimensions) = N - 2`.
(C20) Given `output_dimensions = [output_batch_dimension] +
      output_spatial_dimensions + [output_feature_dimension]`:
* `is_unique(output_dimensions)`.
* `0 <= output_dimensions < N`.
(C21) `0 < feature_group_count`.
(C22) `0 < batch_group_count`.
(C23) `feature_group_count = 1 or batch_group_count = 1`.
(C24) `size(precision_config) = 2`.
(C25) `dim(result, result_dim)` is defined as:
* `dim(lhs, input_batch_dimension) / batch_group_count` if `result_dim = output_batch_dimension`.
* `dim(rhs, kernel_output_feature_dimension)` if `result_dim = output_feature_dimension`.
* `num_windows` otherwise, where:
  * `output_spatial_dimensions[spatial_dim] = result_dim`.
  * `lhs_dim = input_spatial_dimensions[spatial_dim]`.
  * `rhs_dim = kernel_spatial_dimensions[spatial_dim]`.
  * `dilated_input_shape[lhs_dim] = dim(lhs, lhs_dim) = 0 ? 0 : (dim(lhs, lhs_dim) - 1) * lhs_dilation[spatial_dim] + 1`.
  * `padded_input_shape[lhs_dim] = padding[spatial_dim, 0] + dilated_input_shape[lhs_dim] + padding[spatial_dim, 1]`.
  * `dilated_window_shape[lhs_dim] = dim(rhs, rhs_dim) = 0 ? 0 : (dim(rhs, rhs_dim) - 1) * rhs_dilation[spatial_dim] + 1`.
  * `is_empty_window[lhs_dim] = padded_input_shape[lhs_dim] = 0 || dilated_window_shape[lhs_dim] > padded_input_shape[lhs_dim]`.
  * `num_windows = is_empty_window[lhs_dim] ? 0 : floor((padded_input_shape[lhs_dim] - dilated_window_shape[lhs_dim]) / window_strides[spatial_dim]) + 1`.
(C26) `rank(result) = N`.
(C27) `element_type(lhs) = element_type(rhs) = element_type(result)`.
```

These constraints will be comprehensively covered by the following tests:

```
I1: a) `lhs` tensor. (Covered by ODS).
I2: a) `rhs` tensor. (Covered by ODS).
I3: a) `window_strides` is not a 1-dimensional tensor.
    b) element_type(`window_strides`) != `si64`. (Covered by ODS).
I4: a) `padding` is not a 2-dimensional tensor.
    b) element_type(`padding`) != `si64`. (Covered by ODS).
I5: a) `lhs_dilation` is not a 1-dimensional tensor.
    b)  element_type(`lhs_dilation`) != `si64`. (Covered by ODS).
I6: a) `rhs_dilation` is not a 1-dimensional tensor.
    b) element_type(`rhs_dilation`) != `si64`. (Covered by ODS).
I7: a) `window_reversal` is not a 1-dimensional tensor.
    b) element_type(`window_reversal`) != `i1`. (Covered by ODS).
I8: a) element_type(`input_batch_dimension`) != `si64`. (Covered by ODS).
I9: a) element_type(`input_feature_dimension`) != `si64`. (Covered by ODS).
I10: a) `input_spatial_dimensions` is not a 1-dimensional tensor. (Covered by ODS).
     b) element_type(`input_spatial_dimensions`) != `si64`. (Covered by ODS).
I11: a) element_type(`kernel_input_feature_dimension`) != `si64`. (Covered by ODS).
I12: a) element_type(`kernel_output_feature_dimension`) != `si64`. (Covered by ODS).
I13: a) `kernel_spatial_dimensions` is not a 1-dimensional tensor. (Covered by ODS).
     b) element_type(`kernel_spatial_dimensions`) != `si64`. (Covered by ODS).
I14: a) element_type(`output_batch_dimension`) != `si64`. (Covered by ODS).
I15: a) element_type(`output_feature_dimension`) != `si64`. (Covered by ODS).
I16: a) `output_spatial_dimensions` is not a 1-dimensional tensor. (Covered by ODS).
     b) element_type(`output_spatial_dimensions`) != `si64`. (Covered by ODS).
I17: a) element_type(`feature_group_count`) != `si64`. (Covered by ODS).
I18: a) element_type(`batch_group_count`) != `si64`. (Covered by ODS).
I19: a) `precision_config` does not have variadic number of enums of `DEFAULT`, `HIGH`, and `HIGHEST`. (Covered by ODS).
C1: a) N = rank(`lhs`) != rank(`rhs`).
C2: a) size(`window_strides`) != N - 2.
C3: a) `window_strides[i]` <= 0 for any i in [0, size(`window_strides`)).
C4: a) dim(`padding`, 0) != N - 2.
    b) dim(`padding`, 1) != 2.
C5: a) size(`lhs_dilation`) != N - 2.
C6: a) `lhs_dilation[i]` <= 0 for any i in [0, size(`lhs_dilation`)).
C7: a) size(`rhs_dilation`) != N - 2.
C8: a) `rhs_dilation[i]` <= 0 for any i in [0, size(`rhs_dilation`)).
C9: a) size(`window_reversal`) != N - 2.
C10: a) `dim(lhs, input_batch_dimension) % batch_group_count != 0`.
C11: a) `dim(lhs, input_feature_dimension) % feature_group_count != 0`.
C12: a) size(`input_spatial_dimensions`) != N - 2.
C13: a) Given `input_dimensions = [input_batch_dimension] +
     input_spatial_dimensions + [input_feature_dimension]`:
     * Any dimensions in `input_dimensions` are not unique.
     b) Given `input_dimensions = [input_batch_dimension] +
     input_spatial_dimensions + [input_feature_dimension]`:
     * For any i in `input_dimensions`, i < 0.
     c) Given `input_dimensions = [input_batch_dimension] +
     input_spatial_dimensions + [input_feature_dimension]`:
     * For any i in `input_dimensions`, i >= N.
C14: a) `dim(rhs, kernel_input_feature_dimension != dim(lhs, input_feature_dimension) / feature_group_count`.
C15: a) `dim(rhs, kernel_output_feature_dimension) % batch_group_count != 0`.
C16: a) `dim(rhs, kernel_output_feature_dimension) % feature_group_count != 0`.
C17: a) size(`kernel_spatial_dimensions`) != N - 2.
C18: a) Given `kernel_dimensions = kernel_spatial_dimensions +
     [kernel_input_feature_dimension] + [kernel_output_feature_dimension]`:
     * Any dimensions in `kernel_dimensions` are not unique.
     b) Given `kernel_dimensions = kernel_spatial_dimensions +
     [kernel_input_feature_dimension] + [kernel_output_feature_dimension]`:
     * For any i in$ `kernel_dimensions`, i < 0.
     c) Given `kernel_dimensions = kernel_spatial_dimensions +
     [kernel_input_feature_dimension] + [kernel_output_feature_dimension]`:
     * For any i in `kernel_dimensions`, i >= N.
C19: a) size(`output_spatial_dimensions`) != N - 2.
C20: a) Given `output_dimensions = [output_batch_dimension] +
     output_spatial_dimensions + [output_feature_dimension]`:
     * Any dimensions in `output_dimensions` are not unique.
     b) Given `output_dimensions = [output_batch_dimension] +
     output_spatial_dimensions + [output_feature_dimension]`:
     * For any i in `output_dimensions`, i < 0.
     c) Given `output_dimensions = [output_batch_dimension] +
     output_spatial_dimensions + [output_feature_dimension]`:
     * For any i in `output_dimensions`, i >= N.
C21: a) `feature_group_count <= 0`.
C22: a) `batch_group_count <= 0`.
C23: a) `feature_group_count` != 1 and `batch_group_count` != 1.
C24: a) size(`precision_config`) != 2.
C25: a) For result_dim in [0, N):
        `dim(result, result_dim)` != `dim(lhs, input_batch_dimension) / batch_group_count`, if `result_dim = output_batch_dimension`.
     b) For result_dim in [0, N):
        `dim(result, result_dim)` != `dim(rhs, kernel_output_feature_dimension)`, if `result_dim = output_feature_dimension`.
     c) For result_dim in [0, N):
        `dim(result, result_dim)` != `num_windows` otherwise, where:
       * `output_spatial_dimensions[spatial_dim] = result_dim`.
       * `lhs_dim = input_spatial_dimensions[spatial_dim]`.
       * `rhs_dim = kernel_spatial_dimensions[spatial_dim]`.
       * `dilated_input_shape[lhs_dim] = dim(lhs, lhs_dim) == 0 ? 0 : (dim(lhs, lhs_dim) - 1) * lhs_dilation[spatial_dim] + 1`.
       * `padded_input_shape[lhs_dim] = padding[spatial_dim, 0] + dilated_input_shape[lhs_dim] + padding[spatial_dim, 1]`.
       * `dilated_window_shape[lhs_dim] = dim(rhs, rhs_dim) == 0 ? 0 : (dim(rhs, rhs_dim) - 1) * rhs_dilation[spatial_dim] + 1`.
       * `num_windows = (padded_input_shape[lhs_dim] == 0 || dilated_window_shape[lhs_dim] > padded_input_shape[lhs_dim]) ? 0 : floor((padded_input_shape[lhs_dim] - dilated_window_shape[lhs_dim]) / window_strides[spatial_dim]) + 1`.
C26: a) rank(result) != N.
C27: a) element_type(`lhs`) != element_type(`rhs`).
```

If we drop the "Covered by ODS" pieces, this will leave us with the following test cases:

```
I3a: `window_strides` is not a 1-dimensional tensor.
I4a: `padding` is not a 2-dimensional tensor.
I5a: `lhs_dilation` is not a 1-dimensional tensor.
I6a: `rhs_dilation` is not a 1-dimensional tensor.
I7a: `window_reversal` is not a 1-dimensional tensor.
C1a: rank(`lhs`) != rank(`rhs`) != N.
C2a: size(`window_strides`) != N - 2.
C3a: `window_strides[i]` <= 0 for any i in [0, size(`window_strides`)).
C4a: dim(`padding`, 0) != N - 2.
C4b: dim(`padding`, 1) != 2.
C5a: size(`lhs_dilation`) != N - 2.
C6a: `lhs_dilation[i]` <= 0 for any i in [0, size(`lhs_dilation`)).
C7a: size(`rhs_dilation`) != N - 2.
C8a: `rhs_dilation[i]` <= 0 for any i in [0, size(`rhs_dilation`)).
C9a: size(`window_reversal`) != N - 2.
C10a: `dim(lhs, input_batch_dimension) % batch_group_count != 0`.
C11a: `dim(lhs, input_feature_dimension) % feature_group_count != 0`.
C12a: size(`input_spatial_dimensions`) != N - 2.
C13a: Given `input_dimensions = [input_batch_dimension] +
      input_spatial_dimensions + [input_feature_dimension]`:
      * Any dimensions in `input_dimensions` are not unique.
C13b: Given `input_dimensions = [input_batch_dimension] +
      input_spatial_dimensions + [input_feature_dimension]`:
      * For any i in `input_dimensions`, i < 0.
C13c: Given `input_dimensions = [input_batch_dimension] +
      input_spatial_dimensions + [input_feature_dimension]`:
      * For any i in `input_dimensions`, i >= N.
C14a: `dim(rhs, kernel_input_feature_dimension != dim(lhs, input_feature_dimension) / feature_group_count`.
C15a: `dim(rhs, kernel_output_feature_dimension) % batch_group_count != 0`.
C16a: `dim(rhs, kernel_output_feature_dimension) % feature_group_count != 0`.
C17a: size(`kernel_spatial_dimensions`) != N - 2.
C18a: Given `kernel_dimensions = kernel_spatial_dimensions +
      [kernel_input_feature_dimension] + [kernel_output_feature_dimension]`:
      * Any dimensions in `kernel_dimensions` are not unique.
C18b: Given `kernel_dimensions = kernel_spatial_dimensions +
      [kernel_input_feature_dimension] + [kernel_output_feature_dimension]`:
      * For any i in$ `kernel_dimensions`, i < 0.
C18c: Given `kernel_dimensions = kernel_spatial_dimensions +
      [kernel_input_feature_dimension] + [kernel_output_feature_dimension]`:
      * For any i in `kernel_dimensions`, i >= N.
C19a: size(`output_spatial_dimensions`) != N - 2.
C20a: Given `output_dimensions = [output_batch_dimension] +
     output_spatial_dimensions + [output_feature_dimension]`:
     * Any dimensions in `output_dimensions` are not unique.
     b) Given `output_dimensions = [output_batch_dimension] +
     output_spatial_dimensions + [output_feature_dimension]`:
     * For any i in `output_dimensions`, i < 0.
     c) Given `output_dimensions = [output_batch_dimension] +
     output_spatial_dimensions + [output_feature_dimension]`:
     * For any i in `output_dimensions`, i >= N.
C21a: `feature_group_count <= 0`.
C22a: `batch_group_count <= 0`.
C23a: `feature_group_count` != 1 and `batch_group_count` != 1.
C24a: size(`precision_config`) != 2.
C25a: For result_dim in [0, N):
      `dim(result, result_dim)` != `dim(lhs, input_batch_dimension) / batch_group_count`, if `result_dim = output_batch_dimension`.
C25b: For result_dim in [0, N):
      `dim(result, result_dim)` != `dim(rhs, kernel_output_feature_dimension)`, if `result_dim = output_feature_dimension`.
C25c: For result_dim in [0, N):
      `dim(result, result_dim)` != `num_windows` otherwise, where:
        * `output_spatial_dimensions[spatial_dim] = result_dim`.
        * `lhs_dim = input_spatial_dimensions[spatial_dim]`.
        * `rhs_dim = kernel_spatial_dimensions[spatial_dim]`.
        * `dilated_input_shape[lhs_dim] = dim(lhs, lhs_dim) == 0 ? 0 : (dim(lhs, lhs_dim) - 1) * lhs_dilation[spatial_dim] + 1`.
        * `padded_input_shape[lhs_dim] = padding[spatial_dim, 0] + dilated_input_shape[lhs_dim] + padding[spatial_dim, 1]`.
        * `dilated_window_shape[lhs_dim] = dim(rhs, rhs_dim) == 0 ? 0 : (dim(rhs, rhs_dim) - 1) * rhs_dilation[spatial_dim] + 1`.
        * `num_windows = (padded_input_shape[lhs_dim] == 0 || dilated_window_shape[lhs_dim] > padded_input_shape[lhs_dim]) ? 0 : floor((padded_input_shape[lhs_dim] - dilated_window_shape[lhs_dim]) / window_strides[spatial_dim]) + 1`.
C26a: rank(result) != N.
C27a: element_type(`lhs`) != element_type(`rhs`).
```

Notes:
* (new C24) is left untouched as there are still pending action item regarding the number of precision config values allowed in #879.

closes #970