### PR TITLE
Add interpreter for SignOp.

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -5032,10 +5032,11 @@ def sign(x):
 #### Examples
 
 ```mlir
-// Logical values: -Inf, +Inf, NaN, ...
-// %operand: [0xFF800000, 0x7F800000, 0x7FFFFFFF, -10.0, -0.0, 0.0, 10.0]
-%result = "stablehlo.sign"(%operand) : (tensor<7xf32>) -> tensor<7xf32>
-// %result: [-1.0, 1.0, 0x7FFFFFFF, -1.0, -0.0, 0.0, 1.0]
+// Logical values: +NaN, -1.0, -0.0, +0.0, 1.0
+// operand: [0x7FFFFFFFFFFFFFFF, -1.0, -0.0, 0.0, 1.0]
+%result = "stablehlo.sign"(%operand) : (tensor<5xf64>) -> tensor<5xf64>
+// Logical values: +NaN, -1.0, -0.0, +0.0, 1.0
+// %result: [0x7FFFFFFFFFFFFFFF, -1.0, -0.0, 0.0, 1.0]
 ```
 
 &nbsp;[More Examples](../stablehlo/tests/interpret_sign.mlir)

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -5038,6 +5038,8 @@ def sign(x):
 // %result: [-1.0, 1.0, 0x7FFFFFFF, -1.0, -0.0, 0.0, 1.0]
 ```
 
+&nbsp;[More Examples](../stablehlo/tests/interpret_sign.mlir)
+
 ### sine
 
 #### Semantics

--- a/docs/status.md
+++ b/docs/status.md
@@ -140,7 +140,7 @@ one of the following tracking labels.
 | shift_left               | yes           | yes          | yes            | yes             | no          |
 | shift_right_arithmetic   | yes           | yes          | yes            | yes             | no          |
 | shift_right_logical      | yes           | yes          | yes            | yes             | no          |
-| sign                     | yes           | yes          | yes            | yes             | no          |
+| sign                     | yes           | yes          | yes            | yes             | yes         |
 | sine                     | yes           | yes          | yes            | yes             | yes         |
 | slice                    | yes           | yes          | yes            | no              | yes         |
 | sort                     | yes           | yes          | yes            | no              | no          |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -575,8 +575,8 @@ def StableHLO_RsqrtOp: StableHLO_UnaryElementwiseOp<"rsqrt", [Pure,
 }
 
 def StableHLO_SignOp: StableHLO_UnaryElementwiseOp<"sign",
-    [Pure, HLO_CompatibleOperandsAndResultType],
-    TensorOf<[HLO_SInt, HLO_Float, HLO_Complex]>> {
+    [Pure, HLO_CompatibleOperandsAndResultType /*sign_c1*/],
+    TensorOf<[HLO_SInt, HLO_Float, HLO_Complex]> /*sign_i1*/> { /*sign_c1*/
   let summary = "Sign operation";
   let description = [{
     Returns the sign of the `operand` element-wise and produces a `result`
@@ -587,7 +587,7 @@ def StableHLO_SignOp: StableHLO_UnaryElementwiseOp<"sign",
 
     Example:
     ```mlir
