### PR TITLE
Introduce QuantizedType

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -575,13 +575,13 @@ Performs element-wise addition of two tensors `lhs` and `rhs` and produces a
 | Label | Name  | Type   | Constraints |
 |-------|-------|--------|-------------|
 | (I1)  | `lhs` | tensor | (C1)-(C6)   |
-| (I2)  | `rhs` | tensor | (C1)-(C6)   |
+| (I2)  | `rhs` | tensor | (C1)-(C3)   |
 
 #### Outputs
 
 | Name     | Type   | Constraints |
 |----------|--------|-------------|
-| `result` | tensor | (C1)-(C6)   |
+| `result` | tensor | (C1)-(C3)   |
 
 #### Constraints
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -213,19 +213,24 @@ Quantized types satisfy the following constraints:
 * (C1) `num_bits(storage_type) < num_bits(expressed_type)`.
 * (C2) `type(storage_min) = storage_type`.
 * (C3) `type(storage_max) = storage_type`.
-* (C4) `storage_min` and `storage_max` have the following values:
-  * If `is_signed(storage_type)` and `d = num_bits(storage_type)`:
-    * `storage_min = -2^(d-1)`, `storage_max = 2^(d-1)-1` OR
-    * `storage_min = -2^(d-1)+1`, `storage_max = 2^(d-1)-1`.
-  * If `is_unsigned(storage_type)`:
-    * `storage_min = 0`, `storage_max = 2^d - 1`.
-* (C5) For all `i`, `type(scales[i]) = expressed_type`.
-* (C6) For all `i`, `scales[i] > 0`.
-* (C7) For all `i`, `storage_min <= zero_points[i] <= storage_max`.
-* (C8) For all `i`, `type(zero_points[i]) = storage_type`.
-* (C9) `size(scales) = size(zero_points)`.
-* (C10) If `quantization_dimension` is empty, then `size(scales) = 1`.
-* (C11) If `quantization_dimension` is not empty, then
+* (C4) If `storage_min` is empty and `d = num_bits(storage_type)`:
+  * `storage_min = is_signed(storage_type) ? -2^(d-1) : 0`.
+* (C5) If `storage_max` is empty:
+  * `storage_max = is_signed(storage_type) ? 2^(d-1) : 2^d - 1`.
+* (C6) If `storage_min` is not empty:
+  * If `is_signed(storage_type)`, `storage_min >= -2^(d-1)`.
+  * If `is_unsigned(storage_type)`, `storage_min >= 0`.
+* (C7) If `storage_max` is not empty:
+  * If `is_signed(storage_type)`, `storage_max <= 2^(d-1)-1`
+  * If `is_unsigned(storage_type)`, `storage_max <= 2^d - 1`.
+* (C8) `storage_max - storage_min > 0`.
+* (C9) For all `i`, `type(scales[i]) = expressed_type`.
+* (C10) For all `i`, `scales[i] > 0`.
+* (C11) For all `i`, `storage_min <= zero_points[i] <= storage_max`.
+* (C12) For all `i`, `type(zero_points[i]) = storage_type`.
+* (C13) `size(scales) = size(zero_points)`.
+* (C14) If `quantization_dimension` is empty, then `size(scales) = 1`.
+* (C15) If `quantization_dimension` is not empty, then
   `0 <= quantization_dimension`.
 
 Furthermore, tensors of quantized types satisfy the following constraints:
@@ -233,8 +238,8 @@ Furthermore, tensors of quantized types satisfy the following constraints:
 * For per-tensor quantization:
   * No additional constraints.
 * For per-axis quantization:
-  * (C12) `quantization_dimension < size(shape)`.
-  * (C13) `size(scales) = shape[quantization_dimension]`.
+  * (C16) `quantization_dimension < size(shape)`.
+  * (C17) `size(scales) = shape[quantization_dimension]`.
 
 ```ebnf
 FunctionType ::= '(' [ValueType {',' ValueType}] ')' '->' '(' [ValueType {',' ValueType}] ')'
@@ -592,8 +597,9 @@ Performs element-wise addition of two tensors `lhs` and `rhs` and produces a
 * If the operation uses quantized types:
   * (C3) `element_type(lhs) = element_type(rhs) = element_type(result)`,
     except for scales and zero points which may differ.
-  * (C4) `abs(storage_min(lhs)) != abs(storage_max(lhs))`.
-  * (C5) `quantization_dimension(lhs)` is empty.
+  * (C4) `storage_min = is_signed(storage_type) ? -2^(d-1) : 0, where d = num_bits(storage_type)`.
+  * (C5) `storage_max = is_signed(storage_type) ? 2^(d-1) : 2^d - 1`.
+  * (C6) `quantization_dimension(lhs)` is empty.
 
 #### Examples
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -228,8 +228,8 @@ Furthermore, tensors of quantized types satisfy the following constraints:
 * For per-tensor quantization:
   * No additional constraints.
 * For per-axis quantization:
-  * (C10) `size(scales) = shape[quantization_dimension]`.
   * (C11) `quantization_dimension < size(shape)`.
+  * (C12) `size(scales) = shape[quantization_dimension]`.
 
 ```ebnf
 FunctionType ::= '(' [ValueType {',' ValueType}] ')' '->' '(' [ValueType {',' ValueType}] ')'

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -566,36 +566,23 @@ Performs element-wise addition of two tensors `lhs` and `rhs` and produces a
 * For integers: integer addition.
 * For floats: `addition` from IEEE-754.
 * For complex numbers: complex addition.
-* For quantized types:
-  * `float_result = (lhs - zero_point(lhs)) * scale(lhs) +
-    (rhs - zero_point(rhs)) * scale(rhs)`.
-  * `rounded_result = round_nearest_even(float_result / scale(result))`.
-  * `result = clamp(storage_min(result), rounded_result + zero_point(result), storage_max(result))`.
 
 #### Inputs
 
-| Label | Name  | Type                       | Constraints |
-|-------|-------|----------------------------|-------------|
-| (I1)  | `lhs` | tensor or quantized tensor | (C1)-(C6)   |
-| (I2)  | `rhs` | tensor or quantized tensor | (C1)-(C3)   |
+| Label | Name  | Type   | Constraints |
+|-------|-------|--------|-------------|
+| (I1)  | `lhs` | tensor | (C1)        |
+| (I2)  | `rhs` | tensor | (C1)        |
 
 #### Outputs
 
-| Name     | Type                       | Constraints |
-|----------|----------------------------|-------------|
-| `result` | tensor or quantized tensor | (C1)-(C3)   |
+| Name     | Type   | Constraints |
+|----------|--------|-------------|
+| `result` | tensor | (C1)        |
 
 #### Constraints
 
-* (C1) `shape(lhs) = shape(rhs) = shape(result)`.
-* If the operation uses non-quantized tensors:
-  * (C2) `element_type(lhs) = element_type(rhs) = element_type(result)`.
-* If the operation uses quantized tensors:
-  * (C3) `element_type(lhs) = element_type(rhs) = element_type(result)`,
-    except for scales and zero points which may differ.
-  * (C4) `storage_min(lhs) = min_value(storage_type)`.
-  * (C5) `storage_max(lhs) = max_value(storage_type)`.
-  * (C6) `quantization_dimension(lhs)` is empty.
+* (C1) `lhs`, `rhs` and `result` have the same type.
 
 #### Examples
 
@@ -2189,11 +2176,9 @@ tensor and produces a `result` tensor.
 #### Semantics
 
 Encapsulates an implementation-defined operation `call_target_name` that takes
-`inputs` and `called_computations` and produces `results`. The metadata
-`has_side_effect` is used to prevent optimizations like speculation (e.g
-loop-invariant code motion) and dead-code elimination. `backend_config`
-and `api_version` may be used to provide additional implementation-defined
-metadata.
+`inputs` and `called_computations` and produces `results`. `has_side_effect`,
+`backend_config` and `api_version` may be used to provide additional
+implementation-defined metadata.
 
 At the moment, this operation contains a fairly disorganized collection of
 metadata which reflects organic evolution of its counterpart operation in
@@ -2869,10 +2854,10 @@ Produces the size of the given `dimension` of the `operand`.
 
 #### Inputs
 
-| Label | Name        | Type                         | Constraints |
-|-------|-------------|------------------------------|-------------|
-| (I1)  | `operand`   | tensor                       | (C1)        |
-| (I2)  | `dimension` | constant of type `si64`      | (C1)        |
+| Label | Name        | Type                    | Constraints |
+|-------|-------------|-------------------------|-------------|
+| (I1)  | `operand`   | tensor                  | (C1)        |
+| (I2)  | `dimension` | constant of type `si64` | (C1)        |
 
 #### Outputs
 
@@ -4718,11 +4703,11 @@ where `pred_val = rank(pred) == 0 ? pred : pred[i0, ..., iR-1]`.
 
 #### Inputs
 
