### PR TITLE
Add interpreter for BatchNormTrainingOp

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -419,6 +419,7 @@ cc_library(
     ],
     strip_include_prefix = ".",
     deps = [
+        ":reference_axes",
         ":reference_element",
         ":reference_errors",
         ":reference_index",

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1281,7 +1281,8 @@ def batch_norm_training(operand, scale, offset, epsilon, feature_index):
 %output, %batch_mean, %batch_var = "stablehlo.batch_norm_training"(%operand, %scale, %offset) {
   epsilon = 0.0 : f32,
   feature_index = 2 : i64
-} : (tensor<2x2x2xf32>, tensor<2xf32>, tensor<2xf32>) -> (tensor<2x2x2xf32>, tensor<2xf32>, tensor<2xf32>)
+} : (tensor<2x2x2xf64>, tensor<2xf64>, tensor<2xf64>) ->
+    (tensor<2x2x2xf64>, tensor<2xf64>, tensor<2xf64>)
 // %output: [
 //           [[0.0, 0.0], [2.0, 2.0]],
 //           [[2.0, 2.0], [0.0, 0.0]]
@@ -1289,6 +1290,8 @@ def batch_norm_training(operand, scale, offset, epsilon, feature_index):
 // %batch_mean: [2.0, 3.0]
 // %batch_var: [1.0, 1.0]
 ```
+
+&nbsp;[More Examples](../stablehlo/tests/interpret_batch_norm_training.mlir)
 
 ### bitcast_convert
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1220,10 +1220,11 @@ follows:
 def compute_mean(operand, feature_index):
   (sum,) = reduce(
       inputs=[operand],
-      init_values=[0.0],
+      init_values=[constant(0.0, element_type(operand))],
       dimensions=[i for i in range(rank(operand)) if i != feature_index],
       body=lambda x, y: add(x, y))
-  divisor = constant(num_elements(operand) / dim(operand, feature_index))
+  divisor = constant(num_elements(operand) / dim(operand, feature_index),
+                     element_type(operand))
   divisor_bcast = broadcast_in_dim(divisor, [], shape(sum))
   return divide(sum, divisor_bcast)
 
@@ -1236,8 +1237,9 @@ def compute_variance(operand, feature_index):
 def batch_norm_training(operand, scale, offset, epsilon, feature_index):
   mean = compute_mean(operand, feature_index)
   variance = compute_variance(operand, feature_index)
-  return batch_norm_inference(operand, scale, offset, mean,
-                              variance, epsilon, feature_index)
+  return batch_norm_inference(operand, scale, offset, mean, variance, epsilon,
+                              feature_index),
+         mean, variance
 ```
 
 #### Inputs

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1263,13 +1263,13 @@ def batch_norm_training(operand, scale, offset, epsilon, feature_index):
 #### Constraints
 
 * (C1) 0 $\le$ `feature_index` $\lt$ rank(`operand`).
-* (C2) `operand`, `scale`, `offset`, `result`, `batch_mean` and `batch_var`
+* (C2) `operand`, `scale`, `offset`, `output`, `batch_mean` and `batch_var`
        have the same element type.
 * (C3) size(`scale`) $=$ `dim(operand, feature_index)`.
 * (C4) size(`offset`) $=$ `dim(operand, feature_index)`.
 * (C5) size(`batch_mean`) $=$ `dim(operand, feature_index)`.
 * (C6) size(`batch_var`) $=$ `dim(operand, feature_index)`.
-* (C7) `operand` and `output` have the same type.
+* (C7) `operand` and `output` have the same shape.
 
 #### Examples
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -52,7 +52,7 @@ one of the following tracking labels.
 | atan2                    | yes           | yes          | yes            | yes             | yes         |
 | batch_norm_grad          | yes           | revisit      | yes            | no              | no          |
 | batch_norm_inference     | yes           | revisit      | yes            | no              | yes         |
-| batch_norm_training      | yes           | revisit      | yes            | no              | no          |
+| batch_norm_training      | yes           | revisit      | yes            | no              | yes         |
 | bitcast_convert          | yes           | yes          | infeasible     | yes             | no          |
 | broadcast                | no            | yes\*        | yes\*          | yes             | no          |
 | broadcast_in_dim         | yes           | yes          | infeasible     | yes             | yes         |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1761,8 +1761,9 @@ def StableHLO_BatchNormInferenceOp : StableHLO_Op<"batch_norm_inference",
 }
 
 def StableHLO_BatchNormTrainingOp : StableHLO_Op<"batch_norm_training",
