### PR TITLE
Synchronize our BUILD.bazel with downstream build

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -22,6 +22,7 @@ exports_files([
     "LICENSE",
     "stablehlo/integrations/python/ChloModule.cpp",
     "stablehlo/integrations/python/StablehloModule.cpp",
+    "stablehlo/integrations/python/VhloModule.cpp",
 ])
 
 filegroup(
@@ -385,6 +386,7 @@ cc_library(
     strip_include_prefix = ".",
     deps = [
         ":reference_tensor",
+        "@llvm-project//llvm:Support",
         "@llvm-project//mlir:Support",
     ],
 )
@@ -453,7 +455,10 @@ cc_library(
         ":stablehlo_ops",
         ":vhlo_ops",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:QuantOps",
+        "@llvm-project//mlir:ShapeDialect",
         "@llvm-project//mlir:SparseTensorDialect",
+        "@llvm-project//mlir:TensorDialect",
     ],
 )
 
@@ -572,10 +577,20 @@ gentbl_cc_library(
     td_file = "stablehlo/tests/CheckOps.td",
     strip_include_prefix = ".",
     deps = [
-        "base_td_files",
+        ":check_ops_td_files",
     ],
 )
 
+td_library(
+    name = "check_ops_td_files",
+    srcs = [
+        "stablehlo/tests/CheckOps.td",
+    ],
+    includes = ["."],
+    deps = [
+        ":base_td_files",
+    ],
+)
 
 gentbl_cc_library(
     name = "stablehlo_enums_inc_gen",
@@ -715,6 +730,8 @@ cc_library(
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:InferTypeOpInterface",
         "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:QuantOps",
+        "@llvm-project//mlir:ShapeDialect",
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:TransformUtils",
@@ -801,11 +818,15 @@ cc_binary(
         "stablehlo/tools/StablehloTranslateMain.cpp",
     ],
     deps = [
-        ":reference_ops",
-        ":register",
         ":check_ops",
+        ":reference_errors",
+        ":reference_ops",
+        ":reference_scope",
+        ":reference_tensor",
+        ":register",
         ":stablehlo_ops",
         ":stablehlo_serialization",
+        ":test_utils",
         ":vhlo_ops",
         "@llvm-project//mlir:AllPassesAndDialects",
         "@llvm-project//mlir:FuncDialect",
@@ -833,8 +854,8 @@ filegroup(
     name = "test_data",
     testonly = True,
     data = [
-        ":stablehlo-translate",
         ":stablehlo-opt",
+        ":stablehlo-translate",
         "@llvm-project//llvm:FileCheck",
     ],
 )


### PR DESCRIPTION
Our BUILD.bazel file has diverged from the downstream build file a little bit, and this PR gets them back in sync again.