-| Label | Name       | Type                         | Constraints |
-|-------|------------|------------------------------|-------------|
-| (I1)  | `pred`     | tensor of type `i1`          | (C1)        |
-| (I2)  | `on_true`  | tensor                       | (C1), (C2)  |
-| (I3)  | `on_false` | tensor                       | (C2)        |
+| Label | Name       | Type                | Constraints |
+|-------|------------|---------------------|-------------|
+| (I1)  | `pred`     | tensor of type `i1` | (C1)        |
+| (I2)  | `on_true`  | tensor              | (C1), (C2)  |
+| (I3)  | `on_false` | tensor              | (C2)        |
 
 #### Outputs
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -197,7 +197,9 @@ values of type `tensor<T>`).
   `f = (i - zero_point) * scale`, where `scale` and `zero_point` are called
   **quantization parameters**. The `storage_min` and `storage_max`, being
   optional, have default values which should satisfy the associated constraints
-  as laid out in this document.
+  as laid out in this document. The `storage_min` and `storage_max` are optional
+  in the grammar, but have default values of `min_value(storage_type)` and
+  `max_value(storage_type)` respectively.
 
 Quantization can be **per-tensor**, meaning, having one `scale` and/or
 `zero_point` for the entire tensor or can be **per-axis**, meaning, having
@@ -213,24 +215,16 @@ Quantized types satisfy the following constraints:
 * (C1) `num_bits(storage_type) < num_bits(expressed_type)`.
 * (C2) `type(storage_min) = storage_type`.
 * (C3) `type(storage_max) = storage_type`.
-* (C4) If `storage_min` is empty and `d = num_bits(storage_type)`:
-  * `storage_min = is_signed(storage_type) ? -2^(d-1) : 0`.
-* (C5) If `storage_max` is empty:
-  * `storage_max = is_signed(storage_type) ? 2^(d-1) : 2^d - 1`.
-* (C6) If `storage_min` is not empty:
-  * If `is_signed(storage_type)`, `storage_min >= -2^(d-1)`.
-  * If `is_unsigned(storage_type)`, `storage_min >= 0`.
-* (C7) If `storage_max` is not empty:
-  * If `is_signed(storage_type)`, `storage_max <= 2^(d-1)-1`
-  * If `is_unsigned(storage_type)`, `storage_max <= 2^d - 1`.
-* (C8) `storage_max - storage_min > 0`.
-* (C9) For all `i`, `type(scales[i]) = expressed_type`.
-* (C10) For all `i`, `scales[i] > 0`.
-* (C11) For all `i`, `storage_min <= zero_points[i] <= storage_max`.
-* (C12) For all `i`, `type(zero_points[i]) = storage_type`.
-* (C13) `size(scales) = size(zero_points)`.
-* (C14) If `quantization_dimension` is empty, then `size(scales) = 1`.
-* (C15) If `quantization_dimension` is not empty, then
+* (C4) `storage_min >= min_value(storage_type)`.
+* (C5) `storage_max <= max_value(storage_type)`.
+* (C6) `storage_max - storage_min > 0`.
+* (C7) For all `i`, `type(scales[i]) = expressed_type`.
+* (C8) For all `i`, `scales[i] > 0`.
+* (C9) For all `i`, `storage_min <= zero_points[i] <= storage_max`.
+* (C10) For all `i`, `type(zero_points[i]) = storage_type`.
+* (C11) `size(scales) = size(zero_points)`.
+* (C12) If `quantization_dimension` is empty, then `size(scales) = 1`.
+* (C13) If `quantization_dimension` is not empty, then
   `0 <= quantization_dimension`.
 
 Furthermore, tensors of quantized types satisfy the following constraints:
@@ -238,8 +232,8 @@ Furthermore, tensors of quantized types satisfy the following constraints:
 * For per-tensor quantization:
   * No additional constraints.
 * For per-axis quantization:
-  * (C16) `quantization_dimension < size(shape)`.
-  * (C17) `size(scales) = shape[quantization_dimension]`.
+  * (C14) `quantization_dimension < size(shape)`.
+  * (C15) `size(scales) = shape[quantization_dimension]`.
 
 ```ebnf
 FunctionType ::= '(' [ValueType {',' ValueType}] ')' '->' '(' [ValueType {',' ValueType}] ')'
@@ -597,8 +591,8 @@ Performs element-wise addition of two tensors `lhs` and `rhs` and produces a
 * If the operation uses quantized types:
   * (C3) `element_type(lhs) = element_type(rhs) = element_type(result)`,
     except for scales and zero points which may differ.
-  * (C4) `storage_min = is_signed(storage_type) ? -2^(d-1) : 0, where d = num_bits(storage_type)`.
-  * (C5) `storage_max = is_signed(storage_type) ? 2^(d-1) : 2^d - 1`.
+  * (C4) `storage_min = min_value(storage_type)`.
+  * (C5) `storage_max = max_value(storage_type)`.
   * (C6) `quantization_dimension(lhs)` is empty.
 
 #### Examples

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -146,22 +146,21 @@ IntegerType ::= 'si4' | 'si8' | 'si16' | 'si32' | 'si64'
               | 'ui4' | 'ui8' | 'ui16' | 'ui32' | 'ui64'
 FloatType   ::= 'f8E4M3FN' | 'f8E5M2' | 'bf16' | 'f16' | 'f32' | 'f64'
 ComplexType ::= 'complex' '<' ('f32' | 'f64') '>'
-
-QuantizedType ::= '!quant.uniform' '<' QuantizationStorageTypeSpec
-                ':' QuantizationExpressedType
-                [':' QuantizationDimension]
-                ',' QuantizationScalesAndZeroPoints '>'
-QuantizationStorageTypeSpec ::= QuantizationStorageType
-                              ['<' QuantizationStorageMin ':' QuantizationStorageMax '>']
+QuantizedType ::= '!quant.uniform' '<'
+                  QuantizationStorageType
+                  ['<' QuantizationStorageMin ':' QuantizationStorageMax '>']
+                  ':' QuantizationExpressedType
+                  [':' QuantizationDimension]
+                  ',' QuantizationParameters '>'
 QuantizationStorageType ::= IntegerType
 QuantizationStorageMin ::= IntegerConstant
 QuantizationStorageMax ::= IntegerConstant
 QuantizationExpressedType ::= FloatType
 QuantizationDimension ::= IntegerConstant
-QuantizationScalesAndZeroPoints ::= (QuantizationScaleAndZero
-                                  | '{' QuantizationScaleAndZero {',' QuantizationScaleAndZero} '}')
-QuantizationScaleAndZero ::= QuantizationScale ':' QuantizationZeroPoint
-QuantizationScale ::=  FloatConstant
+QuantizationParameters ::= QuantizationParameter
+                         | '{' QuantizationParameter {',' QuantizationParameter} '}'
+QuantizationParameter ::= QuantizationScale ':' QuantizationZeroPoint
+QuantizationScale ::= FloatConstant
 QuantizationZeroPoint ::=  IntegerConstant
 ```
 
@@ -218,12 +217,12 @@ Quantized types satisfy the following constraints:
     * `storage_min = -2^(d-1)+1`, `storage_max = 2^(d-1)-1`.
   * If `is_unsigned(storage_type)`:
     * `storage_min = 0`, `storage_max = 2^d - 1`.
-* (C5) `type(scale) = expressed_type`.
-* (C6) `scale > 0`.
-* (C7) `type(zero_point) = i64`.
-* (C8) If `quantization_dimension` is empty, then
-  `size(scales_and_zero_points) = 1`.
-* (C9) If `quantization_dimension` is not empty, then
+* (C5) For all `i`, `type(scales[i]) = expressed_type`.
+* (C6) For all `i`, `scales[i] > 0`.
+* (C7) For all `i`, `type(zero_points[i]) = i64`.
+* (C8) `size(scales) = size(zero_points)`.
+* (C9) If `quantization_dimension` is empty, then `size(scales) = 1`.
+* (C10) If `quantization_dimension` is not empty, then
   `0 <= quantization_dimension`.
 
 Furthermore, tensors of quantized types satisfy the following constraints:
@@ -231,8 +230,8 @@ Furthermore, tensors of quantized types satisfy the following constraints:
 * For per-tensor quantization:
   * No additional constraints.
 * For per-axis quantization:
