### PR TITLE
Add interpreter for ConvertOp

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1920,8 +1920,8 @@ part is ignored.
 
 For **boolean-to-any-supported-type** conversions, the value `false` is
 converted to zero, and the value `true` is converted to one. For
-**any-supported-type-to-boolean** conversions, a zero value is converted to
-`false` and any non-zero value is converted to `true`.
+**any-supported-type-to-boolean** conversions, a zero real value is converted to
+`false`, and a non-zero real value is converted to `true`.
 
 #### Inputs
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1884,46 +1884,30 @@ Produces an `output` tensor from a constant `value`.
 Performs an element-wise conversion from one element type to another on
 `operand` tensor and produces a `result` tensor.
 
-For conversions involving **integer-to-integer**, if there is an unsigned/signed
-overflow, the result is implementation-defined and one of the following:
+For **boolean-to-any-supported-type** conversions, the value `false` is
+converted to zero, and the value `true` is converted to one. For
+**any-supported-type-to-boolean** conversions, a zero value is converted to
+`false`, and non-zero values are converted to `true`. See below for how this
+work for complex types.
 
-* mathematical result modulo $2^n$, where n is the bit width of the result,
-  for unsigned overflow. For signed integer overflow, wraps the result around
-  the representable range $[-2^{n-1},\ 2^{n-1} - 1]$.
-* saturation to $2^{n-1} - 1$ (or $-2^{n-1}$) for signed overflow and
-  saturation to $2^n - 1$ (or $0$) for unsigned overflow.
-
-For conversions involving **floating-point-to-floating-point** or
-**integer-to-floating-point**, if the source value can be exactly represented in
-the destination type, the result value is that exact representation. Otherwise,
-the behavior is TBD ([#180](https://github.com/openxla/stablehlo/issues/180)).
-
-Conversion involving **complex-to-complex** follows the same behavior of
-**floating-point-to-floating-point** conversions for converting real and
-imaginary parts.
-
-For conversions involving **floating-point-to-complex** or
-**complex-to-floating-point**, the destination imaginary value is zeroed or the
-source imaginary value is ignored, respectively. The conversion of the real part
-follows the **floating-point-to-floating-point** conversion.
-
-Conversions involving **integer-to-complex** follows the same behavior as
-**integer-to-floating-point** conversion while converting the source integer to
-destination real part. The destination imaginary part is zeroed.
+For conversions involving **integer-to-integer**, **integer-to-floating-point**
+or **floating-point-to-floating-point**, if the source value can be exactly
+represented in the destination type, the result value is that exact
+representation. Otherwise, the behavior is TBD
+([#180](https://github.com/openxla/stablehlo/issues/180)).
 
 For conversions involving **floating-point-to-integer**, the fractional part is
 truncated. If the truncated value cannot be represented in the destination type,
 the behavior is TBD ([#180](https://github.com/openxla/stablehlo/issues/180)).
-Conversions involving **complex-to-integer** follows the same behavior while
-converting the source real part to destination integer. The source imaginary
-part is ignored.
 
-For **boolean-to-any-supported-type** conversions, the value `false` is
-converted to zero, and the value `true` is converted to one. For
-**any-supported-type-to-boolean** conversions, a zero value for non-complex
-element type or a zero real value for complex element type is converted to
-`false`, and a non-zero value for non-complex element type or a non-zero real
-value for complex element type is converted to `true`.
+Conversion involving **complex-to-complex** follow the same behavior of
+**floating-point-to-floating-point** conversions for converting real and
+imaginary parts.
+
+For **complex-to-any-other-type** and **any-other-type-to-complex** conversions,
+the source imaginary value is ignored or the destination imaginary value is
+zeroed, respectively. The conversion of the real part follows the
+floating-point conversions.
 
 #### Inputs
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1942,10 +1942,12 @@ converted to zero, and the value `true` is converted to one. For
 #### Examples
 
 ```mlir
-// %operand: [1, 2, 3]
-%result = "stablehlo.convert"(%operand) : (tensor<3xi32>) -> tensor<3xcomplex<f32>>
-// %result: [(1.0, 0.0), (2.0, 0.0), (3.0, 0.0)]
+// %operand: [-1, 0, 1]
+%result = "stablehlo.convert"(%operand) : (tensor<3xi64>) -> tensor<3xcomplex<f64>>
+// %result: [(-1.0, 0.0), (0.0, 0.0), (1.0, 0.0)]
 ```
+
+&nbsp;[More Examples](../stablehlo/tests/interpret_convert.mlir)
 
 ### convolution
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1920,8 +1920,10 @@ part is ignored.
 
 For **boolean-to-any-supported-type** conversions, the value `false` is
 converted to zero, and the value `true` is converted to one. For
-**any-supported-type-to-boolean** conversions, a zero real value is converted to
-`false`, and a non-zero real value is converted to `true`.
+**any-supported-type-to-boolean** conversions, a zero value for non-complex
+element type or a zero real value for complex element type is converted to
+`false`, and a non-zero value for non-complex element type or a non-zero real
+value for complex element type is converted to `true`.
 
 #### Inputs
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -67,7 +67,7 @@ one of the following tracking labels.
 | compute_reshape_shape    | no            | revisit      | no             | yes             | no          |
 | concatenate              | yes           | yes          | yes            | yes             | yes         |
 | constant                 | yes           | yes          | yes            | yes             | yes         |
-| convert                  | yes           | yes          | infeasible     | yes             | no          |
+| convert                  | yes           | yes          | infeasible     | yes             | yes         |
 | convolution              | yes           | yes          | infeasible     | revisit         | no          |
 | cosine                   | yes           | yes          | yes            | yes             | yes         |
 | count_leading_zeros      | yes           | yes          | yes            | yes             | yes         |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -252,7 +252,7 @@ def StableHLO_CeilOp: StableHLO_UnaryElementwiseOp<"ceil",
 }
 
 def StableHLO_ConvertOp : StableHLO_UnaryElementwiseOp<"convert",
-    [Pure, SameOperandsAndResultShape], HLO_Tensor> {
+    [Pure, SameOperandsAndResultShape /*convert_c1*/], HLO_Tensor> { /*convert_i1*/
   let summary = "Convert operation";
   let description = [{
     Performs an element-wise conversion from one element type to another on
@@ -263,7 +263,7 @@ def StableHLO_ConvertOp : StableHLO_UnaryElementwiseOp<"convert",
 
     Example:
     ```mlir
-    %result = stablehlo.convert %operand : (tensor<3xi32>) -> tensor<3xcomplex<f32>>
+    %result = stablehlo.convert %operand : (tensor<3xi64>) -> tensor<3xcomplex<f64>>
     ```
   }];
   let builders = [

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -1692,7 +1692,8 @@ LogicalResult inferConstantOp(std::optional<Location>, ElementsAttr value,
 LogicalResult inferConvertOp(
     std::optional<Location> location, Value operand,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
-  auto operandType = operand.getType().cast<ShapedType>();
+  auto operandType = operand.getType().dyn_cast<ShapedType>();
+  // convert_c1
   inferredReturnShapes.emplace_back(
       operandType.hasRank() ? operandType.getShape() : ArrayRef<int64_t>{});
   return success();

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -1692,7 +1692,7 @@ LogicalResult inferConstantOp(std::optional<Location>, ElementsAttr value,
 LogicalResult inferConvertOp(
     std::optional<Location> location, Value operand,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
-  auto operandType = operand.getType().dyn_cast<ShapedType>();
+  auto operandType = operand.getType().cast<ShapedType>();
   // convert_c1
   inferredReturnShapes.emplace_back(
       operandType.hasRank() ? operandType.getShape() : ArrayRef<int64_t>{});

--- a/stablehlo/reference/Element.h
+++ b/stablehlo/reference/Element.h
@@ -48,7 +48,8 @@ class Element {
   Element(Type type, APFloat value);
 
   /// Initializes Element object with type 'type' and value 'value'. 'type' must
-  /// be a complex type and the bitwidth of 'type' and 'value' must match.
+  /// be a complex type and the bitwidth, w.r.t. the real and imaginary part, of
+  /// 'type' and 'value' must match.
   Element(Type type, std::complex<APFloat> value);
 
   Element(const Element &other) = default;
@@ -185,13 +186,19 @@ Element convert(Type type, APFloat value);
 Element convert(Type type, double value);
 
 /// Returns converted Element object of type 'type' from source complex<APFloat>
-/// 'value'. If the value cannot be exactly represented in the destination type,
-/// then the behavior is TBD (#180).
+/// 'value'. Only the real part of 'value' is used to convert to non-complex
+/// destination types. If the value cannot be exactly represented in the complex
+/// destination type, then the behavior is TBD (#180). If the real part of
+/// 'value' cannot be exactly represented in the non-complex destination type,
+/// then the behavior is also TBD (#180).
 Element convert(Type type, std::complex<APFloat> value);
 
 /// Returns converted Element object of type 'type' from source complex<double>
-/// 'value'. If the value cannot be exactly represented in the destination type,
-/// then the behavior is TBD (#180).
+/// 'value'. Only the real part of 'value' is used to convert to non-complex
+/// destination types. If the value cannot be exactly represented in the complex
+/// destination type, then the behavior is TBD (#180). If the real part of
+/// 'value' cannot be exactly represented in the non-complex destination type,
+/// then the behavior is also TBD (#180).
 Element convert(Type type, std::complex<double> value);
 
 /// Returns cosine of Element object.

--- a/stablehlo/reference/Element.h
+++ b/stablehlo/reference/Element.h
@@ -34,22 +34,21 @@ class Element {
  public:
   /// \name Constructors
   /// @{
-  /// Initializes Element object with type 'type' and value 'value'. 'type' must
-  /// be an integer type and the bitwidth of 'type' and 'value' must match.
+  /// Initializes Element object with type `type` and value `value`. `type` must
+  /// be an integer type.
   Element(Type type, APInt value);
 
-  /// Initializes Element object with type 'type' and value 'value'. 'type' must
-  /// be a boolean type and the bitwidth of 'type' and 'value' must match.
+  /// Initializes Element object with type `type` and value `value`. `type` must
+  /// be a boolean type.
   Element(Type type, bool value);
 
-  /// Initializes Element object with type 'type' and value 'value'. 'type' must
-  /// be a floating-point type and the bitwidth of 'type' and 'value' must
-  /// match.
+  /// Initializes Element object with type `type` and value `value`. `type` must
+  /// be a floating-point type of the same semantics as `value`.
   Element(Type type, APFloat value);
 
-  /// Initializes Element object with type 'type' and value 'value'. 'type' must
-  /// be a complex type and the bitwidth, w.r.t. the real and imaginary part, of
-  /// 'type' and 'value' must match.
+  /// Initializes Element object with type `type` and value `value`. `type` must
+  /// be a complex type and the bitwidths of both the real and the imaginary
+  /// parts of `type` and `value` must match.
   Element(Type type, std::complex<APFloat> value);
 
   Element(const Element &other) = default;
@@ -160,46 +159,44 @@ Element ceil(const Element &e);
 /// Returns a complex type Element object.
 Element complex(const Element &e1, const Element &e2);
 
-/// Returns converted Element object of type 'type' from source boolean 'value'.
-/// If the value cannot be exactly represented in the destination type, then the
-/// behavior is TBD (#180).
+/// Returns converted Element object of type `type` from source boolean `value`.
 Element convert(Type type, bool value);
 
-/// Returns converted Element object of type 'type' from source signed integer
-/// 'value'. If the value cannot be exactly represented in the destination type,
+/// Returns converted Element object of type `type` from source signed integer
+/// `value`. If the value cannot be exactly represented in the destination type,
 /// then the behavior is TBD (#180).
 Element convert(Type type, int64_t value);
 
-/// Returns converted Element object of type 'type' from source unsigned integer
-/// 'value'. If the value cannot be exactly represented in the destination type,
+/// Returns converted Element object of type `type` from source unsigned integer
+/// `value`. If the value cannot be exactly represented in the destination type,
 /// then the behavior is TBD (#180).
 Element convert(Type type, uint64_t value);
 
-/// Returns converted Element object of type 'type' from source APFloat 'value'.
+/// Returns converted Element object of type `type` from source APFloat `value`.
 /// If the value cannot be exactly represented in the destination type, then the
 /// behavior is TBD (#180).
 Element convert(Type type, APFloat value);
 
-/// Returns converted Element object of type 'type' from source double 'value'.
+/// Returns converted Element object of type `type` from source double `value`.
 /// If the value cannot be exactly represented in the destination type, then the
 /// behavior is TBD (#180).
 Element convert(Type type, double value);
 
-/// Returns converted Element object of type 'type' from source complex<APFloat>
-/// 'value'. Only the real part of 'value' is used to convert to non-complex
+/// Returns converted Element object of type `type` from source complex<APFloat>
+/// `value`. Only the real part of `value` is used to convert to non-complex
 /// destination types. If the value (or the real part of `value`) cannot be
 /// exactly represented in the complex destination type (or non-complex
 /// destination type), then then the behavior is TBD (#180). If the real part of
-/// 'value' cannot be exactly represented in the non-complex destination type,
+/// `value` cannot be exactly represented in the non-complex destination type,
 /// then the behavior is also TBD (#180).
 Element convert(Type type, std::complex<APFloat> value);
 
-/// Returns converted Element object of type 'type' from source complex<double>
-/// 'value'. Only the real part of 'value' is used to convert to non-complex
+/// Returns converted Element object of type `type` from source complex<double>
+/// `value`. Only the real part of `value` is used to convert to non-complex
 /// destination types. If the value (or the real part of `value`) cannot be
 /// exactly represented in the complex destination type (or non-complex
 /// destination type), then then the behavior is TBD (#180). If the real part of
-/// 'value' cannot be exactly represented in the non-complex destination type,
+/// `value` cannot be exactly represented in the non-complex destination type,
 /// then the behavior is also TBD (#180).
 Element convert(Type type, std::complex<double> value);
 

--- a/stablehlo/reference/Element.h
+++ b/stablehlo/reference/Element.h
@@ -187,16 +187,18 @@ Element convert(Type type, double value);
 
 /// Returns converted Element object of type 'type' from source complex<APFloat>
 /// 'value'. Only the real part of 'value' is used to convert to non-complex
-/// destination types. If the value cannot be exactly represented in the complex
-/// destination type, then the behavior is TBD (#180). If the real part of
+/// destination types. If the value (or the real part of `value`) cannot be
+/// exactly represented in the complex destination type (or non-complex
+/// destination type), then then the behavior is TBD (#180). If the real part of
 /// 'value' cannot be exactly represented in the non-complex destination type,
 /// then the behavior is also TBD (#180).
 Element convert(Type type, std::complex<APFloat> value);
 
 /// Returns converted Element object of type 'type' from source complex<double>
 /// 'value'. Only the real part of 'value' is used to convert to non-complex
-/// destination types. If the value cannot be exactly represented in the complex
-/// destination type, then the behavior is TBD (#180). If the real part of
+/// destination types. If the value (or the real part of `value`) cannot be
+/// exactly represented in the complex destination type (or non-complex
+/// destination type), then then the behavior is TBD (#180). If the real part of
 /// 'value' cannot be exactly represented in the non-complex destination type,
 /// then the behavior is also TBD (#180).
 Element convert(Type type, std::complex<double> value);

--- a/stablehlo/reference/Element.h
+++ b/stablehlo/reference/Element.h
@@ -42,9 +42,13 @@ class Element {
 
   Element(Type type, APFloat value);
 
-  /// The double `value` can be used to construct two types: floating-point or
-  /// complex element types. By specifying a double value for complex element
-  /// type, the real part is set to `value`, and the imaginary part is zero.
+  /// The double `value` can be used to construct other element types. By
+  /// specifying a double value for:
+  /// * boolean: non-zero value is converted to 'true' otherwise false.
+  /// * integer: fractional part is truncated.
+  /// * float: exactly representable value, TBD(#180) otherwise.
+  /// * complex: the real part is set to exactly representable value or
+  ///   TBD(#180) otherwise, and the imaginary part is zero.
   Element(Type type, double value);
 
   Element(Type type, std::complex<APFloat> value);

--- a/stablehlo/reference/Element.h
+++ b/stablehlo/reference/Element.h
@@ -34,26 +34,22 @@ class Element {
  public:
   /// \name Constructors
   /// @{
+  /// Initializes Element object with type 'type' and value 'value'. 'type' must
+  /// be an integer type and the bitwidth of 'type' and 'value' must match.
   Element(Type type, APInt value);
 
-  Element(Type type, int64_t value);
-
+  /// Initializes Element object with type 'type' and value 'value'. 'type' must
+  /// be a boolean type and the bitwidth of 'type' and 'value' must match.
   Element(Type type, bool value);
 
+  /// Initializes Element object with type 'type' and value 'value'. 'type' must
+  /// be a floating-point type and the bitwidth of 'type' and 'value' must
+  /// match.
   Element(Type type, APFloat value);
 
-  /// The double `value` can be used to construct other element types. By
-  /// specifying a double value for:
-  /// * boolean: non-zero value is converted to 'true' otherwise false.
-  /// * integer: fractional part is truncated.
-  /// * float: exactly representable value, TBD(#180) otherwise.
-  /// * complex: the real part is set to exactly representable value or
-  ///   TBD(#180) otherwise, and the imaginary part is zero.
-  Element(Type type, double value);
-
+  /// Initializes Element object with type 'type' and value 'value'. 'type' must
+  /// be a complex type and the bitwidth of 'type' and 'value' must match.
   Element(Type type, std::complex<APFloat> value);
-
-  Element(Type type, std::complex<double> value);
 
   Element(const Element &other) = default;
   /// @}
@@ -162,6 +158,41 @@ Element ceil(const Element &e);
 
 /// Returns a complex type Element object.
 Element complex(const Element &e1, const Element &e2);
+
+/// Returns converted Element object of type 'type' from source boolean 'value'.
+/// If the value cannot be exactly represented in the destination type, then the
+/// behavior is TBD (#180).
+Element convert(Type type, bool value);
+
+/// Returns converted Element object of type 'type' from source signed integer
+/// 'value'. If the value cannot be exactly represented in the destination type,
+/// then the behavior is TBD (#180).
+Element convert(Type type, int64_t value);
+
+/// Returns converted Element object of type 'type' from source unsigned integer
+/// 'value'. If the value cannot be exactly represented in the destination type,
+/// then the behavior is TBD (#180).
+Element convert(Type type, uint64_t value);
+
+/// Returns converted Element object of type 'type' from source APFloat 'value'.
+/// If the value cannot be exactly represented in the destination type, then the
+/// behavior is TBD (#180).
+Element convert(Type type, APFloat value);
+
+/// Returns converted Element object of type 'type' from source double 'value'.
+/// If the value cannot be exactly represented in the destination type, then the
+/// behavior is TBD (#180).
+Element convert(Type type, double value);
+
+/// Returns converted Element object of type 'type' from source complex<APFloat>
+/// 'value'. If the value cannot be exactly represented in the destination type,
+/// then the behavior is TBD (#180).
+Element convert(Type type, std::complex<APFloat> value);
+
+/// Returns converted Element object of type 'type' from source complex<double>
+/// 'value'. If the value cannot be exactly represented in the destination type,
+/// then the behavior is TBD (#180).
+Element convert(Type type, std::complex<double> value);
 
 /// Returns cosine of Element object.
 Element cosine(const Element &e);

--- a/stablehlo/reference/Element.h
+++ b/stablehlo/reference/Element.h
@@ -47,8 +47,7 @@ class Element {
   Element(Type type, APFloat value);
 
   /// Initializes Element object with type `type` and value `value`. `type` must
-  /// be a complex type and the bitwidths of both the real and the imaginary
-  /// parts of `type` and `value` must match.
+  /// be a complex type of the same semantics as `value`.
   Element(Type type, std::complex<APFloat> value);
 
   Element(const Element &other) = default;

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -521,31 +521,30 @@ Tensor evalConstantOp(ElementsAttr value) {
 
 Tensor evalConvertOp(const Tensor &operand, ShapedType resultType) {
   Tensor result(resultType);
-  Type operandElementType = operand.getElementType();
-  Type resultElementType = result.getElementType();
+  auto operandElementType = operand.getElementType();
+  auto resultElementType = result.getElementType();
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
-    if (isSupportedBooleanType(operandElementType)) {
+    if (isSupportedBooleanType(operandElementType))
       result.set(
           *it, convert(resultElementType, operand.get(*it).getBooleanValue()));
-    } else if (isSupportedSignedIntegerType(operandElementType)) {
+    else if (isSupportedSignedIntegerType(operandElementType))
       result.set(*it,
                  convert(resultElementType,
                          operand.get(*it).getIntegerValue().getSExtValue()));
-    } else if (isSupportedUnsignedIntegerType(operandElementType)) {
+    else if (isSupportedUnsignedIntegerType(operandElementType))
       result.set(*it,
                  convert(resultElementType,
                          operand.get(*it).getIntegerValue().getZExtValue()));
-    } else if (isSupportedFloatType(operandElementType)) {
+    else if (isSupportedFloatType(operandElementType))
       result.set(*it,
                  convert(resultElementType, operand.get(*it).getFloatValue()));
-    } else if (isSupportedComplexType(operandElementType)) {
+    else if (isSupportedComplexType(operandElementType))
       result.set(
           *it, convert(resultElementType, operand.get(*it).getComplexValue()));
-    } else {
+    else
       report_fatal_error(
           invalidArgument("Unsupported element type: %s",
                           debugString(operandElementType).c_str()));
-    }
   }
   return result;
 }
@@ -649,17 +648,8 @@ Tensor evalImagOp(const Tensor &operand, ShapedType resultType) {
 Tensor evalIotaOp(Axis iotaDimension, ShapedType resultType) {
   Tensor result(resultType);
   auto elementType = result.getElementType();
-  for (auto it = result.index_begin(); it != result.index_end(); ++it) {
-    if (isSupportedIntegerType(elementType))
-      result.set(*it, convert(elementType, (*it)[iotaDimension]));
-    else if (isSupportedFloatType(elementType))
-      result.set(*it, convert(elementType, (*it)[iotaDimension]));
-    else if (isSupportedComplexType(elementType))
-      result.set(*it, convert(elementType, (*it)[iotaDimension]));
-    else
-      report_fatal_error(invalidArgument("Unsupported element type: %s",
-                                         debugString(elementType).c_str()));
-  }
+  for (auto it = result.index_begin(); it != result.index_end(); ++it)
+    result.set(*it, convert(elementType, (*it)[iotaDimension]));
   return result;
 }
 

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -562,7 +562,7 @@ Tensor evalClzOp(const Tensor &operand, ShapedType resultType) {
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
     auto element =
         convert(resultType.getElementType(),
-                static_cast<int64_t>(
+                static_cast<uint64_t>(
                     operand.get(*it).getIntegerValue().countLeadingZeros()));
     result.set(*it, element);
   }
@@ -629,7 +629,7 @@ Tensor evalGetDimensionSizeOp(const Tensor &operand, Axis dimension,
                               ShapedType resultType) {
   Tensor result(resultType);
   result.set(
-      {}, Element(resultType.getElementType(), operand.getShape()[dimension]));
+      {}, convert(resultType.getElementType(), operand.getShape()[dimension]));
   return result;
 }
 

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -648,22 +648,17 @@ Tensor evalImagOp(const Tensor &operand, ShapedType resultType) {
 
 Tensor evalIotaOp(Axis iotaDimension, ShapedType resultType) {
   Tensor result(resultType);
-  Type elementType = result.getElementType();
+  auto elementType = result.getElementType();
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
-    if (isSupportedIntegerType(elementType)) {
+    if (isSupportedIntegerType(elementType))
       result.set(*it, convert(elementType, (*it)[iotaDimension]));
-    } else if (isSupportedFloatType(elementType)) {
-      result.set(
-          *it, convert(elementType, static_cast<double>((*it)[iotaDimension])));
-    } else if (isSupportedComplexType(elementType)) {
-      result.set(*it,
-                 convert(elementType,
-                         std::complex<double>(
-                             static_cast<double>((*it)[iotaDimension]), 0.0)));
-    } else {
+    else if (isSupportedFloatType(elementType))
+      result.set(*it, convert(elementType, (*it)[iotaDimension]));
+    else if (isSupportedComplexType(elementType))
+      result.set(*it, convert(elementType, (*it)[iotaDimension]));
+    else
       report_fatal_error(invalidArgument("Unsupported element type: %s",
                                          debugString(elementType).c_str()));
-    }
   }
   return result;
 }

--- a/stablehlo/testdata/bessel_i0e_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/bessel_i0e_shape_bfloat16_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/bessel_i0e_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/bessel_i0e_shape_float16_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bfloat16_100_100__olddtype_bfloat16_newdtype_float16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bfloat16_100_100__olddtype_bfloat16_newdtype_float16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bfloat16_100_100__olddtype_bfloat16_newdtype_float32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bfloat16_100_100__olddtype_bfloat16_newdtype_float32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bfloat16_100_100__olddtype_bfloat16_newdtype_int16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bfloat16_100_100__olddtype_bfloat16_newdtype_int16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bfloat16_100_100__olddtype_bfloat16_newdtype_int32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bfloat16_100_100__olddtype_bfloat16_newdtype_int32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bfloat16_100_100__olddtype_bfloat16_newdtype_int8.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bfloat16_100_100__olddtype_bfloat16_newdtype_int8.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bool_100_100__olddtype_bool_newdtype_bfloat16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bool_100_100__olddtype_bool_newdtype_bfloat16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bool_100_100__olddtype_bool_newdtype_float16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bool_100_100__olddtype_bool_newdtype_float16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bool_100_100__olddtype_bool_newdtype_float32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bool_100_100__olddtype_bool_newdtype_float32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bool_100_100__olddtype_bool_newdtype_int16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bool_100_100__olddtype_bool_newdtype_int16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bool_100_100__olddtype_bool_newdtype_int32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bool_100_100__olddtype_bool_newdtype_int32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bool_100_100__olddtype_bool_newdtype_int8.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bool_100_100__olddtype_bool_newdtype_int8.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bool_100_100__olddtype_bool_newdtype_uint16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bool_100_100__olddtype_bool_newdtype_uint16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bool_100_100__olddtype_bool_newdtype_uint32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bool_100_100__olddtype_bool_newdtype_uint32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bool_100_100__olddtype_bool_newdtype_uint8.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bool_100_100__olddtype_bool_newdtype_uint8.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float16_100_100__olddtype_float16_newdtype_bfloat16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float16_100_100__olddtype_float16_newdtype_bfloat16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float16_100_100__olddtype_float16_newdtype_float32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float16_100_100__olddtype_float16_newdtype_float32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float16_100_100__olddtype_float16_newdtype_int16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float16_100_100__olddtype_float16_newdtype_int16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float16_100_100__olddtype_float16_newdtype_int32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float16_100_100__olddtype_float16_newdtype_int32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float16_100_100__olddtype_float16_newdtype_int8.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float16_100_100__olddtype_float16_newdtype_int8.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float32_100_100__olddtype_float32_newdtype_bfloat16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float32_100_100__olddtype_float32_newdtype_bfloat16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float32_100_100__olddtype_float32_newdtype_float16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float32_100_100__olddtype_float32_newdtype_float16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float32_100_100__olddtype_float32_newdtype_int16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float32_100_100__olddtype_float32_newdtype_int16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float32_100_100__olddtype_float32_newdtype_int32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float32_100_100__olddtype_float32_newdtype_int32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float32_100_100__olddtype_float32_newdtype_int8.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float32_100_100__olddtype_float32_newdtype_int8.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int16_100_100__olddtype_int16_newdtype_bfloat16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int16_100_100__olddtype_int16_newdtype_bfloat16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int16_100_100__olddtype_int16_newdtype_float16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int16_100_100__olddtype_int16_newdtype_float16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int16_100_100__olddtype_int16_newdtype_float32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int16_100_100__olddtype_int16_newdtype_float32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int16_100_100__olddtype_int16_newdtype_int32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int16_100_100__olddtype_int16_newdtype_int32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int16_100_100__olddtype_int16_newdtype_int8.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int16_100_100__olddtype_int16_newdtype_int8.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int16_100_100__olddtype_int16_newdtype_uint16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int16_100_100__olddtype_int16_newdtype_uint16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int16_100_100__olddtype_int16_newdtype_uint32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int16_100_100__olddtype_int16_newdtype_uint32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int16_100_100__olddtype_int16_newdtype_uint8.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int16_100_100__olddtype_int16_newdtype_uint8.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int32_100_100__olddtype_int32_newdtype_bfloat16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int32_100_100__olddtype_int32_newdtype_bfloat16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int32_100_100__olddtype_int32_newdtype_float16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int32_100_100__olddtype_int32_newdtype_float16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int32_100_100__olddtype_int32_newdtype_float32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int32_100_100__olddtype_int32_newdtype_float32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int32_100_100__olddtype_int32_newdtype_int16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int32_100_100__olddtype_int32_newdtype_int16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int32_100_100__olddtype_int32_newdtype_int8.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int32_100_100__olddtype_int32_newdtype_int8.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int32_100_100__olddtype_int32_newdtype_uint16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int32_100_100__olddtype_int32_newdtype_uint16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int32_100_100__olddtype_int32_newdtype_uint32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int32_100_100__olddtype_int32_newdtype_uint32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int32_100_100__olddtype_int32_newdtype_uint8.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int32_100_100__olddtype_int32_newdtype_uint8.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_bfloat16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_bfloat16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_float16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_float16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_float32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_float32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_int16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_int16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_int32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_int32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_uint16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_uint16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_uint32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_uint32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_uint8.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_uint8.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint16_100_100__olddtype_uint16_newdtype_bfloat16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint16_100_100__olddtype_uint16_newdtype_bfloat16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint16_100_100__olddtype_uint16_newdtype_float16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint16_100_100__olddtype_uint16_newdtype_float16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint16_100_100__olddtype_uint16_newdtype_float32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint16_100_100__olddtype_uint16_newdtype_float32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint16_100_100__olddtype_uint16_newdtype_int16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint16_100_100__olddtype_uint16_newdtype_int16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint16_100_100__olddtype_uint16_newdtype_int32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint16_100_100__olddtype_uint16_newdtype_int32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint16_100_100__olddtype_uint16_newdtype_int8.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint16_100_100__olddtype_uint16_newdtype_int8.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint16_100_100__olddtype_uint16_newdtype_uint32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint16_100_100__olddtype_uint16_newdtype_uint32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint16_100_100__olddtype_uint16_newdtype_uint8.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint16_100_100__olddtype_uint16_newdtype_uint8.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint32_100_100__olddtype_uint32_newdtype_bfloat16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint32_100_100__olddtype_uint32_newdtype_bfloat16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint32_100_100__olddtype_uint32_newdtype_float16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint32_100_100__olddtype_uint32_newdtype_float16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint32_100_100__olddtype_uint32_newdtype_float32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint32_100_100__olddtype_uint32_newdtype_float32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint32_100_100__olddtype_uint32_newdtype_int16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint32_100_100__olddtype_uint32_newdtype_int16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint32_100_100__olddtype_uint32_newdtype_int32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint32_100_100__olddtype_uint32_newdtype_int32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint32_100_100__olddtype_uint32_newdtype_int8.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint32_100_100__olddtype_uint32_newdtype_int8.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint32_100_100__olddtype_uint32_newdtype_uint16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint32_100_100__olddtype_uint32_newdtype_uint16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint32_100_100__olddtype_uint32_newdtype_uint8.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint32_100_100__olddtype_uint32_newdtype_uint8.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint8_100_100__olddtype_uint8_newdtype_bfloat16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint8_100_100__olddtype_uint8_newdtype_bfloat16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint8_100_100__olddtype_uint8_newdtype_float16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint8_100_100__olddtype_uint8_newdtype_float16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint8_100_100__olddtype_uint8_newdtype_float32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint8_100_100__olddtype_uint8_newdtype_float32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint8_100_100__olddtype_uint8_newdtype_int16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint8_100_100__olddtype_uint8_newdtype_int16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint8_100_100__olddtype_uint8_newdtype_int32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint8_100_100__olddtype_uint8_newdtype_int32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint8_100_100__olddtype_uint8_newdtype_int8.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint8_100_100__olddtype_uint8_newdtype_int8.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint8_100_100__olddtype_uint8_newdtype_uint16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint8_100_100__olddtype_uint8_newdtype_uint16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint8_100_100__olddtype_uint8_newdtype_uint32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint8_100_100__olddtype_uint8_newdtype_uint32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/cosh_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/cosh_shape_bfloat16_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/cosh_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/cosh_shape_float16_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/erf_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/erf_shape_bfloat16_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/erf_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/erf_shape_float16_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/erfc_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/erfc_shape_bfloat16_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/erfc_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/erfc_shape_float16_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/tests/interpret_convert.mlir
+++ b/stablehlo/tests/interpret_convert.mlir
@@ -74,8 +74,8 @@ func.func @convert_op_test_si64_to_ui64() {
 
 func.func @convert_op_test_si64_to_f64() {
   %operand = stablehlo.constant dense<[-1, 0, 1]> : tensor<3xi64>
-  %result = stablehlo.convert %operand : (tensor<3xi64>) -> tensor<3xf16>
-  check.expect_almost_eq_const %result, dense<[-1.0, 0.0, 1.0]> : tensor<3xf16>
+  %result = stablehlo.convert %operand : (tensor<3xi64>) -> tensor<3xf64>
+  check.expect_almost_eq_const %result, dense<[-1.0, 0.0, 1.0]> : tensor<3xf64>
   func.return
 }
 
@@ -119,8 +119,8 @@ func.func @convert_op_test_ui64_to_ui64() {
 
 func.func @convert_op_test_ui64_to_f64() {
   %operand = stablehlo.constant dense<[0, 1]> : tensor<2xui64>
-  %result = stablehlo.convert %operand : (tensor<2xui64>) -> tensor<2xf16>
-  check.expect_almost_eq_const %result, dense<[0.0, 1.0]> : tensor<2xf16>
+  %result = stablehlo.convert %operand : (tensor<2xui64>) -> tensor<2xf64>
+  check.expect_almost_eq_const %result, dense<[0.0, 1.0]> : tensor<2xf64>
   func.return
 }
 

--- a/stablehlo/tests/interpret_convert.mlir
+++ b/stablehlo/tests/interpret_convert.mlir
@@ -30,7 +30,7 @@ func.func @convert_op_test_i1_to_ui64() {
 func.func @convert_op_test_i1_to_f64() {
   %operand = stablehlo.constant dense<[true, false]> : tensor<2xi1>
   %result = stablehlo.convert %operand : (tensor<2xi1>) -> tensor<2xf64>
-  check.expect_eq_const %result, dense<[1.0, 0.0]> : tensor<2xf64>
+  check.expect_almost_eq_const %result, dense<[1.0, 0.0]> : tensor<2xf64>
   func.return
 }
 
@@ -39,7 +39,7 @@ func.func @convert_op_test_i1_to_f64() {
 func.func @convert_op_test_i1_to_c128() {
   %operand = stablehlo.constant dense<[true, false]> : tensor<2xi1>
   %result = stablehlo.convert %operand : (tensor<2xi1>) -> tensor<2xcomplex<f64>>
-  check.expect_eq_const %result, dense<[(1.0, 0.0), (0.0, 0.0)]> : tensor<2xcomplex<f64>>
+  check.expect_almost_eq_const %result, dense<[(1.0, 0.0), (0.0, 0.0)]> : tensor<2xcomplex<f64>>
   func.return
 }
 
@@ -75,7 +75,7 @@ func.func @convert_op_test_si64_to_ui64() {
 func.func @convert_op_test_si64_to_f64() {
   %operand = stablehlo.constant dense<[-1, 0, 1]> : tensor<3xi64>
   %result = stablehlo.convert %operand : (tensor<3xi64>) -> tensor<3xf16>
-  check.expect_eq_const %result, dense<[-1.0, 0.0, 1.0]> : tensor<3xf16>
+  check.expect_almost_eq_const %result, dense<[-1.0, 0.0, 1.0]> : tensor<3xf16>
   func.return
 }
 
@@ -84,7 +84,52 @@ func.func @convert_op_test_si64_to_f64() {
 func.func @convert_op_test_si64_to_c128() {
   %operand = stablehlo.constant dense<[-1, 0, 1]> : tensor<3xi4>
   %result = stablehlo.convert %operand : (tensor<3xi4>) -> tensor<3xcomplex<f64>>
-  check.expect_eq_const %result, dense<[(-1.0, 0.0), (0.0, 0.0), (1.0, 0.0)]> : tensor<3xcomplex<f64>>
+  check.expect_almost_eq_const %result, dense<[(-1.0, 0.0), (0.0, 0.0), (1.0, 0.0)]> : tensor<3xcomplex<f64>>
+  func.return
+}
+
+// -----
+
+func.func @convert_op_test_ui64_to_i1() {
+  %operand = stablehlo.constant dense<[0, 1]> : tensor<2xui64>
+  %result = stablehlo.convert %operand : (tensor<2xui64>) -> tensor<2xi1>
+  check.expect_eq_const %result, dense<[false, true]> : tensor<2xi1>
+  func.return
+}
+
+// -----
+
+func.func @convert_op_test_ui64_to_si64() {
+  %operand = stablehlo.constant dense<[0, 1]> : tensor<2xui64>
+  %result = stablehlo.convert %operand : (tensor<2xui64>) -> tensor<2xi64>
+  check.expect_eq_const %result, dense<[0, 1]> : tensor<2xi64>
+  func.return
+}
+
+// -----
+
+func.func @convert_op_test_ui64_to_ui64() {
+  %operand = stablehlo.constant dense<[0, 1]> : tensor<2xui4>
+  %result = stablehlo.convert %operand : (tensor<2xui4>) -> tensor<2xui64>
+  check.expect_eq_const %result, dense<[0, 1]> : tensor<2xui64>
+  func.return
+}
+
+// -----
+
+func.func @convert_op_test_ui64_to_f64() {
+  %operand = stablehlo.constant dense<[0, 1]> : tensor<2xui64>
+  %result = stablehlo.convert %operand : (tensor<2xui64>) -> tensor<2xf16>
+  check.expect_almost_eq_const %result, dense<[0.0, 1.0]> : tensor<2xf16>
+  func.return
+}
+
+// -----
+
+func.func @convert_op_test_ui64_to_c128() {
+  %operand = stablehlo.constant dense<[0, 1]> : tensor<2xui4>
+  %result = stablehlo.convert %operand : (tensor<2xui4>) -> tensor<2xcomplex<f64>>
+  check.expect_almost_eq_const %result, dense<[(0.0, 0.0), (1.0, 0.0)]> : tensor<2xcomplex<f64>>
   func.return
 }
 
@@ -120,7 +165,7 @@ func.func @convert_op_test_f64_to_ui64() {
 func.func @convert_op_test_f64_to_f64() {
   %operand = stablehlo.constant dense<[-1.0, 0.0, 1.0]> : tensor<3xf64>
   %result = stablehlo.convert %operand : (tensor<3xf64>) -> tensor<3xf64>
-  check.expect_eq_const %result, dense<[-1.0, 0.0, 1.0]> : tensor<3xf64>
+  check.expect_almost_eq_const %result, dense<[-1.0, 0.0, 1.0]> : tensor<3xf64>
   func.return
 }
 
@@ -129,7 +174,7 @@ func.func @convert_op_test_f64_to_f64() {
 func.func @convert_op_test_f64_to_c128() {
   %operand = stablehlo.constant dense<[-1.0, 0.0, 1.0]> : tensor<3xf64>
   %result = stablehlo.convert %operand : (tensor<3xf64>) -> tensor<3xcomplex<f64>>
-  check.expect_eq_const %result, dense<[(-1.0, 0.0), (0.0, 0.0), (1.0, 0.0)]> : tensor<3xcomplex<f64>>
+  check.expect_almost_eq_const %result, dense<[(-1.0, 0.0), (0.0, 0.0), (1.0, 0.0)]> : tensor<3xcomplex<f64>>
   func.return
 }
 
@@ -165,7 +210,7 @@ func.func @convert_op_test_c128_to_ui64() {
 func.func @convert_op_test_c128_to_f64() {
   %operand = stablehlo.constant dense<[(-1.0, 0.0), (0.0, 1.0), (1.0, 0.0)]> : tensor<3xcomplex<f64>>
   %result = stablehlo.convert %operand : (tensor<3xcomplex<f64>>) -> tensor<3xf64>
-  check.expect_eq_const %result, dense<[-1.0, 0.0, 1.0]> : tensor<3xf64>
+  check.expect_almost_eq_const %result, dense<[-1.0, 0.0, 1.0]> : tensor<3xf64>
   func.return
 }
 
@@ -174,6 +219,6 @@ func.func @convert_op_test_c128_to_f64() {
 func.func @convert_op_test_c128_to_c128() {
   %operand = stablehlo.constant dense<[(-1.0, 0.0), (0.0, 1.0), (1.0, 0.0)]> : tensor<3xcomplex<f64>>
   %result = stablehlo.convert %operand : (tensor<3xcomplex<f64>>) -> tensor<3xcomplex<f64>>
-  check.expect_eq_const %result, dense<[(-1.0, 0.0), (0.0, 1.0), (1.0, 0.0)]> : tensor<3xcomplex<f64>>
+  check.expect_almost_eq_const %result, dense<[(-1.0, 0.0), (0.0, 1.0), (1.0, 0.0)]> : tensor<3xcomplex<f64>>
   func.return
 }

--- a/stablehlo/tests/interpret_convert.mlir
+++ b/stablehlo/tests/interpret_convert.mlir
@@ -136,7 +136,7 @@ func.func @convert_op_test_f64_to_c128() {
 // -----
 
 func.func @convert_op_test_c128_to_i1() {
-  %operand = stablehlo.constant dense<[(-1.0, 0.0), (0.0, 0.0), (1.0, 0.0)]> : tensor<3xcomplex<f64>>
+  %operand = stablehlo.constant dense<[(-1.0, 0.0), (0.0, 1.0), (1.0, 0.0)]> : tensor<3xcomplex<f64>>
   %result = stablehlo.convert %operand : (tensor<3xcomplex<f64>>) -> tensor<3xi1>
   check.expect_eq_const %result, dense<[true, false, true]> : tensor<3xi1>
   func.return
@@ -145,7 +145,7 @@ func.func @convert_op_test_c128_to_i1() {
 // -----
 
 func.func @convert_op_test_c128_to_si64() {
-  %operand = stablehlo.constant dense<[(-1.0, 0.0), (0.0, 0.0), (1.0, 0.0)]> : tensor<3xcomplex<f64>>
+  %operand = stablehlo.constant dense<[(-1.0, 0.0), (0.0, 1.0), (1.0, 0.0)]> : tensor<3xcomplex<f64>>
   %result = stablehlo.convert %operand : (tensor<3xcomplex<f64>>) -> tensor<3xi64>
   check.expect_eq_const %result, dense<[-1, 0, 1]> : tensor<3xi64>
   func.return
@@ -154,7 +154,7 @@ func.func @convert_op_test_c128_to_si64() {
 // -----
 
 func.func @convert_op_test_c128_to_ui64() {
-  %operand = stablehlo.constant dense<[(0.0, 0.0), (1.0, 0.0)]> : tensor<2xcomplex<f64>>
+  %operand = stablehlo.constant dense<[(0.0, 1.0), (1.0, 0.0)]> : tensor<2xcomplex<f64>>
   %result = stablehlo.convert %operand : (tensor<2xcomplex<f64>>) -> tensor<2xui64>
   check.expect_eq_const %result, dense<[0, 1]> : tensor<2xui64>
   func.return
@@ -163,7 +163,7 @@ func.func @convert_op_test_c128_to_ui64() {
 // -----
 
 func.func @convert_op_test_c128_to_f64() {
-  %operand = stablehlo.constant dense<[(-1.0, 0.0), (0.0, 0.0), (1.0, 0.0)]> : tensor<3xcomplex<f64>>
+  %operand = stablehlo.constant dense<[(-1.0, 0.0), (0.0, 1.0), (1.0, 0.0)]> : tensor<3xcomplex<f64>>
   %result = stablehlo.convert %operand : (tensor<3xcomplex<f64>>) -> tensor<3xf64>
   check.expect_eq_const %result, dense<[-1.0, 0.0, 1.0]> : tensor<3xf64>
   func.return
@@ -172,8 +172,8 @@ func.func @convert_op_test_c128_to_f64() {
 // -----
 
 func.func @convert_op_test_c128_to_c128() {
-  %operand = stablehlo.constant dense<[(-1.0, 0.0), (0.0, 0.0), (1.0, 0.0)]> : tensor<3xcomplex<f64>>
+  %operand = stablehlo.constant dense<[(-1.0, 0.0), (0.0, 1.0), (1.0, 0.0)]> : tensor<3xcomplex<f64>>
   %result = stablehlo.convert %operand : (tensor<3xcomplex<f64>>) -> tensor<3xcomplex<f64>>
-  check.expect_eq_const %result, dense<[(-1.0, 0.0), (0.0, 0.0), (1.0, 0.0)]> : tensor<3xcomplex<f64>>
+  check.expect_eq_const %result, dense<[(-1.0, 0.0), (0.0, 1.0), (1.0, 0.0)]> : tensor<3xcomplex<f64>>
   func.return
 }

--- a/stablehlo/tests/interpret_convert.mlir
+++ b/stablehlo/tests/interpret_convert.mlir
@@ -1,0 +1,179 @@
+// RUN: stablehlo-translate --interpret -split-input-file %s
+
+func.func @convert_op_test_i1_to_i1() {
+  %operand = stablehlo.constant dense<[true, false]> : tensor<2xi1>
+  %result = stablehlo.convert %operand : (tensor<2xi1>) -> tensor<2xi1>
+  check.expect_eq_const %result, dense<[true, false]> : tensor<2xi1>
+  func.return
+}
+
+// -----
+
+func.func @convert_op_test_i1_to_si64() {
+  %operand = stablehlo.constant dense<[true, false]> : tensor<2xi1>
+  %result = stablehlo.convert %operand : (tensor<2xi1>) -> tensor<2xi64>
+  check.expect_eq_const %result, dense<[1, 0]> : tensor<2xi64>
+  func.return
+}
+
+// -----
+
+func.func @convert_op_test_i1_to_ui64() {
+  %operand = stablehlo.constant dense<[true, false]> : tensor<2xi1>
+  %result = stablehlo.convert %operand : (tensor<2xi1>) -> tensor<2xui64>
+  check.expect_eq_const %result, dense<[1, 0]> : tensor<2xui64>
+  func.return
+}
+
+// -----
+
+func.func @convert_op_test_i1_to_f64() {
+  %operand = stablehlo.constant dense<[true, false]> : tensor<2xi1>
+  %result = stablehlo.convert %operand : (tensor<2xi1>) -> tensor<2xf64>
+  check.expect_eq_const %result, dense<[1.0, 0.0]> : tensor<2xf64>
+  func.return
+}
+
+// -----
+
+func.func @convert_op_test_i1_to_c128() {
+  %operand = stablehlo.constant dense<[true, false]> : tensor<2xi1>
+  %result = stablehlo.convert %operand : (tensor<2xi1>) -> tensor<2xcomplex<f64>>
+  check.expect_eq_const %result, dense<[(1.0, 0.0), (0.0, 0.0)]> : tensor<2xcomplex<f64>>
+  func.return
+}
+
+// -----
+
+func.func @convert_op_test_si64_to_i1() {
+  %operand = stablehlo.constant dense<[-1, 0, 1]> : tensor<3xi64>
+  %result = stablehlo.convert %operand : (tensor<3xi64>) -> tensor<3xi1>
+  check.expect_eq_const %result, dense<[true, false, true]> : tensor<3xi1>
+  func.return
+}
+
+// -----
+
+func.func @convert_op_test_si64_to_si64() {
+  %operand = stablehlo.constant dense<[-1, 0, 1]> : tensor<3xi64>
+  %result = stablehlo.convert %operand : (tensor<3xi64>) -> tensor<3xi64>
+  check.expect_eq_const %result, dense<[-1, 0, 1]> : tensor<3xi64>
+  func.return
+}
+
+// -----
+
+func.func @convert_op_test_si64_to_ui64() {
+  %operand = stablehlo.constant dense<[0, 1]> : tensor<2xi4>
+  %result = stablehlo.convert %operand : (tensor<2xi4>) -> tensor<2xui64>
+  check.expect_eq_const %result, dense<[0, 1]> : tensor<2xui64>
+  func.return
+}
+
+// -----
+
+func.func @convert_op_test_si64_to_f64() {
+  %operand = stablehlo.constant dense<[-1, 0, 1]> : tensor<3xi64>
+  %result = stablehlo.convert %operand : (tensor<3xi64>) -> tensor<3xf16>
+  check.expect_eq_const %result, dense<[-1.0, 0.0, 1.0]> : tensor<3xf16>
+  func.return
+}
+
+// -----
+
+func.func @convert_op_test_si64_to_c128() {
+  %operand = stablehlo.constant dense<[-1, 0, 1]> : tensor<3xi4>
+  %result = stablehlo.convert %operand : (tensor<3xi4>) -> tensor<3xcomplex<f64>>
+  check.expect_eq_const %result, dense<[(-1.0, 0.0), (0.0, 0.0), (1.0, 0.0)]> : tensor<3xcomplex<f64>>
+  func.return
+}
+
+// -----
+
+func.func @convert_op_test_f64_to_i1() {
+  %operand = stablehlo.constant dense<[-1.0, 0.0, 1.0]> : tensor<3xf64>
+  %result = stablehlo.convert %operand : (tensor<3xf64>) -> tensor<3xi1>
+  check.expect_eq_const %result, dense<[true, false, true]> : tensor<3xi1>
+  func.return
+}
+
+// -----
+
+func.func @convert_op_test_f64_to_si64() {
+  %operand = stablehlo.constant dense<[-1.0, 0.0, 1.0]> : tensor<3xf64>
+  %result = stablehlo.convert %operand : (tensor<3xf64>) -> tensor<3xi64>
+  check.expect_eq_const %result, dense<[-1, 0, 1]> : tensor<3xi64>
+  func.return
+}
+
+// -----
+
+func.func @convert_op_test_f64_to_ui64() {
+  %operand = stablehlo.constant dense<[0.0, 1.0]> : tensor<2xf64>
+  %result = stablehlo.convert %operand : (tensor<2xf64>) -> tensor<2xui64>
+  check.expect_eq_const %result, dense<[0, 1]> : tensor<2xui64>
+  func.return
+}
+
+// -----
+
+func.func @convert_op_test_f64_to_f64() {
+  %operand = stablehlo.constant dense<[-1.0, 0.0, 1.0]> : tensor<3xf64>
+  %result = stablehlo.convert %operand : (tensor<3xf64>) -> tensor<3xf64>
+  check.expect_eq_const %result, dense<[-1.0, 0.0, 1.0]> : tensor<3xf64>
+  func.return
+}
+
+// -----
+
+func.func @convert_op_test_f64_to_c128() {
+  %operand = stablehlo.constant dense<[-1.0, 0.0, 1.0]> : tensor<3xf64>
+  %result = stablehlo.convert %operand : (tensor<3xf64>) -> tensor<3xcomplex<f64>>
+  check.expect_eq_const %result, dense<[(-1.0, 0.0), (0.0, 0.0), (1.0, 0.0)]> : tensor<3xcomplex<f64>>
+  func.return
+}
+
+// -----
+
+func.func @convert_op_test_c128_to_i1() {
+  %operand = stablehlo.constant dense<[(-1.0, 0.0), (0.0, 0.0), (1.0, 0.0)]> : tensor<3xcomplex<f64>>
+  %result = stablehlo.convert %operand : (tensor<3xcomplex<f64>>) -> tensor<3xi1>
+  check.expect_eq_const %result, dense<[true, false, true]> : tensor<3xi1>
+  func.return
+}
+
+// -----
+
+func.func @convert_op_test_c128_to_si64() {
+  %operand = stablehlo.constant dense<[(-1.0, 0.0), (0.0, 0.0), (1.0, 0.0)]> : tensor<3xcomplex<f64>>
+  %result = stablehlo.convert %operand : (tensor<3xcomplex<f64>>) -> tensor<3xi64>
+  check.expect_eq_const %result, dense<[-1, 0, 1]> : tensor<3xi64>
+  func.return
+}
+
+// -----
+
+func.func @convert_op_test_c128_to_ui64() {
+  %operand = stablehlo.constant dense<[(0.0, 0.0), (1.0, 0.0)]> : tensor<2xcomplex<f64>>
+  %result = stablehlo.convert %operand : (tensor<2xcomplex<f64>>) -> tensor<2xui64>
+  check.expect_eq_const %result, dense<[0, 1]> : tensor<2xui64>
+  func.return
+}
+
+// -----
+
+func.func @convert_op_test_c128_to_f64() {
+  %operand = stablehlo.constant dense<[(-1.0, 0.0), (0.0, 0.0), (1.0, 0.0)]> : tensor<3xcomplex<f64>>
+  %result = stablehlo.convert %operand : (tensor<3xcomplex<f64>>) -> tensor<3xf64>
+  check.expect_eq_const %result, dense<[-1.0, 0.0, 1.0]> : tensor<3xf64>
+  func.return
+}
+
+// -----
+
+func.func @convert_op_test_c128_to_c128() {
+  %operand = stablehlo.constant dense<[(-1.0, 0.0), (0.0, 0.0), (1.0, 0.0)]> : tensor<3xcomplex<f64>>
+  %result = stablehlo.convert %operand : (tensor<3xcomplex<f64>>) -> tensor<3xcomplex<f64>>
+  check.expect_eq_const %result, dense<[(-1.0, 0.0), (0.0, 0.0), (1.0, 0.0)]> : tensor<3xcomplex<f64>>
+  func.return
+}

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -5732,16 +5732,24 @@ func.func @invalid_dimension_attr(%arg0: tensor<?x?xf32, #stablehlo.type_extensi
 
 // -----
 
-// CHECK-LABEL: func @f8e4m3fn
-func.func @f8e4m3fn(%arg0: tensor<f16>) -> tensor<f8E4M3FN> {
+// CHECK-LABEL: func @convert
+func.func @convert(%arg0: tensor<f64>) -> tensor<bf16> {
+  %0 = "stablehlo.convert"(%arg0) : (tensor<f64>) -> tensor<bf16>
+  func.return %0 : tensor<bf16>
+}
+
+// -----
+
+// CHECK-LABEL: func @convert_f8e4m3fn
+func.func @convert_f8e4m3fn(%arg0: tensor<f16>) -> tensor<f8E4M3FN> {
   %0 = "stablehlo.convert"(%arg0) : (tensor<f16>) -> tensor<f8E4M3FN>
   func.return %0 : tensor<f8E4M3FN>
 }
 
 // -----
 
-// CHECK-LABEL: func @f8e5m2
-func.func @f8e5m2(%arg0: tensor<f16>) -> tensor<f8E5M2> {
+// CHECK-LABEL: func @convert_f8e5m2
+func.func @convert_f8e5m2(%arg0: tensor<f16>) -> tensor<f8E5M2> {
   %0 = "stablehlo.convert"(%arg0) : (tensor<f16>) -> tensor<f8E5M2>
   func.return %0 : tensor<f8E5M2>
 }


### PR DESCRIPTION
Here are the following constraints:
```
(I1) operand is a tensor. (Covered by ODS).
(C1) `operand` and `result` have the same shape. (Covered by ODS).
```

Notes:
* Added one positive test apart from existing fp8 tests.
* No additional constraint tests are needed as all constraints and shape inference is covered by ODS.
* Left out handling special behaviors for floating-point/complex -> integer and vice versa to #180 (currently the behavior is implementation defined).
* Updated spec to clarify semantics for complex to boolean case.

closes #969