### PR TITLE
refactor to improve evalOp function type checking

### DIFF
--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -39,6 +39,265 @@ Index evalIndices(ArrayRef<Tensor> runtimeIndices) {
 
 }  // namespace
 
+SmallVector<Tensor> eval(
+    Region &region, ArrayRef<Tensor> args, Scope *parent,
+    llvm::function_ref<llvm::Error(Operation &, Scope &)> fallback) {
+  Block &block = region.front();
+  if (block.getArguments().size() != args.size())
+    report_fatal_error(invalidArgument(
+        "Expected same number of block arguments and runtime arguments (%d)",
+        args.size()));
+
+  Scope scope(parent);
+  scope.add(block.getArguments(), args);
+
+  for (Operation &op : block) {
+    if (auto absOp = dyn_cast<AbsOp>(op)) {
+      Tensor runtimeOperand = scope.find(absOp.getOperand());
+      Tensor runtimeResult = evalAbsOp(runtimeOperand, absOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto addOp = dyn_cast<AddOp>(op)) {
+      Tensor runtimeLhs = scope.find(addOp.getLhs());
+      Tensor runtimeRhs = scope.find(addOp.getRhs());
+      Tensor runtimeResult = evalAddOp(runtimeLhs, runtimeRhs, addOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto andOp = dyn_cast<AndOp>(op)) {
+      Tensor runtimeLhs = scope.find(andOp.getLhs());
+      Tensor runtimeRhs = scope.find(andOp.getRhs());
+      Tensor runtimeResult = evalAndOp(runtimeLhs, runtimeRhs, andOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto broadcastInDimOp = dyn_cast<BroadcastInDimOp>(op)) {
+      Tensor runtimeOperand = scope.find(broadcastInDimOp.getOperand());
+      auto broadcastDimensions =
+          Axes(broadcastInDimOp.getBroadcastDimensions());
+      Tensor runtimeResult = evalBroadcastInDimOp(
+          runtimeOperand, broadcastDimensions, broadcastInDimOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto caseOp = dyn_cast<CaseOp>(op)) {
+      Tensor runtimeIndex = scope.find(caseOp.getIndex());
+      auto runtimeResults =
+          evalCaseOp(runtimeIndex, caseOp.getBranches(), scope);
+      scope.add(op.getResults(), {runtimeResults});
+    } else if (auto ceilOp = dyn_cast<CeilOp>(op)) {
+      Tensor runtimeOperand = scope.find(ceilOp.getOperand());
+      Tensor runtimeResult = evalCeilOp(runtimeOperand, ceilOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto clampOp = dyn_cast<ClampOp>(op)) {
+      Tensor runtimeMin = scope.find(clampOp.getMin());
+      Tensor runtimeOperand = scope.find(clampOp.getOperand());
+      Tensor runtimeMax = scope.find(clampOp.getMax());
+      Tensor runtimeResult = evalClampOp(runtimeMin, runtimeOperand, runtimeMax,
+                                         clampOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto compareOp = dyn_cast<CompareOp>(op)) {
+      Tensor runtimeLhs = scope.find(compareOp.getLhs());
+      Tensor runtimeRhs = scope.find(compareOp.getRhs());
+      auto comparisonDirection = compareOp.getComparisonDirection();
+      auto runtimeResult = evalCompareOp(
+          runtimeLhs, runtimeRhs, comparisonDirection, compareOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto concatenateOp = dyn_cast<ConcatenateOp>(op)) {
+      auto runtimeOperands = scope.find(concatenateOp.getOperands());
+      Tensor runtimeResult =
+          evalConcatenateOp(runtimeOperands, concatenateOp.getDimension(),
+                            concatenateOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto constantOp = dyn_cast<ConstantOp>(op)) {
+      Tensor runtimeResult = evalConstantOp(constantOp.getValue());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto convertOp = dyn_cast<ConvertOp>(op)) {
+      Tensor runtimeOperand = scope.find(convertOp.getOperand());
+      Tensor runtimeResult = evalConvertOp(runtimeOperand, convertOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto cosineOp = dyn_cast<CosineOp>(op)) {
+      Tensor runtimeOperand = scope.find(cosineOp.getOperand());
+      Tensor runtimeResult = evalCosineOp(runtimeOperand, cosineOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto divideOp = dyn_cast<DivOp>(op)) {
+      Tensor runtimeLhs = scope.find(divideOp.getLhs());
+      Tensor runtimeRhs = scope.find(divideOp.getRhs());
+      Tensor runtimeResult =
+          evalDivideOp(runtimeLhs, runtimeRhs, divideOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto dynamicSliceOp = dyn_cast<DynamicSliceOp>(op)) {
+      Tensor runtimeOperand = scope.find(dynamicSliceOp.getOperand());
+      SmallVector<Tensor> runtimeStartIndices =
+          scope.find(dynamicSliceOp.getStartIndices());
+      auto runtimeSliceSizes = Sizes(dynamicSliceOp.getSliceSizes());
+      Tensor runtimeResult =
+          evalDynamicSliceOp(runtimeOperand, runtimeStartIndices,
+                             runtimeSliceSizes, dynamicSliceOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto dynamicUpdateSliceOp = dyn_cast<DynamicUpdateSliceOp>(op)) {
+      Tensor runtimeOperand = scope.find(dynamicUpdateSliceOp.getOperand());
+      Tensor runtimeUpdate = scope.find(dynamicUpdateSliceOp.getUpdate());
+      SmallVector<Tensor> runtimeStartIndices =
+          scope.find(dynamicUpdateSliceOp.getStartIndices());
+      Tensor runtimeResult = evalDynamicUpdateSliceOp(
+          runtimeOperand, runtimeUpdate, runtimeStartIndices,
+          dynamicUpdateSliceOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto expOp = dyn_cast<ExpOp>(op)) {
+      Tensor runtimeOperand = scope.find(expOp.getOperand());
+      Tensor runtimeResult = evalExponentialOp(runtimeOperand, expOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto floorOp = dyn_cast<FloorOp>(op)) {
+      Tensor runtimeOperand = scope.find(floorOp.getOperand());
+      Tensor runtimeResult = evalFloorOp(runtimeOperand, floorOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto ifOp = dyn_cast<IfOp>(op)) {
+      Tensor runtimePred = scope.find(ifOp.getPred());
+      auto runtimeResults = evalIfOp(runtimePred, ifOp.getTrueBranch(),
+                                     ifOp.getFalseBranch(), scope);
+      scope.add(op.getResults(), runtimeResults);
+    } else if (auto imagOp = dyn_cast<ImagOp>(op)) {
+      Tensor runtimeOperand = scope.find(imagOp.getOperand());
+      Tensor runtimeResult = evalImagOp(runtimeOperand, imagOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto iotaOp = dyn_cast<IotaOp>(op)) {
+      Tensor runtimeResult =
+          evalIotaOp(iotaOp.getIotaDimension(), iotaOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto logOp = dyn_cast<LogOp>(op)) {
+      Tensor runtimeOperand = scope.find(logOp.getOperand());
+      Tensor runtimeResult = evalLogOp(runtimeOperand, logOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto logisticOp = dyn_cast<LogisticOp>(op)) {
+      Tensor runtimeOperand = scope.find(logisticOp.getOperand());
+      Tensor runtimeResult =
+          evalLogisticOp(runtimeOperand, logisticOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto maxOp = dyn_cast<MaxOp>(op)) {
+      Tensor runtimeLhs = scope.find(maxOp.getLhs());
+      Tensor runtimeRhs = scope.find(maxOp.getRhs());
+      Tensor runtimeResult = evalMaxOp(runtimeLhs, runtimeRhs, maxOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto minOp = dyn_cast<MinOp>(op)) {
+      Tensor runtimeLhs = scope.find(minOp.getLhs());
+      Tensor runtimeRhs = scope.find(minOp.getRhs());
+      Tensor runtimeResult = evalMinOp(runtimeLhs, runtimeRhs, minOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto multiplyOp = dyn_cast<MulOp>(op)) {
+      Tensor runtimeLhs = scope.find(multiplyOp.getLhs());
+      Tensor runtimeRhs = scope.find(multiplyOp.getRhs());
+      Tensor runtimeResult =
+          evalMultiplyOp(runtimeLhs, runtimeRhs, multiplyOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto negOp = dyn_cast<NegOp>(op)) {
+      Tensor runtimeOperand = scope.find(negOp.getOperand());
+      Tensor runtimeResult = evalNegOp(runtimeOperand, negOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto notOp = dyn_cast<NotOp>(op)) {
+      Tensor runtimeOperand = scope.find(notOp.getOperand());
+      Tensor runtimeResult = evalNotOp(runtimeOperand, notOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto orOp = dyn_cast<OrOp>(op)) {
+      Tensor runtimeLhs = scope.find(orOp.getLhs());
+      Tensor runtimeRhs = scope.find(orOp.getRhs());
+      Tensor runtimeResult = evalOrOp(runtimeLhs, runtimeRhs, orOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto padOp = dyn_cast<PadOp>(op)) {
+      Tensor runtimeOperand = scope.find(padOp.getOperand());
+      Tensor runtimePaddingValue = scope.find(padOp.getPaddingValue());
+      auto edgePaddingLow = Sizes(padOp.getEdgePaddingLow());
+      auto interiorPadding = Sizes(padOp.getInteriorPadding());
+      Tensor runtimeResult =
+          evalPadOp(runtimeOperand, runtimePaddingValue, edgePaddingLow,
+                    interiorPadding, padOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto powerOp = dyn_cast<PowOp>(op)) {
+      Tensor runtimeLhs = scope.find(powerOp.getLhs());
+      Tensor runtimeRhs = scope.find(powerOp.getRhs());
+      Tensor runtimeResult =
+          evalPowerOp(runtimeLhs, runtimeRhs, powerOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto remOp = dyn_cast<RemOp>(op)) {
+      Tensor runtimeLhs = scope.find(remOp.getLhs());
+      Tensor runtimeRhs = scope.find(remOp.getRhs());
+      Tensor runtimeResult = evalRemOp(runtimeLhs, runtimeRhs, remOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto whileOp = dyn_cast<WhileOp>(op)) {
+      SmallVector<Value> runtimeOperands(whileOp.getOperand().begin(),
+                                         whileOp.getOperand().end());
+      auto runtimeInputs = scope.find(runtimeOperands);
+      auto runtimeResults = evalWhileOp(runtimeInputs, whileOp.getCond(),
+                                        whileOp.getBody(), scope);
+      scope.add(op.getResults(), runtimeResults);
+    } else if (auto realOp = dyn_cast<RealOp>(op)) {
+      Tensor runtimeOperand = scope.find(realOp.getOperand());
+      Tensor runtimeResult = evalRealOp(runtimeOperand, realOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto reshapeOp = dyn_cast<ReshapeOp>(op)) {
+      Tensor runtimeOperand = scope.find(reshapeOp.getOperand());
+      Tensor runtimeResult = evalReshapeOp(runtimeOperand, reshapeOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto reverseOp = dyn_cast<ReverseOp>(op)) {
+      Tensor runtimeOperand = scope.find(reverseOp.getOperand());
+      auto dimensions = Axes(reverseOp.getDimensions());
+      Tensor runtimeResult =
+          evalReverseOp(runtimeOperand, dimensions, reverseOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto returnOp = dyn_cast<func::ReturnOp>(op)) {
+      return scope.find(returnOp.getOperands());
+    } else if (auto returnOp = dyn_cast<ReturnOp>(op)) {
+      return scope.find(returnOp.getResults());
+    } else if (auto selectOp = dyn_cast<SelectOp>(op)) {
+      Tensor runtimeResult = evalSelectOp(
+          scope.find(selectOp.getPred()), scope.find(selectOp.getOnTrue()),
+          scope.find(selectOp.getOnFalse()), selectOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto rsqrtOp = dyn_cast<RsqrtOp>(op)) {
+      Tensor runtimeOperand = scope.find(rsqrtOp.getOperand());
+      Tensor runtimeResult = evalRsqrtOp(runtimeOperand, rsqrtOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto sineOp = dyn_cast<SineOp>(op)) {
+      Tensor runtimeOperand = scope.find(sineOp.getOperand());
+      Tensor runtimeResult = evalSineOp(runtimeOperand, sineOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto sliceOp = dyn_cast<SliceOp>(op)) {
+      Tensor runtimeOperand = scope.find(sliceOp.getOperand());
+      auto startIndices = Sizes(sliceOp.getStartIndices());
+      auto strides = Sizes(sliceOp.getStrides());
+      Tensor runtimeResult =
+          evalSliceOp(runtimeOperand, startIndices, strides, sliceOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto sqrtOp = dyn_cast<SqrtOp>(op)) {
+      Tensor runtimeOperand = scope.find(sqrtOp.getOperand());
+      Tensor runtimeResult = evalSqrtOp(runtimeOperand, sqrtOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto subtractOp = dyn_cast<SubtractOp>(op)) {
+      Tensor runtimeLhs = scope.find(subtractOp.getLhs());
+      Tensor runtimeRhs = scope.find(subtractOp.getRhs());
+      Tensor runtimeResult =
+          evalSubtractOp(runtimeLhs, runtimeRhs, subtractOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto tanhOp = dyn_cast<TanhOp>(op)) {
+      Tensor runtimeOperand = scope.find(tanhOp.getOperand());
+      Tensor runtimeResult = evalTanhOp(runtimeOperand, tanhOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto transposeOp = dyn_cast<TransposeOp>(op)) {
+      Tensor runtimeOperand = scope.find(transposeOp.getOperand());
+      auto permutation = Axes(transposeOp.getPermutation());
+      Tensor runtimeResult =
+          evalTransposeOp(runtimeOperand, permutation, transposeOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else if (auto xorOp = dyn_cast<XorOp>(op)) {
+      Tensor runtimeLhs = scope.find(xorOp.getLhs());
+      Tensor runtimeRhs = scope.find(xorOp.getRhs());
+      Tensor runtimeResult = evalXorOp(runtimeLhs, runtimeRhs, xorOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
+    } else {
+      if (!fallback)
+        report_fatal_error(
+            invalidArgument("Unsupported op: %s", debugString(op).c_str()));
+      auto status = fallback(op, scope);
+      if (status) llvm::report_fatal_error(std::move(status));
+    }
+  }
+
+  llvm::report_fatal_error("Expected a terminator when evaluating a region");
+}
+
 Tensor evalAbsOp(const Tensor &operand, TensorType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
@@ -479,265 +738,6 @@ Tensor evalXorOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType) {
   for (auto it = lhs.index_begin(); it != lhs.index_end(); ++it)
     result.set(*it, lhs.get(*it) ^ rhs.get(*it));
   return result;
-}
-
-SmallVector<Tensor> eval(
-    Region &region, ArrayRef<Tensor> args, Scope *parent,
-    llvm::function_ref<llvm::Error(Operation &, Scope &)> fallback) {
-  Block &block = region.front();
-  if (block.getArguments().size() != args.size())
-    report_fatal_error(invalidArgument(
-        "Expected same number of block arguments and runtime arguments (%d)",
-        args.size()));
-
-  Scope scope(parent);
-  scope.add(block.getArguments(), args);
-
-  for (Operation &op : block) {
-    if (auto absOp = dyn_cast<AbsOp>(op)) {
-      Tensor runtimeOperand = scope.find(absOp.getOperand());
-      Tensor runtimeResult = evalAbsOp(runtimeOperand, absOp.getType());
-      scope.add(op.getResults(), {runtimeResult});
-    } else if (auto addOp = dyn_cast<AddOp>(op)) {
-      Tensor runtimeLhs = scope.find(addOp.getLhs());
-      Tensor runtimeRhs = scope.find(addOp.getRhs());
-      Tensor runtimeResult = evalAddOp(runtimeLhs, runtimeRhs, addOp.getType());
-      scope.add(op.getResults(), {runtimeResult});
-    } else if (auto andOp = dyn_cast<AndOp>(op)) {
-      Tensor runtimeLhs = scope.find(andOp.getLhs());
-      Tensor runtimeRhs = scope.find(andOp.getRhs());
-      Tensor runtimeResult = evalAndOp(runtimeLhs, runtimeRhs, andOp.getType());
-      scope.add(op.getResults(), {runtimeResult});
-    } else if (auto broadcastInDimOp = dyn_cast<BroadcastInDimOp>(op)) {
-      Tensor runtimeOperand = scope.find(broadcastInDimOp.getOperand());
-      auto broadcastDimensions =
-          Axes(broadcastInDimOp.getBroadcastDimensions());
-      Tensor runtimeResult = evalBroadcastInDimOp(
-          runtimeOperand, broadcastDimensions, broadcastInDimOp.getType());
-      scope.add(op.getResults(), {runtimeResult});
-    } else if (auto caseOp = dyn_cast<CaseOp>(op)) {
-      Tensor runtimeIndex = scope.find(caseOp.getIndex());
-      auto runtimeResults =
-          evalCaseOp(runtimeIndex, caseOp.getBranches(), scope);
-      scope.add(op.getResults(), {runtimeResults});
-    } else if (auto ceilOp = dyn_cast<CeilOp>(op)) {
-      Tensor runtimeOperand = scope.find(ceilOp.getOperand());
-      Tensor runtimeResult = evalCeilOp(runtimeOperand, ceilOp.getType());
-      scope.add(op.getResults(), {runtimeResult});
-    } else if (auto clampOp = dyn_cast<ClampOp>(op)) {
-      Tensor runtimeMin = scope.find(clampOp.getMin());
-      Tensor runtimeOperand = scope.find(clampOp.getOperand());
-      Tensor runtimeMax = scope.find(clampOp.getMax());
-      Tensor runtimeResult = evalClampOp(runtimeMin, runtimeOperand, runtimeMax,
-                                         clampOp.getType());
-      scope.add(op.getResults(), {runtimeResult});
-    } else if (auto compareOp = dyn_cast<CompareOp>(op)) {
-      Tensor runtimeLhs = scope.find(compareOp.getLhs());
-      Tensor runtimeRhs = scope.find(compareOp.getRhs());
-      auto comparisonDirection = compareOp.getComparisonDirection();
-      auto runtimeResult = evalCompareOp(
-          runtimeLhs, runtimeRhs, comparisonDirection, compareOp.getType());
-      scope.add(op.getResults(), {runtimeResult});
-    } else if (auto concatenateOp = dyn_cast<ConcatenateOp>(op)) {
-      auto runtimeOperands = scope.find(concatenateOp.getOperands());
-      Tensor runtimeResult =
-          evalConcatenateOp(runtimeOperands, concatenateOp.getDimension(),
-                            concatenateOp.getType());
-      scope.add(op.getResults(), {runtimeResult});
-    } else if (auto constantOp = dyn_cast<ConstantOp>(op)) {
-      Tensor runtimeResult = evalConstantOp(constantOp.getValue());
-      scope.add(op.getResults(), {runtimeResult});
-    } else if (auto convertOp = dyn_cast<ConvertOp>(op)) {
-      Tensor runtimeOperand = scope.find(convertOp.getOperand());
-      Tensor runtimeResult = evalConvertOp(runtimeOperand, convertOp.getType());
-      scope.add(op.getResults(), {runtimeResult});
-    } else if (auto cosineOp = dyn_cast<CosineOp>(op)) {
-      Tensor runtimeOperand = scope.find(cosineOp.getOperand());
-      Tensor runtimeResult = evalCosineOp(runtimeOperand, cosineOp.getType());
-      scope.add(op.getResults(), {runtimeResult});
-    } else if (auto divideOp = dyn_cast<DivOp>(op)) {
-      Tensor runtimeLhs = scope.find(divideOp.getLhs());
-      Tensor runtimeRhs = scope.find(divideOp.getRhs());
-      Tensor runtimeResult =
-          evalDivideOp(runtimeLhs, runtimeRhs, divideOp.getType());
-      scope.add(op.getResults(), {runtimeResult});
-    } else if (auto dynamicSliceOp = dyn_cast<DynamicSliceOp>(op)) {
-      Tensor runtimeOperand = scope.find(dynamicSliceOp.getOperand());
-      SmallVector<Tensor> runtimeStartIndices =
-          scope.find(dynamicSliceOp.getStartIndices());
-      auto runtimeSliceSizes = Sizes(dynamicSliceOp.getSliceSizes());
-      Tensor runtimeResult =
-          evalDynamicSliceOp(runtimeOperand, runtimeStartIndices,
-                             runtimeSliceSizes, dynamicSliceOp.getType());
-      scope.add(op.getResults(), {runtimeResult});
-    } else if (auto dynamicUpdateSliceOp = dyn_cast<DynamicUpdateSliceOp>(op)) {
-      Tensor runtimeOperand = scope.find(dynamicUpdateSliceOp.getOperand());
-      Tensor runtimeUpdate = scope.find(dynamicUpdateSliceOp.getUpdate());
-      SmallVector<Tensor> runtimeStartIndices =
-          scope.find(dynamicUpdateSliceOp.getStartIndices());
-      Tensor runtimeResult = evalDynamicUpdateSliceOp(
-          runtimeOperand, runtimeUpdate, runtimeStartIndices,
-          dynamicUpdateSliceOp.getType());
-      scope.add(op.getResults(), {runtimeResult});
-    } else if (auto expOp = dyn_cast<ExpOp>(op)) {
-      Tensor runtimeOperand = scope.find(expOp.getOperand());
-      Tensor runtimeResult = evalExponentialOp(runtimeOperand, expOp.getType());
-      scope.add(op.getResults(), {runtimeResult});
-    } else if (auto floorOp = dyn_cast<FloorOp>(op)) {
-      Tensor runtimeOperand = scope.find(floorOp.getOperand());
-      Tensor runtimeResult = evalFloorOp(runtimeOperand, floorOp.getType());
-      scope.add(op.getResults(), {runtimeResult});
-    } else if (auto ifOp = dyn_cast<IfOp>(op)) {
-      Tensor runtimePred = scope.find(ifOp.getPred());
-      auto runtimeResults = evalIfOp(runtimePred, ifOp.getTrueBranch(),
-                                     ifOp.getFalseBranch(), scope);
-      scope.add(op.getResults(), runtimeResults);
-    } else if (auto imagOp = dyn_cast<ImagOp>(op)) {
-      Tensor runtimeOperand = scope.find(imagOp.getOperand());
-      Tensor runtimeResult = evalImagOp(runtimeOperand, imagOp.getType());
-      scope.add(op.getResults(), {runtimeResult});
-    } else if (auto iotaOp = dyn_cast<IotaOp>(op)) {
-      Tensor runtimeResult =
-          evalIotaOp(iotaOp.getIotaDimension(), iotaOp.getType());
-      scope.add(op.getResults(), {runtimeResult});
-    } else if (auto logOp = dyn_cast<LogOp>(op)) {
-      Tensor runtimeOperand = scope.find(logOp.getOperand());
-      Tensor runtimeResult = evalLogOp(runtimeOperand, logOp.getType());
-      scope.add(op.getResults(), {runtimeResult});
-    } else if (auto logisticOp = dyn_cast<LogisticOp>(op)) {
-      Tensor runtimeOperand = scope.find(logisticOp.getOperand());
-      Tensor runtimeResult =
-          evalLogisticOp(runtimeOperand, logisticOp.getType());
-      scope.add(op.getResults(), {runtimeResult});
-    } else if (auto maxOp = dyn_cast<MaxOp>(op)) {
-      Tensor runtimeLhs = scope.find(maxOp.getLhs());
-      Tensor runtimeRhs = scope.find(maxOp.getRhs());
-      Tensor runtimeResult = evalMaxOp(runtimeLhs, runtimeRhs, maxOp.getType());
-      scope.add(op.getResults(), {runtimeResult});
-    } else if (auto minOp = dyn_cast<MinOp>(op)) {
-      Tensor runtimeLhs = scope.find(minOp.getLhs());
-      Tensor runtimeRhs = scope.find(minOp.getRhs());
-      Tensor runtimeResult = evalMinOp(runtimeLhs, runtimeRhs, minOp.getType());
-      scope.add(op.getResults(), {runtimeResult});
-    } else if (auto multiplyOp = dyn_cast<MulOp>(op)) {
-      Tensor runtimeLhs = scope.find(multiplyOp.getLhs());
-      Tensor runtimeRhs = scope.find(multiplyOp.getRhs());
-      Tensor runtimeResult =
-          evalMultiplyOp(runtimeLhs, runtimeRhs, multiplyOp.getType());
-      scope.add(op.getResults(), {runtimeResult});
-    } else if (auto negOp = dyn_cast<NegOp>(op)) {
-      Tensor runtimeOperand = scope.find(negOp.getOperand());
-      Tensor runtimeResult = evalNegOp(runtimeOperand, negOp.getType());
-      scope.add(op.getResults(), {runtimeResult});
-    } else if (auto notOp = dyn_cast<NotOp>(op)) {
-      Tensor runtimeOperand = scope.find(notOp.getOperand());
-      Tensor runtimeResult = evalNotOp(runtimeOperand, notOp.getType());
-      scope.add(op.getResults(), {runtimeResult});
-    } else if (auto orOp = dyn_cast<OrOp>(op)) {
-      Tensor runtimeLhs = scope.find(orOp.getLhs());
-      Tensor runtimeRhs = scope.find(orOp.getRhs());
-      Tensor runtimeResult = evalOrOp(runtimeLhs, runtimeRhs, orOp.getType());
-      scope.add(op.getResults(), {runtimeResult});
-    } else if (auto padOp = dyn_cast<PadOp>(op)) {
-      Tensor runtimeOperand = scope.find(padOp.getOperand());
-      Tensor runtimePaddingValue = scope.find(padOp.getPaddingValue());
-      auto edgePaddingLow = Sizes(padOp.getEdgePaddingLow());
-      auto interiorPadding = Sizes(padOp.getInteriorPadding());
-      Tensor runtimeResult =
-          evalPadOp(runtimeOperand, runtimePaddingValue, edgePaddingLow,
-                    interiorPadding, padOp.getType());
-      scope.add(op.getResults(), {runtimeResult});
-    } else if (auto powerOp = dyn_cast<PowOp>(op)) {
-      Tensor runtimeLhs = scope.find(powerOp.getLhs());
-      Tensor runtimeRhs = scope.find(powerOp.getRhs());
-      Tensor runtimeResult =
-          evalPowerOp(runtimeLhs, runtimeRhs, powerOp.getType());
-      scope.add(op.getResults(), {runtimeResult});
-    } else if (auto remOp = dyn_cast<RemOp>(op)) {
-      Tensor runtimeLhs = scope.find(remOp.getLhs());
-      Tensor runtimeRhs = scope.find(remOp.getRhs());
-      Tensor runtimeResult = evalRemOp(runtimeLhs, runtimeRhs, remOp.getType());
-      scope.add(op.getResults(), {runtimeResult});
-    } else if (auto whileOp = dyn_cast<WhileOp>(op)) {
-      SmallVector<Value> runtimeOperands(whileOp.getOperand().begin(),
-                                         whileOp.getOperand().end());
-      auto runtimeInputs = scope.find(runtimeOperands);
-      auto runtimeResults = evalWhileOp(runtimeInputs, whileOp.getCond(),
-                                        whileOp.getBody(), scope);
-      scope.add(op.getResults(), runtimeResults);
-    } else if (auto realOp = dyn_cast<RealOp>(op)) {
-      Tensor runtimeOperand = scope.find(realOp.getOperand());
-      Tensor runtimeResult = evalRealOp(runtimeOperand, realOp.getType());
-      scope.add(op.getResults(), {runtimeResult});
-    } else if (auto reshapeOp = dyn_cast<ReshapeOp>(op)) {
-      Tensor runtimeOperand = scope.find(reshapeOp.getOperand());
-      Tensor runtimeResult = evalReshapeOp(runtimeOperand, reshapeOp.getType());
-      scope.add(op.getResults(), {runtimeResult});
-    } else if (auto reverseOp = dyn_cast<ReverseOp>(op)) {
-      Tensor runtimeOperand = scope.find(reverseOp.getOperand());
-      auto dimensions = Axes(reverseOp.getDimensions());
-      Tensor runtimeResult =
-          evalReverseOp(runtimeOperand, dimensions, reverseOp.getType());
-      scope.add(op.getResults(), {runtimeResult});
-    } else if (auto returnOp = dyn_cast<func::ReturnOp>(op)) {
-      return scope.find(returnOp.getOperands());
-    } else if (auto returnOp = dyn_cast<ReturnOp>(op)) {
-      return scope.find(returnOp.getResults());
-    } else if (auto selectOp = dyn_cast<SelectOp>(op)) {
-      Tensor runtimeResult = evalSelectOp(
-          scope.find(selectOp.getPred()), scope.find(selectOp.getOnTrue()),
-          scope.find(selectOp.getOnFalse()), selectOp.getType());
-      scope.add(op.getResults(), {runtimeResult});
-    } else if (auto rsqrtOp = dyn_cast<RsqrtOp>(op)) {
-      Tensor runtimeOperand = scope.find(rsqrtOp.getOperand());
-      Tensor runtimeResult = evalRsqrtOp(runtimeOperand, rsqrtOp.getType());
-      scope.add(op.getResults(), {runtimeResult});
-    } else if (auto sineOp = dyn_cast<SineOp>(op)) {
-      Tensor runtimeOperand = scope.find(sineOp.getOperand());
-      Tensor runtimeResult = evalSineOp(runtimeOperand, sineOp.getType());
-      scope.add(op.getResults(), {runtimeResult});
-    } else if (auto sliceOp = dyn_cast<SliceOp>(op)) {
-      Tensor runtimeOperand = scope.find(sliceOp.getOperand());
-      auto startIndices = Sizes(sliceOp.getStartIndices());
-      auto strides = Sizes(sliceOp.getStrides());
-      Tensor runtimeResult =
-          evalSliceOp(runtimeOperand, startIndices, strides, sliceOp.getType());
-      scope.add(op.getResults(), {runtimeResult});
-    } else if (auto sqrtOp = dyn_cast<SqrtOp>(op)) {
-      Tensor runtimeOperand = scope.find(sqrtOp.getOperand());
-      Tensor runtimeResult = evalSqrtOp(runtimeOperand, sqrtOp.getType());
-      scope.add(op.getResults(), {runtimeResult});
-    } else if (auto subtractOp = dyn_cast<SubtractOp>(op)) {
-      Tensor runtimeLhs = scope.find(subtractOp.getLhs());
-      Tensor runtimeRhs = scope.find(subtractOp.getRhs());
-      Tensor runtimeResult =
-          evalSubtractOp(runtimeLhs, runtimeRhs, subtractOp.getType());
-      scope.add(op.getResults(), {runtimeResult});
-    } else if (auto tanhOp = dyn_cast<TanhOp>(op)) {
-      Tensor runtimeOperand = scope.find(tanhOp.getOperand());
-      Tensor runtimeResult = evalTanhOp(runtimeOperand, tanhOp.getType());
-      scope.add(op.getResults(), {runtimeResult});
-    } else if (auto transposeOp = dyn_cast<TransposeOp>(op)) {
-      Tensor runtimeOperand = scope.find(transposeOp.getOperand());
-      auto permutation = Axes(transposeOp.getPermutation());
-      Tensor runtimeResult =
-          evalTransposeOp(runtimeOperand, permutation, transposeOp.getType());
-      scope.add(op.getResults(), {runtimeResult});
-    } else if (auto xorOp = dyn_cast<XorOp>(op)) {
-      Tensor runtimeLhs = scope.find(xorOp.getLhs());
-      Tensor runtimeRhs = scope.find(xorOp.getRhs());
-      Tensor runtimeResult = evalXorOp(runtimeLhs, runtimeRhs, xorOp.getType());
-      scope.add(op.getResults(), {runtimeResult});
-    } else {
-      if (!fallback)
-        report_fatal_error(
-            invalidArgument("Unsupported op: %s", debugString(op).c_str()));
-      auto status = fallback(op, scope);
-      if (status) llvm::report_fatal_error(std::move(status));
-    }
-  }
-
-  llvm::report_fatal_error("Expected a terminator when evaluating a region");
 }
 
 }  // namespace stablehlo


### PR DESCRIPTION
This is to make sure that, during compilation, the interfatce-type-checking  for the `evalOp*` function calls in eval function (https://github.com/openxla/stablehlo/blob/311f14ce78c7fe35d304ee91007b58c335cf821e/stablehlo/reference/Ops.cpp#L484) are relying on the declarations in Ops.h. Currently, the checking is happening locally within Ops.cpp as the calls to those `evalOps*` functions are preceded by the corresponding definitions. The problem with the current setup is that a change in declaration Ops.h will go unnoticed, which is what exactly happened in  https://github.com/openxla/stablehlo/pull/1343. The proposed fix will make sure that such inconsistencies can be caught during compilation time. 