-  * (C10) `quantization_dimension < size(shape)`.
-  * (C11) `size(scales_and_zero_points) = shape[quantization_dimension]`.
+  * (C11) `quantization_dimension < size(shape)`.
+  * (C12) `size(scales) = shape[quantization_dimension]`.
 
 ```ebnf
 FunctionType ::= '(' [ValueType {',' ValueType}] ')' '->' '(' [ValueType {',' ValueType}] ')'

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -152,7 +152,7 @@ following constraints:
 * (C4) `min_value(storage_type) <= storage_min < storage_max <= max_value(storage_type)`.
 * (C5) For all `i`, `type(scales[i]) = expressed_type`.
 * (C6) For all `i`, `scales[i] > 0`.
-* (C7) For all `i`, `is_finite(scales[i]) = true`.
+* (C7) For all `i`, `is_finite(scales[i])`.
 * (C8) For all `i`, `storage_min <= zero_points[i] <= storage_max`.
 * (C9) For all `i`, `type(zero_points[i]) = storage_type`.
 * (C10) `size(scales) = size(zero_points)`.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -574,14 +574,14 @@ Performs element-wise addition of two tensors `lhs` and `rhs` and produces a
 
 | Label | Name  | Type   | Constraints |
 |-------|-------|--------|-------------|
-| (I1)  | `lhs` | tensor | (C1)-(C5)   |
-| (I2)  | `rhs` | tensor | (C1)-(C5)   |
+| (I1)  | `lhs` | tensor | (C1)-(C6)   |
+| (I2)  | `rhs` | tensor | (C1)-(C6)   |
 
 #### Outputs
 
 | Name     | Type   | Constraints |
 |----------|--------|-------------|
-| `result` | tensor | (C1)-(C5)   |
+| `result` | tensor | (C1)-(C6)   |
 
 #### Constraints
 
@@ -591,8 +591,8 @@ Performs element-wise addition of two tensors `lhs` and `rhs` and produces a
 * If the operation uses quantized types:
   * (C3) `element_type(lhs) = element_type(rhs) = element_type(result)`,
     except for scales and zero points which may differ.
-  * (C4) `storage_min = min_value(storage_type)`.
-  * (C5) `storage_max = max_value(storage_type)`.
+  * (C4) `storage_min(lhs) = min_value(storage_type)`.
+  * (C5) `storage_max(lhs) = max_value(storage_type)`.
   * (C6) `quantization_dimension(lhs)` is empty.
 
 #### Examples

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2117,9 +2117,11 @@ tensor and produces a `result` tensor.
 #### Semantics
 
 Encapsulates an implementation-defined operation `call_target_name` that takes
-`inputs` and `called_computations` and produces `results`. `has_side_effect`,
-`backend_config` and `api_version` may be used to provide additional
-implementation-defined metadata.
+`inputs` and `called_computations` and produces `results`. The metadata
+`has_side_effect` is used to prevent optimizations like speculation (e.g
+loop-invariant code motion) and dead-code elimination. `backend_config`
+and `api_version` may be used to provide additional implementation-defined
+metadata.
 
 At the moment, this operation contains a fairly disorganized collection of
 metadata which reflects organic evolution of its counterpart operation in

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -661,7 +661,7 @@ Afterwards, within each `process_group`:
 
 | Label | Name                    | Type                                         | Constraints |
 |-------|-------------------------|----------------------------------------------|-------------|
-| (I1)  | `operand`               | tensor                                       | (C1), (C6)  |
+| (I1)  | `operand`               | tensor of non-quantized type                 | (C1), (C6)  |
 | (I2)  | `all_gather_dim`        | constant of type `si64`                      | (C1), (C6)  |
 | (I3)  | `replica_groups`        | 2-dimensional tensor constant of type `si64` | (C2-C4)     |
 | (I4)  | `channel_id`            | constant of type `si64`                      | (C5)        |
@@ -669,9 +669,9 @@ Afterwards, within each `process_group`:
 
 #### Outputs
 
-| Name     | Type   | Constraints |
-|----------|--------|-------------|
-| `result` | tensor | (C6)        |
+| Name     | Type                         | Constraints |
+|----------|------------------------------|-------------|
+| `result` | tensor of non-quantized type | (C6)        |
 
 #### Constraints
 
@@ -745,7 +745,7 @@ Afterwards, within each `process_group`:
 
 | Label | Name                    | Type                                                             | Constraints |
 |-------|-------------------------|------------------------------------------------------------------|-------------|
-| (I1)  | `operand`               | tensor                                                           | (C5), (C6)  |
+| (I1)  | `operand`               | tensor of non-quantized type                                     | (C5), (C6)  |
 | (I2)  | `replica_groups`        | variadic number of 1-dimensional tensor constants of type `si64` | (C1-C3)     |
 | (I3)  | `channel_id`            | constant of type `si64`                                          | (C4)        |
 | (I4)  | `use_global_device_ids` | constant of type `i1`                                            | (C4)        |
@@ -753,9 +753,9 @@ Afterwards, within each `process_group`:
 
 #### Outputs
 
-| Name     | Type   | Constraints |
-|----------|--------|-------------|
-| `result` | tensor | (C6)        |
+| Name     | Type                         | Constraints |
+|----------|------------------------------|-------------|
+| `result` | tensor of non-quantized type | (C6)        |
 
 #### Constraints
 
@@ -843,7 +843,7 @@ Afterwards, within each `process_group`:
 
 | Label | Name               | Type                                         | Constraints      |
 |-------|--------------------|----------------------------------------------|------------------|
-| (I1)  | `operand`          | tensor                                       | (C1)             |
+| (I1)  | `operand`          | tensor of non-quantized type                 | (C1)             |
 | (I2)  | `split_dimension`  | constant of type `si64`                      | (C1), (C2), (C8) |
 | (I3)  | `concat_dimension` | constant of type `si64`                      | (C3), (C8)       |
 | (I4)  | `split_count`      | constant of type `si64`                      | (C2), (C4), (C8) |
@@ -852,9 +852,9 @@ Afterwards, within each `process_group`:
 
 #### Outputs
 
-| Name     | Type   | Constraints |
-|----------|--------|-------------|
-| `result` | tensor | (C8)        |
+| Name     | Type                         | Constraints |
+|----------|------------------------------|-------------|
+| `result` | tensor of non-quantized type | (C8)        |
 
 #### Constraints
 
@@ -1282,15 +1282,15 @@ representation of element types is implementation-defined as well.
 
 #### Inputs
 
-| Label | Name      | Type   | Constraints |
-|-------|-----------|--------|-------------|
-| (I1)  | `operand` | tensor | (C1), (C2)  |
+| Label | Name      | Type                         | Constraints |
+|-------|-----------|------------------------------|-------------|
+| (I1)  | `operand` | tensor of non-quantized type | (C1), (C2)  |
 
 #### Outputs
 
-| Name     | Type   | Constraints |
-|----------|--------|-------------|
-| `result` | tensor | (C1), (C2)  |
+| Name     | Type                         | Constraints |
+|----------|------------------------------|-------------|
+| `result` | tensor of non-quantized type | (C1), (C2)  |
 
 #### Constraints
 
@@ -1332,14 +1332,14 @@ dimensions `k` in `operand`.
 
 | Label | Name                   | Type                                         | Constraints   |
 |-------|------------------------|----------------------------------------------|---------------|
-| (I1)  | `operand`              | tensor                                       | (C1-C3), (C5) |
+| (I1)  | `operand`              | tensor of non-quantized type                 | (C1-C3), (C5) |
 | (I2)  | `broadcast_dimensions` | 1-dimensional tensor constant of type `si64` | (C2-C5)       |
 
 #### Outputs
 
-| Name     | Type   | Constraints      |
-|----------|--------|------------------|
-| `result` | tensor | (C1), (C3), (C5) |
+| Name     | Type                         | Constraints      |
+|----------|------------------------------|------------------|
+| `result` | tensor of non-quantized type | (C1), (C3), (C5) |
 
 #### Constraints
 
@@ -1395,9 +1395,9 @@ returned.
 
 #### Outputs
 
-| Name      | Type                                 | Constraints |
-|-----------|--------------------------------------|-------------|
-| `results` | variadic number of tensors or tokens | (C4)        |
+| Name      | Type                                                       | Constraints |
+|-----------|------------------------------------------------------------|-------------|
+| `results` | variadic number of tensors of non-quantized type or tokens | (C4)        |
 
 #### Constraints
 
@@ -1560,17 +1560,17 @@ for this operation ([#560](https://github.com/openxla/stablehlo/issues/560)).
 
 #### Inputs
 
-| Label | Name      | Type   | Constraints |
-|-------|-----------|--------|-------------|
-| (I1)  | `min`     | tensor | (C1), (C3)  |
-| (I2)  | `operand` | tensor | (C1-C4)     |
-| (I3)  | `max`     | tensor | (C2), (C3)  |
+| Label | Name      | Type                         | Constraints |
+|-------|-----------|------------------------------|-------------|
+| (I1)  | `min`     | tensor of non-quantized type | (C1), (C3)  |
+| (I2)  | `operand` | tensor of non-quantized type | (C1-C4)     |
+| (I3)  | `max`     | tensor of non-quantized type | (C2), (C3)  |
 
 #### Outputs
 
-| Name     | Type   | Constraints |
-|----------|--------|-------------|
-| `result` | tensor | (C4)        |
+| Name     | Type                         | Constraints |
+|----------|------------------------------|-------------|
+| `result` | tensor of non-quantized type | (C4)        |
 
 #### Constraints
 
@@ -1617,15 +1617,15 @@ Afterwards, `result@process` is given by:
 
 | Label | Name                  | Type                                         | Constraints |
 |-------|-----------------------|----------------------------------------------|-------------|
-| (I1)  | `operand`             | tensor                                       | (C5)        |
+| (I1)  | `operand`             | tensor of non-quantized type                 | (C5)        |
 | (I2)  | `source_target_pairs` | 2-dimensional tensor constant of type `si64` | (C1-C4)     |
 | (I3)  | `channel_id`          | constant of type `si64`                      |             |
 
 #### Outputs
 
-| Name     | Type   | Constraints |
-|----------|--------|-------------|
-| `result` | tensor | (C1)        |
+| Name     | Type                         | Constraints |
+|----------|------------------------------|-------------|
+| `result` | tensor of non-quantized type | (C1)        |
 
 #### Constraints
 
@@ -1700,8 +1700,8 @@ when `comparison_direction` is `GE`, `GT`, `LE` or `LT`
 
 | Label | Name                   | Type                                                    | Constraints |
 |-------|------------------------|---------------------------------------------------------|-------------|
-| (I1)  | `lhs`                  | tensor                                                  | (C1-C3)     |
-| (I2)  | `rhs`                  | tensor                                                  | (C1), (C2)  |
+| (I1)  | `lhs`                  | tensor of non-quantized type                            | (C1-C3)     |
+| (I2)  | `rhs`                  | tensor of non-quantized type                            | (C1), (C2)  |
 | (I3)  | `comparison_direction` | enum of `EQ`, `NE`, `GE`, `GT`, `LE`, and `LT`          |             |
 | (I4)  | `compare_type`         | enum of `FLOAT`, `TOTALORDER`, `SIGNED`, and `UNSIGNED` | (C3)        |
 
@@ -1787,16 +1787,16 @@ tensor. More formally,
 
 #### Inputs
 
-| Label | Name        | Type                       | Constraints      |
-|-------|-------------|----------------------------|------------------|
-| (I1)  | `inputs`    | variadic number of tensors | (C1-C6)          |
-| (I2)  | `dimension` | constant of type `si64`    | (C2), (C4), (C6) |
+| Label | Name        | Type                                             | Constraints      |
+|-------|-------------|--------------------------------------------------|------------------|
+| (I1)  | `inputs`    | variadic number of tensors of non-quantized type | (C1-C6)          |
+| (I2)  | `dimension` | constant of type `si64`                          | (C2), (C4), (C6) |
 
 #### Outputs
 
-| Name     | Type   | Constraints |
-|----------|--------|-------------|
-| `result` | tensor | (C5), (C6)  |
+| Name     | Type                         | Constraints |
+|----------|------------------------------|-------------|
+| `result` | tensor of non-quantized type | (C5), (C6)  |
 
 #### Constraints
 
@@ -1837,9 +1837,9 @@ Produces an `output` tensor from a constant `value`.
 
 #### Outputs
 
-| Name     | Type   | Constraints |
-|----------|--------|-------------|
-| `output` | tensor | (C1)        |
+| Name     | Type                         | Constraints |
+|----------|------------------------------|-------------|
+| `output` | tensor of non-quantized type | (C1)        |
 
 #### Constraints
 
@@ -1904,15 +1904,15 @@ converted to zero, and the value `true` is converted to one. For
 
 #### Inputs
 
-| Label | Name      | Type   | Constraints |
-|-------|-----------|--------|-------------|
-| (I1)  | `operand` | tensor | (C1)        |
+| Label | Name      | Type                         | Constraints |
+|-------|-----------|------------------------------|-------------|
+| (I1)  | `operand` | tensor of non-quantized type | (C1)        |
 
 #### Outputs
 
-| Name     | Type   | Constraints |
-|----------|--------|-------------|
-| `result` | tensor | (C1)        |
+| Name     | Type                         | Constraints |
+|----------|------------------------------|-------------|
+| `result` | tensor of non-quantized type | (C1)        |
 
 #### Constraints
 
@@ -1987,8 +1987,8 @@ If `batch_group_count > 1`:
 
 | Label | Name                              | Type                                                         | Constraints                                  |
 |-------|-----------------------------------|--------------------------------------------------------------|----------------------------------------------|
-| (I1)  | `lhs`                             | tensor                                                       | (C1), (C2), (C11), (C12), (C15) (C26), (C27) |
-| (I2)  | `rhs`                             | tensor                                                       | (C1), (C2), (C15-C17), (C26)                 |
+| (I1)  | `lhs`                             | tensor of non-quantized type                                 | (C1), (C2), (C11), (C12), (C15) (C26), (C27) |
+| (I2)  | `rhs`                             | tensor of non-quantized type                                 | (C1), (C2), (C15-C17), (C26)                 |
 | (I3)  | `window_strides`                  | 1-dimensional tensor constant of type `si64`                 | (C3), (C4), (C26)                            |
 | (I4)  | `padding`                         | 2-dimensional tensor constant of type `si64`                 | (C5), (C26)                                  |
 | (I5)  | `lhs_dilation`                    | 1-dimensional tensor constant of type `si64`                 | (C6), (C7), (C26)                            |
@@ -2009,9 +2009,9 @@ If `batch_group_count > 1`:
 
 #### Outputs
 
-| Name     | Type   | Constraints |
-|----------|--------|-------------|
-| `result` | tensor | (C26-C28)   |
+| Name     | Type                         | Constraints |
+|----------|------------------------------|-------------|
+| `result` | tensor of non-quantized type | (C26-C28)   |
 
 #### Constraints
 
@@ -2312,8 +2312,8 @@ planning to address this in
 
 | Label | Name                         | Type                                                         | Constraints                           |
 |-------|------------------------------|--------------------------------------------------------------|---------------------------------------|
-| (I1)  | `lhs`                        | tensor                                                       | (C1), (C6), (C7), (C10), (C11), (C13) |
-| (I2)  | `rhs`                        | tensor                                                       | (C1), (C8), (C9), (C10), (C11), (C13) |
+| (I1)  | `lhs`                        | tensor of non-quantized type                                 | (C1), (C6), (C7), (C10), (C11), (C13) |
+| (I2)  | `rhs`                        | tensor of non-quantized type                                 | (C1), (C8), (C9), (C10), (C11), (C13) |
 | (I3)  | `lhs_batching_dimensions`    | 1-dimensional tensor constant of type `si64`                 | (C2), (C4), (C6), (C10), (C13)        |
 | (I4)  | `rhs_batching_dimensions`    | 1-dimensional tensor constant of type `si64`                 | (C2), (C5), (C8), (C10)               |
 | (I5)  | `lhs_contracting_dimensions` | 1-dimensional tensor constant of type `si64`                 | (C3), (C4), (C7), (C11)               |
@@ -2322,9 +2322,9 @@ planning to address this in
 
 #### Outputs
 
-| Name     | Type   | Constraints |
-|----------|--------|-------------|
-| `result` | tensor | (C13)       |
+| Name     | Type                         | Constraints |
+|----------|------------------------------|-------------|
+| `result` | tensor of non-quantized type | (C13)       |
 
 #### Constraints
 
@@ -2407,15 +2407,15 @@ More formally, `result[i0, ..., iR-1] = operand[j0, ..., jR-1]` where:
 
 | Label | Name            | Type                                                     | Constraints      |
 |-------|-----------------|----------------------------------------------------------|------------------|
-| (I1)  | `operand`       | tensor                                                   | (C1), (C2), (C4) |
+| (I1)  | `operand`       | tensor of non-quantized type                             | (C1), (C2), (C4) |
 | (I2)  | `start_indices` | variadic number of 0-dimensional tensors of integer type | (C2), (C3)       |
 | (I3)  | `slice_sizes`   | 1-dimensional tensor constant of type `si64`             | (C2), (C4), (C5) |
 
 #### Outputs
 
-| Name     | Type   | Constraints |
-|----------|--------|-------------|
-| `result` | tensor | (C1), (C5)  |
+| Name     | Type                         | Constraints |
+|----------|------------------------------|-------------|
+| `result` | tensor of non-quantized type | (C1), (C5)  |
 
 #### Constraints
 
@@ -2466,15 +2466,15 @@ More formally, `result[i0, ..., iR-1]` is defined as:
 
 | Label | Name            | Type                                                     | Constraints      |
 |-------|-----------------|----------------------------------------------------------|------------------|
-| (I1)  | `operand`       | tensor                                                   | (C1-C4), (C6)    |
-| (I2)  | `update`        | tensor                                                   | (C3), (C3), (C6) |
+| (I1)  | `operand`       | tensor of non-quantized type                             | (C1-C4), (C6)    |
+| (I2)  | `update`        | tensor of non-quantized type                             | (C3), (C3), (C6) |
 | (I3)  | `start_indices` | variadic number of 0-dimensional tensors of integer type | (C4), (C5)       |
 
 #### Outputs
 
-| Name     | Type   | Constraints |
-|----------|--------|-------------|
-| `result` | tensor | (C1)        |
+| Name     | Type                         | Constraints |
+|----------|------------------------------|-------------|
+| `result` | tensor of non-quantized type | (C1)        |
 
 #### Constraints
 
@@ -2776,7 +2776,7 @@ behavior is undefined. More formally, for all `id < jd` from `indices(result)`,
 
 | Label | Name                   | Type                                         | Constraints                   |
 |-------|------------------------|----------------------------------------------|-------------------------------|
-| (I1)  | `operand`              | tensor                                       | (C1), (C10-C12), (C15)        |
+| (I1)  | `operand`              | tensor of non-quantized type                 | (C1), (C10-C12), (C15)        |
 | (I2)  | `start_indices`        | tensor of integer type                       | (C2), (C3), (C13)             |
 | (I3)  | `offset_dims`          | 1-dimensional tensor constant of type `si64` | (C1), (C4), (C5), (C13)       |
 | (I4)  | `collapsed_slice_dims` | 1-dimensional tensor constant of type `si64` | (C1), (C6), (C7), (C8), (C13) |
@@ -2787,9 +2787,9 @@ behavior is undefined. More formally, for all `id < jd` from `indices(result)`,
 
 #### Outputs
 
-| Name     | Type   | Constraints        |
-|----------|--------|--------------------|
-| `result` | tensor | (C5), (C13), (C15) |
+| Name     | Type                         | Constraints        |
+|----------|------------------------------|--------------------|
+| `result` | tensor of non-quantized type | (C5), (C13), (C15) |
 
 #### Constraints
 
@@ -2867,10 +2867,10 @@ Produces the size of the given `dimension` of the `operand`.
 
 #### Inputs
 
-| Label | Name        | Type                    | Constraints |
-|-------|-------------|-------------------------|-------------|
-| (I1)  | `operand`   | tensor                  | (C1)        |
-| (I2)  | `dimension` | constant of type `si64` | (C1)        |
+| Label | Name        | Type                         | Constraints |
+|-------|-------------|------------------------------|-------------|
+| (I1)  | `operand`   | tensor of non-quantized type | (C1)        |
+| (I2)  | `dimension` | constant of type `si64`      | (C1)        |
 
 #### Outputs
 
@@ -2946,9 +2946,9 @@ output of `true_branch` is returned, else if pred is `false`, output of
 
 #### Outputs
 
-| Name      | Type                                 | Constraints |
-|-----------|--------------------------------------|-------------|
-| `results` | variadic number of tensors or tokens | (C3)        |
+| Name      | Type                                                       | Constraints |
+|-----------|------------------------------------------------------------|-------------|
+| `results` | variadic number of tensors of non-quantized type or tokens | (C3)        |
 
 #### Constraints
 
@@ -3032,9 +3032,9 @@ to improve clarity ([#670](https://github.com/openxla/stablehlo/issues/670)).
 
 #### Outputs
 
-| Name      | Type                                 | Constraints |
-|-----------|--------------------------------------|-------------|
-| `results` | variadic number of tensors or tokens | (C1), (C2)  |
+| Name      | Type                                                       | Constraints |
+|-----------|------------------------------------------------------------|-------------|
+| `results` | variadic number of tensors of non-quantized type or tokens | (C1), (C2)  |
 
 #### Constraints
 
@@ -3254,17 +3254,17 @@ and will likely be removed in the future
 
 #### Inputs
 
-| Label | Name          | Type                                         | Constraints |
-|-------|---------------|----------------------------------------------|-------------|
-| (I1)  | `inputs`      | variadic number of tensors                   | (C1-C4)     |
-| (I2)  | `dimensions`  | 1-dimensional tensor constant of type `si64` | (C3)        |
-| (I3)  | `computation` | function                                     | (C4)        |
+| Label | Name          | Type                                             | Constraints |
+|-------|---------------|--------------------------------------------------|-------------|
+| (I1)  | `inputs`      | variadic number of tensors of non-quantized type | (C1-C4)     |
+| (I2)  | `dimensions`  | 1-dimensional tensor constant of type `si64`     | (C3)        |
+| (I3)  | `computation` | function                                         | (C4)        |
 
 #### Outputs
 
-| Name     | Type   | Constraints |
-|----------|--------|-------------|
-| `result` | tensor | (C1), (C4)  |
+| Name     | Type                         | Constraints |
+|----------|------------------------------|-------------|
+| `result` | tensor of non-quantized type | (C1), (C4)  |
 
 #### Constraints
 
@@ -3308,16 +3308,16 @@ Performs element-wise max operation on tensors `lhs` and `rhs` and produces a
 
 #### Inputs
 
-| Label | Name  | Type   | Constraints |
-|-------|-------|--------|-------------|
-| (I1)  | `lhs` | tensor | (C1)        |
-| (I2)  | `rhs` | tensor | (C1)        |
+| Label | Name  | Type                         | Constraints |
+|-------|-------|------------------------------|-------------|
+| (I1)  | `lhs` | tensor of non-quantized type | (C1)        |
+| (I2)  | `rhs` | tensor of non-quantized type | (C1)        |
 
 #### Outputs
 
-| Name     | Type   | Constraints |
-|----------|--------|-------------|
-| `result` | tensor | (C1)        |
+| Name     | Type                         | Constraints |
+|----------|------------------------------|-------------|
+| `result` | tensor of non-quantized type | (C1)        |
 
 #### Constraints
 
@@ -3351,16 +3351,16 @@ Performs element-wise min operation on tensors `lhs` and `rhs` and produces a
 
 #### Inputs
 
-| Label | Name  | Type   | Constraints |
-|-------|-------|--------|-------------|
-| (I1)  | `lhs` | tensor | (C1)        |
-| (I2)  | `rhs` | tensor | (C1)        |
+| Label | Name  | Type                         | Constraints |
+|-------|-------|------------------------------|-------------|
+| (I1)  | `lhs` | tensor of non-quantized type | (C1)        |
+| (I2)  | `rhs` | tensor of non-quantized type | (C1)        |
 
 #### Outputs
 
-| Name     | Type   | Constraints |
-|----------|--------|-------------|
-| `result` | tensor | (C1)        |
+| Name     | Type                         | Constraints |
+|----------|------------------------------|-------------|
+| `result` | tensor of non-quantized type | (C1)        |
 
 #### Constraints
 
@@ -3391,16 +3391,16 @@ Performs element-wise product of two tensors `lhs` and `rhs` and produces a
 
 #### Inputs
 
-| Label | Name  | Type   | Constraints |
-|-------|-------|--------|-------------|
-| (I1)  | `lhs` | tensor | (C1)        |
-| (I2)  | `rhs` | tensor | (C1)        |
+| Label | Name  | Type                         | Constraints |
+|-------|-------|------------------------------|-------------|
+| (I1)  | `lhs` | tensor of non-quantized type | (C1)        |
+| (I2)  | `rhs` | tensor of non-quantized type | (C1)        |
 
 #### Outputs
 
-| Name     | Type   | Constraints |
-|----------|--------|-------------|
-| `result` | tensor | (C1)        |
+| Name     | Type                         | Constraints |
+|----------|------------------------------|-------------|
+| `result` | tensor of non-quantized type | (C1)        |
 
 #### Constraints
 
@@ -3513,15 +3513,15 @@ an identity, i.e. `result` = `operand`.
 
 #### Arguments
 
-| Name      | Type                                 | Constraints |
-|-----------|--------------------------------------|-------------|
-| `operand` | variadic number of tensors or tokens | (C1), (C2)  |
+| Name      | Type                                                       | Constraints |
+|-----------|------------------------------------------------------------|-------------|
+| `operand` | variadic number of tensors of non-quantized type or tokens | (C1), (C2)  |
 
 #### Outputs
 
-| Name     | Type                                 | Constraints |
-|----------|--------------------------------------|-------------|
-| `result` | variadic number of tensors or tokens | (C1), (C2)  |
+| Name     | Type                                                       | Constraints |
+|----------|------------------------------------------------------------|-------------|
+| `result` | variadic number of tensors of non-quantized type or tokens | (C1), (C2)  |
 
 #### Constraints
 
@@ -3594,11 +3594,11 @@ as a value that other operations can take a data dependency on.
 
 #### Inputs
 
-| Label | Name             | Type                       |
-|-------|------------------|----------------------------|
-| (I1)  | `inputs`         | variadic number of tensors |
-| (I2)  | `token`          | `token`                    |
-| (I3)  | `outfeed_config` | constant of type `string`  |
+| Label | Name             | Type                                             |
+|-------|------------------|--------------------------------------------------|
+| (I1)  | `inputs`         | variadic number of tensors of non-quantized type |
+| (I2)  | `token`          | `token`                                          |
+| (I3)  | `outfeed_config` | constant of type `string`                        |
 
 #### Outputs
 
@@ -3642,17 +3642,17 @@ More formally, `result[i0, ..., iR-1]` is equal to:
 
 | Label | Name                | Type                                         | Constraints      |
 |-------|---------------------|----------------------------------------------|------------------|
-| (I1)  | `operand`           | tensor                                       | (C1), (C2), (C4) |
-| (I2)  | `padding_value`     | 0-dimensional tensor                         | (C1)             |
+| (I1)  | `operand`           | tensor of non-quantized type                 | (C1), (C2), (C4) |
+| (I2)  | `padding_value`     | 0-dimensional tensor of non-quantized type   | (C1)             |
 | (I3)  | `edge_padding_low`  | 1-dimensional tensor constant of type `si64` | (C2), (C4)       |
 | (I4)  | `edge_padding_high` | 1-dimensional tensor constant of type `si64` | (C2), (C4)       |
 | (I5)  | `interior_padding`  | 1-dimensional tensor constant of type `si64` | (C2-C4)          |
 
 #### Outputs
 
-| Name     | Type   | Constraints |
-|----------|--------|-------------|
-| `result` | tensor | (C1)        |
+| Name     | Type                         | Constraints |
+|----------|------------------------------|-------------|
+| `result` | tensor of non-quantized type | (C1)        |
 
 #### Constraints
 
@@ -3844,9 +3844,9 @@ to split the payload and the token into two separate outputs to improve clarity
 
 #### Outputs
 
-| Name      | Type                                 | Constraints |
-|-----------|--------------------------------------|-------------|
-| `results` | variadic number of tensors or tokens | (C2), (C3)  |
+| Name      | Type                                                       | Constraints |
+|-----------|------------------------------------------------------------|-------------|
+| `results` | variadic number of tensors of non-quantized type or tokens | (C2), (C3)  |
 
 #### Constraints
 
@@ -3898,18 +3898,18 @@ More formally, `results[:][j0, ..., jR-1] = reduce(input_slices)` where:
 
 #### Inputs
 
-| Label | Name          | Type                                         | Constraints         |
-|-------|---------------|----------------------------------------------|---------------------|
-| (I1)  | `inputs`      | variadic number of tensors                   | (C1-C4), (C6), (C7) |
-| (I2)  | `init_values` | variadic number of 0-dimensional tensors     | (C2), (C3)          |
-| (I3)  | `dimensions`  | 1-dimensional tensor constant of type `si64` | (C4), (C5), (C7)    |
-| (I4)  | `body`        | function                                     | (C6)                |
+| Label | Name          | Type                                                           | Constraints         |
+|-------|---------------|----------------------------------------------------------------|---------------------|
+| (I1)  | `inputs`      | variadic number of tensors of non-quantized type               | (C1-C4), (C6), (C7) |
+| (I2)  | `init_values` | variadic number of 0-dimensional tensors of non-quantized type | (C2), (C3)          |
+| (I3)  | `dimensions`  | 1-dimensional tensor constant of type `si64`                   | (C4), (C5), (C7)    |
+| (I4)  | `body`        | function                                                       | (C6)                |
 
 #### Outputs
 
-| Name      | Type                       | Constraints      |
-|-----------|----------------------------|------------------|
-| `results` | variadic number of tensors | (C2), (C3), (C7) |
+| Name      | Type                                             | Constraints      |
+|-----------|--------------------------------------------------|------------------|
+| `results` | variadic number of tensors of non-quantized type | (C2), (C3), (C7) |
 
 #### Constraints
 
@@ -4029,7 +4029,7 @@ Afterwards, within each `process_group`:
 
 | Label | Name                    | Type                                         | Constraints            |
 |-------|-------------------------|----------------------------------------------|------------------------|
-| (I1)  | `operand`               | tensor                                       | (C1), (C2), (C7), (C8) |
+| (I1)  | `operand`               | tensor of non-quantized type                 | (C1), (C2), (C7), (C8) |
 | (I2)  | `scatter_dimension`     | constant of type `si64`                      | (C1), (C2), (C8)       |
 | (I3)  | `replica_groups`        | 2-dimensional tensor constant of type `si64` | (C3-C5)                |
 | (I4)  | `channel_id`            | constant of type `si64`                      | (C6)                   |
@@ -4038,9 +4038,9 @@ Afterwards, within each `process_group`:
 
 #### Outputs
 
-| Name     | Type   | Constraints |
-|----------|--------|-------------|
-| `result` | tensor | (C8)        |
+| Name     | Type                         | Constraints |
+|----------|------------------------------|-------------|
+| `result` | tensor of non-quantized type | (C8)        |
 
 #### Constraints
 
@@ -4120,22 +4120,22 @@ where:
 
 #### Inputs
 
-| Label | Name                | Type                                         | Constraints                                     |
-|-------|---------------------|----------------------------------------------|-------------------------------------------------|
-| (I1)  | `inputs`            | variadic number of tensors                   | (C1-C4), (C6), (C8), (C10), (C12), (C13), (C15) |
-| (I2)  | `init_values`       | variadic number of 0-dimensional tensors     | (C1), (C13), (C16)                              |
-| (I3)  | `window_dimensions` | 1-dimensional tensor constant of type `si64` | (C4), (C5), (C15)                               |
-| (I4)  | `window_strides`    | 1-dimensional tensor constant of type `si64` | (C6), (C7), (C15)                               |
-| (I5)  | `base_dilations`    | 1-dimensional tensor constant of type `si64` | (C8), (C9), (C15)                               |
-| (I6)  | `window_dilations`  | 1-dimensional tensor constant of type `si64` | (C10), (C11), (C15)                             |
-| (I7)  | `padding`           | 2-dimensional tensor constant of type `si64` | (C12), (C15)                                    |
-| (I8)  | `body`              | function                                     | (C13)                                           |
+| Label | Name                | Type                                                           | Constraints                                     |
+|-------|---------------------|----------------------------------------------------------------|-------------------------------------------------|
+| (I1)  | `inputs`            | variadic number of tensors of non-quantized type               | (C1-C4), (C6), (C8), (C10), (C12), (C13), (C15) |
+| (I2)  | `init_values`       | variadic number of 0-dimensional tensors of non-quantized type | (C1), (C13), (C16)                              |
+| (I3)  | `window_dimensions` | 1-dimensional tensor constant of type `si64`                   | (C4), (C5), (C15)                               |
+| (I4)  | `window_strides`    | 1-dimensional tensor constant of type `si64`                   | (C6), (C7), (C15)                               |
+| (I5)  | `base_dilations`    | 1-dimensional tensor constant of type `si64`                   | (C8), (C9), (C15)                               |
+| (I6)  | `window_dilations`  | 1-dimensional tensor constant of type `si64`                   | (C10), (C11), (C15)                             |
+| (I7)  | `padding`           | 2-dimensional tensor constant of type `si64`                   | (C12), (C15)                                    |
+| (I8)  | `body`              | function                                                       | (C13)                                           |
 
 #### Outputs
 
-| Name      | Type                       | Constraints     |
-|-----------|----------------------------|-----------------|
-| `results` | variadic number of tensors | (C1), (C14-C16) |
+| Name      | Type                                             | Constraints     |
+|-----------|--------------------------------------------------|-----------------|
+| `results` | variadic number of tensors of non-quantized type | (C1), (C14-C16) |
 
 #### Constraints
 
@@ -4266,15 +4266,15 @@ spaces of `result` and `operand`.
 
 #### Inputs
 
-| Label | Name      | Type   | Constraints |
-|-------|-----------|--------|-------------|
-| (I1)  | `operand` | tensor | (C1), (C2)  |
+| Label | Name      | Type                         | Constraints |
+|-------|-----------|------------------------------|-------------|
+| (I1)  | `operand` | tensor of non-quantized type | (C1), (C2)  |
 
 #### Outputs
 
-| Name     | Type   | Constraints |
-|----------|--------|-------------|
-| `result` | tensor | (C1), (C2)  |
+| Name     | Type                         | Constraints |
+|----------|------------------------------|-------------|
+| `result` | tensor of non-quantized type | (C1), (C2)  |
 
 #### Constraints
 
@@ -4304,14 +4304,14 @@ and produces a `result` tensor. More formally,
 
 | Label | Name         | Type                                         | Constraints |
 |-------|--------------|----------------------------------------------|-------------|
-| (I1)  | `operand`    | tensor                                       | (C1)        |
+| (I1)  | `operand`    | tensor of non-quantized type                 | (C1)        |
 | (I2)  | `dimensions` | 1-dimensional tensor constant of type `si64` | (C2), (C3)  |
 
 #### Outputs
 
-| Name     | Type   | Constraints |
-|----------|--------|-------------|
-| `result` | tensor | (C1), (C3)  |
+| Name     | Type                         | Constraints |
+|----------|------------------------------|-------------|
+| `result` | tensor of non-quantized type | (C1), (C3)  |
 
 #### Constraints
 
@@ -4611,24 +4611,24 @@ undefined.
 
 #### Inputs
 
-| Label | Name                           | Type                                         | Constraints                                     |
-|-------|--------------------------------|----------------------------------------------|-------------------------------------------------|
-| (I1)  | `inputs`                       | variadic number of tensors                   | (C1), (C2), (C4-C6), (C10), (C13), (C15), (C16) |
-| (I2)  | `scatter_indices`              | tensor of integer type                       | (C4), (C11), (C14)                              |
-| (I3)  | `updates`                      | variadic number of tensors                   | (C3-C6), (C8)                                   |
-| (I4)  | `update_window_dims`           | 1-dimensional tensor constant of type `si64` | (C2), (C4), (C7), (C8)                          |
-| (I5)  | `inserted_window_dims`         | 1-dimensional tensor constant of type `si64` | (C2), (C4), (C9), (C10)                         |
-| (I6)  | `scatter_dims_to_operand_dims` | 1-dimensional tensor constant of type `si64` | (C11-C13)                                       |
-| (I7)  | `index_vector_dim`             | constant of type `si64`                      | (C4), (C11), (C14)                              |
-| (I8)  | `indices_are_sorted`           | constant of type `i1`                        |                                                 |
-| (I9)  | `unique_indices`               | constant of type `i1`                        |                                                 |
-| (I10) | `update_computation`           | function                                     | (C15)                                           |
+| Label | Name                           | Type                                             | Constraints                                     |
+|-------|--------------------------------|--------------------------------------------------|-------------------------------------------------|
+| (I1)  | `inputs`                       | variadic number of tensors of non-quantized type | (C1), (C2), (C4-C6), (C10), (C13), (C15), (C16) |
+| (I2)  | `scatter_indices`              | tensor of integer type                           | (C4), (C11), (C14)                              |
+| (I3)  | `updates`                      | variadic number of tensors of non-quantized type | (C3-C6), (C8)                                   |
+| (I4)  | `update_window_dims`           | 1-dimensional tensor constant of type `si64`     | (C2), (C4), (C7), (C8)                          |
+| (I5)  | `inserted_window_dims`         | 1-dimensional tensor constant of type `si64`     | (C2), (C4), (C9), (C10)                         |
+| (I6)  | `scatter_dims_to_operand_dims` | 1-dimensional tensor constant of type `si64`     | (C11-C13)                                       |
+| (I7)  | `index_vector_dim`             | constant of type `si64`                          | (C4), (C11), (C14)                              |
+| (I8)  | `indices_are_sorted`           | constant of type `i1`                            |                                                 |
+| (I9)  | `unique_indices`               | constant of type `i1`                            |                                                 |
+| (I10) | `update_computation`           | function                                         | (C15)                                           |
 
 #### Outputs
 
-| Name      | Type                       |
-|-----------|----------------------------|
-| `results` | variadic number of tensors |
+| Name      | Type                                             |
+|-----------|--------------------------------------------------|
+| `results` | variadic number of tensors of non-quantized type |
 
 #### Constraints
 
@@ -4716,17 +4716,17 @@ where `pred_val = rank(pred) == 0 ? pred : pred[i0, ..., iR-1]`.
 
 #### Inputs
 
-| Label | Name       | Type                | Constraints |
-|-------|------------|---------------------|-------------|
-| (I1)  | `pred`     | tensor of type `i1` | (C1)        |
-| (I2)  | `on_true`  | tensor              | (C1), (C2)  |
-| (I3)  | `on_false` | tensor              | (C2)        |
+| Label | Name       | Type                         | Constraints |
+|-------|------------|------------------------------|-------------|
+| (I1)  | `pred`     | tensor of type `i1`          | (C1)        |
+| (I2)  | `on_true`  | tensor of non-quantized type | (C1), (C2)  |
+| (I3)  | `on_false` | tensor of non-quantized type | (C2)        |
 
 #### Outputs
 
-| Name     | Type   | Constraints |
-|----------|--------|-------------|
-| `result` | tensor | (C2)        |
+| Name     | Type                         | Constraints |
+|----------|------------------------------|-------------|
+| `result` | tensor of non-quantized type | (C2)        |
 
 #### Constraints
 
@@ -4791,9 +4791,9 @@ More formally:
 
 | Label | Name                | Type                                         | Constraints             |
 |-------|---------------------|----------------------------------------------|-------------------------|
-| (I1)  | `operand`           | tensor                                       | (C1-C5), (C7), (C9-C12) |
-| (I2)  | `source`            | tensor                                       | (C2), (C3)              |
-| (I3)  | `init_value`        | 0-dimensional tensor                         | (C4)                    |
+| (I1)  | `operand`           | tensor of non-quantized type                 | (C1-C5), (C7), (C9-C12) |
+| (I2)  | `source`            | tensor of non-quantized type                 | (C2), (C3)              |
+| (I3)  | `init_value`        | 0-dimensional tensor of non-quantized type   | (C4)                    |
 | (I4)  | `window_dimensions` | 1-dimensional tensor constant of type `si64` | (C1), (C3), (C5), (C6)  |
 | (I5)  | `window_strides`    | 1-dimensional tensor constant of type `si64` | (C3), (C7), (C8)        |
 | (I6)  | `padding`           | 2-dimensional tensor constant of type `si64` | (C3), (C9)              |
@@ -4802,9 +4802,9 @@ More formally:
 
 #### Outputs
 
-| Name     | Type   | Constraints |
-|----------|--------|-------------|
-| `result` | tensor | (C12)       |
+| Name     | Type                         | Constraints |
+|----------|------------------------------|-------------|
+| `result` | tensor of non-quantized type | (C12)       |
 
 #### Constraints
 
@@ -4867,13 +4867,13 @@ implementation-defined. This flag duplicates the information provided in
 
 #### Inputs
 
-| Label | Name               | Type                                            | Constraints |
-|-------|--------------------|-------------------------------------------------|-------------|
-| (I1)  | `inputs`           | variadic number of tensors                      |             |
-| (I2)  | `token`            | `token`                                         |             |
-| (I3)  | `channel_id`       | constant of type `si64`                         |             |
-| (I4)  | `channel_type`     | enum of `DEVICE_TO_DEVICE` and `DEVICE_TO_HOST` | (C1)        |
-| (I5)  | `is_host_transfer` | constant of type `i1`                           | (C1)        |
+| Label | Name               | Type                                             | Constraints |
+|-------|--------------------|--------------------------------------------------|-------------|
+| (I1)  | `inputs`           | variadic number of tensors of non-quantized type |             |
+| (I2)  | `token`            | `token`                                          |             |
+| (I3)  | `channel_id`       | constant of type `si64`                          |             |
+| (I4)  | `channel_type`     | enum of `DEVICE_TO_DEVICE` and `DEVICE_TO_HOST`  | (C1)        |
+| (I5)  | `is_host_transfer` | constant of type `i1`                            | (C1)        |
 
 #### Outputs
 
@@ -5107,16 +5107,16 @@ More formally, `result[i0, ..., iR-1] = operand[j0, ..., jR-1]` where
 
 | Label | Name            | Type                                         | Constraints      |
 |-------|-----------------|----------------------------------------------|------------------|
-| (I1)  | `operand`       | tensor                                       | (C1-C3), (C5)    |
+| (I1)  | `operand`       | tensor of non-quantized type                 | (C1-C3), (C5)    |
 | (I2)  | `start_indices` | 1-dimensional tensor constant of type `si64` | (C2), (C3), (C5) |
 | (I3)  | `limit_indices` | 1-dimensional tensor constant of type `si64` | (C2), (C3), (C5) |
 | (I4)  | `strides`       | 1-dimensional tensor constant of type `si64` | (C2), (C4)       |
 
 #### Outputs
 
-| Name     | Type   | Constraints |
-|----------|--------|-------------|
-| `result` | tensor | (C1), (C5)  |
+| Name     | Type                         | Constraints |
+|----------|------------------------------|-------------|
+| `result` | tensor of non-quantized type | (C1), (C5)  |
 
 #### Constraints
 
@@ -5173,18 +5173,18 @@ More formally, for all `0 <= id < jd < dim(inputs[0], d)`, either
 
 #### Inputs
 
-| Label | Name         | Type                       | Constraints |
-|-------|--------------|----------------------------|-------------|
-| (I1)  | `inputs`     | variadic number of tensors | (C1)        |
-| (I2)  | `dimension`  | constant of type `si64`    | (C4)        |
-| (I3)  | `is_stable`  | constant of type `i1`      |             |
-| (I4)  | `comparator` | function                   | (C5)        |
+| Label | Name         | Type                                             | Constraints |
+|-------|--------------|--------------------------------------------------|-------------|
+| (I1)  | `inputs`     | variadic number of tensors of non-quantized type | (C1)        |
+| (I2)  | `dimension`  | constant of type `si64`                          | (C4)        |
+| (I3)  | `is_stable`  | constant of type `i1`                            |             |
+| (I4)  | `comparator` | function                                         | (C5)        |
 
 #### Outputs
 
-| Name      | Type                       | Constraints |
-|-----------|----------------------------|-------------|
-| `results` | variadic number of tensors | (C2), (C3)  |
+| Name      | Type                                             | Constraints |
+|-----------|--------------------------------------------------|-------------|
+| `results` | variadic number of tensors of non-quantized type | (C2), (C3)  |
 
 #### Constraints
 
@@ -5358,14 +5358,14 @@ where `i[d] = j[permutation[d]]`.
 
 | Label | Name          | Type                                         | Constraints |
 |-------|---------------|----------------------------------------------|-------------|
-| (I1)  | `operand`     | tensor                                       | (C1-C3)     |
+| (I1)  | `operand`     | tensor of non-quantized type                 | (C1-C3)     |
 | (I2)  | `permutation` | 1-dimensional tensor constant of type `si64` | (C2), (C3)  |
 
 #### Outputs
 
-| Name     | Type   | Constraints |
-|----------|--------|-------------|
-| `result` | tensor | (C1), (C3)  |
+| Name     | Type                         | Constraints |
+|----------|------------------------------|-------------|
+| `result` | tensor of non-quantized type | (C1), (C3)  |
 
 #### Constraints
 
@@ -5521,17 +5521,17 @@ The behavior of an infinite loop is TBD
 
 #### Inputs
 
-| Label | Name      | Type                                 | Constraints |
-|-------|-----------|--------------------------------------|-------------|
-| (I1)  | `operand` | variadic number of tensors or tokens | (C1-C3)     |
-| (I2)  | `cond`    | function                             | (C1)        |
-| (I3)  | `body`    | function                             | (C2)        |
+| Label | Name      | Type                                                       | Constraints |
+|-------|-----------|------------------------------------------------------------|-------------|
+| (I1)  | `operand` | variadic number of tensors of non-quantized type or tokens | (C1-C3)     |
+| (I2)  | `cond`    | function                                                   | (C1)        |
+| (I3)  | `body`    | function                                                   | (C2)        |
 
 #### Outputs
 
-| Name      | Type                                 | Constraints |
-|-----------|--------------------------------------|-------------|
-| `results` | variadic number of tensors or tokens | (C3)        |
+| Name      | Type                                                       | Constraints |
+|-----------|------------------------------------------------------------|-------------|
+| `results` | variadic number of tensors of non-quantized type or tokens | (C3)        |
 
 #### Constraints
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -152,11 +152,12 @@ following constraints:
 * (C4) `min_value(storage_type) <= storage_min < storage_max <= max_value(storage_type)`.
 * (C5) For all `i`, `type(scales[i]) = expressed_type`.
 * (C6) For all `i`, `scales[i] > 0`.
-* (C7) For all `i`, `storage_min <= zero_points[i] <= storage_max`.
-* (C8) For all `i`, `type(zero_points[i]) = storage_type`.
-* (C9) `size(scales) = size(zero_points)`.
-* (C10) If `quantization_dimension` is empty, then `size(scales) = 1`.
-* (C11) If `quantization_dimension` is not empty, then
+* (C7) For all `i`, `is_finite(scales[i]) = true`.
+* (C8) For all `i`, `storage_min <= zero_points[i] <= storage_max`.
+* (C9) For all `i`, `type(zero_points[i]) = storage_type`.
+* (C10) `size(scales) = size(zero_points)`.
+* (C11) If `quantization_dimension` is empty, then `size(scales) = 1`.
+* (C12) If `quantization_dimension` is not empty, then
   `0 <= quantization_dimension`.
 
 **Quantized tensor types** represent tensors with quantized elements. These

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -149,16 +149,14 @@ following constraints:
 * (C1) `num_bits(storage_type) < num_bits(expressed_type)`.
 * (C2) `type(storage_min) = storage_type`.
 * (C3) `type(storage_max) = storage_type`.
-* (C4) `storage_min >= min_value(storage_type)`.
-* (C5) `storage_max <= max_value(storage_type)`.
-* (C6) `storage_max - storage_min > 0`.
-* (C7) For all `i`, `type(scales[i]) = expressed_type`.
-* (C8) For all `i`, `scales[i] > 0`.
-* (C9) For all `i`, `storage_min <= zero_points[i] <= storage_max`.
-* (C10) For all `i`, `type(zero_points[i]) = storage_type`.
-* (C11) `size(scales) = size(zero_points)`.
-* (C12) If `quantization_dimension` is empty, then `size(scales) = 1`.
-* (C13) If `quantization_dimension` is not empty, then
+* (C4) `min_value(storage_type) <= storage_min < storage_max <= max_value(storage_type)`.
+* (C5) For all `i`, `type(scales[i]) = expressed_type`.
+* (C6) For all `i`, `scales[i] > 0`.
+* (C7) For all `i`, `storage_min <= zero_points[i] <= storage_max`.
+* (C8) For all `i`, `type(zero_points[i]) = storage_type`.
+* (C9) `size(scales) = size(zero_points)`.
+* (C10) If `quantization_dimension` is empty, then `size(scales) = 1`.
+* (C11) If `quantization_dimension` is not empty, then
   `0 <= quantization_dimension`.
 
 **Quantized tensor types** represent tensors with quantized elements. These
@@ -177,8 +175,8 @@ quantization parameters. Quantized tensor types have the following constraints:
 * For per-tensor quantization:
   * No additional constraints.
 * For per-axis quantization:
-  * (C14) `quantization_dimension < size(shape)`.
-  * (C15) `size(scales) = shape[quantization_dimension]`.
+  * (C12) `quantization_dimension < size(shape)`.
+  * (C13) `size(scales) = shape[quantization_dimension]`.
 
 ```ebnf
 TokenType ::= 'token'

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -195,7 +195,9 @@ values of type `tensor<T>`).
   floating-point values of an **expressed type**. For a given integer value `i`,
   the corresponding floating-point value `f` can be computed as
   `f = (i - zero_point) * scale`, where `scale` and `zero_point` are called
