### PR TITLE
Audit casts to ShapedType and TensorType

### DIFF
--- a/stablehlo/dialect/AssemblyFormat.cpp
+++ b/stablehlo/dialect/AssemblyFormat.cpp
@@ -175,9 +175,9 @@ ParseResult parseVariadicOperandWithAttribute(
 // Operation Printers and Parsers
 //===----------------------------------------------------------------------===//
 
-void printComplexOpType(OpAsmPrinter& p, Operation* op, Type lhs, Type rhs,
-                        Type result) {
-  Type realType = createRealType(result.cast<TensorType>());
+void printComplexOpType(OpAsmPrinter& p, Operation* op, ShapedType lhs,
+                        ShapedType rhs, ShapedType result) {
+  Type realType = createRealType(result);
 
   if (lhs != realType || rhs != realType) {
     p.printFunctionalType(op);
@@ -198,19 +198,20 @@ ParseResult parseComplexOpType(OpAsmParser& parser, Type& lhs, Type& rhs,
     return assignFromFunctionType(parser, loc, {&lhs, &rhs}, result, fnType);
 
   // Otherwise, operand type is inferred from complex type
-  auto tensorType = type.dyn_cast<TensorType>();
-  if (!tensorType || !tensorType.getElementType().isa<ComplexType>())
+  auto shapedType = type.dyn_cast<ShapedType>();
+  if (!shapedType || !shapedType.getElementType().isa<ComplexType>())
     return parser.emitError(loc, "expected tensor with complex element type");
 
   // Assign LHS and RHS to inferred type
-  Type realType = createRealType(type.cast<TensorType>());
+  Type realType = createRealType(type);
   lhs = rhs = realType;
   result = type;
   return success();
 }
 
-void printSelectOpType(OpAsmPrinter& p, Operation* op, Type pred, Type onTrue,
-                       Type onFalse, Type result) {
+void printSelectOpType(OpAsmPrinter& p, Operation* op, ShapedType pred,
+                       ShapedType onTrue, ShapedType onFalse,
+                       ShapedType result) {
   // Print functional type if true/false branches don't match return type.
   if (onTrue != result || onFalse != result) {
     p.printFunctionalType(op);

--- a/stablehlo/dialect/AssemblyFormat.h
+++ b/stablehlo/dialect/AssemblyFormat.h
@@ -148,8 +148,8 @@ ParseResult parseVariadicOperandWithAttribute(
 //    %0 : tensor<4xcomplex<f32>>
 //    %1 : tensor<4xf32>
 //    %2 : tensor<4xf32>
-void printComplexOpType(OpAsmPrinter& p, Operation* op, Type lhs, Type rhs,
-                        Type result);
+void printComplexOpType(OpAsmPrinter& p, Operation* op, ShapedType lhs,
+                        ShapedType rhs, ShapedType result);
 
 ParseResult parseComplexOpType(OpAsmParser& parser, Type& lhs, Type& rhs,
                                Type& result);
@@ -163,8 +163,9 @@ ParseResult parseComplexOpType(OpAsmParser& parser, Type& lhs, Type& rhs,
 //    %1 : tensor<2xi32>
 //    %2 : tensor<2xi32>
 //    %3 : tensor<2xi32>
-void printSelectOpType(OpAsmPrinter& p, Operation* op, Type pred, Type onTrue,
-                       Type onFalse, Type result);
+void printSelectOpType(OpAsmPrinter& p, Operation* op, ShapedType pred,
+                       ShapedType onTrue, ShapedType onFalse,
+                       ShapedType result);
 
 ParseResult parseSelectOpType(OpAsmParser& parser, Type& pred, Type& onTrue,
                               Type& onFalse, Type& result);

--- a/stablehlo/dialect/Base.h
+++ b/stablehlo/dialect/Base.h
@@ -141,12 +141,12 @@ LogicalResult deriveShapeFromOperand(
     SmallVectorImpl<Value> *reifiedReturnShapes);
 
 // Type derivation function that returns a tensor type with a new element type.
-TensorType getSameShapeTensorType(TensorType tensorType, Type elementType);
+ShapedType getSameShapeTensorType(ShapedType shapedType, Type elementType);
 
 // Takes a tensor type that may have complex elements and returns a type that
 // maintains the shape, but with real numeric data types.
 //   Ex: tensor<4xcomplex<f32>>  -->  tensor<4xf32>
-Type createRealType(TensorType type);
+ShapedType createRealType(ShapedType type);
 
 // Verify bounds expressed by HLO_BoundedAttrInterface against the provided
 // type. See documentation for HLO_BoundedAttrInterface for the list of checks.
@@ -305,7 +305,9 @@ class CompatibleOperandsAndResultType
     if (failed(inferReturnTypes(context, location, operands.getValues(),
                                 attributes, regions, inferredReturnTypes)))
       return failure();
-    auto inferredReturnType = inferredReturnTypes[0].cast<ShapedType>();
+    if (inferredReturnTypes.size() != 1) return failure();
+    auto inferredReturnType = inferredReturnTypes[0].dyn_cast<ShapedType>();
+    if (!inferredReturnType) return failure();
     inferredReturnShapes.push_back(inferredReturnType);
     return success();
   }

--- a/stablehlo/dialect/ChloOps.cpp
+++ b/stablehlo/dialect/ChloOps.cpp
@@ -190,7 +190,7 @@ LogicalResult BroadcastComplexOp::inferReturnTypeComponents(
     ValueShapeRange operands, DictionaryAttr attributes,
     RegionRange /*regions*/,
     SmallVectorImpl<ShapedTypeComponents>& inferedReturnShapes) {
-  ShapedType lhsType = operands[0].getType().cast<ShapedType>();
+  ShapedType lhsType = operands[0].getType();
   Type elementType = ComplexType::get(lhsType.getElementType());
   return InferBroadcastBinaryOpReturnTypeComponents(context, location, operands,
                                                     attributes, elementType,
@@ -242,7 +242,7 @@ LogicalResult BroadcastCompareOp::reifyReturnTypeShapes(
 
 static Type getIsInfLikeReturnType(Value operand) {
   Builder b(operand.getContext());
-  return hlo::getSameShapeTensorType(operand.getType().cast<TensorType>(),
+  return hlo::getSameShapeTensorType(operand.getType().cast<ShapedType>(),
                                      b.getI1Type());
 }
 
@@ -318,7 +318,7 @@ BROADCAST_BINARY_OP_DEFS(BroadcastZetaOp)
 #undef BROADCAST_BINARY_OP_DEFS
 
 LogicalResult ConstantLikeOp::verify() {
-  if (getValue().getType() != getType().cast<ShapedType>().getElementType())
+  if (getValue().getType() != getType().getElementType())
     return emitOpError() << "value's type doesn't match element return type";
   return success();
 }
@@ -366,7 +366,7 @@ LogicalResult ConstantLikeOp::reifyReturnTypeShapes(
 }
 
 OpFoldResult ConstantLikeOp::fold(FoldAdaptor /*adaptor*/) {
-  auto opType = getOperand().getType().cast<ShapedType>();
+  auto opType = getOperand().getType();
   if (!opType.hasStaticShape()) return {};
   auto type = RankedTensorType::get(opType.getShape(), getValue().getType());
   if (auto complexAttr = getValue().dyn_cast<complex::NumberAttr>())

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -226,7 +226,7 @@ OpFoldResult ConstantOp::fold(FoldAdaptor adaptor) {
 // Builds a constant op with the specified attribute `value`.
 void ConstantOp::build(OpBuilder& /*builder*/, OperationState& result,
                        Attribute value) {
-  Type type;
+  ShapedType type;
   if (auto elemAttr = value.dyn_cast<ElementsAttr>()) {
     type = elemAttr.getType();
   } else if (value.isa<BoolAttr, FloatAttr, IntegerAttr>()) {
@@ -235,12 +235,11 @@ void ConstantOp::build(OpBuilder& /*builder*/, OperationState& result,
     // need to wrap it up with ElementsAttr to construct valid XLA constants.
     type =
         RankedTensorType::get(/*shape=*/{}, value.cast<TypedAttr>().getType());
-    value = DenseElementsAttr::get(type.cast<TensorType>(), value);
+    value = DenseElementsAttr::get(type, value);
   } else if (auto complexAttr = value.dyn_cast<complex::NumberAttr>()) {
     type = RankedTensorType::get(/*shape=*/{},
                                  complexAttr.cast<TypedAttr>().getType());
-    value =
-        DenseElementsAttr::get(type.cast<TensorType>(), complexAttr.getValue());
+    value = DenseElementsAttr::get(type, complexAttr.getValue());
   }
 
   // TODO: support other XLA specific types.
@@ -260,8 +259,9 @@ LogicalResult ConstantOp::inferReturnTypes(
 
 bool ConstantOp::isCompatibleReturnTypes(TypeRange l, TypeRange r) {
   if (l.size() != r.size() || l.size() != 1) return false;
-  auto lhsTy = l.front().cast<TensorType>();
-  auto rhsTy = r.front().cast<TensorType>();
+  auto lhsTy = l.front().dyn_cast<ShapedType>();
+  auto rhsTy = r.front().dyn_cast<ShapedType>();
+  if (!lhsTy || !rhsTy) return false;
   // For comparisons of the uniform quantized element based tensor type, use the
   // storage type since the constant value will be stored through the underlying
   // storage type.
@@ -359,11 +359,11 @@ LogicalResult CustomCallOp::verify() {
         if (type.isa<TupleType>())
           return emitOpError() << "Tuple types are not fully supported with "
                                   "layout constraints yet";
-        auto tensorType = type.dyn_cast<TensorType>();
+        auto shapedType = type.dyn_cast<ShapedType>();
 
         // For non-tensor types such as !stablehlo.token, the layout should be
         // empty.
-        if (!tensorType) {
+        if (!shapedType) {
           if (layout.empty()) continue;
           return emitOpError()
                  << "Only tensor types can have non-empty layout: " << valueName
@@ -373,18 +373,18 @@ LogicalResult CustomCallOp::verify() {
 
         // For unranked tensors, we cannot verify the compatibility with layout
         // any further.
-        if (!tensorType.hasRank()) continue;
+        if (!shapedType.hasRank()) continue;
 
         // Layout must be a permutation of [0, N) where N is the rank of the
         // tensor type.
-        std::vector<int64_t> range(tensorType.getRank());
+        std::vector<int64_t> range(shapedType.getRank());
         std::iota(range.begin(), range.end(), 0);
-        if (tensorType.getRank() != layout.size() ||
+        if (shapedType.getRank() != layout.size() ||
             !std::is_permutation(range.begin(), range.end(), layout.begin()))
           return emitOpError()
                  << "incorrect layout " << layout << " for type " << type
                  << ", layout must be a permutation of [0, "
-                 << tensorType.getRank() << ")";
+                 << shapedType.getRank() << ")";
       }
       return success();
     };
@@ -552,8 +552,8 @@ LogicalResult DotGeneralOp::verify() {
 LogicalResult DotGeneralOp::reifyReturnTypeShapes(
     OpBuilder& builder, ValueRange operands,
     SmallVectorImpl<Value>& reifiedReturnShapes) {
-  auto lhsType = getLhs().getType().cast<ShapedType>();
-  auto rhsType = getRhs().getType().cast<ShapedType>();
+  auto lhsType = getLhs().getType();
+  auto rhsType = getRhs().getType();
   if (!lhsType.hasRank() || !rhsType.hasRank()) return failure();
 
   Adaptor adaptor(operands);
@@ -1465,7 +1465,7 @@ static bool isEligibleForCompactPrint(ReduceOp op) {
   if (op.getInputs().empty()) return false;
 
   auto elemType =
-      op.getInputs()[0].getType().cast<TensorType>().getElementType();
+      op.getInputs()[0].getType().cast<ShapedType>().getElementType();
   auto expectedInnerOpType = RankedTensorType::get(/*shape=*/{}, elemType);
   if (innerOp.getOperands()[0].getType() != expectedInnerOpType) return false;
 
@@ -3348,8 +3348,8 @@ static void buildSortComparisonBody(llvm::ArrayRef<Type> elementTypes,
   Block* block = builder->createBlock(body);
   // Add two arguments for each element type.
   for (Type elementType : elementTypes) {
-    TensorType tensorType = RankedTensorType::get({}, elementType);
-    block->addArguments({tensorType, tensorType},
+    ShapedType shapedType = RankedTensorType::get({}, elementType);
+    block->addArguments({shapedType, shapedType},
                         SmallVector<Location, 2>(2, loc));
   }
 

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -103,8 +103,7 @@ bool tensorsHaveSameElType(Type type1, Type type2,
 bool compatibleShapeAndElementType(Type type1, Type type2,
                                    bool ignoreFpPrecision = false) {
   if (failed(verifyCompatibleShape(type1, type2))) return false;
-  return tensorsHaveSameElType(type1.cast<ShapedType>(),
-                               type2.cast<ShapedType>(), ignoreFpPrecision);
+  return tensorsHaveSameElType(type1, type2, ignoreFpPrecision);
 }
 
 bool verifyCompatibleDims(int64_t dimSize1, int64_t dimSize2) {
@@ -455,8 +454,8 @@ LogicalResult verifyReplicaGroups(std::optional<Location> location,
 }
 
 LogicalResult verifyReduceOpInputsAndInferShape(
-    std::optional<Location> location, SmallVector<TensorType> inputArgTypes,
-    SmallVector<TensorType> initValueTypes, DenseIntElementsAttr dimensions,
+    std::optional<Location> location, SmallVector<ShapedType> inputArgTypes,
+    SmallVector<ShapedType> initValueTypes, DenseIntElementsAttr dimensions,
     SmallVector<int64_t>& newDimensions, Attribute& encoding) {
   // Check for unranked tensors in input operands.
   uint64_t numInputs = inputArgTypes.size();
@@ -515,8 +514,8 @@ LogicalResult verifyReduceOpInputsAndInferShape(
 
 // TODO(zhouxin) remove args `allInputsUnranked` and `numInputs`
 LogicalResult verifyReducerShape(std::optional<Location> loc, Block& block,
-                                 ArrayRef<TensorType> inputArgTypes,
-                                 ArrayRef<TensorType> initValueTypes,
+                                 ArrayRef<ShapedType> inputArgTypes,
+                                 ArrayRef<ShapedType> initValueTypes,
                                  int64_t numInputs,
                                  ArrayRef<int64_t> allowedDimensions,
                                  bool allInputsUnranked) {
@@ -541,17 +540,17 @@ LogicalResult verifyReducerShape(std::optional<Location> loc, Block& block,
                              block.getTerminator()->getOperands().size(),
                              " instead");
 
-  SmallVector<TensorType> accumulatorSubShapes;
+  SmallVector<ShapedType> accumulatorSubShapes;
   for (Value retOperand : block.getTerminator()->getOperands()) {
-    auto tensorTy = retOperand.getType().dyn_cast<TensorType>();
-    if (!tensorTy)
+    auto shapedTy = retOperand.getType().dyn_cast<ShapedType>();
+    if (!shapedTy)
       return emitOptionalError(loc,
                                "Reduction-region here must produce "
                                "tensor-typed result(s), but "
                                "produces ",
                                retOperand.getType(), " instead");
 
-    accumulatorSubShapes.push_back(tensorTy);
+    accumulatorSubShapes.push_back(shapedTy);
   }
 
   // Consider typical reduce-* op syntax:
@@ -627,7 +626,7 @@ LogicalResult verifyReducerShape(std::optional<Location> loc, Block& block,
 
     // Check C4.2.
     Type blockArgType = block.getArgument(numInputs + inputIdx).getType();
-    auto blockArgTensorTy = blockArgType.cast<TensorType>();
+    auto blockArgTensorTy = blockArgType.cast<ShapedType>();
 
     if (allInputsUnranked || !blockArgTensorTy.hasRank()) return success();
 
@@ -661,8 +660,8 @@ LogicalResult verifyReducerShape(std::optional<Location> loc, Block& block,
 }
 
 LogicalResult verifyReduceWindowOpInputsAndInferWindow(
-    std::optional<Location> location, SmallVector<TensorType> inputArgTypes,
-    SmallVector<TensorType> initValueTypes,
+    std::optional<Location> location, SmallVector<ShapedType> inputArgTypes,
+    SmallVector<ShapedType> initValueTypes,
     DenseIntElementsAttr windowDimensions,
     std::optional<DenseIntElementsAttr> windowStrides,
     std::optional<DenseIntElementsAttr> baseDilations,
@@ -1416,7 +1415,7 @@ LogicalResult inferAllToAllOp(
   auto operandRankedType = operandType.dyn_cast<RankedTensorType>();
   if (!operandRankedType) {
     inferredReturnShapes.emplace_back(
-        operandType.cast<TensorType>().getElementType());
+        operandType.cast<ShapedType>().getElementType());
     return success();
   }
 
@@ -1527,7 +1526,7 @@ LogicalResult inferCholeskyOp(
   RankedTensorType aRankedType = aType.dyn_cast<RankedTensorType>();
   if (!aRankedType) {
     inferredReturnShapes.emplace_back(
-        aType.cast<TensorType>().getElementType());
+        aType.cast<ShapedType>().getElementType());
     return success();
   }
 
@@ -1587,7 +1586,7 @@ LogicalResult inferCompareOp(
   // compare_c1
   ShapedTypeComponents& components =
       inferredReturnShapes.emplace_back(IntegerType::get(context, /*width=*/1));
-  auto argTy = lhs.getType().cast<TensorType>();
+  auto argTy = lhs.getType().cast<ShapedType>();
   // compare_c2
   if (argTy.hasRank())
     components =
@@ -1597,7 +1596,7 @@ LogicalResult inferCompareOp(
 
 LogicalResult inferComplexOp(std::optional<Location> location, Value lhs,
                              SmallVectorImpl<Type>& inferredReturnTypes) {
-  TensorType operandType = lhs.getType().cast<TensorType>();
+  ShapedType operandType = lhs.getType().cast<ShapedType>();
   ComplexType elementTy = ComplexType::get(operandType.getElementType());
   inferredReturnTypes.push_back(getSameShapeTensorType(operandType, elementTy));
   return success();
@@ -2168,7 +2167,7 @@ LogicalResult inferFftOp(
   // IFFT : C -> C
   // RFFT : R -> C
   // IRFFT : C -> R
-  auto operandType = operand.getType().cast<TensorType>();
+  auto operandType = operand.getType().cast<ShapedType>();
   Type operandElementType = operandType.getElementType();
   // Check the input element type and infer return element type
   if (isFftTypeRfft) {
@@ -2331,14 +2330,14 @@ LogicalResult inferImagOp(std::optional<Location> location, Value operand,
                           SmallVectorImpl<Type>& inferredReturnTypes) {
   // imag_c2
   inferredReturnTypes.push_back(
-      createRealType(operand.getType().cast<TensorType>()));
+      createRealType(operand.getType().cast<ShapedType>()));
   return success();
 }
 
 LogicalResult inferIsFiniteOp(MLIRContext* context, std::optional<Location>,
                               Value x,
                               SmallVectorImpl<Type>& inferredReturnTypes) {
-  auto argTy = x.getType().cast<TensorType>();
+  auto argTy = x.getType().cast<ShapedType>();
   Builder b(context);
   inferredReturnTypes.push_back(getSameShapeTensorType(argTy, b.getI1Type()));
   return success();
@@ -2377,7 +2376,7 @@ LogicalResult inferMapOp(
           indexedArg.index(), " of type ", indexedArg.value().getType());
     auto operandElemTy = inputs[indexedArg.index()]
                              .getType()
-                             .cast<TensorType>()
+                             .cast<ShapedType>()
                              .getElementType();
     if (argType.getElementType() != operandElemTy)
       return emitOptionalError(location,
@@ -2420,7 +2419,7 @@ LogicalResult inferMapOp(
   ArrayRef<int64_t> resultShape;
   bool allInputsUnranked = true;
   for (auto operand : inputs) {
-    auto operandType = operand.getType().cast<TensorType>();
+    auto operandType = operand.getType().cast<ShapedType>();
     if (operandType.hasRank()) {
       if (dimensions.size() !=
           static_cast<int64_t>(operandType.getShape().size()))
@@ -2542,7 +2541,7 @@ LogicalResult inferRealOp(std::optional<Location>, Value operand,
                           SmallVectorImpl<Type>& inferredReturnTypes) {
   // real_c2
   inferredReturnTypes.push_back(
-      createRealType(operand.getType().cast<TensorType>()));
+      createRealType(operand.getType().cast<ShapedType>()));
   return success();
 }
 
@@ -2550,11 +2549,10 @@ LogicalResult inferReduceOp(
     std::optional<Location> location, TypeRange inputTypes,
     TypeRange initValueTypes, DenseIntElementsAttr dimensions,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
-  SmallVector<TensorType> inputArgTensorTypes{llvm::map_range(
-      inputTypes, [](Type t) -> TensorType { return t.cast<TensorType>(); })};
-  SmallVector<TensorType> initValueTensorTypes{llvm::map_range(
-      initValueTypes,
-      [](Type t) -> TensorType { return t.cast<TensorType>(); })};
+  SmallVector<ShapedType> inputArgTensorTypes{
+      llvm::map_range(inputTypes, [](Type t) { return t.cast<ShapedType>(); })};
+  SmallVector<ShapedType> initValueTensorTypes{llvm::map_range(
+      initValueTypes, [](Type t) { return t.cast<ShapedType>(); })};
 
   SmallVector<int64_t> newDimensions;
   Attribute encoding;
@@ -2564,7 +2562,7 @@ LogicalResult inferReduceOp(
     return failure();
 
   for (uint64_t inputIdx = 0; inputIdx < inputTypes.size(); ++inputIdx) {
-    TensorType inputType = inputArgTensorTypes[inputIdx];
+    ShapedType inputType = inputArgTensorTypes[inputIdx];
     Type elementType = inputType.getElementType();
     if (inputType.hasRank())
       inferredReturnShapes.emplace_back(newDimensions, elementType, encoding);
@@ -2583,12 +2581,10 @@ LogicalResult inferReduceWindowOp(
     std::optional<DenseIntElementsAttr> windowDilations,
     std::optional<DenseIntElementsAttr> padding,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
-  SmallVector<TensorType> inputArgTypes{llvm::map_range(
-      inputs.getTypes(),
-      [](Type t) -> TensorType { return t.cast<TensorType>(); })};
-  SmallVector<TensorType> initValueTypes{llvm::map_range(
-      initValues.getTypes(),
-      [](Type t) -> TensorType { return t.cast<TensorType>(); })};
+  SmallVector<ShapedType> inputArgTypes{llvm::map_range(
+      inputs.getTypes(), [](Type t) { return t.cast<ShapedType>(); })};
+  SmallVector<ShapedType> initValueTypes{llvm::map_range(
+      initValues.getTypes(), [](Type t) { return t.cast<ShapedType>(); })};
 
   SmallVector<int64_t> windowDims;
   SmallVector<WindowDimension> inferredWindow;
@@ -2640,8 +2636,8 @@ LogicalResult inferRngOp(
     bool isRngDistributionUniform,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   if (!isRngDistributionUniform) {
-    auto muTy = a.getType().cast<TensorType>().getElementType();
-    auto sigmaTy = b.getType().cast<TensorType>().getElementType();
+    auto muTy = a.getType().cast<ShapedType>().getElementType();
+    auto sigmaTy = b.getType().cast<ShapedType>().getElementType();
     if (!muTy.isa<FloatType>() || !sigmaTy.isa<FloatType>())
       return emitOptionalError(location, "mu and sigma must be floats");
   }
@@ -2734,7 +2730,7 @@ LogicalResult inferSetDimensionSizeOp(
   auto inputType = operandType.dyn_cast<RankedTensorType>();
   if (!inputType) {
     inferredReturnShapes.emplace_back(
-        operandType.cast<TensorType>().getElementType());
+        operandType.cast<ShapedType>().getElementType());
     return success();
   }
   int64_t rank = inputType.getRank();
@@ -3067,7 +3063,7 @@ LogicalResult verifyAllReduceOp(std::optional<Location> location, Value operand,
                                  /*expectedGroupSize=*/std::nullopt)))
     return failure();
 
-  auto operandType = operand.getType().cast<TensorType>();
+  auto operandType = operand.getType().cast<ShapedType>();
   bool operandTypeRanked = operandType.isa<RankedTensorType>();
   Block& block = computation.front();
   if (failed(verifyReducerShape(
@@ -3091,23 +3087,23 @@ LogicalResult verifyAllReduceOp(std::optional<Location> location, Value operand,
  */
 LogicalResult verifyBitcastConvertOp(std::optional<Location> location,
                                      Value operand, Value result) {
-  auto operandTensorType = operand.getType().cast<TensorType>();
-  auto targetTensorType = result.getType().cast<TensorType>();
+  auto operandShapedType = operand.getType().cast<ShapedType>();
+  auto targetShapedType = result.getType().cast<ShapedType>();
 
   // P1.
-  auto targetElt = targetTensorType.getElementType();
-  auto operandElt = operandTensorType.getElementType();
+  auto targetElt = targetShapedType.getElementType();
+  auto operandElt = operandShapedType.getElementType();
   if (targetElt.isa<ComplexType>() != operandElt.isa<ComplexType>())
     return emitOptionalError(
         location, "cannot convert between real and complex types, but got: ",
-        operandTensorType, " and ", targetTensorType);
+        operandShapedType, " and ", targetShapedType);
 
   auto targetEltBitwidth = potentiallyComplexBitwidth(targetElt);
   auto operandEltBitwidth = potentiallyComplexBitwidth(operandElt);
 
   // P2.
-  auto operandType = operandTensorType.dyn_cast<RankedTensorType>();
-  auto targetType = targetTensorType.dyn_cast<RankedTensorType>();
+  auto operandType = operandShapedType.dyn_cast<RankedTensorType>();
+  auto targetType = targetShapedType.dyn_cast<RankedTensorType>();
   if (!operandType || !targetType) return success();
 
   auto targetShape = targetType.getShape();
@@ -3624,12 +3620,10 @@ LogicalResult verifyRecvOp(HloDialectInterface* dialect,
 LogicalResult verifyReduceOp(std::optional<Location> location,
                              ValueRange inputs, ValueRange initValues,
                              DenseIntElementsAttr dimensions, Region& body) {
-  SmallVector<TensorType> inputArgTypes{llvm::map_range(
-      inputs.getTypes(),
-      [](Type t) -> TensorType { return t.cast<TensorType>(); })};
-  SmallVector<TensorType> initValueTypes{llvm::map_range(
-      initValues.getTypes(),
-      [](Type t) -> TensorType { return t.cast<TensorType>(); })};
+  SmallVector<ShapedType> inputArgTypes{llvm::map_range(
+      inputs.getTypes(), [](Type t) { return t.cast<ShapedType>(); })};
+  SmallVector<ShapedType> initValueTypes{llvm::map_range(
+      initValues.getTypes(), [](Type t) { return t.cast<ShapedType>(); })};
 
   // P1. & P2.
   SmallVector<int64_t> newDimensions;
@@ -3679,7 +3673,7 @@ LogicalResult verifyReduceScatterOp(std::optional<Location> location,
                                  useGlobalDeviceIds,
                                  /*expectedGroupSize=*/std::nullopt)))
     return failure();
-  auto operandType = operand.getType().cast<TensorType>();
+  auto operandType = operand.getType().cast<ShapedType>();
   bool operandTypeRanked = operandType.isa<RankedTensorType>();
   Block& block = computation.front();
   if (failed(verifyReducerShape(
@@ -3748,12 +3742,10 @@ LogicalResult verifyReduceWindowOp(
     std::optional<DenseIntElementsAttr> baseDilations,
     std::optional<DenseIntElementsAttr> windowDilations,
     std::optional<DenseIntElementsAttr> padding, Region& body) {
-  SmallVector<TensorType> inputArgTypes{llvm::map_range(
-      inputs.getTypes(),
-      [](Type t) -> TensorType { return t.cast<TensorType>(); })};
-  SmallVector<TensorType> initValueTypes{llvm::map_range(
-      initValues.getTypes(),
-      [](Type t) -> TensorType { return t.cast<TensorType>(); })};
+  SmallVector<ShapedType> inputArgTypes{llvm::map_range(
+      inputs.getTypes(), [](Type t) { return t.cast<ShapedType>(); })};
+  SmallVector<ShapedType> initValueTypes{llvm::map_range(
+      initValues.getTypes(), [](Type t) { return t.cast<ShapedType>(); })};
   uint64_t numInputs = inputs.size();
 
   // P1. ~ P3.
@@ -3870,12 +3862,12 @@ LogicalResult verifyScatterOp(std::optional<Location> location,
   // Get the first operand and update, since variadic Scatter is not yet
   // implemented
   auto numOperands = inputs.size();
-  auto scatterIndicesType = scatterIndices.getType().dyn_cast<TensorType>();
+  auto scatterIndicesType = scatterIndices.getType().cast<ShapedType>();
 
-  SmallVector<TensorType, 1> operandTypes = llvm::to_vector(llvm::map_range(
-      inputs.getTypes(), [](Type type) { return type.cast<TensorType>(); }));
-  SmallVector<TensorType, 1> updatesTypes = llvm::to_vector(llvm::map_range(
-      updates.getTypes(), [](Type type) { return type.cast<TensorType>(); }));
+  SmallVector<ShapedType, 1> operandTypes = llvm::to_vector(llvm::map_range(
+      inputs.getTypes(), [](Type type) { return type.cast<ShapedType>(); }));
+  SmallVector<ShapedType, 1> updatesTypes = llvm::to_vector(llvm::map_range(
+      updates.getTypes(), [](Type type) { return type.cast<ShapedType>(); }));
   bool allOperandTypesRanked = llvm::all_of(inputs.getTypes(), [](Type type) {
     return type.isa<RankedTensorType>();
   });
@@ -3893,7 +3885,7 @@ LogicalResult verifyScatterOp(std::optional<Location> location,
   }
   // P2.
   Block& block = updateComputation.front();
-  SmallVector<TensorType> inputTypes, initValueTypes;
+  SmallVector<ShapedType> inputTypes, initValueTypes;
   for (int64_t i = 0; i < static_cast<int64_t>(numOperands); i++) {
     inputTypes.push_back(operandTypes[i]);
     initValueTypes.push_back(
@@ -4029,9 +4021,9 @@ LogicalResult verifySelectAndScatterOp(
     std::optional<DenseIntElementsAttr> windowStrides,
     std::optional<DenseIntElementsAttr> padding, Region& select,
     Region& scatter) {
-  auto operandType = operand.getType().cast<TensorType>();
-  auto initValueType = initValue.getType().cast<TensorType>();
-  auto sourceType = source.getType().cast<TensorType>();
+  auto operandType = operand.getType().cast<ShapedType>();
+  auto initValueType = initValue.getType().cast<ShapedType>();
+  auto sourceType = source.getType().cast<ShapedType>();
 
   // P1.
   Block& selectBlock = select.front();
@@ -4058,7 +4050,7 @@ LogicalResult verifySelectAndScatterOp(
         location, "expects select-region to return single value, but got: ",
         selectResult.size());
 
-  auto selectResultType = selectResult[0].getType().dyn_cast<TensorType>();
+  auto selectResultType = selectResult[0].getType().dyn_cast<ShapedType>();
   if (!selectResultType || !selectResultType.getElementType().isInteger(1) ||
       (selectResultType.hasRank() &&
        selectResultType.cast<RankedTensorType>().getRank() != 0))
@@ -4106,7 +4098,7 @@ LogicalResult verifySelectAndScatterOp(
   if (failed(windowOrErr)) return failure();
 
   // P5.
-  TensorType windowResultType;
+  ShapedType windowResultType;
   if (!operandType.hasRank())
     windowResultType = UnrankedTensorType::get(operandType.getElementType());
   else
@@ -4149,12 +4141,12 @@ LogicalResult verifySortOp(std::optional<Location> location, ValueRange inputs,
     int index = indexedOperandType.index();
     Type elementType =
         indexedOperandType.value().cast<ShapedType>().getElementType();
-    Type tensorType = RankedTensorType::get({}, elementType);
+    Type shapedType = RankedTensorType::get({}, elementType);
     for (int i : {2 * index, 2 * index + 1}) {
       Type argType = block.getArgument(i).getType();
-      if (argType != tensorType)
+      if (argType != shapedType)
         return emitOptionalError(location, "comparator block argument #", i,
-                                 " should be of type ", tensorType, " but got ",
+                                 " should be of type ", shapedType, " but got ",
                                  argType);
     }
   }
@@ -4165,7 +4157,7 @@ LogicalResult verifySortOp(std::optional<Location> location, ValueRange inputs,
     return emitOptionalError(location,
                              "comparator must return single output but got ",
                              comparatorResult.size());
-  auto comparatorResultType = comparatorResult[0].getType().cast<TensorType>();
+  auto comparatorResultType = comparatorResult[0].getType().cast<ShapedType>();
   if ((comparatorResultType.hasRank() && comparatorResultType.getRank() != 0) ||
       !comparatorResultType.getElementType().isInteger(1))
     return emitOptionalError(location,
@@ -4205,7 +4197,7 @@ LogicalResult verifyWhileOp(std::optional<Location> location,
         location, "expect condition body returns a single value but got ",
         condReturnTypes.size());
   // while_c1
-  auto operandType = condReturnTypes[0].cast<TensorType>();
+  auto operandType = condReturnTypes[0].cast<ShapedType>();
   if ((operandType.hasRank() && operandType.getRank() != 0) ||
       !operandType.getElementType().isInteger(1))
     return emitOptionalError(

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -302,21 +302,21 @@ SmallVector<Tensor> eval(
   llvm::report_fatal_error("Expected a terminator when evaluating a region");
 }
 
-Tensor evalAbsOp(const Tensor &operand, TensorType resultType) {
+Tensor evalAbsOp(const Tensor &operand, ShapedType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, abs(operand.get(*it)));
   return result;
 }
 
-Tensor evalAddOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType) {
+Tensor evalAddOp(const Tensor &lhs, const Tensor &rhs, ShapedType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, lhs.get(*it) + rhs.get(*it));
   return result;
 }
 
-Tensor evalAndOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType) {
+Tensor evalAndOp(const Tensor &lhs, const Tensor &rhs, ShapedType resultType) {
   Tensor result(resultType);
   for (auto it = lhs.index_begin(); it != lhs.index_end(); ++it)
     result.set(*it, lhs.get(*it) & rhs.get(*it));
@@ -324,7 +324,7 @@ Tensor evalAndOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType) {
 }
 
 Tensor evalBroadcastInDimOp(const Tensor &operand, Axes broadcastDimensions,
-                            TensorType resultType) {
+                            ShapedType resultType) {
   Tensor result(resultType);
   auto operandShape = operand.getShape();
   for (auto resultIt = result.index_begin(); resultIt != result.index_end();
@@ -346,7 +346,7 @@ SmallVector<Tensor> evalCaseOp(const Tensor &index, RegionRange branches,
   return eval(*branches[idx], {}, &scope);
 }
 
-Tensor evalCeilOp(const Tensor &operand, TensorType resultType) {
+Tensor evalCeilOp(const Tensor &operand, ShapedType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, ceil(operand.get(*it)));
@@ -354,7 +354,7 @@ Tensor evalCeilOp(const Tensor &operand, TensorType resultType) {
 }
 
 Tensor evalClampOp(const Tensor &min, const Tensor &operand, const Tensor &max,
-                   TensorType resultType) {
+                   ShapedType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
     Element minElement = min.getRank() != 0 ? min.get(*it) : min.get({});
@@ -367,7 +367,7 @@ Tensor evalClampOp(const Tensor &min, const Tensor &operand, const Tensor &max,
 
 Tensor evalCompareOp(const Tensor &lhs, const Tensor &rhs,
                      ComparisonDirection comparisonDirection,
-                     TensorType resultType) {
+                     ShapedType resultType) {
   Tensor result(resultType);
   auto elementTy = lhs.getElementType();
 
@@ -410,7 +410,7 @@ Tensor evalCompareOp(const Tensor &lhs, const Tensor &rhs,
 }
 
 Tensor evalConcatenateOp(ArrayRef<Tensor> inputs, Axis dimension,
-                         TensorType resultType) {
+                         ShapedType resultType) {
   Tensor result(resultType);
   int64_t dimensionOffset = 0;
   for (const auto &input : inputs) {
@@ -431,7 +431,7 @@ Tensor evalConstantOp(ElementsAttr value) {
 
 // This is an simplified implementation of convert op semantics dealing only
 // with integer to bool conversion. To be updated as part of #969.
-Tensor evalConvertOp(const Tensor &operand, TensorType resultType) {
+Tensor evalConvertOp(const Tensor &operand, ShapedType resultType) {
   Tensor result(resultType);
   Type elementType = result.getElementType();
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
@@ -440,14 +440,14 @@ Tensor evalConvertOp(const Tensor &operand, TensorType resultType) {
   return result;
 }
 
-Tensor evalCosineOp(const Tensor &operand, TensorType resultType) {
+Tensor evalCosineOp(const Tensor &operand, ShapedType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, cosine(operand.get(*it)));
   return result;
 }
 
-Tensor evalClzOp(const Tensor &operand, TensorType resultType) {
+Tensor evalClzOp(const Tensor &operand, ShapedType resultType) {
   Tensor result(resultType);
   for (auto resultIt = result.index_begin(); resultIt != result.index_end();
        ++resultIt) {
@@ -461,7 +461,7 @@ Tensor evalClzOp(const Tensor &operand, TensorType resultType) {
 }
 
 Tensor evalDivideOp(const Tensor &lhs, const Tensor &rhs,
-                    TensorType resultType) {
+                    ShapedType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, lhs.get(*it) / rhs.get(*it));
@@ -469,7 +469,7 @@ Tensor evalDivideOp(const Tensor &lhs, const Tensor &rhs,
 }
 
 Tensor evalDynamicSliceOp(const Tensor &operand, ArrayRef<Tensor> startIndices,
-                          Sizes sliceSizes, TensorType resultType) {
+                          Sizes sliceSizes, ShapedType resultType) {
   Tensor result(resultType);
   auto adjustedStartIndices =
       clamp(0, evalIndices(startIndices), operand.getShape() - sliceSizes);
@@ -482,7 +482,7 @@ Tensor evalDynamicSliceOp(const Tensor &operand, ArrayRef<Tensor> startIndices,
 
 Tensor evalDynamicUpdateSliceOp(const Tensor &operand, const Tensor &update,
                                 ArrayRef<Tensor> startIndices,
-                                TensorType resultType) {
+                                ShapedType resultType) {
   Tensor result(resultType);
   auto adjustedStartIndices = clamp(0, evalIndices(startIndices),
                                     operand.getShape() - update.getShape());
@@ -495,14 +495,14 @@ Tensor evalDynamicUpdateSliceOp(const Tensor &operand, const Tensor &update,
   return result;
 }
 
-Tensor evalExponentialOp(const Tensor &operand, TensorType resultType) {
+Tensor evalExponentialOp(const Tensor &operand, ShapedType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, exponential(operand.get(*it)));
   return result;
 }
 
-Tensor evalFloorOp(const Tensor &operand, TensorType resultType) {
+Tensor evalFloorOp(const Tensor &operand, ShapedType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, floor(operand.get(*it)));
@@ -515,14 +515,14 @@ SmallVector<Tensor> evalIfOp(const Tensor &pred, Region &trueBranch,
                                         : eval(falseBranch, {}, &scope);
 }
 
-Tensor evalImagOp(const Tensor &operand, TensorType resultType) {
+Tensor evalImagOp(const Tensor &operand, ShapedType resultType) {
   Tensor result(resultType);
   for (auto it = operand.index_begin(); it != operand.index_end(); ++it)
     result.set(*it, imag(operand.get(*it)));
   return result;
 }
 
-Tensor evalIotaOp(Axis iotaDimension, TensorType resultType) {
+Tensor evalIotaOp(Axis iotaDimension, ShapedType resultType) {
   Tensor result(resultType);
   Type elementType = result.getElementType();
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
@@ -544,28 +544,28 @@ Tensor evalIotaOp(Axis iotaDimension, TensorType resultType) {
   return result;
 }
 
-Tensor evalLogOp(const Tensor &operand, TensorType resultType) {
+Tensor evalLogOp(const Tensor &operand, ShapedType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, log(operand.get(*it)));
   return result;
 }
 
-Tensor evalLogisticOp(const Tensor &operand, TensorType resultType) {
+Tensor evalLogisticOp(const Tensor &operand, ShapedType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, logistic(operand.get(*it)));
   return result;
 }
 
-Tensor evalMaxOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType) {
+Tensor evalMaxOp(const Tensor &lhs, const Tensor &rhs, ShapedType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, max(lhs.get(*it), rhs.get(*it)));
   return result;
 }
 
-Tensor evalMinOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType) {
+Tensor evalMinOp(const Tensor &lhs, const Tensor &rhs, ShapedType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, min(lhs.get(*it), rhs.get(*it)));
@@ -573,28 +573,28 @@ Tensor evalMinOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType) {
 }
 
 Tensor evalMultiplyOp(const Tensor &lhs, const Tensor &rhs,
-                      TensorType resultType) {
+                      ShapedType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, lhs.get(*it) * rhs.get(*it));
   return result;
 }
 
-Tensor evalNegOp(const Tensor &operand, TensorType resultType) {
+Tensor evalNegOp(const Tensor &operand, ShapedType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, -operand.get(*it));
   return result;
 }
 
-Tensor evalNotOp(const Tensor &operand, TensorType resultType) {
+Tensor evalNotOp(const Tensor &operand, ShapedType resultType) {
   Tensor result(resultType);
   for (auto it = operand.index_begin(); it != operand.index_end(); ++it)
     result.set(*it, ~operand.get(*it));
   return result;
 }
 
-Tensor evalOrOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType) {
+Tensor evalOrOp(const Tensor &lhs, const Tensor &rhs, ShapedType resultType) {
   Tensor result(resultType);
   for (auto it = lhs.index_begin(); it != lhs.index_end(); ++it)
     result.set(*it, lhs.get(*it) | rhs.get(*it));
@@ -603,7 +603,7 @@ Tensor evalOrOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType) {
 
 Tensor evalPadOp(const Tensor &operand, const Tensor &paddingValue,
                  Sizes edgePaddingLow, Sizes interiorPadding,
-                 TensorType resultType) {
+                 ShapedType resultType) {
   Tensor result(resultType);
   for (auto resultIt = result.index_begin(); resultIt != result.index_end();
        ++resultIt)
@@ -620,28 +620,28 @@ Tensor evalPadOp(const Tensor &operand, const Tensor &paddingValue,
 }
 
 Tensor evalPowerOp(const Tensor &lhs, const Tensor &rhs,
-                   TensorType resultType) {
+                   ShapedType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, power(lhs.get(*it), rhs.get(*it)));
   return result;
 }
 
-Tensor evalRealOp(const Tensor &operand, TensorType resultType) {
+Tensor evalRealOp(const Tensor &operand, ShapedType resultType) {
   Tensor result(resultType);
   for (auto it = operand.index_begin(); it != operand.index_end(); ++it)
     result.set(*it, real(operand.get(*it)));
   return result;
 }
 
-Tensor evalRemOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType) {
+Tensor evalRemOp(const Tensor &lhs, const Tensor &rhs, ShapedType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, rem(lhs.get(*it), rhs.get(*it)));
   return result;
 }
 
-Tensor evalReshapeOp(const Tensor &operand, TensorType resultType) {
+Tensor evalReshapeOp(const Tensor &operand, ShapedType resultType) {
   Tensor result(resultType);
   for (auto resultIt = result.index_begin(), operandIt = operand.index_begin();
        resultIt != result.index_end(); ++resultIt, ++operandIt)
@@ -650,7 +650,7 @@ Tensor evalReshapeOp(const Tensor &operand, TensorType resultType) {
 }
 
 Tensor evalReverseOp(const Tensor &operand, Axes dimensions,
-                     TensorType resultType) {
+                     ShapedType resultType) {
   Tensor result(resultType);
   auto resultShape = result.getShape();
   for (auto resultIt = result.index_begin(); resultIt != result.index_end();
@@ -663,7 +663,7 @@ Tensor evalReverseOp(const Tensor &operand, Axes dimensions,
   return result;
 }
 
-Tensor evalRsqrtOp(const Tensor &operand, TensorType resultType) {
+Tensor evalRsqrtOp(const Tensor &operand, ShapedType resultType) {
   Tensor result(resultType);
   for (auto resultIt = result.index_begin(); resultIt != result.index_end();
        ++resultIt)
@@ -672,7 +672,7 @@ Tensor evalRsqrtOp(const Tensor &operand, TensorType resultType) {
 }
 
 Tensor evalSelectOp(const Tensor &pred, const Tensor &onTrue,
-                    const Tensor &onFalse, TensorType resultType) {
+                    const Tensor &onFalse, ShapedType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
     Element predValue = pred.getRank() != 0 ? pred.get(*it) : pred.get({});
@@ -682,7 +682,7 @@ Tensor evalSelectOp(const Tensor &pred, const Tensor &onTrue,
   return result;
 }
 
-Tensor evalSineOp(const Tensor &operand, TensorType resultType) {
+Tensor evalSineOp(const Tensor &operand, ShapedType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, sine(operand.get(*it)));
@@ -690,7 +690,7 @@ Tensor evalSineOp(const Tensor &operand, TensorType resultType) {
 }
 
 Tensor evalSliceOp(const Tensor &operand, Index startIndices, Sizes strides,
-                   TensorType resultType) {
+                   ShapedType resultType) {
   Tensor result(resultType);
   for (auto resultIt = result.index_begin(); resultIt != result.index_end();
        ++resultIt) {
@@ -699,7 +699,7 @@ Tensor evalSliceOp(const Tensor &operand, Index startIndices, Sizes strides,
   return result;
 }
 
-Tensor evalSqrtOp(const Tensor &operand, TensorType resultType) {
+Tensor evalSqrtOp(const Tensor &operand, ShapedType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, sqrt(operand.get(*it)));
@@ -707,14 +707,14 @@ Tensor evalSqrtOp(const Tensor &operand, TensorType resultType) {
 }
 
 Tensor evalSubtractOp(const Tensor &lhs, const Tensor &rhs,
-                      TensorType resultType) {
+                      ShapedType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, lhs.get(*it) - rhs.get(*it));
   return result;
 }
 
-Tensor evalTanhOp(const Tensor &operand, TensorType resultType) {
+Tensor evalTanhOp(const Tensor &operand, ShapedType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, tanh(operand.get(*it)));
@@ -722,7 +722,7 @@ Tensor evalTanhOp(const Tensor &operand, TensorType resultType) {
 }
 
 Tensor evalTransposeOp(const Tensor &operand, const Axes &permutation,
-                       TensorType resultType) {
+                       ShapedType resultType) {
   Tensor result(resultType);
   for (auto operandIt = operand.index_begin(); operandIt != operand.index_end();
        ++operandIt) {
@@ -750,7 +750,7 @@ SmallVector<Tensor> evalWhileOp(ArrayRef<Tensor> operand, Region &cond,
   return runtimeResults;
 }
 
-Tensor evalXorOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType) {
+Tensor evalXorOp(const Tensor &lhs, const Tensor &rhs, ShapedType resultType) {
   Tensor result(resultType);
   for (auto it = lhs.index_begin(); it != lhs.index_end(); ++it)
     result.set(*it, lhs.get(*it) ^ rhs.get(*it));

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -27,71 +27,71 @@ namespace mlir {
 namespace stablehlo {
 
 // Evaluators for StableHLO ops.
-Tensor evalAbsOp(const Tensor &operand, TensorType resultType);
-Tensor evalAddOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType);
-Tensor evalAndOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType);
+Tensor evalAbsOp(const Tensor &operand, ShapedType resultType);
+Tensor evalAddOp(const Tensor &lhs, const Tensor &rhs, ShapedType resultType);
+Tensor evalAndOp(const Tensor &lhs, const Tensor &rhs, ShapedType resultType);
 Tensor evalBroadcastInDimOp(const Tensor &operand, Axes broadcastDimensions,
-                            TensorType resultType);
+                            ShapedType resultType);
 SmallVector<Tensor> evalCaseOp(const Tensor &index, RegionRange branches,
                                Scope &scope);
-Tensor evalCeilOp(const Tensor &operand, TensorType resultType);
+Tensor evalCeilOp(const Tensor &operand, ShapedType resultType);
 Tensor evalClampOp(const Tensor &min, const Tensor &operand, const Tensor &max,
-                   TensorType resultType);
-Tensor evalClzOp(const Tensor &operand, TensorType resultType);
+                   ShapedType resultType);
+Tensor evalClzOp(const Tensor &operand, ShapedType resultType);
 Tensor evalCompareOp(const Tensor &lhs, const Tensor &rhs,
                      ComparisonDirection comparisonDirection,
-                     TensorType resultType);
+                     ShapedType resultType);
 Tensor evalConcatenateOp(ArrayRef<Tensor> inputs, Axis dimension,
-                         TensorType resultType);
+                         ShapedType resultType);
 Tensor evalConstantOp(ElementsAttr value);
-Tensor evalConvertOp(const Tensor &operand, TensorType resultType);
-Tensor evalCosineOp(const Tensor &operand, TensorType resultType);
+Tensor evalConvertOp(const Tensor &operand, ShapedType resultType);
+Tensor evalCosineOp(const Tensor &operand, ShapedType resultType);
 Tensor evalDivideOp(const Tensor &lhs, const Tensor &rhs,
-                    TensorType resultType);
+                    ShapedType resultType);
 Tensor evalDynamicSliceOp(const Tensor &operand, ArrayRef<Tensor> startIndices,
-                          Sizes sliceSizes, TensorType resultType);
+                          Sizes sliceSizes, ShapedType resultType);
 Tensor evalDynamicUpdateSliceOp(const Tensor &operand, const Tensor &update,
                                 ArrayRef<Tensor> startIndices,
-                                TensorType resultType);
-Tensor evalExponentialOp(const Tensor &operand, TensorType resultType);
-Tensor evalFloorOp(const Tensor &operand, TensorType resultType);
+                                ShapedType resultType);
+Tensor evalExponentialOp(const Tensor &operand, ShapedType resultType);
+Tensor evalFloorOp(const Tensor &operand, ShapedType resultType);
 SmallVector<Tensor> evalIfOp(const Tensor &pred, Region &trueBranch,
                              Region &falseBranch, Scope &scope);
-Tensor evalImagOp(const Tensor &operand, TensorType resultType);
-Tensor evalIotaOp(Axis iotaDimension, TensorType resultType);
-Tensor evalLogOp(const Tensor &operand, TensorType resultType);
-Tensor evalLogisticOp(const Tensor &operand, TensorType resultType);
-Tensor evalMaxOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType);
-Tensor evalMinOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType);
+Tensor evalImagOp(const Tensor &operand, ShapedType resultType);
+Tensor evalIotaOp(Axis iotaDimension, ShapedType resultType);
+Tensor evalLogOp(const Tensor &operand, ShapedType resultType);
+Tensor evalLogisticOp(const Tensor &operand, ShapedType resultType);
+Tensor evalMaxOp(const Tensor &lhs, const Tensor &rhs, ShapedType resultType);
+Tensor evalMinOp(const Tensor &lhs, const Tensor &rhs, ShapedType resultType);
 Tensor evalMultiplyOp(const Tensor &lhs, const Tensor &rhs,
-                      TensorType resultType);
-Tensor evalNegOp(const Tensor &operand, TensorType resultType);
-Tensor evalNotOp(const Tensor &operand, TensorType resultType);
-Tensor evalOrOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType);
+                      ShapedType resultType);
+Tensor evalNegOp(const Tensor &operand, ShapedType resultType);
+Tensor evalNotOp(const Tensor &operand, ShapedType resultType);
+Tensor evalOrOp(const Tensor &lhs, const Tensor &rhs, ShapedType resultType);
 Tensor evalPadOp(const Tensor &operand, const Tensor &paddingValue,
                  Sizes edgePaddingLow, Sizes interiorPadding,
-                 TensorType resultType);
-Tensor evalPowerOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType);
-Tensor evalRealOp(const Tensor &operand, TensorType resultType);
-Tensor evalRemOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType);
-Tensor evalReshapeOp(const Tensor &operand, TensorType resultType);
+                 ShapedType resultType);
+Tensor evalPowerOp(const Tensor &lhs, const Tensor &rhs, ShapedType resultType);
+Tensor evalRealOp(const Tensor &operand, ShapedType resultType);
+Tensor evalRemOp(const Tensor &lhs, const Tensor &rhs, ShapedType resultType);
+Tensor evalReshapeOp(const Tensor &operand, ShapedType resultType);
 Tensor evalReverseOp(const Tensor &operand, Axes dimensions,
-                     TensorType resultType);
-Tensor evalRsqrtOp(const Tensor &operand, TensorType resultType);
+                     ShapedType resultType);
+Tensor evalRsqrtOp(const Tensor &operand, ShapedType resultType);
 Tensor evalSelectOp(const Tensor &pred, const Tensor &onTrue,
-                    const Tensor &onFalse, TensorType resultType);
-Tensor evalSineOp(const Tensor &operand, TensorType resultType);
+                    const Tensor &onFalse, ShapedType resultType);
+Tensor evalSineOp(const Tensor &operand, ShapedType resultType);
 Tensor evalSliceOp(const Tensor &operand, Index startIndices, Sizes strides,
-                   TensorType resultType);
-Tensor evalSqrtOp(const Tensor &operand, TensorType resultType);
+                   ShapedType resultType);
+Tensor evalSqrtOp(const Tensor &operand, ShapedType resultType);
 Tensor evalSubtractOp(const Tensor &lhs, const Tensor &rhs,
-                      TensorType resultType);
-Tensor evalTanhOp(const Tensor &operand, TensorType resultType);
+                      ShapedType resultType);
+Tensor evalTanhOp(const Tensor &operand, ShapedType resultType);
 Tensor evalTransposeOp(const Tensor &operand, const Axes &permutation,
-                       TensorType resultType);
+                       ShapedType resultType);
 SmallVector<Tensor> evalWhileOp(ArrayRef<Tensor> operand, Region &cond,
                                 Region &body, Scope &scope);
-Tensor evalXorOp(const Tensor &lhs, const Tensor &rhs, TensorType resultType);
+Tensor evalXorOp(const Tensor &lhs, const Tensor &rhs, ShapedType resultType);
 
 /// Evaluates an mlir::Region `region` using the runtime values `args`
 /// corresponding to the arguments of the entry block of the region.

--- a/stablehlo/reference/Tensor.cpp
+++ b/stablehlo/reference/Tensor.cpp
@@ -75,22 +75,22 @@ int64_t flattenIndex(const Sizes &shape, const Index &index) {
 
 namespace detail {
 
-Buffer::Buffer(TensorType type)
+Buffer::Buffer(ShapedType type)
     : type_(type),
       blob_(
           HeapAsmResourceBlob::allocate(getSizeInBytes(type), alignof(char))) {}
 
-Buffer::Buffer(TensorType type, AsmResourceBlob blob)
+Buffer::Buffer(ShapedType type, AsmResourceBlob blob)
     : type_(type), blob_(std::move(blob)) {}
 
 }  // namespace detail
 
 Tensor::Tensor() {}
 
-Tensor::Tensor(TensorType type)
+Tensor::Tensor(ShapedType type)
     : impl_(llvm::makeIntrusiveRefCnt<detail::Buffer>(type)) {}
 
-Tensor::Tensor(TensorType type, AsmResourceBlob blob)
+Tensor::Tensor(ShapedType type, AsmResourceBlob blob)
     : impl_(llvm::makeIntrusiveRefCnt<detail::Buffer>(type, std::move(blob))) {}
 
 Element Tensor::get(const Index &index) const {
@@ -350,7 +350,7 @@ void Tensor::print(raw_ostream &os) const {
 void Tensor::dump() const { print(llvm::errs()); }
 
 Tensor makeTensor(DenseElementsAttr attr) {
-  auto type = attr.getType().cast<TensorType>();
+  auto type = attr.getType();
   auto elemType = type.getElementType();
 
   // Handle floating-point types.

--- a/stablehlo/reference/Tensor.h
+++ b/stablehlo/reference/Tensor.h
@@ -39,8 +39,8 @@ class Buffer : public llvm::RefCountedBase<Buffer> {
  public:
   /// \name Constructors
   /// @{
-  explicit Buffer(TensorType type);
-  Buffer(TensorType type, AsmResourceBlob blob);
+  explicit Buffer(ShapedType type);
+  Buffer(ShapedType type, AsmResourceBlob blob);
   Buffer(Buffer &&other) = default;
   /// @}
 
@@ -48,7 +48,7 @@ class Buffer : public llvm::RefCountedBase<Buffer> {
   Buffer &operator=(Buffer &&other) = delete;
 
   /// Returns type of the Buffer object.
-  TensorType getType() { return type_; }
+  ShapedType getType() { return type_; }
 
   /// Provides access to the underlying non-mutable storage.
   ArrayRef<char> getData() const { return blob_.getData(); }
@@ -57,7 +57,7 @@ class Buffer : public llvm::RefCountedBase<Buffer> {
   MutableArrayRef<char> getMutableData() { return blob_.getMutableData(); }
 
  private:
-  TensorType type_;
+  ShapedType type_;
   AsmResourceBlob blob_;
 };
 
@@ -70,8 +70,8 @@ class Tensor {
   /// \name Constructors
   /// @{
   Tensor();
-  explicit Tensor(TensorType type);
-  explicit Tensor(TensorType type, AsmResourceBlob blob);
+  explicit Tensor(ShapedType type);
+  explicit Tensor(ShapedType type, AsmResourceBlob blob);
   Tensor(const Tensor &other) = default;
   /// @}
 
@@ -79,7 +79,7 @@ class Tensor {
   Tensor &operator=(const Tensor &other) = default;
 
   /// Returns type of the Tensor object.
-  TensorType getType() const { return impl_->getType(); };
+  ShapedType getType() const { return impl_->getType(); };
 
   /// Returns rank of the Tensor object.
   int64_t getRank() const { return impl_->getType().getRank(); }

--- a/stablehlo/transforms/StablehloCanonicalizeDynamism.cpp
+++ b/stablehlo/transforms/StablehloCanonicalizeDynamism.cpp
@@ -98,7 +98,7 @@ struct CanonicalizeDynamicBroadcastInDimOpPattern
     if (!succeeded(hlo::matchInts(op.getOutputDimensions(), outputDimensions)))
       return rewriter.notifyMatchFailure(op,
                                          "expected static output_dimensions");
-    if (!op.getType().cast<ShapedType>().hasStaticShape())
+    if (!op.getType().hasStaticShape())
       return rewriter.notifyMatchFailure(op, "expected static result type");
     rewriter.replaceOpWithNewOp<BroadcastInDimOp>(
         op, op.getType(), op.getOperand(), op.getBroadcastDimensions());
@@ -158,7 +158,7 @@ struct CanonicalizeDynamicIotaOpPattern
     SmallVector<int64_t> outputShape;
     if (!succeeded(hlo::matchInts(op.getOutputShape(), outputShape)))
       return rewriter.notifyMatchFailure(op, "expected static output_shape");
-    if (!op.getType().cast<ShapedType>().hasStaticShape())
+    if (!op.getType().hasStaticShape())
       return rewriter.notifyMatchFailure(op, "expected static result type");
     rewriter.replaceOpWithNewOp<IotaOp>(op, op.getType(),
                                         op.getIotaDimension());
@@ -198,7 +198,7 @@ struct CanonicalizeDynamicReshapeOpPattern
     SmallVector<int64_t> outputShape;
     if (!succeeded(hlo::matchInts(op.getOutputShape(), outputShape)))
       return rewriter.notifyMatchFailure(op, "expected static output_shape");
-    if (!op.getType().cast<ShapedType>().hasStaticShape())
+    if (!op.getType().hasStaticShape())
       return rewriter.notifyMatchFailure(op, "expected static result type");
     rewriter.replaceOpWithNewOp<ReshapeOp>(op, op.getType(), op.getOperand());
     return success();
@@ -248,7 +248,7 @@ struct CanonicalizeRealDynamicSliceOpToDynamicSliceOpPattern
     SmallVector<Value> startIndices;
     for (auto i = 0; i < static_cast<int64_t>(sliceSizes.size()); ++i) {
       auto startIndexElementType =
-          op.getStartIndices().getType().cast<ShapedType>().getElementType();
+          op.getStartIndices().getType().getElementType();
       auto startIndex1DType = RankedTensorType::get({1}, startIndexElementType);
       auto startIndex1D = rewriter.create<SliceOp>(
           op.getLoc(), startIndex1DType, op.getStartIndices(),

--- a/stablehlo/transforms/StablehloRefineShapes.cpp
+++ b/stablehlo/transforms/StablehloRefineShapes.cpp
@@ -144,7 +144,7 @@ struct EvalBroadcastInDimOpPattern : public OpRewritePattern<BroadcastInDimOp> {
     auto scalar = operand[0];
 
     rewriter.replaceOpWithNewOp<ConstantOp>(
-        op, DenseIntElementsAttr::get(op.getResult().getType(), scalar));
+        op, DenseIntElementsAttr::get(op.getType(), scalar));
     return success();
   }
 };
@@ -186,7 +186,7 @@ struct EvalConcatenateOpPattern : public OpRewritePattern<ConcatenateOp> {
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(ConcatenateOp op,
                                 PatternRewriter& rewriter) const override {
-    auto resultType = op.getResult().getType();
+    auto resultType = op.getType();
     if (!resultType.hasRank() || op.getDimension() != 0)
       return rewriter.notifyMatchFailure(op, "expected dimension = 0");
 
@@ -312,7 +312,7 @@ struct EvalSelectOpPattern : public OpRewritePattern<SelectOp> {
     }
 
     rewriter.replaceOpWithNewOp<ConstantOp>(
-        op, DenseIntElementsAttr::get(op.getResult().getType(), result));
+        op, DenseIntElementsAttr::get(op.getType(), result));
     return success();
   }
 };
@@ -343,7 +343,7 @@ struct EvalSliceOpPattern : public OpRewritePattern<SliceOp> {
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(SliceOp op,
                                 PatternRewriter& rewriter) const override {
-    auto resultType = op.getResult().getType();
+    auto resultType = op.getType();
     if (!resultType.hasRank() || resultType.getRank() != 1)
       return rewriter.notifyMatchFailure(op, "expected 1-dimensional type");
 

--- a/stablehlo/transforms/StablehloRefineShapes.cpp
+++ b/stablehlo/transforms/StablehloRefineShapes.cpp
@@ -66,7 +66,7 @@ LogicalResult evalUnary(PatternRewriter& rewriter, OpType op, FuncType fn) {
   if (op->getNumOperands() != 1)
     llvm::report_fatal_error("expected one operand");
 
-  auto resultType = op.getResult().getType().template cast<ShapedType>();
+  auto resultType = op.getType();
   if (!resultType.hasRank() || !resultType.getElementType().isIntOrIndex())
     return rewriter.notifyMatchFailure(
         op, "expected integer or index result tensor type");
@@ -88,7 +88,7 @@ LogicalResult evalBinary(PatternRewriter& rewriter, OpType op, FuncType fn) {
   if (op->getNumOperands() != 2)
     llvm::report_fatal_error("expected two operands");
 
-  auto resultType = op.getResult().getType().template cast<ShapedType>();
+  auto resultType = op.getType();
   if (!resultType.hasRank() || !resultType.getElementType().isIntOrIndex())
     return rewriter.notifyMatchFailure(
         op, "expected integer or index result tensor type");
@@ -119,7 +119,7 @@ struct EvalAndOpPattern : public OpRewritePattern<AndOp> {
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(AndOp op,
                                 PatternRewriter& rewriter) const override {
-    auto resultType = op.getResult().getType().cast<ShapedType>();
+    auto resultType = op.getType();
     if (!resultType.getElementType().isInteger(1))
       return rewriter.notifyMatchFailure(op, "expected boolean element type");
 
@@ -134,8 +134,8 @@ struct EvalBroadcastInDimOpPattern : public OpRewritePattern<BroadcastInDimOp> {
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(BroadcastInDimOp op,
                                 PatternRewriter& rewriter) const override {
-    auto operandType = op.getOperand().getType().dyn_cast<RankedTensorType>();
-    if (!operandType || operandType.getRank() != 0)
+    auto operandType = op.getOperand().getType();
+    if (!operandType.hasRank() || operandType.getRank() != 0)
       return rewriter.notifyMatchFailure(op, "expected 0-dimensional type");
 
     SmallVector<APInt> operand;
@@ -153,7 +153,7 @@ struct EvalCompareOpPattern : public OpRewritePattern<CompareOp> {
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(CompareOp op,
                                 PatternRewriter& rewriter) const override {
-    auto resultType = op.getResult().getType().cast<ShapedType>();
+    auto resultType = op.getType();
     auto isResultUnsigned = resultType.getElementType().isUnsignedInteger();
     return evalBinary(rewriter, op, [&](APInt lhs, APInt rhs) {
       bool result;
@@ -186,8 +186,8 @@ struct EvalConcatenateOpPattern : public OpRewritePattern<ConcatenateOp> {
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(ConcatenateOp op,
                                 PatternRewriter& rewriter) const override {
-    auto resultType = op.getResult().getType().dyn_cast<RankedTensorType>();
-    if (!resultType || op.getDimension() != 0)
+    auto resultType = op.getResult().getType();
+    if (!resultType.hasRank() || op.getDimension() != 0)
       return rewriter.notifyMatchFailure(op, "expected dimension = 0");
 
     SmallVector<APInt> result;
@@ -206,9 +206,9 @@ struct EvalConvertOpPattern : public OpRewritePattern<ConvertOp> {
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(ConvertOp op,
                                 PatternRewriter& rewriter) const override {
-    auto operandType = op.getOperand().getType().cast<ShapedType>();
+    auto operandType = op.getOperand().getType();
     auto isOperandUnsigned = operandType.getElementType().isUnsignedInteger();
-    auto resultType = op.getResult().getType().cast<ShapedType>();
+    auto resultType = op.getType();
     if (!resultType.getElementType().isIntOrIndex())
       return rewriter.notifyMatchFailure(op,
                                          "expected integer result tensor type");
@@ -223,7 +223,7 @@ struct EvalDivOpPattern : public OpRewritePattern<DivOp> {
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(DivOp op,
                                 PatternRewriter& rewriter) const override {
-    auto resultType = op.getResult().getType().cast<ShapedType>();
+    auto resultType = op.getType();
     auto isResultUnsigned = resultType.getElementType().isUnsignedInteger();
     return evalBinary(rewriter, op, [&](APInt lhs, APInt rhs) {
       return isResultUnsigned ? lhs.udiv(rhs) : lhs.sdiv(rhs);
@@ -236,16 +236,15 @@ struct EvalGetDimensionSizeOpPattern
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(GetDimensionSizeOp op,
                                 PatternRewriter& rewriter) const override {
-    auto operandType = op.getOperand().getType().dyn_cast<RankedTensorType>();
-    if (!operandType)
+    auto operandType = op.getOperand().getType();
+    if (!operandType.hasRank())
       return rewriter.notifyMatchFailure(op, "expected ranked operand");
     if (operandType.isDynamicDim(op.getDimension()))
       return rewriter.notifyMatchFailure(op, "expected static dimension");
 
-    auto resultType = op.getResult().getType().cast<RankedTensorType>();
     auto result = operandType.getDimSize(op.getDimension());
     rewriter.replaceOpWithNewOp<ConstantOp>(
-        op, DenseIntElementsAttr::get<int32_t>(resultType, result));
+        op, DenseIntElementsAttr::get<int32_t>(op.getType(), result));
     return success();
   }
 };
@@ -254,7 +253,7 @@ struct EvalMaxOpPattern : public OpRewritePattern<MaxOp> {
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(MaxOp op,
                                 PatternRewriter& rewriter) const override {
-    auto resultType = op.getResult().getType().cast<ShapedType>();
+    auto resultType = op.getType();
     auto isResultUnsigned = resultType.getElementType().isUnsignedInteger();
     return evalBinary(rewriter, op, [&](APInt lhs, APInt rhs) {
       return isResultUnsigned ? llvm::APIntOps::umax(lhs, rhs)
@@ -276,7 +275,7 @@ struct EvalRemOpPattern : public OpRewritePattern<RemOp> {
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(RemOp op,
                                 PatternRewriter& rewriter) const override {
-    auto resultType = op.getResult().getType().cast<ShapedType>();
+    auto resultType = op.getType();
     auto isResultUnsigned = resultType.getElementType().isUnsignedInteger();
     return evalBinary(rewriter, op, [&](APInt lhs, APInt rhs) {
       return isResultUnsigned ? lhs.urem(rhs) : lhs.srem(rhs);
@@ -322,7 +321,7 @@ struct EvalSignOpPattern : public OpRewritePattern<SignOp> {
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(SignOp op,
                                 PatternRewriter& rewriter) const override {
-    auto resultType = op.getResult().getType().cast<ShapedType>();
+    auto resultType = op.getType();
     if (!resultType.getElementType().isIntOrIndex())
       return rewriter.notifyMatchFailure(op,
                                          "expected integer result tensor type");
@@ -344,8 +343,8 @@ struct EvalSliceOpPattern : public OpRewritePattern<SliceOp> {
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(SliceOp op,
                                 PatternRewriter& rewriter) const override {
-    auto resultType = op.getResult().getType().dyn_cast<RankedTensorType>();
-    if (!resultType || resultType.getRank() != 1)
+    auto resultType = op.getResult().getType();
+    if (!resultType.hasRank() || resultType.getRank() != 1)
       return rewriter.notifyMatchFailure(op, "expected 1-dimensional type");
 
     SmallVector<int64_t> operand;
@@ -509,10 +508,14 @@ LogicalResult refineReturnTypes(PatternRewriter& rewriter, Operation* op,
   SmallVector<Type> refinedTypes;
   for (auto [currentType, refinement] :
        llvm::zip(op->getResultTypes(), refinements)) {
-    auto refinedElementType =
-        refinement.getElementType()
-            ? refinement.getElementType()
-            : currentType.cast<ShapedType>().getElementType();
+    auto refinedElementType = refinement.getElementType();
+    if (!refinedElementType) {
+      auto currentShapedType = currentType.dyn_cast<ShapedType>();
+      if (!currentShapedType)
+        return rewriter.notifyMatchFailure(
+            op, "refineReturnTypes failed: expected shaped return types");
+      refinedElementType = currentShapedType.getElementType();
+    }
     if (refinement.hasRank()) {
       auto refinedShape = refinement.getDims();
       auto refinedEncoding = refinement.getAttribute();
@@ -556,7 +559,7 @@ struct RefineAllGatherOpPattern : public OpRewritePattern<AllGatherOp> {
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(AllGatherOp op,
                                 PatternRewriter& rewriter) const override {
-    auto operandType = op.getOperand().getType().cast<ShapedType>();
+    auto operandType = op.getOperand().getType();
     if (!operandType.hasRank())
       return rewriter.notifyMatchFailure(op, "expected ranked operand type");
 
@@ -580,7 +583,7 @@ struct RefineBitcastConvertOpPattern
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(BitcastConvertOp op,
                                 PatternRewriter& rewriter) const override {
-    auto operandType = op.getOperand().getType().cast<ShapedType>();
+    auto operandType = op.getOperand().getType();
     if (!operandType.hasRank())
       return rewriter.notifyMatchFailure(op, "expected ranked operand type");
 
@@ -588,7 +591,7 @@ struct RefineBitcastConvertOpPattern
     // operand and result shapes have different ranks.
     // This complicates the logic quite a bit and is not needed to pass the
     // current tests, so we leave this for future work.
-    auto resultType = op.getResult().getType().cast<ShapedType>();
+    auto resultType = op.getType();
     auto getBitWidthFn = [](ShapedType type) {
       auto elementType = type.getElementType();
       if (auto complexType = elementType.dyn_cast<ComplexType>())
@@ -824,7 +827,7 @@ struct RefineRealDynamicSliceOpPattern
       // DynamicSliceOp::start_indices is a vararg of 0-dimensional tensors.
       // Adapt accordingly in order to be compatible with inferDynamicSliceOp.
       auto startIndicesElementType =
-          op.getStartIndices().getType().cast<ShapedType>().getElementType();
+          op.getStartIndices().getType().getElementType();
       SmallVector<Type> startIndicesTypes(
           sliceSizesAttr.size(),
           RankedTensorType::get({}, startIndicesElementType));
@@ -856,7 +859,7 @@ struct RefineReduceScatterOpPattern : public OpRewritePattern<ReduceScatterOp> {
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(ReduceScatterOp op,
                                 PatternRewriter& rewriter) const override {
-    auto operandType = op.getOperand().getType().cast<ShapedType>();
+    auto operandType = op.getOperand().getType();
     if (!operandType.hasRank())
       return rewriter.notifyMatchFailure(op, "expected ranked operand type");
 


### PR DESCRIPTION
When working on adding support for tuple types to
RefineCustomCallOpPattern, I noticed that some logic in
StablehloRefineShapes.cpp assumes shaped types where we aren't
guaranteed to have shaped types and casts to ShapedType at will.

1) This led me to audit our uses of casts to ShapedType, and during that
audit I realized that many of these casts are not needed because in
many cases TableGen generates TypedValue accessors for stuff like
`::mlir::TypedValue<::mlir::TensorType> getLhs()`. This simplified
the code quite a bit.

2) Furthermore, I realized that in some places in our code we use
TensorType, so I audited casts to TensorType as well. To simplify
further refactorings, I figured that we could standardize on just one
kind of type between ShapedType and TensorType, and since ShapedType
is more general, I replaced all usages of TensorType with ShapedType.

3) Overall, after all the refactorings we still have some casts to
ShapedType in ChloOps.cpp, StablehloOps.cpp and TypeInference.cpp.
They are there for the following reasons:
  * Unlike ops, op adaptors don't produce TypedValue, and use
    regular Value instead. This means that there's a tradeoff between:
    a) TypeInference.cpp using Value and doing casts internally,
    b) TypeInference.cpp using TypedValue and forcing all users to
       do casts. I think a) is preferable.
  * Unlike singular fields, variadic fields don't produce TypedValue
    either, and instead use ValueRange, so stuff that comes from there
    also has to be cast.

4) The refactorings exposed the following latent bugs in our code which
could lead to crashes in the future. Even though these bugs cannot be
exercised at the moment, I figured it would be good to safeguard against
them:
  * inferReturnTypeComponentsFromOperands used to cast the result of
    inferReturnTypes to ShapedType. An oversight in user-level
    implementation of inferReturnTypes could lead to a crash.
  * ConstantOp::isCompatibleReturnTypes used to cast both the left-hand
    side and the right-hand side to TensorType. Same as the previous
    bullet.
  * refineReturnTypes used to cast types in op->getResultTypes()
    to ShapedType. Calling this functions on ops which can take
    tuples could lead to a crash.