-    [Pure, AllElementTypesMatch<["operand", "output", "batch_mean", "batch_var"]>,
-    InferTensorType]> {
+    [Pure, AllElementTypesMatch<["operand", "scale", "offset", "output",
+     "batch_mean", "batch_var"]> /*batch_norm_training_c2*/,
+     InferTensorType /*batch_norm_training_c5, batch_norm_training_c6, batch_norm_training_c7*/]> {
   let summary = "BatchNormTraining operation";
   let description = [{
     Computes mean and variance across batch and spatial dimensions and
@@ -1777,16 +1778,17 @@ def StableHLO_BatchNormTrainingOp : StableHLO_Op<"batch_norm_training",
     %output, %batch_mean, %batch_var = "stablehlo.batch_norm_training"(%operand, %scale, %offset) {
       epsilon = 0.0 : f32,
       feature_index = 2 : i64
-    } : (tensor<2x2x2xf32>, tensor<2xf32>, tensor<2xf32>) -> (tensor<2x2x2xf32>, tensor<2xf32>, tensor<2xf32>)
+    } : (tensor<2x2x2xf64>, tensor<2xf64>, tensor<2xf64>) ->
+        (tensor<2x2x2xf64>, tensor<2xf64>, tensor<2xf64>)
     ```
   }];
 
   let arguments = (ins
-    RankedTensorOf<[HLO_Float]>:$operand,
-    1DTensorOf<[HLO_Float]>:$scale,
-    1DTensorOf<[HLO_Float]>:$offset,
-    F32Attr:$epsilon,
-    I64Attr:$feature_index
+    RankedTensorOf<[HLO_Float]>:$operand /*batch_norm_training_i1*/,
+    1DTensorOf<[HLO_Float]>:$scale /*batch_norm_training_i2*/,
+    1DTensorOf<[HLO_Float]>:$offset /*batch_norm_training_i3*/,
+    F32Attr:$epsilon /*batch_norm_training_i4*/,
+    I64Attr:$feature_index /*batch_norm_training_i5*/
   );
 
   let results = (outs

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -231,7 +231,7 @@ LogicalResult verifyBatchNorm(std::optional<Location> location,
         "expects single-dimensional operands to have compatible shapes.");
 
   auto multiDimType = multiDimOperands[0].getType().cast<RankedTensorType>();
-  // batch_norm_inference_c1
+  // batch_norm_inference_c1, batch_norm_training_c1
   if (featureIndex >= multiDimType.getRank())
     return emitOptionalError(
         location,
@@ -239,7 +239,7 @@ LogicalResult verifyBatchNorm(std::optional<Location> location,
         "multi-dimensional operands; got featureIndex ",
         featureIndex, ", and rank ", multiDimType.getRank(), ".");
 
-  // batch_norm_inference_c1
+  // batch_norm_inference_c1, batch_norm_training_c1
   if (featureIndex < 0)
     return emitOptionalError(location, "expects featureIndex to be a ",
                              "non-negative number, got ", featureIndex, ".");
@@ -271,7 +271,7 @@ LogicalResult inferBatchNormOp(
 
   // Batch norm ops require operands to be ranked.
   auto multiDimType = multiDimOperands[0].getType().cast<RankedTensorType>();
-  // batch_norm_inference_c7
+  // batch_norm_inference_c7, batch_norm_training_c7
   inferredReturnShapes.emplace_back(multiDimType.getShape(),
                                     multiDimType.getElementType(),
                                     multiDimType.getEncoding());
@@ -291,8 +291,9 @@ LogicalResult inferBatchNormOp(
       singleDimBounds.empty()
           ? nullptr
           : boundsToEncoding(multiDimType.getEncoding(), singleDimBounds));
-
+  // batch_norm_training_c5
   inferredReturnShapes.emplace_back(singleDimReturnShape);
+  // batch_norm_training_c6
   inferredReturnShapes.emplace_back(singleDimReturnShape);
   return success();
 }

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -248,7 +248,8 @@ LogicalResult verifyBatchNorm(std::optional<Location> location,
   const int64_t singleDimSize =
       singleDimOperands[0].getType().cast<RankedTensorType>().getDimSize(0);
 
-  // batch_norm_inference_c3...batch_norm_inference_c6
+  // batch_norm_inference_c3...batch_norm_inference_c6, batch_norm_training_c3,
+  // batch_norm_training_c4
   if (!verifyCompatibleDims(singleDimSize, featureCount))
     return emitOptionalError(
         location,

--- a/stablehlo/reference/CMakeLists.txt
+++ b/stablehlo/reference/CMakeLists.txt
@@ -71,6 +71,7 @@ add_mlir_library(StablehloReferenceTensor
 
   LINK_LIBS PUBLIC
   MLIRIR
+  StablehloReferenceAxes
   StablehloReferenceElement
   StablehloReferenceIndex
   StablehloReferenceSizes

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -119,7 +119,7 @@ Tensor computeSum(const Tensor &input, const Tensor &initValue,
 
 Tensor computeMean(const Tensor &operand, Axis featureIndex,
                    ShapedType resultType) {
-  Axes dimensions(operand.getAxes());
+  auto dimensions = operand.getAxes();
   dimensions.erase(dimensions.begin() + featureIndex);
 
   auto sum =

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -102,18 +102,6 @@ Tensor evalSliceOp(const Tensor &operand, const Sizes &startIndices,
                      inferredTypes[0].cast<ShapedType>());
 }
 
-template <typename T>
-DenseIntElementsAttr getDenseIntElementsAttr(
-    Type elementType, T values,
-    std::optional<SmallVector<int64_t>> valuesShape) {
-  SmallVector<int64_t> shape =
-      valuesShape.has_value()
-          ? *valuesShape
-          : SmallVector<int64_t>({static_cast<int64_t>(values.size())});
-  return DenseIntElementsAttr::get(RankedTensorType::get(shape, elementType),
-                                   values);
-}
-
 static Tensor computeSum(const Tensor &operand, const Tensor &initValue,
                          const Axes &dimensions, ShapedType resultType) {
   Tensor result(resultType);

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -35,6 +35,11 @@ Tensor evalBatchNormInferenceOp(const Tensor &operand, const Tensor &scale,
                                 const Tensor &offset, const Tensor &mean,
                                 const Tensor &variance, APFloat epsilon,
                                 Axis featureIndex, ShapedType resultType);
+SmallVector<Tensor> evalBatchNormTrainingOp(const Tensor &operand,
+                                            const Tensor &scale,
+                                            const Tensor &offset,
+                                            APFloat epsilon, Axis featureIndex,
+                                            ArrayRef<ShapedType> resultTypes);
 Tensor evalBroadcastInDimOp(const Tensor &operand,
                             const Axes &broadcastDimensions,
                             ShapedType resultType);

--- a/stablehlo/reference/Tensor.h
+++ b/stablehlo/reference/Tensor.h
@@ -16,6 +16,7 @@ limitations under the License.
 #ifndef STABLEHLO_REFERENCE_TENSOR_H
 #define STABLEHLO_REFERENCE_TENSOR_H
 
+#include <numeric>
 #include <vector>
 
 #include "llvm/ADT/ArrayRef.h"
@@ -25,6 +26,7 @@ limitations under the License.
 #include "mlir/IR/AsmState.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "stablehlo/reference/Axes.h"
 #include "stablehlo/reference/Element.h"
 #include "stablehlo/reference/Index.h"
 #include "stablehlo/reference/Sizes.h"
@@ -86,6 +88,13 @@ class Tensor {
 
   /// Returns rank of the Tensor object.
   int64_t getRank() const { return impl_->getType().getRank(); }
+
+  /// Returns axes of the Tensor object: [0, 1, ..., getRank() - 1].
+  Axes getAxes() const {
+    Axes result(getRank());
+    std::iota(result.begin(), result.end(), 0);
+    return result;
+  }
 
   /// Returns shape of the Tensor object.
   Sizes getShape() const { return Sizes(impl_->getType().getShape()); }

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -266,9 +266,13 @@ func.func @batch_norm_grad(%input: tensor<2x2x2x2xf32>, %scale: tensor<2xf32>, %
 
 // -----
 
-// CHECK-LABEL: func @batch_norm_train
-func.func @batch_norm_train(%input: tensor<2x?x2x2xf32>, %scale: tensor<2xf32>, %offset: tensor<2xf32>) -> tensor<*xindex> {
-  %0:3 = "stablehlo.batch_norm_training" (%input, %scale, %offset) {epsilon = 0.001 : f32, feature_index = 1 : i64} : (tensor<2x?x2x2xf32>, tensor<2xf32>, tensor<2xf32>) -> (tensor<2x?x2x2xf32>, tensor<?xf32>, tensor<?xf32>)
+// CHECK-LABEL: func @batch_norm_training
+func.func @batch_norm_training(%input: tensor<2x?x2x2xf32>, %scale: tensor<2xf32>, %offset: tensor<2xf32>) -> tensor<*xindex> {
+  %0:3 = "stablehlo.batch_norm_training" (%input, %scale, %offset) {
+    epsilon = 0.001 : f32,
+    feature_index = 1 : i64
+  } : (tensor<2x?x2x2xf32>, tensor<2xf32>, tensor<2xf32>) ->
+      (tensor<2x?x2x2xf32>, tensor<?xf32>, tensor<?xf32>)
   // CHECK: types0 = tensor<2x?x2x2xf32>
   // CHECK-SAME: types1 = tensor<?xf32>
   // CHECK-SAME: types2 = tensor<?xf32>
@@ -321,33 +325,6 @@ func.func @batch_norm_grad_bounds(
     tensor<?xf32, #stablehlo.bounds<64>>,
     tensor<?xf32, #stablehlo.bounds<64>>,
     tensor<2x?xf32, #stablehlo.bounds<?, 64>>
-  ) ->
-    (
-    tensor<2x?xf32, #stablehlo.bounds<?, 64>>,
-    tensor<?xf32, #stablehlo.bounds<64>>,
-    tensor<?xf32, #stablehlo.bounds<64>>
-  )
-  // CHECK: types0 = tensor<2x?xf32, #stablehlo.bounds<?, 64>>
-  // CHECK-SAME: types1 = tensor<?xf32, #stablehlo.bounds<64>>
-  // CHECK-SAME: types2 = tensor<?xf32, #stablehlo.bounds<64>>
-  %1 = "hlo_test_infer.get_return_types"(%0#0) : (tensor<2x?xf32, #stablehlo.bounds<?, 64>>) -> tensor<*xindex>
-  func.return %1 : tensor<*xindex>
-}
-
-// -----
-
-// CHECK-LABEL: func @batch_norm_train_bounds
-func.func @batch_norm_train_bounds(
-  %input: tensor<2x?xf32, #stablehlo.bounds<?, 64>>,
-  %scale: tensor<?xf32, #stablehlo.bounds<64>>,
-  %offset: tensor<?xf32, #stablehlo.bounds<64>>
-) -> tensor<*xindex> {
-  %0:3 = "stablehlo.batch_norm_training" (%input, %scale, %offset) {
-    epsilon = 0.001 : f32, feature_index = 1 : i64
-  } : (
-    tensor<2x?xf32, #stablehlo.bounds<?, 64>>,
-    tensor<?xf32, #stablehlo.bounds<64>>,
-    tensor<?xf32, #stablehlo.bounds<64>>
   ) ->
     (
     tensor<2x?xf32, #stablehlo.bounds<?, 64>>,

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -298,6 +298,33 @@ func.func @batch_norm_training_c5_c6_c7(%input: tensor<2x2x2x2xf32>, %scale: ten
 
 // -----
 
+// CHECK-LABEL: func @batch_norm_training_bounds
+func.func @batch_norm_training_bounds(
+  %input: tensor<2x?xf32, #stablehlo.bounds<?, 64>>,
+  %scale: tensor<?xf32, #stablehlo.bounds<64>>,
+  %offset: tensor<?xf32, #stablehlo.bounds<64>>
+) -> tensor<*xindex> {
+  %0:3 = "stablehlo.batch_norm_training" (%input, %scale, %offset) {
+    epsilon = 0.001 : f32, feature_index = 1 : i64
+  } : (
+    tensor<2x?xf32, #stablehlo.bounds<?, 64>>,
+    tensor<?xf32, #stablehlo.bounds<64>>,
+    tensor<?xf32, #stablehlo.bounds<64>>
+  ) ->
+    (
+    tensor<2x?xf32, #stablehlo.bounds<?, 64>>,
+    tensor<?xf32, #stablehlo.bounds<64>>,
+    tensor<?xf32, #stablehlo.bounds<64>>
+  )
+  // CHECK: types0 = tensor<2x?xf32, #stablehlo.bounds<?, 64>>
+  // CHECK-SAME: types1 = tensor<?xf32, #stablehlo.bounds<64>>
+  // CHECK-SAME: types2 = tensor<?xf32, #stablehlo.bounds<64>>
+  %1 = "hlo_test_infer.get_return_types"(%0#0) : (tensor<2x?xf32, #stablehlo.bounds<?, 64>>) -> tensor<*xindex>
+  func.return %1 : tensor<*xindex>
+}
+
+// -----
+
 // CHECK-LABEL: @batch_norm_inference_c7
 func.func @batch_norm_inference_c7(%input: tensor<4x256xf32>, %scale: tensor<256xf32>, %offset: tensor<256xf32>, %mean: tensor<256xf32>, %variance: tensor<256xf32>) -> (tensor<*xindex>) {
   %0 = "stablehlo.batch_norm_inference" (%input, %scale, %offset, %mean, %variance) {epsilon = 1.001000e-05 : f32, feature_index = 1 : i64} :

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -282,6 +282,22 @@ func.func @batch_norm_training(%input: tensor<2x?x2x2xf32>, %scale: tensor<2xf32
 
 // -----
 
+
+func.func @batch_norm_training_c5_c6_c7(%input: tensor<2x2x2x2xf32>, %scale: tensor<2xf32>, %offset: tensor<2xf32>) -> tensor<*xindex> {
+  %0:3 = "stablehlo.batch_norm_training" (%input, %scale, %offset) {
+    epsilon = 0.001 : f32,
+    feature_index = 1 : i64
+  } : (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>) ->
+      (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>)
+  // CHECK: types0 = tensor<2x2x2x2xf32>
+  // CHECK-SAME: types1 = tensor<2xf32>
+  // CHECK-SAME: types2 = tensor<2xf32>
+  %1 = "hlo_test_infer.get_return_types"(%0#0) : (tensor<2x2x2x2xf32>) -> tensor<*xindex>
+  func.return %1 : tensor<*xindex>
+}
+
+// -----
+
 // CHECK-LABEL: @batch_norm_inference_c7
 func.func @batch_norm_inference_c7(%input: tensor<4x256xf32>, %scale: tensor<256xf32>, %offset: tensor<256xf32>, %mean: tensor<256xf32>, %variance: tensor<256xf32>) -> (tensor<*xindex>) {
   %0 = "stablehlo.batch_norm_inference" (%input, %scale, %offset, %mean, %variance) {epsilon = 1.001000e-05 : f32, feature_index = 1 : i64} :

--- a/stablehlo/tests/interpret_batch_norm_training.mlir
+++ b/stablehlo/tests/interpret_batch_norm_training.mlir
@@ -1,0 +1,18 @@
+// RUN: stablehlo-translate --interpret -split-input-file %s
+
+func.func @batch_norm_training() {
+  %operand = stablehlo.constant dense<[[[1.0, 2.0], [3.0, 4.0]],
+                                       [[3.0, 4.0], [1.0, 2.0]]]> : tensor<2x2x2xf64>
+  %scale = stablehlo.constant dense<[1.0, 1.0]> : tensor<2xf64>
+  %offset = stablehlo.constant dense<[1.0, 1.0]> : tensor<2xf64>
+  %output, %batch_mean, %batch_var = "stablehlo.batch_norm_training"(%operand, %scale, %offset) {
+    epsilon = 0.0 : f32,
+    feature_index = 2 : i64
+  } : (tensor<2x2x2xf64>, tensor<2xf64>, tensor<2xf64>) ->
+      (tensor<2x2x2xf64>, tensor<2xf64>, tensor<2xf64>)
+  check.expect_almost_eq_const %output, dense<[[[0.0, 0.0], [2.0, 2.0]],
+                                               [[2.0, 2.0], [0.0, 0.0]]]> : tensor<2x2x2xf64>
+  check.expect_almost_eq_const %batch_mean, dense<[2.0, 3.0]> : tensor<2xf64>
+  check.expect_almost_eq_const %batch_var, dense<[1.0, 1.0]> : tensor<2xf64>
+  func.return
+}

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -4737,18 +4737,20 @@ func.func @error_incompatible_alias_element_types (%arg0: tensor<2xf32> {stableh
 
 // -----
 
-// stablehlo.batch_norm_training
-
-// CHECK-LABEL: @batch_norm_train
-func.func @batch_norm_train(%input: tensor<2x2x2x2xf32>, %scale: tensor<2xf32>, %offset: tensor<2xf32>) -> tensor<2x2x2x2xf32> {
-  %0:3 = "stablehlo.batch_norm_training" (%input, %scale, %offset) {epsilon = 0.001 : f32, feature_index = 1 : i64} : (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>) -> (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>)
-  func.return %0#0 : tensor<2x2x2x2xf32>
+// CHECK-LABEL: @batch_norm_training
+func.func @batch_norm_training(%input: tensor<2x2x2x2xf64>, %scale: tensor<2xf64>, %offset: tensor<2xf64>) -> tensor<2x2x2x2xf64> {
+  %0:3 = "stablehlo.batch_norm_training" (%input, %scale, %offset) {
+    epsilon = 0.001 : f32,
+    feature_index = 1 : i64
+  } : (tensor<2x2x2x2xf64>, tensor<2xf64>, tensor<2xf64>) ->
+      (tensor<2x2x2x2xf64>, tensor<2xf64>, tensor<2xf64>)
+  func.return %0#0 : tensor<2x2x2x2xf64>
 }
 
 // -----
 
-// CHECK-LABEL: @batch_norm_train_dynamic
-func.func @batch_norm_train_dynamic(%input: tensor<?x?x2x2xf32>, %scale: tensor<2xf32>, %offset: tensor<2xf32>) -> tensor<?x?x2x2xf32> {
+// CHECK-LABEL: @batch_norm_training_dynamic
+func.func @batch_norm_training_dynamic(%input: tensor<?x?x2x2xf32>, %scale: tensor<2xf32>, %offset: tensor<2xf32>) -> tensor<?x?x2x2xf32> {
   %0:3 = "stablehlo.batch_norm_training" (%input, %scale, %offset) {
     epsilon = 0.001 : f32, feature_index = 1 : i64
   } : (tensor<?x?x2x2xf32>, tensor<2xf32>, tensor<2xf32>) -> (tensor<?x?x2x2xf32>, tensor<2xf32>, tensor<2xf32>)
@@ -4757,16 +4759,7 @@ func.func @batch_norm_train_dynamic(%input: tensor<?x?x2x2xf32>, %scale: tensor<
 
 // -----
 
-func.func @error_batch_norm_train(%input: tensor<2x2x2x2xf32>, %scale: tensor<2xf32>, %offset: tensor<2xf32>) -> tensor<2x2x2x2xf32> {
-  // expected-error@+2 {{failed to infer returned types}}
-  // expected-error@+1 {{expects featureIndex to be smaller than the rank of multi-dimensional operands; got featureIndex 4, and rank 4.}}
-  %0:3 = "stablehlo.batch_norm_training" (%input, %scale, %offset) {epsilon = 0.001 : f32, feature_index = 4 : i64} : (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>) -> (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>)
-  func.return %0#0 : tensor<2x2x2x2xf32>
-}
-
-// -----
-
-func.func @error_batch_norm_train(%input: tensor<2x2x2x2xf32>, %scale: tensor<2xf32>, %offset: tensor<2xf32>) -> tensor<2x2x2x2xf32> {
+func.func @batch_norm_training_c1(%input: tensor<2x2x2x2xf32>, %scale: tensor<2xf32>, %offset: tensor<2xf32>) -> tensor<2x2x2x2xf32> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{expects featureIndex to be a non-negative number, got -1.}}
   %0:3 = "stablehlo.batch_norm_training" (%input, %scale, %offset) {epsilon = 0.001 : f32, feature_index = -1 : i64} : (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>) -> (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>)
@@ -4775,7 +4768,16 @@ func.func @error_batch_norm_train(%input: tensor<2x2x2x2xf32>, %scale: tensor<2x
 
 // -----
 
-func.func @error_batch_norm_train(%input: tensor<2x2x2x2xf32>, %scale: tensor<3xf32>, %offset: tensor<3xf32>) -> tensor<2x2x2x2xf32> {
+func.func @batch_norm_training_c1(%input: tensor<2x2x2x2xf32>, %scale: tensor<2xf32>, %offset: tensor<2xf32>) -> tensor<2x2x2x2xf32> {
+  // expected-error@+2 {{failed to infer returned types}}
+  // expected-error@+1 {{expects featureIndex to be smaller than the rank of multi-dimensional operands; got featureIndex 4, and rank 4.}}
+  %0:3 = "stablehlo.batch_norm_training" (%input, %scale, %offset) {epsilon = 0.001 : f32, feature_index = 4 : i64} : (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>) -> (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>)
+  func.return %0#0 : tensor<2x2x2x2xf32>
+}
+
+// -----
+
+func.func @batch_norm_training_c3_c4(%input: tensor<2x2x2x2xf32>, %scale: tensor<3xf32>, %offset: tensor<3xf32>) -> tensor<2x2x2x2xf32> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{expects the size of single-dimensional operands to be compatible with feature count, but the size of single-dimensional operands is 3 and the feature count is 2.}}
   %0:3 = "stablehlo.batch_norm_training" (%input, %scale, %offset) {epsilon = 0.001 : f32, feature_index = 3 : i64} : (tensor<2x2x2x2xf32>, tensor<3xf32>, tensor<3xf32>) -> (tensor<2x2x2x2xf32>, tensor<3xf32>, tensor<3xf32>)

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -4752,8 +4752,10 @@ func.func @batch_norm_training(%input: tensor<2x2x2x2xf64>, %scale: tensor<2xf64
 // CHECK-LABEL: @batch_norm_training_dynamic
 func.func @batch_norm_training_dynamic(%input: tensor<?x?x2x2xf32>, %scale: tensor<2xf32>, %offset: tensor<2xf32>) -> tensor<?x?x2x2xf32> {
   %0:3 = "stablehlo.batch_norm_training" (%input, %scale, %offset) {
-    epsilon = 0.001 : f32, feature_index = 1 : i64
-  } : (tensor<?x?x2x2xf32>, tensor<2xf32>, tensor<2xf32>) -> (tensor<?x?x2x2xf32>, tensor<2xf32>, tensor<2xf32>)
+    epsilon = 0.001 : f32,
+    feature_index = 1 : i64
+  } : (tensor<?x?x2x2xf32>, tensor<2xf32>, tensor<2xf32>) ->
+      (tensor<?x?x2x2xf32>, tensor<2xf32>, tensor<2xf32>)
   func.return %0#0 : tensor<?x?x2x2xf32>
 }
 
@@ -4762,7 +4764,11 @@ func.func @batch_norm_training_dynamic(%input: tensor<?x?x2x2xf32>, %scale: tens
 func.func @batch_norm_training_c1(%input: tensor<2x2x2x2xf32>, %scale: tensor<2xf32>, %offset: tensor<2xf32>) -> tensor<2x2x2x2xf32> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{expects featureIndex to be a non-negative number, got -1.}}
-  %0:3 = "stablehlo.batch_norm_training" (%input, %scale, %offset) {epsilon = 0.001 : f32, feature_index = -1 : i64} : (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>) -> (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>)
+  %0:3 = "stablehlo.batch_norm_training" (%input, %scale, %offset) {
+    epsilon = 0.001 : f32,
+    feature_index = -1 : i64
+  } : (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>) ->
+      (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>)
   func.return %0#0 : tensor<2x2x2x2xf32>
 }
 
@@ -4771,7 +4777,11 @@ func.func @batch_norm_training_c1(%input: tensor<2x2x2x2xf32>, %scale: tensor<2x
 func.func @batch_norm_training_c1(%input: tensor<2x2x2x2xf32>, %scale: tensor<2xf32>, %offset: tensor<2xf32>) -> tensor<2x2x2x2xf32> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{expects featureIndex to be smaller than the rank of multi-dimensional operands; got featureIndex 4, and rank 4.}}
-  %0:3 = "stablehlo.batch_norm_training" (%input, %scale, %offset) {epsilon = 0.001 : f32, feature_index = 4 : i64} : (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>) -> (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>)
+  %0:3 = "stablehlo.batch_norm_training" (%input, %scale, %offset) {
+    epsilon = 0.001 : f32,
+    feature_index = 4 : i64
+  } : (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>) ->
+      (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>)
   func.return %0#0 : tensor<2x2x2x2xf32>
 }
 
@@ -4780,7 +4790,11 @@ func.func @batch_norm_training_c1(%input: tensor<2x2x2x2xf32>, %scale: tensor<2x
 func.func @batch_norm_training_c3_c4(%input: tensor<2x2x2x2xf32>, %scale: tensor<3xf32>, %offset: tensor<3xf32>) -> tensor<2x2x2x2xf32> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{expects the size of single-dimensional operands to be compatible with feature count, but the size of single-dimensional operands is 3 and the feature count is 2.}}
-  %0:3 = "stablehlo.batch_norm_training" (%input, %scale, %offset) {epsilon = 0.001 : f32, feature_index = 3 : i64} : (tensor<2x2x2x2xf32>, tensor<3xf32>, tensor<3xf32>) -> (tensor<2x2x2x2xf32>, tensor<3xf32>, tensor<3xf32>)
+  %0:3 = "stablehlo.batch_norm_training" (%input, %scale, %offset) {
+    epsilon = 0.001 : f32,
+    feature_index = 3 : i64
+  } : (tensor<2x2x2x2xf32>, tensor<3xf32>, tensor<3xf32>) ->
+      (tensor<2x2x2x2xf32>, tensor<3xf32>, tensor<3xf32>)
   func.return %0#0 : tensor<2x2x2x2xf32>
 }
 


### PR DESCRIPTION
We have the following constraints in the spec:

```
(I1) `operand`: tensor of floating-point type.
(I2) `scale`: 1-dimensional tensor of floating-point type.
(I3) `offset`: 1-dimensional tensor of floating-point type.
(I4) `epsilon`: constant of type `f32`.
(I5) `feature_index`: constant of type `si64`.
(C1) 0 <= `feature_index` < rank(`operand`).
(C2) `operand`, `scale`, `offset`, `result`, `batch_mean` and `batch_var`
     have the same element type.
(C3) size(`scale`) = `dim(operand, feature_index)`.
(C4) size(`offset`) = `dim(operand, feature_index)`.
(C5) size(`batch_mean`) = `dim(operand, feature_index)`.
(C6) size(`batch_var`) = `dim(operand, feature_index)`.
(C7) `operand` and `output` have the same type.
```

These constraints will be comprehensively covered by the following tests:

```
I1: a) `operand` is not a tensor of floating-point type. (Covered by ODS).
I2: a) `scale` is not a 1-dimensional tensor. (Covered by ODS).
    b) `scale` is not a tensor of floating-point type. (Covered by ODS).