-    %result = stablehlo.sign %operand : tensor<7xf32>
+    %result = stablehlo.sign %operand : tensor<5xf64>
     ```
   }];
 }

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -774,18 +774,6 @@ Element sign(const Element &el) {
       return Element(type, std::complex<APFloat>(APFloat::getNaN(elSemantics),
                                                  APFloat::getNaN(elSemantics)));
 
-    // auto absElVal = abs(el).getFloatValue();
-    // if (absElVal.isZero()) return Element(type, (double)0.0);
-
-    // bool roundingErr;
-    // APFloat resultReal(elVal.real().convertToDouble() /
-    //                    absElVal.convertToDouble());
-    // resultReal.convert(elSemantics, APFloat::rmNearestTiesToEven,
-    // &roundingErr); APFloat resultImag(elVal.imag().convertToDouble() /
-    //                    absElVal.convertToDouble());
-    // resultImag.convert(elSemantics, APFloat::rmNearestTiesToEven,
-    // &roundingErr);
-
     return el / Element(type, abs(el).getFloatValue().convertToDouble());
   }
 

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -747,6 +747,72 @@ Element rsqrt(const Element &el) {
       [](std::complex<double> e) { return 1.0 / std::sqrt(e); });
 }
 
+Element sign(const Element &el) {
+  Type type = el.getType();
+
+  if (isSupportedIntegerType(type)) {
+    auto intEl = el.getIntegerValue();
+    if (intEl.isZero()) {
+      return Element(type, (int64_t)0);
+    } else if (intEl.isNegative()) {
+      return Element(type, (int64_t)-1);
+    } else {
+      return Element(type, (int64_t)1);
+    }
+  }
+
+  if (isSupportedFloatType(type)) {
+    auto elVal = el.getFloatValue();
+
+    if (elVal.isNaN()) {
+      return Element(el);
+    } else {
+      if (elVal.isNegZero()) {
+        return Element(type, (double)-0.0);
+      } else if (elVal.isPosZero()) {
+        return Element(type, (double)+0.0);
+      } else if (elVal.isNegInfinity()) {
+        return Element(type, (double)-1.0);
+      } else if (elVal.isPosInfinity()) {
+        return Element(type, (double)+1.0);
+      } else if (elVal.isNegative()) {
+        return Element(type, (double)-1.0);
+      } else if (!elVal.isNegative()) {
+        return Element(type, (double)+1.0);
+      }
+    }
+  }
+
+  if (isSupportedComplexType(type)) {
+    auto elVal = el.getComplexValue();
+    const llvm::fltSemantics &elSemantics = elVal.real().getSemantics();
+    if (elVal.real().isNaN() || elVal.imag().isNaN()) {
+      return Element(type,
+                     std::complex<APFloat>(APFloat::getNaN(elSemantics),
+                                           APFloat::getZero(elSemantics)));
+    } else {
+      auto absElValDouble = abs(el).getFloatValue().convertToDouble();
+      auto signVal =
+          std::complex<double>(elVal.real().convertToDouble() / absElValDouble,
+                               elVal.imag().convertToDouble() / absElValDouble);
+
+      bool roundingErr;
+      APFloat resultReal(signVal.real());
+      resultReal.convert(elSemantics, APFloat::rmNearestTiesToEven,
+                         &roundingErr);
+      APFloat resultImag(signVal.imag());
+      resultImag.convert(elSemantics, APFloat::rmNearestTiesToEven,
+                         &roundingErr);
+      auto retVal =
+          Element(type, std::complex<APFloat>(resultReal, resultImag));
+      return retVal;
+    }
+  }
+
+  report_fatal_error(invalidArgument("Unsupported element type: %s",
+                                     debugString(type).c_str()));
+}
+
 Element sine(const Element &el) {
   return mapWithUpcastToDouble(
       el, [](double e) { return std::sin(e); },

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -752,13 +752,12 @@ Element sign(const Element &el) {
 
   if (isSupportedIntegerType(type)) {
     auto intEl = el.getIntegerValue();
-    if (intEl.isZero()) {
+    if (intEl.isZero())
       return Element(type, (int64_t)0);
-    } else if (intEl.isNegative()) {
+    else if (intEl.isNegative())
       return Element(type, (int64_t)-1);
-    } else {
+    else
       return Element(type, (int64_t)1);
-    }
   }
 
   if (isSupportedFloatType(type)) {
@@ -766,20 +765,19 @@ Element sign(const Element &el) {
 
     if (elVal.isNaN()) {
       return Element(el);
-    } else {
-      if (elVal.isNegZero()) {
-        return Element(type, (double)-0.0);
-      } else if (elVal.isPosZero()) {
-        return Element(type, (double)+0.0);
-      } else if (elVal.isNegInfinity()) {
-        return Element(type, (double)-1.0);
-      } else if (elVal.isPosInfinity()) {
-        return Element(type, (double)+1.0);
-      } else if (elVal.isNegative()) {
-        return Element(type, (double)-1.0);
-      } else if (!elVal.isNegative()) {
-        return Element(type, (double)+1.0);
-      }
+    }
+    if (elVal.isNegZero()) {
+      return Element(type, (double)-0.0);
+    } else if (elVal.isPosZero()) {
+      return Element(type, (double)+0.0);
+    } else if (elVal.isNegInfinity()) {
+      return Element(type, (double)-1.0);
+    } else if (elVal.isPosInfinity()) {
+      return Element(type, (double)+1.0);
+    } else if (elVal.isNegative()) {
+      return Element(type, (double)-1.0);
+    } else if (!elVal.isNegative()) {
+      return Element(type, (double)+1.0);
     }
   }
 
@@ -790,23 +788,19 @@ Element sign(const Element &el) {
       return Element(type,
                      std::complex<APFloat>(APFloat::getNaN(elSemantics),
                                            APFloat::getZero(elSemantics)));
-    } else {
-      auto absElValDouble = abs(el).getFloatValue().convertToDouble();
-      auto signVal =
-          std::complex<double>(elVal.real().convertToDouble() / absElValDouble,
-                               elVal.imag().convertToDouble() / absElValDouble);
-
-      bool roundingErr;
-      APFloat resultReal(signVal.real());
-      resultReal.convert(elSemantics, APFloat::rmNearestTiesToEven,
-                         &roundingErr);
-      APFloat resultImag(signVal.imag());
-      resultImag.convert(elSemantics, APFloat::rmNearestTiesToEven,
-                         &roundingErr);
-      auto retVal =
-          Element(type, std::complex<APFloat>(resultReal, resultImag));
-      return retVal;
     }
+    auto absElValDouble = abs(el).getFloatValue().convertToDouble();
+    auto signVal =
+        std::complex<double>(elVal.real().convertToDouble() / absElValDouble,
+                             elVal.imag().convertToDouble() / absElValDouble);
+
+    bool roundingErr;
+    APFloat resultReal(signVal.real());
+    resultReal.convert(elSemantics, APFloat::rmNearestTiesToEven, &roundingErr);
+    APFloat resultImag(signVal.imag());
+    resultImag.convert(elSemantics, APFloat::rmNearestTiesToEven, &roundingErr);
+    auto retVal = Element(type, std::complex<APFloat>(resultReal, resultImag));
+    return retVal;
   }
 
   report_fatal_error(invalidArgument("Unsupported element type: %s",

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -774,18 +774,19 @@ Element sign(const Element &el) {
       return Element(type, std::complex<APFloat>(APFloat::getNaN(elSemantics),
                                                  APFloat::getNaN(elSemantics)));
 
-    auto absElVal = abs(el).getFloatValue();
-    if (absElVal.isZero()) return Element(type, (double)0.0);
+    // auto absElVal = abs(el).getFloatValue();
+    // if (absElVal.isZero()) return Element(type, (double)0.0);
 
-    bool roundingErr;
-    APFloat resultReal(elVal.real().convertToDouble() /
-                       absElVal.convertToDouble());
-    resultReal.convert(elSemantics, APFloat::rmNearestTiesToEven, &roundingErr);
-    APFloat resultImag(elVal.imag().convertToDouble() /
-                       absElVal.convertToDouble());
-    resultImag.convert(elSemantics, APFloat::rmNearestTiesToEven, &roundingErr);
+    // bool roundingErr;
+    // APFloat resultReal(elVal.real().convertToDouble() /
+    //                    absElVal.convertToDouble());
+    // resultReal.convert(elSemantics, APFloat::rmNearestTiesToEven,
+    // &roundingErr); APFloat resultImag(elVal.imag().convertToDouble() /
+    //                    absElVal.convertToDouble());
+    // resultImag.convert(elSemantics, APFloat::rmNearestTiesToEven,
+    // &roundingErr);
 
-    return Element(type, std::complex<APFloat>(resultReal, resultImag));
+    return el / Element(type, abs(el).getFloatValue().convertToDouble());
   }
 
   report_fatal_error(invalidArgument("Unsupported element type: %s",

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -778,6 +778,11 @@ Element sign(const Element &el) {
                      std::complex<APFloat>(APFloat::getNaN(elSemantics),
                                            APFloat::getZero(elSemantics)));
 
+    if (elVal.real().isZero() && elVal.imag().isZero())
+      return Element(type,
+                     std::complex<APFloat>(APFloat::getZero(elSemantics),
+                                           APFloat::getZero(elSemantics)));
+
     auto absElValDouble = abs(el).getFloatValue().convertToDouble();
     bool roundingErr;
 

--- a/stablehlo/reference/Element.h
+++ b/stablehlo/reference/Element.h
@@ -191,6 +191,9 @@ Element rem(const Element &e1, const Element &e2);
 /// Returns reverse square root of Element object.
 Element rsqrt(const Element &e);
 
+/// Returns sign of Element object.
+Element sign(const Element &e);
+
 /// Returns sine of Element object.
 Element sine(const Element &e);
 

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -717,14 +717,14 @@ Tensor evalSelectOp(const Tensor &pred, const Tensor &onTrue,
   return result;
 }
 
-Tensor evalSignOp(const Tensor &operand, TensorType resultType) {
+Tensor evalSignOp(const Tensor &operand, ShapedType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, sign(operand.get(*it)));
   return result;
 }
 
-Tensor evalSineOp(const Tensor &operand, TensorType resultType) {
+Tensor evalSineOp(const Tensor &operand, ShapedType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, sine(operand.get(*it)));

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -257,6 +257,10 @@ SmallVector<Tensor> eval(
           scope.find(selectOp.getPred()), scope.find(selectOp.getOnTrue()),
           scope.find(selectOp.getOnFalse()), selectOp.getType());
       scope.add(op.getResults(), {runtimeResult});
+    } else if (auto signOp = dyn_cast<SignOp>(op)) {
+      Tensor runtimeOperand = scope.find(signOp.getOperand());
+      Tensor runtimeResult = evalSignOp(runtimeOperand, signOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
     } else if (auto sineOp = dyn_cast<SineOp>(op)) {
       Tensor runtimeOperand = scope.find(sineOp.getOperand());
       Tensor runtimeResult = evalSineOp(runtimeOperand, sineOp.getType());
@@ -713,7 +717,14 @@ Tensor evalSelectOp(const Tensor &pred, const Tensor &onTrue,
   return result;
 }
 
-Tensor evalSineOp(const Tensor &operand, ShapedType resultType) {
+Tensor evalSignOp(const Tensor &operand, TensorType resultType) {
+  Tensor result(resultType);
+  for (auto it = result.index_begin(); it != result.index_end(); ++it)
+    result.set(*it, sign(operand.get(*it)));
+  return result;
+}
+
+Tensor evalSineOp(const Tensor &operand, TensorType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, sine(operand.get(*it)));

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -82,8 +82,9 @@ Tensor evalReverseOp(const Tensor &operand, Axes dimensions,
                      ShapedType resultType);
 Tensor evalRsqrtOp(const Tensor &operand, ShapedType resultType);
 Tensor evalSelectOp(const Tensor &pred, const Tensor &onTrue,
-                    const Tensor &onFalse, ShapedType resultType);
-Tensor evalSineOp(const Tensor &operand, ShapedType resultType);
+                    const Tensor &onFalse, TensorType resultType);
+Tensor evalSignOp(const Tensor &operand, TensorType resultType);
+Tensor evalSineOp(const Tensor &operand, TensorType resultType);
 Tensor evalSliceOp(const Tensor &operand, Index startIndices, Sizes strides,
                    ShapedType resultType);
 Tensor evalSqrtOp(const Tensor &operand, ShapedType resultType);

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -82,9 +82,9 @@ Tensor evalReverseOp(const Tensor &operand, Axes dimensions,
                      ShapedType resultType);
 Tensor evalRsqrtOp(const Tensor &operand, ShapedType resultType);
 Tensor evalSelectOp(const Tensor &pred, const Tensor &onTrue,
-                    const Tensor &onFalse, TensorType resultType);
-Tensor evalSignOp(const Tensor &operand, TensorType resultType);
-Tensor evalSineOp(const Tensor &operand, TensorType resultType);
+                    const Tensor &onFalse, ShapedType resultType);
+Tensor evalSignOp(const Tensor &operand, ShapedType resultType);
+Tensor evalSineOp(const Tensor &operand, ShapedType resultType);
 Tensor evalSliceOp(const Tensor &operand, Index startIndices, Sizes strides,
                    ShapedType resultType);
 Tensor evalSqrtOp(const Tensor &operand, ShapedType resultType);

--- a/stablehlo/testdata/sign_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/sign_shape_bfloat16_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/sign_shape_complex64_20_20.mlir
+++ b/stablehlo/testdata/sign_shape_complex64_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/sign_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/sign_shape_float16_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/sign_shape_float32_20_20.mlir
+++ b/stablehlo/testdata/sign_shape_float32_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/sign_shape_int16_20_20.mlir
+++ b/stablehlo/testdata/sign_shape_int16_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/sign_shape_int32_20_20.mlir
+++ b/stablehlo/testdata/sign_shape_int32_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/sign_shape_int8_20_20.mlir
+++ b/stablehlo/testdata/sign_shape_int8_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/sign_special_0_dtype_bfloat16.mlir
+++ b/stablehlo/testdata/sign_special_0_dtype_bfloat16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/sign_special_0_dtype_complex64.mlir
+++ b/stablehlo/testdata/sign_special_0_dtype_complex64.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/sign_special_0_dtype_complex64.mlir
+++ b/stablehlo/testdata/sign_special_0_dtype_complex64.mlir
@@ -1,4 +1,4 @@
-// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/sign_special_0_dtype_float16.mlir
+++ b/stablehlo/testdata/sign_special_0_dtype_float16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/sign_special_0_dtype_float32.mlir
+++ b/stablehlo/testdata/sign_special_0_dtype_float32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/sign_special_0_dtype_int16.mlir
+++ b/stablehlo/testdata/sign_special_0_dtype_int16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/sign_special_0_dtype_int32.mlir
+++ b/stablehlo/testdata/sign_special_0_dtype_int32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/sign_special_0_dtype_int8.mlir
+++ b/stablehlo/testdata/sign_special_0_dtype_int8.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/tests/interpret_sign.mlir
+++ b/stablehlo/tests/interpret_sign.mlir
@@ -1,60 +1,8 @@
 // RUN: stablehlo-translate --interpret -split-input-file %s
 
-// CHECK-LABEL: Evaluated results of function: sign_op_test_si4
-func.func @sign_op_test_si4() -> tensor<3xi4> {
-  %operand = stablehlo.constant dense<[-7, 0, 7]> : tensor<3xi4>
-  %result = stablehlo.sign %operand : tensor<3xi4>
-  func.return %result : tensor<3xi4>
-  // CHECK-NEXT: tensor<3xi4>
-  // CHECK-NEXT: -1 : i4
-  // CHECK-NEXT: 0 : i4
-  // CHECK-NEXT: 1 : i4
-}
-
-// -----
-
-// CHECK-LABEL: Evaluated results of function: sign_op_test_si8
-func.func @sign_op_test_si8() -> tensor<3xi8> {
-  %operand = stablehlo.constant dense<[-127, 0, 127]> : tensor<3xi8>
-  %result = stablehlo.sign %operand : tensor<3xi8>
-  func.return %result : tensor<3xi8>
-  // CHECK-NEXT: tensor<3xi8>
-  // CHECK-NEXT: -1 : i8
-  // CHECK-NEXT: 0 : i8
-  // CHECK-NEXT: 1 : i8
-}
-
-// -----
-
-// CHECK-LABEL: Evaluated results of function: sign_op_test_si16
-func.func @sign_op_test_si16() -> tensor<3xi16> {
-  %operand = stablehlo.constant dense<[-32767, 0, 32767]> : tensor<3xi16>
-  %result = stablehlo.sign %operand : tensor<3xi16>
-  func.return %result : tensor<3xi16>
-  // CHECK-NEXT: tensor<3xi16>
-  // CHECK-NEXT: -1 : i16
-  // CHECK-NEXT: 0 : i16
-  // CHECK-NEXT: 1 : i16
-}
-
-// -----
-
-// CHECK-LABEL: Evaluated results of function: sign_op_test_si32
-func.func @sign_op_test_si32() -> tensor<3xi32> {
-  %operand = stablehlo.constant dense<[-2147483647, 0, 2147483647]> : tensor<3xi32>
-  %result = stablehlo.sign %operand : tensor<3xi32>
-  func.return %result : tensor<3xi32>
-  // CHECK-NEXT: tensor<3xi32>
-  // CHECK-NEXT: -1 : i32
-  // CHECK-NEXT: 0 : i32
-  // CHECK-NEXT: 1 : i32
-}
-
-// -----
-
 // CHECK-LABEL: Evaluated results of function: sign_op_test_si64
 func.func @sign_op_test_si64() -> tensor<3xi64> {
-  %operand = stablehlo.constant dense<[-9223372036854775807, 0, 9223372036854775807]> : tensor<3xi64>
+  %operand = stablehlo.constant dense<[-1, 0, 1]> : tensor<3xi64>
   %result = stablehlo.sign %operand : tensor<3xi64>
   func.return %result : tensor<3xi64>
   // CHECK-NEXT: tensor<3xi64>
@@ -65,91 +13,18 @@ func.func @sign_op_test_si64() -> tensor<3xi64> {
 
 // -----
 
-// CHECK-LABEL: Evaluated results of function: sign_op_test_bf16
-func.func @sign_op_test_bf16() -> tensor<8xbf16> {
-  // -0.0, +0.0, -3.14, +3.14, -NaN, +NaN, -Inf, +Inf
-  %operand = stablehlo.constant dense<[-0.0, 0.0, -3.140625, 3.140625, 0xFFFF, 0x7FFF, 0xFF80, 0x7F80]> : tensor<8xbf16>
-  %result = stablehlo.sign %operand : tensor<8xbf16>
-  func.return %result : tensor<8xbf16>
-  // CHECK-NEXT: tensor<8xbf16>
-  // CHECK-NEXT: -0.000000e+00 : bf16
-  // CHECK-NEXT: 0.000000e+00 : bf16
-  // CHECK-NEXT: -1.000000e+00 : bf16
-  // CHECK-NEXT: 1.000000e+00 : bf16
-  // CHECK-NEXT: 0xFFFF : bf16
-  // CHECK-NEXT: 0x7FFF : bf16
-  // CHECK-NEXT: -1.000000e+00 : bf16
-  // CHECK-NEXT: 1.000000e+00 : bf16
-}
-
-// -----
-
-// CHECK-LABEL: Evaluated results of function: sign_op_test_f16
-func.func @sign_op_test_f16() -> tensor<6xf16> {
-  // -0.0, +0.0, -3.14, +3.14, -NaN, +NaN, -Inf, +Inf
-  %operand = stablehlo.constant dense<[-0.0, 0.0, -3.141, 3.141, 0xFFFF, 0x7FFF]> : tensor<6xf16>
-  %result = stablehlo.sign %operand : tensor<6xf16>
-  func.return %result : tensor<6xf16>
-  // CHECK-NEXT: tensor<6xf16>
-  // CHECK-NEXT: -0.000000e+00 : f16
-  // CHECK-NEXT: 0.000000e+00 : f16
-  // CHECK-NEXT: -1.000000e+00 : f16
-  // CHECK-NEXT: 1.000000e+00 : f16
-  // CHECK-NEXT: 0xFFFF : f16
-  // CHECK-NEXT: 0x7FFF : f16
-}
-
-// -----
-
-// CHECK-LABEL: Evaluated results of function: sign_op_test_f32
-func.func @sign_op_test_f32() -> tensor<8xf32> {
-  // -0.0, +0.0, -3.14, +3.14, -NaN, +NaN, -Inf, +Inf
-  %operand = stablehlo.constant dense<[-0.0, 0.0, -3.14159265, 3.14159265, 0xFFFFFFFF, 0x7FFFFFFF, 0xFF800000, 0x7F800000]> : tensor<8xf32>
-  %result = stablehlo.sign %operand : tensor<8xf32>
-  func.return %result : tensor<8xf32>
-  // CHECK-NEXT: tensor<8xf32>
-  // CHECK-NEXT: -0.000000e+00 : f32
-  // CHECK-NEXT: 0.000000e+00 : f32
-  // CHECK-NEXT: -1.000000e+00 : f32
-  // CHECK-NEXT: 1.000000e+00 : f32
-  // CHECK-NEXT: 0xFFFFFFFF : f32
-  // CHECK-NEXT: 0x7FFFFFFF : f32
-  // CHECK-NEXT: -1.000000e+00 : f32
-  // CHECK-NEXT: 1.000000e+00 : f32
-}
-
-// -----
-
 // CHECK-LABEL: Evaluated results of function: sign_op_test_f64
-func.func @sign_op_test_f64() -> tensor<8xf64> {
-  // -0.0, +0.0, -3.14, +3.14, -NaN, +NaN, -Inf, +Inf
-  %operand = stablehlo.constant dense<[-0.0, 0.0, -3.14159265358979323846, 3.14159265358979323846, 0xFFFFFFFFFFFFFFFF, 0x7FFFFFFFFFFFFFFF, 0xFFF0000000000000, 0x7FF0000000000000]> : tensor<8xf64>
-  %result = stablehlo.sign %operand : tensor<8xf64>
-  func.return %result : tensor<8xf64>
-  // CHECK-NEXT: tensor<8xf64>
+func.func @sign_op_test_f64() -> tensor<5xf64> {
+  // +NaN, -1.0, -0.0, +0.0, 1.0
+  %operand = stablehlo.constant dense<[0x7FFFFFFFFFFFFFFF, -1.0, -0.0, 0.0, 1.0]> : tensor<5xf64>
+  %result = stablehlo.sign %operand : tensor<5xf64>
+  func.return %result : tensor<5xf64>
+  // CHECK-NEXT: tensor<5xf64>
+  // CHECK-NEXT: 0xFFFFFFFFFFFFFFFF : f64
+  // CHECK-NEXT: -1.000000e+00 : f64
   // CHECK-NEXT: -0.000000e+00 : f64
   // CHECK-NEXT: 0.000000e+00 : f64
-  // CHECK-NEXT: -1.000000e+00 : f64
   // CHECK-NEXT: 1.000000e+00 : f64
-  // CHECK-NEXT: 0xFFFFFFFFFFFFFFFF : f64
-  // CHECK-NEXT: 0x7FFFFFFFFFFFFFFF : f64
-  // CHECK-NEXT: -1.000000e+00 : f64
-  // CHECK-NEXT: 1.000000e+00 : f64
-}
-
-// -----
-
-// CHECK-LABEL: Evaluated results of function: sign_op_test_c64
-func.func @sign_op_test_c64() -> tensor<3xcomplex<f32>> {
-  // (+NaN, +0.0), (+0.0, +NaN), (-1.0, 0.0)
-  // (+NaN, +0.0), (+0.0, +NaN), (1.0, 1.0)
-  %operand = stablehlo.constant dense<[(0x7FFFFFFF, 0.0), (0.0, 0x7FFFFFFF), (-1.0, 0.0)]> : tensor<3xcomplex<f32>>
-  %result = stablehlo.sign %operand : tensor<3xcomplex<f32>>
-  func.return %result : tensor<3xcomplex<f32>>
-  // CHECK-NEXT: tensor<3xcomplex<f32>>
-  // CHECK-NEXT: [0x7FFFFFFF : f32, 0.000000e+00 : f32]
-  // CHECK-NEXT: [0x7FFFFFFF : f32, 0.000000e+00 : f32]
-  // CHECK-NEXT: [-1.000000e+00 : f32, 0.000000e+00 : f32]
 }
 
 // -----

--- a/stablehlo/tests/interpret_sign.mlir
+++ b/stablehlo/tests/interpret_sign.mlir
@@ -1,43 +1,35 @@
 // RUN: stablehlo-translate --interpret -split-input-file %s
 
 // CHECK-LABEL: Evaluated results of function: sign_op_test_si64
-func.func @sign_op_test_si64() -> tensor<3xi64> {
+func.func @sign_op_test_si64() {
   %operand = stablehlo.constant dense<[-1, 0, 1]> : tensor<3xi64>
   %result = stablehlo.sign %operand : tensor<3xi64>
-  func.return %result : tensor<3xi64>
-  // CHECK-NEXT: tensor<3xi64>
-  // CHECK-NEXT: -1 : i64
-  // CHECK-NEXT: 0 : i64
-  // CHECK-NEXT: 1 : i64
+  check.expect_eq_const %result, dense<[-1, 0, 1]> : tensor<3xi64>
+  func.return
 }
 
 // -----
 
 // CHECK-LABEL: Evaluated results of function: sign_op_test_f64
-func.func @sign_op_test_f64() -> tensor<5xf64> {
+func.func @sign_op_test_f64() {
   // +NaN, -1.0, -0.0, +0.0, 1.0
   %operand = stablehlo.constant dense<[0x7FFFFFFFFFFFFFFF, -1.0, -0.0, 0.0, 1.0]> : tensor<5xf64>
   %result = stablehlo.sign %operand : tensor<5xf64>
-  func.return %result : tensor<5xf64>
-  // CHECK-NEXT: tensor<5xf64>
-  // CHECK-NEXT: 0xFFFFFFFFFFFFFFFF : f64
-  // CHECK-NEXT: -1.000000e+00 : f64
-  // CHECK-NEXT: -0.000000e+00 : f64
-  // CHECK-NEXT: 0.000000e+00 : f64
-  // CHECK-NEXT: 1.000000e+00 : f64
+  check.expect_almost_eq_const %result, dense<[0x7FFFFFFFFFFFFFFF, -1.0, -0.0, 0.0, 1.0]> : tensor<5xf64>
+  func.return
 }
 
 // -----
 
 // CHECK-LABEL: Evaluated results of function: sign_op_test_c128
-func.func @sign_op_test_c128() -> tensor<3xcomplex<f64>> {
+func.func @sign_op_test_c128() {
   // (+NaN, +0.0), (+0.0, +NaN), (0.0, 1.0)
-  // (+NaN, +0.0), (+Nan, +0.0), (1.0, 1.0)
-  %operand = stablehlo.constant dense<[(0x7FF0000000000001, 0x0000000000000000), (0x0000000000000000, 0x7FF0000000000001), (0.0, 1.0)]> : tensor<3xcomplex<f64>>
+  %operand = stablehlo.constant dense<[(0x7FF0000000000001, 0x0000000000000000),
+                                       (0x0000000000000000, 0x7FF0000000000001),
+                                       (0.0, 1.0)]> : tensor<3xcomplex<f64>>
   %result = stablehlo.sign %operand : tensor<3xcomplex<f64>>
-  func.return %result : tensor<3xcomplex<f64>>
-  // CHECK-NEXT: tensor<3xcomplex<f64>>
-  // CHECK-NEXT: [0x7FF0000000000001, 0x0000000000000000]
-  // CHECK-NEXT: [0x7FF0000000000001, 0x0000000000000000]
-  // CHECK-NEXT: [0.000000e+00, 1.000000e+00]
+  check.expect_almost_eq_const %result, dense<[(0x7FF0000000000001, 0x7FF0000000000001),
+                                               (0x7FF0000000000001, 0x7FF0000000000001),
+                                               (0.0, 1.0)]> : tensor<3xcomplex<f64>>
+  func.return
 }

--- a/stablehlo/tests/interpret_sign.mlir
+++ b/stablehlo/tests/interpret_sign.mlir
@@ -145,7 +145,7 @@ func.func @sign_op_test_c64() {
   // (+NaN, +0.0), (+0.0, +NaN), (1.0, 1.0)
   %operand = stablehlo.constant dense<[(0x7FFFFFFF, 0.0), (0.0, 0x7FFFFFFF), (-1.0, 0.0)]> : tensor<3xcomplex<f32>>
   %result = stablehlo.sign %operand : tensor<3xcomplex<f32>>
-  func.return % result : tensor<3xcomplex<f32>>
+  func.return %result : tensor<3xcomplex<f32>>
   // CHECK-LABEL: tensor<3xcomplex<f32>>
   // CHECK-LABEL: [0x7FFFFFFF : f32, 0.000000e+00 : f32]
   // CHECK-LABEL: [0x7FFFFFFF : f32, 0.000000e+00 : f32]
@@ -160,7 +160,7 @@ func.func @sign_op_test_c128() {
   // (+NaN, +0.0), (+Nan, +0.0), (1.0, 1.0)
   %operand = stablehlo.constant dense<[(0x7FF0000000000001, 0x0000000000000000), (0x0000000000000000, 0x7FF0000000000001), (0.0, 1.0)]> : tensor<3xcomplex<f64>>
   %result = stablehlo.sign %operand : tensor<3xcomplex<f64>>
-  func.return % result : tensor<3xcomplex<f64>>
+  func.return %result : tensor<3xcomplex<f64>>
   // CHECK-LABEL: tensor<3xcomplex<f64>>
   // CHECK-LABEL: [0x7FF0000000000001, 0x0000000000000000]
   // CHECK-LABEL: [0x7FF0000000000001, 0x0000000000000000]

--- a/stablehlo/tests/interpret_sign.mlir
+++ b/stablehlo/tests/interpret_sign.mlir
@@ -85,7 +85,7 @@ func.func @sign_op_test_bf16() -> tensor<8xbf16> {
 // -----
 
 // CHECK-LABEL: Evaluated results of function: sign_op_test_f16
-func.func @sign_op_test_f16() -> tensor<6xf16>{
+func.func @sign_op_test_f16() -> tensor<6xf16> {
   // -0.0, +0.0, -3.14, +3.14, -NaN, +NaN, -Inf, +Inf
   %operand = stablehlo.constant dense<[-0.0, 0.0, -3.141, 3.141, 0xFFFF, 0x7FFF]> : tensor<6xf16>
   %result = stablehlo.sign %operand : tensor<6xf16>
@@ -102,7 +102,7 @@ func.func @sign_op_test_f16() -> tensor<6xf16>{
 // -----
 
 // CHECK-LABEL: Evaluated results of function: sign_op_test_f32
-func.func @sign_op_test_f32() -> tensor<8xf32>{
+func.func @sign_op_test_f32() -> tensor<8xf32> {
   // -0.0, +0.0, -3.14, +3.14, -NaN, +NaN, -Inf, +Inf
   %operand = stablehlo.constant dense<[-0.0, 0.0, -3.14159265, 3.14159265, 0xFFFFFFFF, 0x7FFFFFFF, 0xFF800000, 0x7F800000]> : tensor<8xf32>
   %result = stablehlo.sign %operand : tensor<8xf32>
@@ -121,7 +121,7 @@ func.func @sign_op_test_f32() -> tensor<8xf32>{
 // -----
 
 // CHECK-LABEL: Evaluated results of function: sign_op_test_f64
-func.func @sign_op_test_f64() -> tensor<8xf64>{
+func.func @sign_op_test_f64() -> tensor<8xf64> {
   // -0.0, +0.0, -3.14, +3.14, -NaN, +NaN, -Inf, +Inf
   %operand = stablehlo.constant dense<[-0.0, 0.0, -3.14159265358979323846, 3.14159265358979323846, 0xFFFFFFFFFFFFFFFF, 0x7FFFFFFFFFFFFFFF, 0xFFF0000000000000, 0x7FF0000000000000]> : tensor<8xf64>
   %result = stablehlo.sign %operand : tensor<8xf64>
@@ -140,29 +140,29 @@ func.func @sign_op_test_f64() -> tensor<8xf64>{
 // -----
 
 // CHECK-LABEL: Evaluated results of function: sign_op_test_c64
-func.func @sign_op_test_c64() {
+func.func @sign_op_test_c64() -> tensor<3xcomplex<f32>> {
   // (+NaN, +0.0), (+0.0, +NaN), (-1.0, 0.0)
   // (+NaN, +0.0), (+0.0, +NaN), (1.0, 1.0)
   %operand = stablehlo.constant dense<[(0x7FFFFFFF, 0.0), (0.0, 0x7FFFFFFF), (-1.0, 0.0)]> : tensor<3xcomplex<f32>>
   %result = stablehlo.sign %operand : tensor<3xcomplex<f32>>
   func.return %result : tensor<3xcomplex<f32>>
-  // CHECK-LABEL: tensor<3xcomplex<f32>>
-  // CHECK-LABEL: [0x7FFFFFFF : f32, 0.000000e+00 : f32]
-  // CHECK-LABEL: [0x7FFFFFFF : f32, 0.000000e+00 : f32]
-  // CHECK-LABEL: [-1.000000e+00 : f32, 0.000000e+00 : f32]
+  // CHECK-NEXT: tensor<3xcomplex<f32>>
+  // CHECK-NEXT: [0x7FFFFFFF : f32, 0.000000e+00 : f32]
+  // CHECK-NEXT: [0x7FFFFFFF : f32, 0.000000e+00 : f32]
+  // CHECK-NEXT: [-1.000000e+00 : f32, 0.000000e+00 : f32]
 }
 
 // -----
 
 // CHECK-LABEL: Evaluated results of function: sign_op_test_c128
-func.func @sign_op_test_c128() {
+func.func @sign_op_test_c128() -> tensor<3xcomplex<f64>> {
   // (+NaN, +0.0), (+0.0, +NaN), (0.0, 1.0)
   // (+NaN, +0.0), (+Nan, +0.0), (1.0, 1.0)
   %operand = stablehlo.constant dense<[(0x7FF0000000000001, 0x0000000000000000), (0x0000000000000000, 0x7FF0000000000001), (0.0, 1.0)]> : tensor<3xcomplex<f64>>
   %result = stablehlo.sign %operand : tensor<3xcomplex<f64>>
   func.return %result : tensor<3xcomplex<f64>>
-  // CHECK-LABEL: tensor<3xcomplex<f64>>
-  // CHECK-LABEL: [0x7FF0000000000001, 0x0000000000000000]
-  // CHECK-LABEL: [0x7FF0000000000001, 0x0000000000000000]
-  // CHECK-LABEL: [0.000000e+00, 1.000000e+00]
+  // CHECK-NEXT: tensor<3xcomplex<f64>>
+  // CHECK-NEXT: [0x7FF0000000000001, 0x0000000000000000]
+  // CHECK-NEXT: [0x7FF0000000000001, 0x0000000000000000]
+  // CHECK-NEXT: [0.000000e+00, 1.000000e+00]
 }

--- a/stablehlo/tests/interpret_sign.mlir
+++ b/stablehlo/tests/interpret_sign.mlir
@@ -1,0 +1,168 @@
+// RUN: stablehlo-translate --interpret -split-input-file %s
+
+// CHECK-LABEL: Evaluated results of function: sign_op_test_si4
+func.func @sign_op_test_si4() -> tensor<3xi4> {
+  %operand = stablehlo.constant dense<[-7, 0, 7]> : tensor<3xi4>
+  %result = stablehlo.sign %operand : tensor<3xi4>
+  func.return %result : tensor<3xi4>
+  // CHECK-NEXT: tensor<3xi4>
+  // CHECK-NEXT: -1 : i4
+  // CHECK-NEXT: 0 : i4
+  // CHECK-NEXT: 1 : i4
+}
+
+// -----
+
+// CHECK-LABEL: Evaluated results of function: sign_op_test_si8
+func.func @sign_op_test_si8() -> tensor<3xi8> {
+  %operand = stablehlo.constant dense<[-127, 0, 127]> : tensor<3xi8>
+  %result = stablehlo.sign %operand : tensor<3xi8>
+  func.return %result : tensor<3xi8>
+  // CHECK-NEXT: tensor<3xi8>
+  // CHECK-NEXT: -1 : i8
+  // CHECK-NEXT: 0 : i8
+  // CHECK-NEXT: 1 : i8
+}
+
+// -----
+
+// CHECK-LABEL: Evaluated results of function: sign_op_test_si16
+func.func @sign_op_test_si16() -> tensor<3xi16> {
+  %operand = stablehlo.constant dense<[-32767, 0, 32767]> : tensor<3xi16>
+  %result = stablehlo.sign %operand : tensor<3xi16>
+  func.return %result : tensor<3xi16>
+  // CHECK-NEXT: tensor<3xi16>
+  // CHECK-NEXT: -1 : i16
+  // CHECK-NEXT: 0 : i16
+  // CHECK-NEXT: 1 : i16
+}
+
+// -----
+
+// CHECK-LABEL: Evaluated results of function: sign_op_test_si32
+func.func @sign_op_test_si32() -> tensor<3xi32> {
+  %operand = stablehlo.constant dense<[-2147483647, 0, 2147483647]> : tensor<3xi32>
+  %result = stablehlo.sign %operand : tensor<3xi32>
+  func.return %result : tensor<3xi32>
+  // CHECK-NEXT: tensor<3xi32>
+  // CHECK-NEXT: -1 : i32
+  // CHECK-NEXT: 0 : i32
+  // CHECK-NEXT: 1 : i32
+}
+
+// -----
+
+// CHECK-LABEL: Evaluated results of function: sign_op_test_si64
+func.func @sign_op_test_si64() -> tensor<3xi64> {
+  %operand = stablehlo.constant dense<[-9223372036854775807, 0, 9223372036854775807]> : tensor<3xi64>
+  %result = stablehlo.sign %operand : tensor<3xi64>
+  func.return %result : tensor<3xi64>
+  // CHECK-NEXT: tensor<3xi64>
+  // CHECK-NEXT: -1 : i64
+  // CHECK-NEXT: 0 : i64
+  // CHECK-NEXT: 1 : i64
+}
+
+// -----
+
+// CHECK-LABEL: Evaluated results of function: sign_op_test_bf16
+func.func @sign_op_test_bf16() -> tensor<8xbf16> {
+  // -0.0, +0.0, -3.14, +3.14, -NaN, +NaN, -Inf, +Inf
+  %operand = stablehlo.constant dense<[-0.0, 0.0, -3.140625, 3.140625, 0xFFFF, 0x7FFF, 0xFF80, 0x7F80]> : tensor<8xbf16>
+  %result = stablehlo.sign %operand : tensor<8xbf16>
+  func.return %result : tensor<8xbf16>
+  // CHECK-NEXT: tensor<8xbf16>
+  // CHECK-NEXT: -0.000000e+00 : bf16
+  // CHECK-NEXT: 0.000000e+00 : bf16
+  // CHECK-NEXT: -1.000000e+00 : bf16
+  // CHECK-NEXT: 1.000000e+00 : bf16
+  // CHECK-NEXT: 0xFFFF : bf16
+  // CHECK-NEXT: 0x7FFF : bf16
+  // CHECK-NEXT: -1.000000e+00 : bf16
+  // CHECK-NEXT: 1.000000e+00 : bf16
+}
+
+// -----
+
+// CHECK-LABEL: Evaluated results of function: sign_op_test_f16
+func.func @sign_op_test_f16() -> tensor<6xf16>{
+  // -0.0, +0.0, -3.14, +3.14, -NaN, +NaN, -Inf, +Inf
+  %operand = stablehlo.constant dense<[-0.0, 0.0, -3.141, 3.141, 0xFFFF, 0x7FFF]> : tensor<6xf16>
+  %result = stablehlo.sign %operand : tensor<6xf16>
+  func.return %result : tensor<6xf16>
+  // CHECK-NEXT: tensor<6xf16>
+  // CHECK-NEXT: -0.000000e+00 : f16
+  // CHECK-NEXT: 0.000000e+00 : f16
+  // CHECK-NEXT: -1.000000e+00 : f16
+  // CHECK-NEXT: 1.000000e+00 : f16
+  // CHECK-NEXT: 0xFFFF : f16
+  // CHECK-NEXT: 0x7FFF : f16
+}
+
+// -----
+
+// CHECK-LABEL: Evaluated results of function: sign_op_test_f32
+func.func @sign_op_test_f32() -> tensor<8xf32>{
+  // -0.0, +0.0, -3.14, +3.14, -NaN, +NaN, -Inf, +Inf
+  %operand = stablehlo.constant dense<[-0.0, 0.0, -3.14159265, 3.14159265, 0xFFFFFFFF, 0x7FFFFFFF, 0xFF800000, 0x7F800000]> : tensor<8xf32>
+  %result = stablehlo.sign %operand : tensor<8xf32>
+  func.return %result : tensor<8xf32>
+  // CHECK-NEXT: tensor<8xf32>
+  // CHECK-NEXT: -0.000000e+00 : f32
+  // CHECK-NEXT: 0.000000e+00 : f32
+  // CHECK-NEXT: -1.000000e+00 : f32
+  // CHECK-NEXT: 1.000000e+00 : f32
+  // CHECK-NEXT: 0xFFFFFFFF : f32
+  // CHECK-NEXT: 0x7FFFFFFF : f32
+  // CHECK-NEXT: -1.000000e+00 : f32
+  // CHECK-NEXT: 1.000000e+00 : f32
+}
+
+// -----
+
+// CHECK-LABEL: Evaluated results of function: sign_op_test_f64
+func.func @sign_op_test_f64() -> tensor<8xf64>{
+  // -0.0, +0.0, -3.14, +3.14, -NaN, +NaN, -Inf, +Inf
+  %operand = stablehlo.constant dense<[-0.0, 0.0, -3.14159265358979323846, 3.14159265358979323846, 0xFFFFFFFFFFFFFFFF, 0x7FFFFFFFFFFFFFFF, 0xFFF0000000000000, 0x7FF0000000000000]> : tensor<8xf64>
+  %result = stablehlo.sign %operand : tensor<8xf64>
+  func.return %result : tensor<8xf64>
+  // CHECK-NEXT: tensor<8xf64>
+  // CHECK-NEXT: -0.000000e+00 : f64
+  // CHECK-NEXT: 0.000000e+00 : f64
+  // CHECK-NEXT: -1.000000e+00 : f64
+  // CHECK-NEXT: 1.000000e+00 : f64
+  // CHECK-NEXT: 0xFFFFFFFFFFFFFFFF : f64
+  // CHECK-NEXT: 0x7FFFFFFFFFFFFFFF : f64
+  // CHECK-NEXT: -1.000000e+00 : f64
+  // CHECK-NEXT: 1.000000e+00 : f64
+}
+
+// -----
+
+// CHECK-LABEL: Evaluated results of function: sign_op_test_c64
+func.func @sign_op_test_c64() {
+  // (+NaN, +0.0), (+0.0, +NaN), (-1.0, 0.0)
+  // (+NaN, +0.0), (+0.0, +NaN), (1.0, 1.0)
+  %operand = stablehlo.constant dense<[(0x7FFFFFFF, 0.0), (0.0, 0x7FFFFFFF), (-1.0, 0.0)]> : tensor<3xcomplex<f32>>
+  %result = stablehlo.sign %operand : tensor<3xcomplex<f32>>
+  func.return % result : tensor<3xcomplex<f32>>
+  // CHECK-LABEL: tensor<3xcomplex<f32>>
+  // CHECK-LABEL: [0x7FFFFFFF : f32, 0.000000e+00 : f32]
+  // CHECK-LABEL: [0x7FFFFFFF : f32, 0.000000e+00 : f32]
+  // CHECK-LABEL: [-1.000000e+00 : f32, 0.000000e+00 : f32]
+}
+
+// -----
+
+// CHECK-LABEL: Evaluated results of function: sign_op_test_c128
+func.func @sign_op_test_c128() {
+  // (+NaN, +0.0), (+0.0, +NaN), (0.0, 1.0)
+  // (+NaN, +0.0), (+Nan, +0.0), (1.0, 1.0)
+  %operand = stablehlo.constant dense<[(0x7FF0000000000001, 0x0000000000000000), (0x0000000000000000, 0x7FF0000000000001), (0.0, 1.0)]> : tensor<3xcomplex<f64>>
+  %result = stablehlo.sign %operand : tensor<3xcomplex<f64>>
+  func.return % result : tensor<3xcomplex<f64>>
+  // CHECK-LABEL: tensor<3xcomplex<f64>>
+  // CHECK-LABEL: [0x7FF0000000000001, 0x0000000000000000]
+  // CHECK-LABEL: [0x7FF0000000000001, 0x0000000000000000]
+  // CHECK-LABEL: [0.000000e+00, 1.000000e+00]
+}


### PR DESCRIPTION
closes #1115 

We have the following constraints in the spec:

```
(I1) operand is a tensor of signed integer, floating-point, or complex type.
(C1) operand and result have the same type.
```

These constraints are covered by the following tests

```
I1: a) operand is not a tensor of signed integer, floating-point, or complex type. (Covered by ODS).
C1: a) type(operand) != type(result). (Covered by ODS).
```