### PR TITLE
Load VHLO before deserialization

### DIFF
--- a/stablehlo/dialect/Serialization.cpp
+++ b/stablehlo/dialect/Serialization.cpp
@@ -63,6 +63,7 @@ LogicalResult serializePortableArtifact(ModuleOp module,
 
 OwningOpRef<ModuleOp> deserializePortableArtifact(StringRef sourceStr,
                                                   MLIRContext* context) {
+  context->loadDialect<vhlo::VhloDialect>();
   auto module = parseSourceString<ModuleOp>(sourceStr, context);
   if (!module) {
     return nullptr;


### PR DESCRIPTION
Since VHLO is an implementation detail of StableHLO, we shouldn't expect users of the API to pre-load the dialect.

Serialization isn't an issue since we list dependent dialects in our conversion passes which get loaded.