### PR TITLE
Add interpreter for ClzOp

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2105,10 +2105,12 @@ tensor and produces a `result` tensor.
 #### Examples
 
 ```mlir
-// %operand: [[0, 1], [127, -1]]
-%result = "stablehlo.count_leading_zeros"(%operand) : (tensor<2x2xi8>) -> tensor<2x2xi8>
-// %result: [[8, 7], [1, 0]]
+// %operand: [[0, 1], [128, -1]]
+%result = "stablehlo.count_leading_zeros"(%operand) : (tensor<2x2xi64>) -> tensor<2x2xi64>
+// %result: [[64, 63], [56, 0]]
 ```
+
+&nbsp;[More Examples](../stablehlo/tests/interpret_count_leading_zeros.mlir)
 
 ### custom_call
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -70,7 +70,7 @@ one of the following tracking labels.
 | convert                  | yes           | yes          | infeasible     | yes             | no          |
 | convolution              | yes           | yes          | infeasible     | revisit         | no          |
 | cosine                   | yes           | yes          | yes            | yes             | yes         |
-| count_leading_zeros      | yes           | yes          | yes            | yes             | no          |
+| count_leading_zeros      | yes           | yes          | yes            | yes             | yes         |
 | create_token             | no            | yes\*        | yes\*          | yes             | no          |
 | cross-replica-sum        | no            | revisit      | yes\*          | no              | no          |
 | cstr_reshapable          | no            | revisit      | no             | yes             | no          |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -269,7 +269,8 @@ def StableHLO_ConvertOp : StableHLO_UnaryElementwiseOp<"convert",
 }
 
 def StableHLO_ClzOp: StableHLO_UnaryElementwiseOp<"count_leading_zeros",
-    [Pure, HLO_CompatibleOperandsAndResultType], HLO_IntTensor> {
+    [Pure, HLO_CompatibleOperandsAndResultType /*count_leading_zeros_c1*/],
+     HLO_IntTensor /*count_leading_zeros_i1*/> { /*count_leading_zeros_c1*/
   let summary = "Clz operation";
   let description = [{
     Performs element-wise count of the number of leading zero bits in the
@@ -280,7 +281,7 @@ def StableHLO_ClzOp: StableHLO_UnaryElementwiseOp<"count_leading_zeros",
 
     Example:
     ```mlir
-    %result = stablehlo.count_leading_zeros %operand : tensor<2x2xi8>
+    %result = stablehlo.count_leading_zeros %operand : tensor<2x2xi64>
     ```
   }];
 }

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -89,6 +89,10 @@ SmallVector<Tensor> eval(
       Tensor runtimeResult = evalClampOp(runtimeMin, runtimeOperand, runtimeMax,
                                          clampOp.getType());
       scope.add(op.getResults(), {runtimeResult});
+    } else if (auto clzOp = dyn_cast<ClzOp>(op)) {
+      Tensor runtimeOperand = scope.find(clzOp.getOperand());
+      Tensor runtimeResult = evalClzOp(runtimeOperand, clzOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
     } else if (auto compareOp = dyn_cast<CompareOp>(op)) {
       Tensor runtimeLhs = scope.find(compareOp.getLhs());
       Tensor runtimeRhs = scope.find(compareOp.getRhs());
@@ -440,6 +444,19 @@ Tensor evalCosineOp(const Tensor &operand, TensorType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, cosine(operand.get(*it)));
+  return result;
+}
+
+Tensor evalClzOp(const Tensor &operand, TensorType resultType) {
+  Tensor result(resultType);
+  for (auto resultIt = result.index_begin(); resultIt != result.index_end();
+       ++resultIt) {
+    auto element = Element(
+        resultType.getElementType(),
+        static_cast<int64_t>(
+            operand.get(*resultIt).getIntegerValue().countLeadingZeros()));
+    result.set(*resultIt, element);
+  }
   return result;
 }
 

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -37,6 +37,7 @@ SmallVector<Tensor> evalCaseOp(const Tensor &index, RegionRange branches,
 Tensor evalCeilOp(const Tensor &operand, TensorType resultType);
 Tensor evalClampOp(const Tensor &min, const Tensor &operand, const Tensor &max,
                    TensorType resultType);
+Tensor evalClzOp(const Tensor &operand, TensorType resultType);
 Tensor evalCompareOp(const Tensor &lhs, const Tensor &rhs,
                      ComparisonDirection comparisonDirection,
                      TensorType resultType);

--- a/stablehlo/tests/interpret_count_leading_zeros.mlir
+++ b/stablehlo/tests/interpret_count_leading_zeros.mlir
@@ -1,0 +1,8 @@
+// RUN: stablehlo-translate --interpret -split-input-file %s
+
+func.func @count_leading_zeros_op_test_si64() {
+  %operand = stablehlo.constant dense<[[0, 1], [128, -1]]> : tensor<2x2xi64>
+  %result = stablehlo.count_leading_zeros %operand : tensor<2x2xi64>
+  check.expect_eq_const %result, dense<[[64, 63], [56, 0]]> : tensor<2x2xi64>
+  func.return
+}


### PR DESCRIPTION
Here are the following constraints:
```
(I1) operand is a tensor of integer type.
(C1) `operand` and `result` have the same type.
```
I1 and C1 are covered by the ODS, so no additional tests are added.

closes #1100