### PR TITLE
fix the spc for transpose op

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -5296,7 +5296,7 @@ where `i[d] = j[permutation[d]]`.
 * (C2) `permutation` is a permutation of `[0, 1, ..., R-1]` where `R` is the
 rank of `operand`.
 * (C3) For all dimensions `i` in `operand`, `dim(operand, i) = dim(result, j)`
-where `j = permutation[i]`.
+where `i = permutation[j]`.
 
 #### Examples
 


### PR DESCRIPTION
Fixes the type constraint (C3) of [transpose op](https://github.com/openxla/stablehlo/blob/main/docs/spec.md#transpose).

fixes https://github.com/openxla/stablehlo/issues/1339. Please refer to the same ticket for more details. 

Note that the implementation of the (C3) is still correct https://github.com/openxla/stablehlo/blob/076c6abc47edb53ed6510fec638112a4dc78ec33/stablehlo/dialect/TypeInference.cpp#L2898