### PR TITLE
Fix bug with eval slice in refine shapes

### DIFF
--- a/stablehlo/tests/stablehlo_refine_shapes.mlir
+++ b/stablehlo/tests/stablehlo_refine_shapes.mlir
@@ -312,6 +312,22 @@ func.func @eval_slice() -> tensor<2xi64> {
 
 // -----
 
+// CHECK-LABEL: func @eval_slice_uint
+func.func @eval_slice_uint() -> tensor<1xui64> {
+  // CHECK-NOT: stablehlo.slice
+  // CHECK: [[RESULT:%.*]] = stablehlo.constant dense<1> : tensor<1xui64>
+  // CHECK: return [[RESULT]]
+  %0 = stablehlo.constant dense<[1, 2]> : tensor<2xui64>
+  %1 = "stablehlo.slice"(%0) {
+    start_indices = dense<0> : tensor<1xi64>,
+    limit_indices = dense<1> : tensor<1xi64>,
+    strides = dense<1> : tensor<1xi64>
+  } : (tensor<2xui64>) -> tensor<1xui64>
+  func.return %1 : tensor<1xui64>
+}
+
+// -----
+
 // CHECK-LABEL: func @eval_subtract
 func.func @eval_subtract() -> tensor<i64> {
   // CHECK-NOT: stablehlo.subtract

--- a/stablehlo/transforms/StablehloRefineShapes.cpp
+++ b/stablehlo/transforms/StablehloRefineShapes.cpp
@@ -23,6 +23,7 @@ limitations under the License.
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -360,14 +361,14 @@ struct EvalSliceOpPattern : public OpRewritePattern<SliceOp> {
     if (!resultType || resultType.getRank() != 1)
       return rewriter.notifyMatchFailure(op, "expected 1-dimensional type");
 
-    SmallVector<int64_t> operand;
+    SmallVector<APInt> operand;
     if (failed(matchInts(op.getOperand(), operand)))
       return rewriter.notifyMatchFailure(op, "expected constant operand");
 
     int64_t start = op.getStartIndices().getValues<int64_t>()[0];
     int64_t limit = op.getLimitIndices().getValues<int64_t>()[0];
     int64_t stride = op.getStrides().getValues<int64_t>()[0];
-    SmallVector<int64_t> result;
+    SmallVector<APInt> result;
     for (auto i = start; i < limit; i += stride) {
       result.push_back(operand[i]);
     }


### PR DESCRIPTION
Converting to uint was asserting when passing a `SmallVector<int64_t>`.