I3: a) `offset` is not a 1-dimensional tensor. (Covered by ODS).
    b) `offset` is not a tensor of floating-point type. (Covered by ODS).
I4: a) `epsilon` is not a constant of type `f32`. (Covered by ODS).
I5: a) `feature_index` is not a constant of type `si64`. (Covered by ODS).
C1: a) `feature_index` < 0.
    b) `feature_index` >= rank(`operand`).
C2: a) element_type(`operand`) != element_type(`scale`). (Covered by ODS).
    b) element_type(`operand`) != element_type(`offset`). (Covered by ODS).
    c) element_type(`operand`) != element_type(`result`). (Covered by ODS).
    d) element_type(`operand`) != element_type(`batch_mean`). (Covered by ODS).
    e) element_type(`operand`) != element_type(`batch_var`). (Covered by ODS).
C3: a) size(`scale`) != dim(operand, feature_index).
C4: a) size(`offset`) != dim(operand, feature_index).
C5: a) size(`batch_mean`) != dim(operand, feature_index).
C6: a) size(`batch_var`) != dim(operand, feature_index).
C7: a) type(`operand`) != type(`output`).
```

If we drop the "Covered by ODS" pieces, this will leave us with the following test cases:

```
C1a: `feature_index` < 0.
C1b: `feature_index` >= rank(`operand`).
C3a: size(`scale`) != dim(operand, feature_index).
C4a: size(`offset`) != dim(operand, feature_index).
C5a: size(`batch_mean`) != dim(operand, feature_index).
C6a: size(`batch_var`) != dim(operand, feature_index).
C7a: type(`operand`) != type(`output`).
```

closes #1122 