### PR TITLE
Fix CompareOp interpreter interface inconsistency

### DIFF
--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -39,7 +39,6 @@ Tensor evalClampOp(const Tensor &min, const Tensor &operand, const Tensor &max,
                    TensorType resultType);
 Tensor evalCompareOp(const Tensor &lhs, const Tensor &rhs,
                      ComparisonDirection comparisonDirection,
-                     std::optional<ComparisonType> compareType,
                      TensorType resultType);
 Tensor evalConcatenateOp(ArrayRef<Tensor> inputs, Axis dimension,
                          TensorType resultType);


### PR DESCRIPTION
It looks like the decl of evalCompareOp has an extra `compareType` parameter.