### PR TITLE
Extend indices_of_shape_operands to work for tuple types

### DIFF
--- a/stablehlo/dialect/Base.cpp
+++ b/stablehlo/dialect/Base.cpp
@@ -358,8 +358,8 @@ FailureOr<ShapedType> inferTypeWithCustomFn(
           anyInputHaveBounds ? inferredBounds : ArrayRef<int64_t>({})))};
 }
 
-FailureOr<Type> inferLeastSpecificType(std::optional<Location> location,
-                                       TypeRange inputTypes) {
+FailureOr<Type> inferLeastSpecificShapedType(std::optional<Location> location,
+                                             TypeRange inputTypes) {
   SmallVector<RankedTensorType> rankedTypes;
   for (auto inputType : inputTypes)
     if (auto rankedType = inputType.dyn_cast<RankedTensorType>())
@@ -370,8 +370,8 @@ FailureOr<Type> inferLeastSpecificType(std::optional<Location> location,
                                inferLeastSpecificDimAndBound);
 }
 
-FailureOr<Type> inferMostSpecificType(std::optional<Location> location,
-                                      TypeRange inputTypes) {
+FailureOr<Type> inferMostSpecificShapedType(std::optional<Location> location,
+                                            TypeRange inputTypes) {
   SmallVector<RankedTensorType> rankedTypes;
   for (auto inputType : inputTypes)
     if (auto rankedType = inputType.dyn_cast<RankedTensorType>())
@@ -379,6 +379,52 @@ FailureOr<Type> inferMostSpecificType(std::optional<Location> location,
   if (rankedTypes.empty()) return inputTypes[0];
   return inferTypeWithCustomFn(location, rankedTypes,
                                inferMostSpecificDimAndBound);
+}
+
+FailureOr<Type> mapOverTupleElements(
+    std::optional<Location> location, TypeRange inputTypes,
+    function_ref<FailureOr<Type>(std::optional<Location>, TypeRange types)>
+        fn) {
+  SmallVector<TupleType> tupleTypes;
+  for (auto inputType : inputTypes) {
+    if (auto tupleType = inputType.dyn_cast<TupleType>())
+      tupleTypes.push_back(tupleType);
+  }
+  if (!tupleTypes.empty()) {
+    if (tupleTypes.size() != inputTypes.size())
+      return emitOptionalError(location,
+                               "Mismatched type kinds: either all types ",
+                               "must be tuples, or no types must be tuples");
+    SmallVector<Type> results(tupleTypes[0].size());
+    for (auto tupleType : tupleTypes) {
+      if (tupleType.size() != results.size())
+        return emitOptionalError(location,
+                                 "Mismatched tuple sizes: all tuple sizes ",
+                                 "must be the same");
+    }
+    for (size_t i = 0; i < results.size(); ++i) {
+      SmallVector<Type> ithElements;
+      for (auto tupleType : tupleTypes)
+        ithElements.push_back(tupleType.getType(i));
+      auto result = fn(location, ithElements);
+      if (failed(result)) return failure();
+      results[i] = *result;
+    }
+    return TupleType::get(tupleTypes[0].getContext(), results);
+  }
+  return fn(location, inputTypes);
+}
+
+FailureOr<Type> inferLeastSpecificType(std::optional<Location> location,
+                                       TypeRange inputTypes) {
+  return mapOverTupleElements(location, inputTypes,
+                              inferLeastSpecificShapedType);
+}
+
+FailureOr<Type> inferMostSpecificType(std::optional<Location> location,
+                                      TypeRange inputTypes) {
+  return mapOverTupleElements(location, inputTypes,
+                              inferMostSpecificShapedType);
 }
 
 LogicalResult inferMostSpecificTypeComponents(
@@ -408,11 +454,19 @@ LogicalResult getShapeRefinements(
                          .dyn_cast_or_null<DenseIntElementsAttr>();
   if (!indicesAttr) return failure();
 
-  if (indicesAttr.getNumElements() != op->getNumResults())
+  SmallVector<Type> flattenedResultTypes;
+  flattenTupleTypes(op->getResultTypes(), flattenedResultTypes);
+  int64_t flattenedNumResults = flattenedResultTypes.size();
+  StringRef flattenedErrorMessageSuffix =
+      op->getNumResults() != flattenedNumResults ? ", with tuples flattened"
+                                                 : "";
+
+  if (indicesAttr.getNumElements() != flattenedNumResults)
     return emitOptionalError(location, "indices_of_shape_operands: number of ",
                              "elements (", indicesAttr.getNumElements(), ") ",
                              "must be equal to the number of operation results",
-                             " (", op->getNumResults(), ")");
+                             " (", flattenedNumResults, ")",
+                             flattenedErrorMessageSuffix);
   if (indicesAttr.getType().getRank() != 1)
     return emitOptionalError(location, "indices_of_shape_operands: must have ",
                              "rank = 1");
@@ -422,7 +476,7 @@ LogicalResult getShapeRefinements(
 
   auto resultIndex = 0;
   for (auto [operandIndex, resultType] :
-       llvm::zip(indicesAttr.getValues<int64_t>(), op->getResultTypes())) {
+       llvm::zip(indicesAttr.getValues<int64_t>(), flattenedResultTypes)) {
     if (operandIndex < 0 || operandIndex >= op->getNumOperands())
       return emitOptionalError(location, "indices_of_shape_operands: index #",
                                resultIndex, " (", operandIndex, ") ",
@@ -435,12 +489,53 @@ LogicalResult getShapeRefinements(
     if (!isCompatibleForHloTypeInference(operand, resultType))
       return emitOptionalError(
           location, "indices_of_shape_operands: refinement #", resultIndex,
-          " ([", refinement, "]) must be compatible with operation result (",
-          resultType, ")");
+          " ([", refinement, "]) must be compatible with operation result #",
+          resultIndex, " (", resultType, ")", flattenedErrorMessageSuffix);
     refinements.emplace_back(refinement);
     ++resultIndex;
   }
   return success();
+}
+
+void flattenTupleTypes(TypeRange types, SmallVector<Type>& result) {
+  for (auto type : types) {
+    if (auto tupleType = type.dyn_cast<TupleType>()) {
+      flattenTupleTypes(tupleType.getTypes(), result);
+      continue;
+    }
+    result.push_back(type);
+  }
+}
+
+LogicalResult unflattenTupleTypes(TypeRange prototype, TypeRange types,
+                                  SmallVector<Type>& result) {
+  // Recursively unflattens types into result according to the prototype
+  // and returns the number of consumed types, with -1 signifying an error.
+  // This specific kind of return value is what enables a recursive formulation
+  // of this algorithm which avoids mutable state except for the result.
+  std::function<int64_t(TypeRange, TypeRange, SmallVector<Type>&)> loop;
+  loop = [&](TypeRange prototype, TypeRange types,
+             SmallVector<Type>& result) -> int64_t {
+    if (prototype.empty() || types.empty())
+      return prototype.empty() && types.empty() ? 0 : -1;
+
+    if (auto tuplePrototype = prototype[0].dyn_cast<TupleType>()) {
+      SmallVector<Type> tupleResult;
+      auto consumed = loop(tuplePrototype.getTypes(), types, tupleResult);
+      if (consumed == -1) return -1;
+      result.push_back(
+          TupleType::get(tuplePrototype.getContext(), tupleResult));
+      return consumed +
+             loop(prototype.drop_front(), types.drop_front(consumed), result);
+    }
+
+    result.push_back(types[0]);
+    auto consumed = loop(prototype.drop_front(), types.drop_front(), result);
+    if (consumed == -1) return -1;
+    return consumed + 1;
+  };
+  auto consumed = loop(prototype, types, result);
+  return success(/*succeeded=*/consumed != -1);
 }
 
 }  // namespace hlo

--- a/stablehlo/dialect/Base.h
+++ b/stablehlo/dialect/Base.h
@@ -162,7 +162,8 @@ ArrayRef<int64_t> encodingToBounds(Attribute encoding);
 // the underlying dialect that knows how to create these attributes.
 Attribute boundsToEncoding(Attribute prototype, ArrayRef<int64_t> bounds);
 
-// Get refinements for return types from an indices_of_shape_operands attribute.
+// Get refinements for return types from an indices_of_shape_operands attribute,
+// with tuples types flattened (see `flattenTupleTypes` below).
 // If the attribute doesn't exist, returns failure.
 // If the attribute exists but is not invalid with respect to the operation,
 // reports an optional error and returns failure.
@@ -171,6 +172,21 @@ Attribute boundsToEncoding(Attribute prototype, ArrayRef<int64_t> bounds);
 LogicalResult getShapeRefinements(
     std::optional<Location> location, Operation *operation,
     SmallVector<ShapedTypeComponents> &refinements);
+
+// For each type in `types`, recursively flatten tuple types into `result`.
+// Result is populated via in-order traversal, i.e.:
+//   * Flattenings of individual types from `types` follow one another in the
+//     same order as `types`.
+//   * Same for flattenings of element types of tuple types.
+void flattenTupleTypes(TypeRange types, SmallVector<Type> &result);
+
+// Does the inverse of `flattenTupleTypes` - takes `types` and recursively
+// unflattens it, potentially creating tuple types following the structure of
+// `prototype`.
+// Fails if the number of elements in flattened prototype is different from
+// the number of elements in types.
+LogicalResult unflattenTupleTypes(TypeRange prototype, TypeRange types,
+                                  SmallVector<Type> &result);
 
 // This interface is implemented by both StableHLO and MHLO dialects
 // and is used as the foundation for sharing verification, type inference and

--- a/stablehlo/dialect/Base.h
+++ b/stablehlo/dialect/Base.h
@@ -174,15 +174,15 @@ LogicalResult getShapeRefinements(
     SmallVector<ShapedTypeComponents> &refinements);
 
 // For each type in `types`, recursively flatten tuple types into `result`.
-// Result is populated via in-order traversal, i.e.:
+// Result is populated via in-order traversal of tuple types in `types`, i.e.:
 //   * Flattenings of individual types from `types` follow one another in the
 //     same order as `types`.
 //   * Same for flattenings of element types of tuple types.
 void flattenTupleTypes(TypeRange types, SmallVector<Type> &result);
 
 // Does the inverse of `flattenTupleTypes` - takes `types` and recursively
-// unflattens it, potentially creating tuple types following the structure of
-// `prototype`.
+// unflattens it, creating tuple types as needed to exactly match the structure
+// of `prototype`.
 // Fails if the number of elements in flattened prototype is different from
 // the number of elements in types.
 LogicalResult unflattenTupleTypes(TypeRange prototype, TypeRange types,

--- a/stablehlo/tests/stablehlo_canonicalize_dynamism.mlir
+++ b/stablehlo/tests/stablehlo_canonicalize_dynamism.mlir
@@ -96,7 +96,7 @@ func.func @custom_call_failure_out_of_bounds_operand_index(%arg0: tensor<4xf32>)
 // -----
 
 func.func @custom_call_failure_incompatible_result_type(%arg0: tensor<4xf32>) -> tensor<1x2xf32> {
-  // expected-error@+2{{refinement #0 ([1, 1]) must be compatible with operation result ('tensor<1x2xf32>')}}
+  // expected-error@+2{{refinement #0 ([1, 1]) must be compatible with operation result #0 ('tensor<1x2xf32>')}}
   %0 = stablehlo.constant dense<[1, 1]> : tensor<2xi64>
   %1 = stablehlo.custom_call @foo(%arg0, %0) {
     indices_of_shape_operands = dense<[1]> : tensor<1xi64>

--- a/stablehlo/transforms/Passes.td
+++ b/stablehlo/transforms/Passes.td
@@ -43,7 +43,6 @@ def StablehloRefineShapesPass : Pass<"stablehlo-refine-shapes", "ModuleOp"> {
     static shapes and running this pass will propagate static shapes across
     the program.
   }];
-  let dependentDialects = ["mlir::tensor::TensorDialect"];
 }
 
 def VhloLegalizeToStablehloPass : Pass<"vhlo-legalize-to-stablehlo", "ModuleOp"> {

--- a/stablehlo/transforms/StablehloRefineShapes.cpp
+++ b/stablehlo/transforms/StablehloRefineShapes.cpp
@@ -27,7 +27,6 @@ limitations under the License.
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -405,17 +404,17 @@ LogicalResult refineValues(PatternRewriter& rewriter, Operation* op,
   for (auto it : llvm::zip(values.getTypes(), types)) {
     // Cannot use structured bindings to simplify this because capturing
     // structured bindings in a lambda is a C++ 20 extension.
-    auto currentReturnType = std::get<0>(it);
+    auto currentType = std::get<0>(it);
     auto refinement = std::get<1>(it);
     auto refinedType = hlo::inferMostSpecificType(
-        /*location=*/{}, {currentReturnType, refinement});
+        /*location=*/{}, {currentType, refinement});
     if (failed(refinedType))
       return rewriter.notifyMatchFailure(op, [&](Diagnostic& diag) {
-        diag << "inferMostSpecificType failed for " << currentReturnType
-             << " and " << refinement;
+        diag << "inferMostSpecificType failed for " << currentType << " and "
+             << refinement;
       });
     refinedTypes.push_back(*refinedType);
-    needsRefinement |= (currentReturnType != *refinedType);
+    needsRefinement |= (currentType != *refinedType);
   }
   if (!needsRefinement)
     return rewriter.notifyMatchFailure(op, "doesn't need refinement");
@@ -459,17 +458,16 @@ LogicalResult refineValues(PatternRewriter& rewriter, Operation* op,
     auto unrefinedType = value.getType();
     value.setType(refinedType);
 
-    // Special case: for `func.return`, guard the refinement with a
-    // `tensor.cast` and leave propagation of the refined return type to a
-    // dedicated pattern.
+    // Special case: for `func.return`, guard the refinement with a cast
+    // and leave propagation of the refined return type to a dedicated pattern.
     auto isFuncReturn = [](OpOperand& use) -> bool {
       return isa<func::ReturnOp>(use.getOwner());
     };
     if (llvm::none_of(value.getUses(), isFuncReturn)) continue;
     rewriter.setInsertionPointAfter(op);
-    auto castToUnrefinedType =
-        rewriter.create<tensor::CastOp>(op->getLoc(), unrefinedType, value);
-    value.replaceUsesWithIf(castToUnrefinedType, isFuncReturn);
+    auto castToUnrefinedType = rewriter.create<UnrealizedConversionCastOp>(
+        op->getLoc(), unrefinedType, value);
+    value.replaceUsesWithIf(castToUnrefinedType.getOutputs()[0], isFuncReturn);
   }
 
   return success();
@@ -494,20 +492,32 @@ LogicalResult refineReturnTypes(PatternRewriter& rewriter, Operation* op,
 }
 
 // Refines the return types of the given operation using the given types.
+// Tricky implementation details:
+//   1) `types` can include non-shaped types. If there are tuple types,
+//      then they are first flattened into non-tuple types using in-order
+//      traversal, and only then we apply the refinements. If there are other
+//      types, then the corresponding refinements must be completely empty.
+//   2) Encodings are not supported. In principle, TypeExtensions should be
+//      supportable, but this needs careful thinking through. Given that noone
+//      asked for support for bounded dynamism in this pass yet, this is left
+//      for future work.
 // This function also signals PatternRewriter that it needs to visit all the
 // users of this op if any updates to its results have happened during execution
 // of the function.
 LogicalResult refineReturnTypes(PatternRewriter& rewriter, Operation* op,
                                 ArrayRef<ShapedTypeComponents> refinements) {
-  if (op->getNumResults() != refinements.size())
+  SmallVector<Type> flattenedTypes;
+  hlo::flattenTupleTypes(op->getResultTypes(), flattenedTypes);
+  auto flattenedSize = flattenedTypes.size();
+  if (flattenedSize != refinements.size())
     return rewriter.notifyMatchFailure(op, [&](Diagnostic& diag) {
-      diag << "refineReturnTypes failed: expected " << op->getNumResults()
+      diag << "refineReturnTypes failed: expected " << flattenedSize
            << " refinements, got " << refinements.size();
     });
 
-  SmallVector<Type> refinedTypes;
+  SmallVector<Type> flattenedRefinedTypes;
   for (auto [currentType, refinement] :
-       llvm::zip(op->getResultTypes(), refinements)) {
+       llvm::zip(flattenedTypes, refinements)) {
     auto refinedElementType = refinement.getElementType();
     if (!refinedElementType) {
       auto currentShapedType = currentType.dyn_cast<ShapedType>();
@@ -519,13 +529,18 @@ LogicalResult refineReturnTypes(PatternRewriter& rewriter, Operation* op,
     if (refinement.hasRank()) {
       auto refinedShape = refinement.getDims();
       auto refinedEncoding = refinement.getAttribute();
-      refinedTypes.push_back(RankedTensorType::get(
+      flattenedRefinedTypes.push_back(RankedTensorType::get(
           refinedShape, refinedElementType, refinedEncoding));
     } else {
-      refinedTypes.push_back(UnrankedTensorType::get(refinedElementType));
+      flattenedRefinedTypes.push_back(
+          UnrankedTensorType::get(refinedElementType));
     }
   }
 
+  SmallVector<Type> refinedTypes;
+  if (failed(hlo::unflattenTupleTypes(op->getResultTypes(), flattenedRefinedTypes,
+                                  refinedTypes)))
+    return failure();
   return refineReturnTypes(rewriter, op, refinedTypes);
 }
 
@@ -933,22 +948,25 @@ struct UpdateFunctionTypePattern : public OpRewritePattern<func::ReturnOp> {
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(func::ReturnOp op,
                                 PatternRewriter& rewriter) const override {
-    // Check whether any of the values returned by `func.return` are
-    // `tensor.cast` ops which cast more specific type to less specific type.
+    // Check whether any of the values returned by `func.return` are casts
+    // which convert more specific type to less specific type.
     // Such ops are produced by the algorithm behind this pass to avoid
     // bringing the enclosing `func.func` op into an inconsistent state when
     // refining individual ops. This pattern cleans this up.
     bool needsUpdate = false;
     SmallVector<Type> updatedResultTypes(op.getOperandTypes());
-    llvm::SmallSet<tensor::CastOp, 4> castsToReplace;
+    llvm::SmallSet<UnrealizedConversionCastOp, 4> castsToReplace;
     for (auto [i, operand] : llvm::enumerate(op.getOperands())) {
-      auto cast = dyn_cast_or_null<tensor::CastOp>(operand.getDefiningOp());
-      if (!cast) continue;
+      auto cast =
+          dyn_cast_or_null<UnrealizedConversionCastOp>(operand.getDefiningOp());
+      if (!cast || cast.getInputs().size() != 1 ||
+          cast.getOutputs().size() != 1)
+        continue;
 
       // Only proceed if the type that we're casting from is more specific
       // than the type that we're casting to.
-      auto sourceType = cast.getSource().getType();
-      auto destType = cast.getType();
+      auto sourceType = cast.getInputs()[0].getType();
+      auto destType = cast.getOutputs()[0].getType();
       auto mostSpecificType = hlo::inferMostSpecificType(
           /*location=*/{}, {sourceType, destType});
       if (failed(mostSpecificType) || destType == *mostSpecificType) continue;

--- a/stablehlo/transforms/StablehloRefineShapes.cpp
+++ b/stablehlo/transforms/StablehloRefineShapes.cpp
@@ -538,8 +538,8 @@ LogicalResult refineReturnTypes(PatternRewriter& rewriter, Operation* op,
   }
 
   SmallVector<Type> refinedTypes;
-  if (failed(hlo::unflattenTupleTypes(op->getResultTypes(), flattenedRefinedTypes,
-                                  refinedTypes)))
+  if (failed(hlo::unflattenTupleTypes(op->getResultTypes(),
+                                      flattenedRefinedTypes, refinedTypes)))
     return failure();
   return refineReturnTypes(rewriter, op, refinedTypes);
 }


### PR DESCRIPTION
At the moment, indices_of_shape_operands are in 1:1 correspondence with
result types, but that doesn't work when custom calls return tuples.

This pull requests addresses this problem, and changes
indices_of_shape_operands to be in 1:1 correspondence with flattened
result types. Originally, I thought that I'd need to redesign
indices_of_shape_operands, e.g. carry arrays of 1-dimensional tensors or
arrays of strings, but this solution keeps the existing structure of
the attribute, i.e. a 1-dimensional tensor of i64.

The changes are surprisingly compact and cover the following three
areas of the implementation:
  1) Verification logic for the attribute that lives in
     getShapeRefinements in Base.h.
  2) Helper logic which applies refinements to operation types
     that lives in refineReturnTypes in StablehloRefineShapes.cpp.
  3) inferMostSpecificType logic which is used to merged unrefined
     types and the corresponding refinements.

These changes also led to an unexpected improvement. Now that
--stablehlo-refine-shapes started operating on tuple types,
tensor::CastOp stopped working (it only applies to tensors), so I was
forced to look for a better solution and remembered about
UnrealizedConversionCastOp. This was an easy migration, and as a nice
bonus the pass no longer depends on the Tensor dialect.