-  **quantization parameters**.
+  **quantization parameters**. The `storage_min` and `storage_max`, being
+  optional, have default values which should satisfy the associated constraints
+  as laid out in this document.
 
 Quantization can be **per-tensor**, meaning, having one `scale` and/or
 `zero_point` for the entire tensor or can be **per-axis**, meaning, having
@@ -219,10 +221,11 @@ Quantized types satisfy the following constraints:
     * `storage_min = 0`, `storage_max = 2^d - 1`.
 * (C5) For all `i`, `type(scales[i]) = expressed_type`.
 * (C6) For all `i`, `scales[i] > 0`.
-* (C7) For all `i`, `type(zero_points[i]) = i64`.
-* (C8) `size(scales) = size(zero_points)`.
-* (C9) If `quantization_dimension` is empty, then `size(scales) = 1`.
-* (C10) If `quantization_dimension` is not empty, then
+* (C7) For all `i`, `storage_min <= zero_points[i] <= storage_max`.
+* (C8) For all `i`, `type(zero_points[i]) = storage_type`.
+* (C9) `size(scales) = size(zero_points)`.
+* (C10) If `quantization_dimension` is empty, then `size(scales) = 1`.
+* (C11) If `quantization_dimension` is not empty, then
   `0 <= quantization_dimension`.
 
 Furthermore, tensors of quantized types satisfy the following constraints:
@@ -230,8 +233,8 @@ Furthermore, tensors of quantized types satisfy the following constraints:
 * For per-tensor quantization:
   * No additional constraints.
 * For per-axis quantization:
-  * (C11) `quantization_dimension < size(shape)`.
-  * (C12) `size(scales) = shape[quantization_dimension]`.
+  * (C12) `quantization_dimension < size(shape)`.
+  * (C13) `size(scales) = shape[quantization_dimension]`.
 
 ```ebnf
 FunctionType ::= '(' [ValueType {',' ValueType}] ')' '->' '(' [ValueType {',' ValueType}] ')'


### PR DESCRIPTION
StableHLO dialect currently supports quantization via:
  1) Supporting `quant.uniform` element types.
  2) Having dedicated ops like `uniform_quantize` / `uniform_dequantize`.
  3) Allowing regular ops like `add` / `convolution` to take quantized tensors.

This support was inherited from MHLO when StableHLO was bootstrapped, and
MHLO support was motivated by mobile use cases and inherited from TFLite.

As pointed out in #1149, StableHLO specification doesn't support quantization
at the moment, and this is an important gap that we would like to fix before
StableHLO v1.0 (see #588).

To continue the discussion started in #1149 and to make progress towards v1.0,
this pull request:
  A) Adds QuantizedType to the StableHLO specification, modelled after
     [TFLite quantization spec](https://www.tensorflow.org/lite/performance/quantization_spec).
  B) To start a conversation about the applications of QuantizedType and the
     semantics of quantized ops, proposes semantics for quantized `add`.

TFLite quantization spec doesn't cover everything. It specs constraints on
types (which we captured accordingly in this pull request), but it doesn't go
into describing semantics of quantized ops.

As a result, the proposed semantics for quantized `add` is intentionally naive,
as compared with the much more involved implementations in the TensorFlow
repository, e.g.:
  * [tfl.add](https://www.google.com/url?sa=D&q=https%3A%2F%2Fgithub.com%2Ftensorflow%2Ftensorflow%2Fblob%2Fmaster%2Ftensorflow%2Flite%2Fkernels%2Fadd.cc).
  * [tf.UniformQuantizedAdd](https://www.google.com/url?sa=D&q=https%3A%2F%2Fgithub.com%2Ftensorflow%2Ftensorflow%2Fblob%2Fmaster%2Ftensorflow%2Fcore%2Fkernels%2Funiform_quant_ops%2Funiform_quantized_add_op.cc).

In this pull request, we are looking for feedback from the community to
determine the right level of detail for speccing quantized types and quantized
ops. Please let us know!