### PR TITLE
Update function type for return with multiple operands, some repeating

### DIFF
--- a/stablehlo/tests/stablehlo_refine_shapes.mlir
+++ b/stablehlo/tests/stablehlo_refine_shapes.mlir
@@ -500,14 +500,6 @@ func.func @refine_dynamic_reshape(%arg0: tensor<4xf32>) -> tensor<*xf32> {
 
 // -----
 
-// CHECK-LABEL: @refine_function_type
-func.func @main(%arg0: tensor<2xf32>, %arg1: tensor<2xf32>) -> (tensor<?xf32>, tensor<?xf32>) {
-  %0 = stablehlo.add %arg0, %arg1 : (tensor<2xf32>, tensor<2xf32>) -> tensor<?xf32>
-  return %0, %0 : tensor<?xf32>, tensor<?xf32>
-}
-
-// -----
-
 // CHECK-LABEL: @refine_infer_type_op_interface_supported_dialect_chlo
 func.func @refine_infer_type_op_interface_supported_dialect_chlo(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<*xf32> {
   // CHECK: chlo.broadcast_add{{.*}} -> tensor<4xf32>
@@ -671,6 +663,16 @@ func.func @update_function_type(%arg0: tensor<4xf32>) -> tensor<*xf32> {
   // CHECK-NOT: tensor.cast
   %0 = tensor.cast %arg0 : tensor<4xf32> to tensor<*xf32>
   return %0 : tensor<*xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func @update_function_type_multiple_outputs
+// CHECK-SAME: (%arg0: tensor<4xf32>) -> (tensor<4xf32>, tensor<4xf32>)
+func.func @update_function_type_multiple_outputs(%arg0: tensor<4xf32>) -> (tensor<*xf32>, tensor<*xf32>) {
+  // CHECK-NOT: tensor.cast
+  %0 = tensor.cast %arg0 : tensor<4xf32> to tensor<*xf32>
+  return %0, %0 : tensor<*xf32>, tensor<*xf32>
 }
 
 // -----

--- a/stablehlo/tests/stablehlo_refine_shapes.mlir
+++ b/stablehlo/tests/stablehlo_refine_shapes.mlir
@@ -500,6 +500,15 @@ func.func @refine_dynamic_reshape(%arg0: tensor<4xf32>) -> tensor<*xf32> {
 
 // -----
 
+// Test for #1350
+// CHECK-LABEL: @refine_function_type
+func.func @refine_function_type(%arg0: tensor<3x2xf32>, %arg1: tensor<3x2xf32>) -> (tensor<3x2xf32>, tensor<3x2xf32>) {
+  %0 = stablehlo.add %arg0, %arg1 : tensor<3x2xf32>
+  return %0, %0 : tensor<3x2xf32>, tensor<3x2xf32>
+}
+
+// -----
+
 // CHECK-LABEL: @refine_infer_type_op_interface_supported_dialect_chlo
 func.func @refine_infer_type_op_interface_supported_dialect_chlo(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<*xf32> {
   // CHECK: chlo.broadcast_add{{.*}} -> tensor<4xf32>

--- a/stablehlo/tests/stablehlo_refine_shapes.mlir
+++ b/stablehlo/tests/stablehlo_refine_shapes.mlir
@@ -500,7 +500,6 @@ func.func @refine_dynamic_reshape(%arg0: tensor<4xf32>) -> tensor<*xf32> {
 
 // -----
 
-// Test for #1350
 // CHECK-LABEL: @refine_function_type
 func.func @main(%arg0: tensor<2xf32>, %arg1: tensor<2xf32>) -> (tensor<?xf32>, tensor<?xf32>) {
   %0 = stablehlo.add %arg0, %arg1 : (tensor<2xf32>, tensor<2xf32>) -> tensor<?xf32>

--- a/stablehlo/tests/stablehlo_refine_shapes.mlir
+++ b/stablehlo/tests/stablehlo_refine_shapes.mlir
@@ -502,9 +502,9 @@ func.func @refine_dynamic_reshape(%arg0: tensor<4xf32>) -> tensor<*xf32> {
 
 // Test for #1350
 // CHECK-LABEL: @refine_function_type
-func.func @refine_function_type(%arg0: tensor<3x2xf32>, %arg1: tensor<3x2xf32>) -> (tensor<3x2xf32>, tensor<3x2xf32>) {
-  %0 = stablehlo.add %arg0, %arg1 : tensor<3x2xf32>
-  return %0, %0 : tensor<3x2xf32>, tensor<3x2xf32>
+func.func @main(%arg0: tensor<2xf32>, %arg1: tensor<2xf32>) -> (tensor<?xf32>, tensor<?xf32>) {
+  %0 = stablehlo.add %arg0, %arg1 : (tensor<2xf32>, tensor<2xf32>) -> tensor<?xf32>
+  return %0, %0 : tensor<?xf32>, tensor<?xf32>
 }
 
 // -----

--- a/stablehlo/transforms/StablehloRefineShapes.cpp
+++ b/stablehlo/transforms/StablehloRefineShapes.cpp
@@ -1001,7 +1001,6 @@ struct UpdateFunctionTypePattern : public OpRewritePattern<func::ReturnOp> {
     auto func = cast<func::FuncOp>(op->getParentOp());
     func.setType(
         rewriter.getFunctionType(func.getArgumentTypes(), updatedResultTypes));
-
     return success();
   }
 };

--- a/stablehlo/transforms/StablehloRefineShapes.cpp
+++ b/stablehlo/transforms/StablehloRefineShapes.cpp
@@ -24,7 +24,6 @@ limitations under the License.
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -53,8 +52,6 @@ namespace stablehlo {
 
 #define GEN_PASS_DEF_STABLEHLOREFINESHAPESPASS
 #include "stablehlo/transforms/Passes.h.inc"
-
-#define DEBUG_TYPE "stablehlo-refine-shapes"
 
 namespace {
 
@@ -1004,7 +1001,6 @@ struct UpdateFunctionTypePattern : public OpRewritePattern<func::ReturnOp> {
     auto func = cast<func::FuncOp>(op->getParentOp());
     func.setType(
         rewriter.getFunctionType(func.getArgumentTypes(), updatedResultTypes));
-    LLVM_DEBUG(llvm::dbgs() << func);
 
     return success();
   }

--- a/stablehlo/transforms/StablehloRefineShapes.cpp
+++ b/stablehlo/transforms/StablehloRefineShapes.cpp
@@ -21,8 +21,10 @@ limitations under the License.
 #include "llvm/ADT/APSInt.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
+#include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -51,6 +53,8 @@ namespace stablehlo {
 
 #define GEN_PASS_DEF_STABLEHLOREFINESHAPESPASS
 #include "stablehlo/transforms/Passes.h.inc"
+
+#define DEBUG_TYPE "stablehlo-refine-shapes"
 
 namespace {
 
@@ -964,6 +968,7 @@ struct UpdateFunctionTypePattern : public OpRewritePattern<func::ReturnOp> {
     // refining individual ops. This pattern cleans this up.
     bool needsUpdate = false;
     SmallVector<Type> updatedResultTypes(op.getOperandTypes());
+    llvm::SmallSet<tensor::CastOp, 4> castsToReplace;
     for (auto [i, operand] : llvm::enumerate(op.getOperands())) {
       auto cast = dyn_cast_or_null<tensor::CastOp>(operand.getDefiningOp());
       if (!cast) continue;
@@ -981,10 +986,17 @@ struct UpdateFunctionTypePattern : public OpRewritePattern<func::ReturnOp> {
       // and that the return type of the function needs an update.
       needsUpdate = true;
       updatedResultTypes[i] = sourceType;
-      rewriter.replaceOp(cast, cast->getOperands());
+
+      // Insert into set and continue iterating.
+      // ReturnOp may point to same value more than once.
+      castsToReplace.insert(cast);
     }
     if (!needsUpdate)
       return rewriter.notifyMatchFailure(op, "doesn't need update");
+
+    // Replace CastOps with more specific operands than results.
+    for (auto cast : castsToReplace)
+      rewriter.replaceOp(cast, cast->getOperands());
 
     // If the type of the enclosing `func.func` needs an update, we simply
     // call setType. We can afford this simplicity because our algorithm
@@ -992,6 +1004,8 @@ struct UpdateFunctionTypePattern : public OpRewritePattern<func::ReturnOp> {
     auto func = cast<func::FuncOp>(op->getParentOp());
     func.setType(
         rewriter.getFunctionType(func.getArgumentTypes(), updatedResultTypes));
+    LLVM_DEBUG(llvm::dbgs() << func);
+
     return success();
   }
 };


### PR DESCRIPTION
The way the refine function type algorithm works currently has an assumption that ReturnOp does not have redundant operands. This is not always the case in practice.

Several JAX tests were hitting this issue.


Closes #1350