### PR TITLE
Drop indices_of_shape_operands once they are no longer needed

### DIFF
--- a/stablehlo/dialect/Base.cpp
+++ b/stablehlo/dialect/Base.cpp
@@ -411,8 +411,8 @@ LogicalResult getShapeRefinements(
   if (indicesAttr.getNumElements() != op->getNumResults())
     return emitOptionalError(location, "indices_of_shape_operands: number of ",
                              "elements (", indicesAttr.getNumElements(), ") ",
-                             "must be equal to the number of results (",
-                             op->getNumResults(), ")");
+                             "must be equal to the number of operation results",
+                             " (", op->getNumResults(), ")");
   if (indicesAttr.getType().getRank() != 1)
     return emitOptionalError(location, "indices_of_shape_operands: must have ",
                              "rank = 1");

--- a/stablehlo/dialect/Base.cpp
+++ b/stablehlo/dialect/Base.cpp
@@ -421,8 +421,8 @@ LogicalResult getShapeRefinements(
                              "i64 element type");
 
   auto resultIndex = 0;
-  for (auto [operandIndex, result] :
-       llvm::zip(indicesAttr.getValues<int64_t>(), op->getResults())) {
+  for (auto [operandIndex, resultType] :
+       llvm::zip(indicesAttr.getValues<int64_t>(), op->getResultTypes())) {
     if (operandIndex < 0 || operandIndex >= op->getNumOperands())
       return emitOptionalError(location, "indices_of_shape_operands: index #",
                                resultIndex, " (", operandIndex, ") ",
@@ -432,11 +432,11 @@ LogicalResult getShapeRefinements(
     Value operand = op->getOperand(operandIndex);
     SmallVector<int64_t> refinement;
     if (failed(hlo::matchInts(operand, refinement))) return failure();
-    if (!isCompatibleForHloTypeInference(operand, result.getType()))
+    if (!isCompatibleForHloTypeInference(operand, resultType))
       return emitOptionalError(
           location, "indices_of_shape_operands: refinement #", resultIndex,
           " ([", refinement, "]) must be compatible with operation result (",
-          result.getType(), ")");
+          resultType, ")");
     refinements.emplace_back(refinement);
     ++resultIndex;
   }

--- a/stablehlo/dialect/Base.cpp
+++ b/stablehlo/dialect/Base.cpp
@@ -18,6 +18,7 @@ limitations under the License.
 
 #include <optional>
 
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "mlir/Dialect/Quant/QuantTypes.h"
 #include "mlir/Dialect/Shape/IR/Shape.h"
@@ -126,6 +127,7 @@ bool isCompatibleForHloTypeInference(ArrayRef<int64_t> shape1, Type tp2) {
 bool isCompatibleForHloTypeInference(Value shape1, Type tp2) {
   SmallVector<int64_t> shapeVec1;
   if (!succeeded(matchInts(shape1, shapeVec1))) return true;
+  if (llvm::any_of(shapeVec1, [&](int64_t x) { return x < 0; })) return false;
   auto stp2 = tp2.dyn_cast<ShapedType>();
   if (!stp2) return false;
   auto tp1 = RankedTensorType::get(shapeVec1, stp2.getElementType());
@@ -396,6 +398,48 @@ LogicalResult inferMostSpecificTypeComponents(
                                       rankedResultType.getEncoding());
   }
 
+  return success();
+}
+
+LogicalResult getShapeRefinements(
+    std::optional<Location> location, Operation* op,
+    SmallVector<ShapedTypeComponents>& refinements) {
+  auto indicesAttr = op->getAttr("indices_of_shape_operands")
+                         .dyn_cast_or_null<DenseIntElementsAttr>();
+  if (!indicesAttr) return failure();
+
+  if (indicesAttr.getNumElements() != op->getNumResults())
+    return emitOptionalError(location, "indices_of_shape_operands: number of ",
+                             "elements (", indicesAttr.getNumElements(), ") ",
+                             "must be equal to the number of results (",
+                             op->getNumResults(), ")");
+  if (indicesAttr.getType().getRank() != 1)
+    return emitOptionalError(location, "indices_of_shape_operands: must have ",
+                             "rank = 1");
+  if (!indicesAttr.getType().getElementType().isInteger(64))
+    return emitOptionalError(location, "indices_of_shape_operands: must have ",
+                             "i64 element type");
+
+  auto resultIndex = 0;
+  for (auto [operandIndex, result] :
+       llvm::zip(indicesAttr.getValues<int64_t>(), op->getResults())) {
+    if (operandIndex < 0 || operandIndex >= op->getNumOperands())
+      return emitOptionalError(location, "indices_of_shape_operands: index #",
+                               resultIndex, " (", operandIndex, ") ",
+                               "must be within bounds for operation operands ",
+                               "(from 0 to ", op->getNumOperands(), ")");
+
+    Value operand = op->getOperand(operandIndex);
+    SmallVector<int64_t> refinement;
+    if (failed(hlo::matchInts(operand, refinement))) return failure();
+    if (!isCompatibleForHloTypeInference(operand, result.getType()))
+      return emitOptionalError(
+          location, "indices_of_shape_operands: refinement #", resultIndex,
+          " ([", refinement, "]) must be compatible with operation result (",
+          result.getType(), ")");
+    refinements.emplace_back(refinement);
+    ++resultIndex;
+  }
   return success();
 }
 

--- a/stablehlo/dialect/Base.h
+++ b/stablehlo/dialect/Base.h
@@ -162,6 +162,16 @@ ArrayRef<int64_t> encodingToBounds(Attribute encoding);
 // the underlying dialect that knows how to create these attributes.
 Attribute boundsToEncoding(Attribute prototype, ArrayRef<int64_t> bounds);
 
+// Get refinements for return types from an indices_of_shape_operands attribute.
+// If the attribute doesn't exist, returns failure.
+// If the attribute exists but is not invalid with respect to the operation,
+// reports an optional error and returns failure.
+// If the attribute is valid but not all shape operands are constants,
+// returns failure.
+LogicalResult getShapeRefinements(
+    std::optional<Location> location, Operation *operation,
+    SmallVector<ShapedTypeComponents> &refinements);
+
 // This interface is implemented by both StableHLO and MHLO dialects
 // and is used as the foundation for sharing verification, type inference and
 // prettyprinting logic between them.

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -865,7 +865,16 @@ func.func @dynamic_broadcast_in_dim_shape_mismatch(%arg0: tensor<32xf32>, %shape
 
 // -----
 
-func.func @dynamic_broadcast_in_dim_output_dimensions_mismatch(%arg0: tensor<4xf32>) -> tensor<3x4xf32> {
+func.func @dynamic_broadcast_in_dim_output_dimensions_negative_size(%arg0: tensor<4xf32>) -> tensor<3x4xf32> {
+  // @expected-error@+2 {{output_dimensions are incompatible with return type of operation 'tensor<3x4xf32>'}}
+  %0 = stablehlo.constant dense<[-1, 4]> : tensor<2xi64>
+  %1 = stablehlo.dynamic_broadcast_in_dim %arg0, %0, dims = [1] : (tensor<4xf32>, tensor<2xi64>) -> tensor<3x4xf32>
+  return %1 : tensor<3x4xf32>
+}
+
+// -----
+
+func.func @dynamic_broadcast_in_dim_output_dimensions_mismatching_size(%arg0: tensor<4xf32>) -> tensor<3x4xf32> {
   // @expected-error@+2 {{output_dimensions are incompatible with return type of operation 'tensor<3x4xf32>'}}
   %0 = stablehlo.constant dense<[1, 4]> : tensor<2xi64>
   %1 = stablehlo.dynamic_broadcast_in_dim %arg0, %0, dims = [1] : (tensor<4xf32>, tensor<2xi64>) -> tensor<3x4xf32>
@@ -3364,7 +3373,16 @@ func.func @dynamic_reshape_incompatible_shapes(%arg0: tensor<?xf32>, %shape: ten
 
 // -----
 
-func.func @dynamic_reshape_output_shape_mismatch(%arg0: tensor<4xf32>) -> tensor<1x4xf32> {
+func.func @dynamic_reshape_output_shape_negative_size(%arg0: tensor<4xf32>) -> tensor<1x4xf32> {
+  // @expected-error@+2 {{output_shape is incompatible with return type of operation 'tensor<1x4xf32>'}}
+  %0 = stablehlo.constant dense<[-1, 1]> : tensor<2xi64>
+  %1 = stablehlo.dynamic_reshape %arg0, %0 : (tensor<4xf32>, tensor<2xi64>) -> tensor<1x4xf32>
+  return %1 : tensor<1x4xf32>
+}
+
+// -----
+
+func.func @dynamic_reshape_output_shape_mismatching_size(%arg0: tensor<4xf32>) -> tensor<1x4xf32> {
   // @expected-error@+2 {{output_shape is incompatible with return type of operation 'tensor<1x4xf32>'}}
   %0 = stablehlo.constant dense<[1, 1]> : tensor<2xi64>
   %1 = stablehlo.dynamic_reshape %arg0, %0 : (tensor<4xf32>, tensor<2xi64>) -> tensor<1x4xf32>
@@ -5716,7 +5734,16 @@ func.func @dynamic_iota_unranked() -> tensor<*xf32> {
 
 // -----
 
-func.func @dynamic_iota_output_shape_mismatch() -> tensor<4xf32> {
+func.func @dynamic_iota_output_shape_negative_size() -> tensor<4xf32> {
+  // @expected-error@+2 {{output_shape is incompatible with return type of operation 'tensor<4xf32>'}}
+  %0 = stablehlo.constant dense<[-1]> : tensor<1xi64>
+  %1 = stablehlo.dynamic_iota %0, dim = 0 : (tensor<1xi64>) -> tensor<4xf32>
+  func.return %1 : tensor<4xf32>
+}
+
+// -----
+
+func.func @dynamic_iota_output_shape_mismatching_size() -> tensor<4xf32> {
   // @expected-error@+2 {{output_shape is incompatible with return type of operation 'tensor<4xf32>'}}
   %0 = stablehlo.constant dense<[1]> : tensor<1xi64>
   %1 = stablehlo.dynamic_iota %0, dim = 0 : (tensor<1xi64>) -> tensor<4xf32>

--- a/stablehlo/tests/stablehlo_canonicalize_dynamism.mlir
+++ b/stablehlo/tests/stablehlo_canonicalize_dynamism.mlir
@@ -14,7 +14,7 @@ func.func @custom_call_success(%arg0: tensor<4xf32>) -> (tensor<1x2xf32>, tensor
 // -----
 
 func.func @custom_call_failure_number_of_elements(%arg0: tensor<4xf32>) -> tensor<1x2xf32> {
-  // expected-error@+3{{indices_of_shape_operands: number of elements (2) must be equal to the number of results (1)}}
+  // expected-error@+3{{indices_of_shape_operands: number of elements (2) must be equal to the number of operation results (1)}}
   %0 = stablehlo.constant dense<[1, 2]> : tensor<2xi64>
   %1 = stablehlo.constant dense<[3, 4]> : tensor<2xi64>
   %2 = stablehlo.custom_call @foo(%arg0, %0, %1) {

--- a/stablehlo/tests/stablehlo_canonicalize_dynamism.mlir
+++ b/stablehlo/tests/stablehlo_canonicalize_dynamism.mlir
@@ -1,7 +1,76 @@
-// RUN: stablehlo-opt --stablehlo-canonicalize-dynamism %s | FileCheck %s
+// RUN: stablehlo-opt --stablehlo-canonicalize-dynamism --split-input-file --verify-diagnostics %s | FileCheck %s
 
-// CHECK-LABEL: func @canonicalize_dynamic_conv
-func.func @canonicalize_dynamic_conv(%arg0: tensor<100x26x26x32xf32>, %arg1: tensor<3x3x1x32xf32>) -> tensor<100x28x28x1xf32> {
+// CHECK-LABEL: func @custom_call_success
+func.func @custom_call_success(%arg0: tensor<4xf32>) -> (tensor<1x2xf32>, tensor<3x4xf32>) {
+  // CHECK: stablehlo.custom_call @foo(%arg0) : (tensor<4xf32>) -> (tensor<1x2xf32>, tensor<3x4xf32>)
+  %0 = stablehlo.constant dense<[1, 2]> : tensor<2xi64>
+  %1 = stablehlo.constant dense<[3, 4]> : tensor<2xi64>
+  %2:2 = stablehlo.custom_call @foo(%arg0, %0, %1) {
+    indices_of_shape_operands = dense<[1, 2]> : tensor<2xi64>
+  } : (tensor<4xf32>, tensor<2xi64>, tensor<2xi64>) -> (tensor<1x2xf32>, tensor<3x4xf32>)
+  return %2#0, %2#1 : tensor<1x2xf32>, tensor<3x4xf32>
+}
+
+// -----
+
+func.func @custom_call_failure_number_of_elements(%arg0: tensor<4xf32>) -> tensor<1x2xf32> {
+  // expected-error@+3{{indices_of_shape_operands: number of elements (2) must be equal to the number of results (1)}}
+  %0 = stablehlo.constant dense<[1, 2]> : tensor<2xi64>
+  %1 = stablehlo.constant dense<[3, 4]> : tensor<2xi64>
+  %2 = stablehlo.custom_call @foo(%arg0, %0, %1) {
+    indices_of_shape_operands = dense<[1, 2]> : tensor<2xi64>
+  } : (tensor<4xf32>, tensor<2xi64>, tensor<2xi64>) -> tensor<1x2xf32>
+  return %2 : tensor<1x2xf32>
+}
+
+// -----
+
+func.func @custom_call_failure_rank(%arg0: tensor<4xf32>) -> tensor<1x2xf32> {
+  // expected-error@+2{{indices_of_shape_operands: must have rank = 1}}
+  %0 = stablehlo.constant dense<[1, 2]> : tensor<2xi64>
+  %2 = stablehlo.custom_call @foo(%arg0, %0) {
+    indices_of_shape_operands = dense<[[1]]> : tensor<1x1xi64>
+  } : (tensor<4xf32>, tensor<2xi64>) -> tensor<1x2xf32>
+  return %2 : tensor<1x2xf32>
+}
+
+// -----
+
+func.func @custom_call_failure_element_type(%arg0: tensor<4xf32>) -> tensor<1x2xf32> {
+  // expected-error@+2{{indices_of_shape_operands: must have i64 element type}}
+  %0 = stablehlo.constant dense<[1, 2]> : tensor<2xi64>
+  %2 = stablehlo.custom_call @foo(%arg0, %0) {
+    indices_of_shape_operands = dense<[1]> : tensor<1xi32>
+  } : (tensor<4xf32>, tensor<2xi64>) -> tensor<1x2xf32>
+  return %2 : tensor<1x2xf32>
+}
+
+// -----
+
+func.func @custom_call_failure_operand_index(%arg0: tensor<4xf32>) -> tensor<1x2xf32> {
+  // expected-error@+2{{indices_of_shape_operands: index #0 (2) must be within bounds for operation operands (from 0 to 2)}}
+  %0 = stablehlo.constant dense<[1, 2]> : tensor<2xi64>
+  %2 = stablehlo.custom_call @foo(%arg0, %0) {
+    indices_of_shape_operands = dense<[2]> : tensor<1xi64>
+  } : (tensor<4xf32>, tensor<2xi64>) -> tensor<1x2xf32>
+  return %2 : tensor<1x2xf32>
+}
+
+// -----
+
+func.func @custom_call_failure_operand_index(%arg0: tensor<4xf32>) -> tensor<1x2xf32> {
+  // expected-error@+2{{refinement #0 ([1, 1]) must be compatible with operation result ('tensor<1x2xf32>')}}
+  %0 = stablehlo.constant dense<[1, 1]> : tensor<2xi64>
+  %2 = stablehlo.custom_call @foo(%arg0, %0) {
+    indices_of_shape_operands = dense<[1]> : tensor<1xi64>
+  } : (tensor<4xf32>, tensor<2xi64>) -> tensor<1x2xf32>
+  return %2 : tensor<1x2xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func @dynamic_conv
+func.func @dynamic_conv(%arg0: tensor<100x26x26x32xf32>, %arg1: tensor<3x3x1x32xf32>) -> tensor<100x28x28x1xf32> {
   //  CHECK-NOT: stablehlo.dynamic_conv
   //      CHECK: stablehlo.convolution(%arg0, %arg1)
   // CHECK-SAME:  dim_numbers = [b, 0, 1, f]x[0, 1, o, i]->[b, 0, 1, f],
@@ -26,8 +95,10 @@ func.func @canonicalize_dynamic_conv(%arg0: tensor<100x26x26x32xf32>, %arg1: ten
   return %1 : tensor<100x28x28x1xf32>
 }
 
-// CHECK-LABEL: func @canonicalize_dynamic_iota
-func.func @canonicalize_dynamic_iota() -> tensor<4xf32> {
+// -----
+
+// CHECK-LABEL: func @dynamic_iota
+func.func @dynamic_iota() -> tensor<4xf32> {
   // CHECK-NOT: stablehlo.dynamic_iota
   // CHECK: stablehlo.iota dim = 0 : tensor<4xf32>
   %0 = stablehlo.constant dense<4> : tensor<1xi64>
@@ -35,8 +106,10 @@ func.func @canonicalize_dynamic_iota() -> tensor<4xf32> {
   return %1 : tensor<4xf32>
 }
 
-// CHECK-LABEL: func @canonicalize_dynamic_broadcast_in_dim
-func.func @canonicalize_dynamic_broadcast_in_dim(%arg0: tensor<4xf32>) -> tensor<3x4xf32> {
+// -----
+
+// CHECK-LABEL: func @dynamic_broadcast_in_dim
+func.func @dynamic_broadcast_in_dim(%arg0: tensor<4xf32>) -> tensor<3x4xf32> {
   // CHECK-NOT: stablehlo.dynamic_broadcast_in_dim
   // CHECK: stablehlo.broadcast_in_dim %arg0, dims = [1] : (tensor<4xf32>) -> tensor<3x4xf32>
   %0 = stablehlo.constant dense<[3, 4]> : tensor<2xi64>
@@ -44,8 +117,10 @@ func.func @canonicalize_dynamic_broadcast_in_dim(%arg0: tensor<4xf32>) -> tensor
   return %1 : tensor<3x4xf32>
 }
 
-// CHECK-LABEL: @canonicalize_dynamic_gather
-func.func @canonicalize_dynamic_gather(%arg0 : tensor<2x4x9xi32>, %arg1 : tensor<1x5x2xi32>, %arg2 : tensor<3xi32>) -> tensor<1x5x8xi32> {
+// -----
+
+// CHECK-LABEL: @dynamic_gather
+func.func @dynamic_gather(%arg0 : tensor<2x4x9xi32>, %arg1 : tensor<1x5x2xi32>, %arg2 : tensor<3xi32>) -> tensor<1x5x8xi32> {
   //  CHECK-NOT: stablehlo.dynamic_gather
   //      CHECK: "stablehlo.gather"(%arg0, %arg1) {
   // CHECK-SAME:   dimension_numbers = #stablehlo.gather<
@@ -68,8 +143,10 @@ func.func @canonicalize_dynamic_gather(%arg0 : tensor<2x4x9xi32>, %arg1 : tensor
   return %1 : tensor<1x5x8xi32>
 }
 
-// CHECK-LABEL: func @canonicalize_dynamic_pad
-func.func @canonicalize_dynamic_pad(%arg0: tensor<4xf32>, %arg1: tensor<f32>) -> tensor<6xf32> {
+// -----
+
+// CHECK-LABEL: func @dynamic_pad
+func.func @dynamic_pad(%arg0: tensor<4xf32>, %arg1: tensor<f32>) -> tensor<6xf32> {
   // CHECK-NOT: stablehlo.dynamic_pad
   // CHECK: stablehlo.pad %arg0, %arg1, low = [1], high = [1], interior = [0] : (tensor<4xf32>, tensor<f32>) -> tensor<6xf32>
   %0 = stablehlo.constant dense<1> : tensor<1xi64>
@@ -78,8 +155,10 @@ func.func @canonicalize_dynamic_pad(%arg0: tensor<4xf32>, %arg1: tensor<f32>) ->
   return %2 : tensor<6xf32>
 }
 
-// CHECK-LABEL: func @canonicalize_dynamic_reshape
-func.func @canonicalize_dynamic_reshape(%arg0: tensor<4xf32>) -> tensor<1x4xf32> {
+// -----
+
+// CHECK-LABEL: func @dynamic_reshape
+func.func @dynamic_reshape(%arg0: tensor<4xf32>) -> tensor<1x4xf32> {
   // CHECK-NOT: stablehlo.dynamic_reshape
   // CHECK: stablehlo.reshape %arg0 : (tensor<4xf32>) -> tensor<1x4xf32>
   %0 = stablehlo.constant dense<[1, 4]> : tensor<2xi64>
@@ -87,8 +166,10 @@ func.func @canonicalize_dynamic_reshape(%arg0: tensor<4xf32>) -> tensor<1x4xf32>
   return %1 : tensor<1x4xf32>
 }
 
-// CHECK-LABEL: func @canonicalize_real_dynamic_slice_to_dynamic_slice
-func.func @canonicalize_real_dynamic_slice_to_dynamic_slice(%arg0: tensor<4xf32>, %arg1: tensor<1xi64>) -> tensor<1xf32> {
+// -----
+
+// CHECK-LABEL: func @real_dynamic_slice_to_dynamic_slice
+func.func @real_dynamic_slice_to_dynamic_slice(%arg0: tensor<4xf32>, %arg1: tensor<1xi64>) -> tensor<1xf32> {
   //  CHECK-NOT: stablehlo.real_dynamic_slice
   //      CHECK: [[SIZE0_1D:%.*]] = "stablehlo.slice"(%arg1) {
   // CHECK-SAME:   limit_indices = dense<1> : tensor<1xi64>,
@@ -103,8 +184,10 @@ func.func @canonicalize_real_dynamic_slice_to_dynamic_slice(%arg0: tensor<4xf32>
   return %2 : tensor<1xf32>
 }
 
-// CHECK-LABEL: func @canonicalize_real_dynamic_slice_to_slice
-func.func @canonicalize_real_dynamic_slice_to_slice(%arg0: tensor<4xf32>) -> tensor<1xf32> {
+// -----
+
+// CHECK-LABEL: func @real_dynamic_slice_to_slice
+func.func @real_dynamic_slice_to_slice(%arg0: tensor<4xf32>) -> tensor<1xf32> {
   //  CHECK-NOT: stablehlo.real_dynamic_slice
   //      CHECK: "stablehlo.slice"(%arg0) {
   // CHECK-SAME:   limit_indices = dense<1> : tensor<1xi64>,

--- a/stablehlo/transforms/StablehloCanonicalizeDynamism.cpp
+++ b/stablehlo/transforms/StablehloCanonicalizeDynamism.cpp
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -33,6 +34,44 @@ namespace stablehlo {
 #include "stablehlo/transforms/Passes.h.inc"
 
 namespace {
+
+struct CanonicalizeCustomCallOpPattern : public OpRewritePattern<CustomCallOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(CustomCallOp op,
+                                PatternRewriter& rewriter) const override {
+    SmallVector<ShapedTypeComponents> refinements;
+    if (failed(hlo::getShapeRefinements(op.getLoc(), op, refinements)))
+      return rewriter.notifyMatchFailure(op, "expected shape refinements");
+    auto indicesAttr =
+        op->getAttr("indices_of_shape_operands").cast<DenseIntElementsAttr>();
+    DenseSet<int64_t> indices(indicesAttr.value_begin<int64_t>(),
+                              indicesAttr.value_end<int64_t>());
+
+    // Discard the indices_of_shape_operands attribute.
+    // We rely on the verification logic implemented in getShapeRefinements to
+    // make sure that its value are consistent with the result type.
+    // In the future, when we upgrade indices_of_shape_operands from an
+    // experiment to a full-fledged StableHLO feature, this logic will be moved
+    // to a proper verifier.
+    SmallVector<NamedAttribute> newAttrs;
+    for (auto attr : op->getAttrs()) {
+      if (attr.getName() == "indices_of_shape_operands") continue;
+      newAttrs.push_back(attr);
+    }
+
+    // Discard the operands that correspond to indices_of_shape_operands.
+    // Similarly, we rely on the verification logic implemented in
+    // getShapeRefinements to make sure that everything checks out.
+    SmallVector<Value> newOperands;
+    for (auto& operand : op->getOpOperands()) {
+      if (indices.contains(operand.getOperandNumber())) continue;
+      newOperands.push_back(operand.get());
+    }
+    rewriter.replaceOpWithNewOp<CustomCallOp>(op, op.getResultTypes(),
+                                              newOperands, newAttrs);
+    return success();
+  }
+};
 
 struct CanonicalizeDynamicBroadcastInDimOpPattern
     : public OpRewritePattern<DynamicBroadcastInDimOp> {
@@ -89,6 +128,7 @@ struct CanonicalizeDynamicGatherOpPattern
     return success();
   }
 };
+
 struct CanonicalizeDynamicIotaOpPattern
     : public OpRewritePattern<DynamicIotaOp> {
   using OpRewritePattern::OpRewritePattern;
@@ -230,6 +270,7 @@ struct StablehloCanonicalizeDynamismPass
     config.strictMode = GreedyRewriteStrictness::AnyOp;
 
     RewritePatternSet patterns(&getContext());
+    patterns.add<CanonicalizeCustomCallOpPattern>(&getContext());
     patterns.add<CanonicalizeDynamicBroadcastInDimOpPattern>(&getContext());
     patterns.add<CanonicalizeDynamicConvOpPattern>(&getContext());
     patterns.add<CanonicalizeDynamicGatherOpPattern>(&getContext());

--- a/stablehlo/transforms/StablehloRefineShapes.cpp
+++ b/stablehlo/transforms/StablehloRefineShapes.cpp
@@ -646,7 +646,7 @@ struct RefineCustomCallOpPattern : public OpRewritePattern<CustomCallOp> {
                                 PatternRewriter& rewriter) const override {
     SmallVector<ShapedTypeComponents> refinements;
     if (failed(hlo::getShapeRefinements(op.getLoc(), op, refinements)))
-      return rewriter.notifyMatchFailure(op, "expected shape refinements");
+      return rewriter.notifyMatchFailure(op, "expected valid refinements");
     return refineReturnTypes(rewriter, op, refinements);
   }
 };

--- a/stablehlo/transforms/StablehloRefineShapes.cpp
+++ b/stablehlo/transforms/StablehloRefineShapes.cpp
@@ -644,24 +644,9 @@ struct RefineCustomCallOpPattern : public OpRewritePattern<CustomCallOp> {
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(CustomCallOp op,
                                 PatternRewriter& rewriter) const override {
-    auto operandIndicesAttr = op->getAttr("indices_of_shape_operands")
-                                  .dyn_cast_or_null<DenseIntElementsAttr>();
-    if (!operandIndicesAttr)
-      return rewriter.notifyMatchFailure(
-          op, "expected an indices_of_shape_operands attribute");
-
     SmallVector<ShapedTypeComponents> refinements;
-    for (auto operandIndexElt : operandIndicesAttr.getValues<APInt>()) {
-      int64_t operandIndex = operandIndexElt.getSExtValue();
-      if (operandIndex < 0 || operandIndex >= op->getNumOperands())
-        return rewriter.notifyMatchFailure(op, "expected valid operand index");
-      SmallVector<int64_t> refinement;
-      if (failed(hlo::matchInts(op->getOperand(operandIndex), refinement)))
-        return rewriter.notifyMatchFailure(op, "expected constant operand");
-      if (llvm::any_of(refinement, [&](int64_t x) { return x < 0; }))
-        return rewriter.notifyMatchFailure(op, "expected non-negative sizes");
-      refinements.emplace_back(refinement);
-    }
+    if (failed(hlo::getShapeRefinements(op.getLoc(), op, refinements)))
+      return rewriter.notifyMatchFailure(op, "expected shape refinements");
     return refineReturnTypes(rewriter, op, refinements);
   }
 };


### PR DESCRIPTION
--stablehlo-canonicalize-dynamism can now drop indices_of_shape_operands once they are no longer needed, similarly to how it transforms dynamic_foo ops to foo ops when operands like output_shape are no longer needed.

To make sure that we only do the transformation on valid IR, I also wrote verification logic for indices_of_shape_operands as well as tests for this logic.

In the future, when we upgrade indices_of_shape_operands from an experiment to a full-fledged StableHLO feature, this logic will be moved to a proper verifier.