### PR TITLE
Improve logging in refineReturnTypes

### DIFF
--- a/stablehlo/transforms/StablehloRefineShapes.cpp
+++ b/stablehlo/transforms/StablehloRefineShapes.cpp
@@ -543,7 +543,7 @@ LogicalResult refineReturnTypes(PatternRewriter& rewriter, Operation* op,
       if (refinement.hasRank() || refinement.getElementType() ||
           refinement.getAttribute())
         return failure("unsupported refinement");
-      refinedTypes.push_back(currentType);
+      flattenedRefinedTypes.push_back(currentType);
       continue;
     }
 
@@ -583,7 +583,6 @@ LogicalResult refineReturnTypes(PatternRewriter& rewriter, Operation* op,
       return failure("expected compatible shapes");
     flattenedRefinedTypes.push_back(refinedType);
   }
-
 
   SmallVector<Type> refinedTypes;
   if (failed(hlo::unflattenTupleTypes(op->getResultTypes(),


### PR DESCRIPTION
NOTE: This pull request is based on https://github.com/openxla/stablehlo/pull/1387.

While working on refineReturnTypes, I made some improvements to
how the application of ShapedTypeComponents to Type happens.
This is mostly an NFC that restructures the code to improve readability
and logging.