### PR TITLE
Add interpreter for BatchNormGradOp

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1028,7 +1028,8 @@ def compute_sum(operand, feature_index):
 
 def compute_mean(operand, feature_index):
   sum = compute_sum(operand, feature_index)
-  divisor = constant(num_elements(operand) / dim(operand, feature_index))
+  divisor = constant(num_elements(operand) / dim(operand, feature_index),
+                     element_type(operand))
   divisor_bcast = broadcast_in_dim(divisor, [], shape(sum))
   return divide(sum, divisor_bcast)
 
@@ -1037,7 +1038,8 @@ def batch_norm_grad(operand, scale, mean, variance, grad_output, epsilon, featur
   scale_bcast = broadcast_in_dim(scale, [feature_index], shape(operand))
   mean_bcast = broadcast_in_dim(mean, [feature_index], shape(operand))
   variance_bcast = broadcast_in_dim(variance, [feature_index], shape(operand))
-  epsilon_bcast = broadcast_in_dim(constant(epsilon), [], shape(operand))
+  epsilon_bcast = broadcast_in_dim(constant(epsilon, element_type(operand)), [],
+                                   shape(operand))
 
   # Perform normalization using the provided `mean` and `variance`
   # Intermediate values will be useful for computing gradients
@@ -1047,27 +1049,26 @@ def batch_norm_grad(operand, scale, mean, variance, grad_output, epsilon, featur
 
   # Use the implementation from batchnorm_expander.cc in XLA
   # Temporary variables have exactly the same names as in the C++ code
-  elements_per_feature = constant(
-    divide(num_elements(operand), dim(operand, feature_index)))
-  i1 = multiply(
-    grad_output,
-    broadcast_in_dim(elements_per_feature, [], shape(operand)))
+  elements_per_feature = broadcast_in_dim(
+      constant(divide(num_elements(operand), dim(operand, feature_index)),
+               element_type(grad_output)),
+      [], shape(operand))
+  i1 = multiply(grad_output, elements_per_feature)
   i2 = broadcast_in_dim(
-    compute_sum(grad_output, feature_index),
-    [feature_index], shape(operand))
+      compute_sum(grad_output, feature_index), [feature_index], shape(operand))
   i3 = broadcast_in_dim(
-    compute_sum(multiply(grad_output, centered_operand), feature_index),
-    [feature_index], shape(operand))
+      compute_sum(multiply(grad_output, centered_operand), feature_index),
+      [feature_index], shape(operand))
   i4 = multiply(i3, centered_operand)
   i5 = divide(i4, add(variance_bcast, epsilon_bcast))
   i6 = subtract(subtract(i1, i2), i5)
-  grad_operand = multiply(
-    divide(divide(scale_bcast, stddev), elements_per_feature),
-    i6)
-  grad_scale = compute_sum(
-    multiply(grad_output, normalized_operand),
-    feature_index)
+
+  grad_operand =
+      multiply(divide(divide(scale_bcast, stddev), elements_per_feature), i6)
+  grad_scale =
+      compute_sum(multiply(grad_output, normalized_operand), feature_index)
   grad_offset = compute_sum(grad_output, feature_index)
+
   return grad_operand, grad_scale, grad_offset
 ```
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1021,7 +1021,7 @@ existing StableHLO operations using Python-like syntax as follows:
 def compute_sum(operand, feature_index):
   (sum,) = reduce(
       inputs=[operand],
-      init_values=[0.0],
+      init_values=[constant(0.0, element_type(operand))],
       dimensions=[i for i in range(rank(operand)) if i != feature_index],
       body=lambda x, y: add(x, y))
   return sum
@@ -1053,10 +1053,10 @@ def batch_norm_grad(operand, scale, mean, variance, grad_output, epsilon, featur
     grad_output,
     broadcast_in_dim(elements_per_feature, [], shape(operand)))
   i2 = broadcast_in_dim(
-    compute_sum(grad_output),
+    compute_sum(grad_output, feature_index),
     [feature_index], shape(operand))
   i3 = broadcast_in_dim(
-    compute_sum(multiply(grad_output, centered_operand)),
+    compute_sum(multiply(grad_output, centered_operand), feature_index),
     [feature_index], shape(operand))
   i4 = multiply(i3, centered_operand)
   i5 = divide(i4, add(variance_bcast, epsilon_bcast))

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1048,23 +1048,25 @@ def batch_norm_grad(operand, scale, mean, variance, grad_output, epsilon, featur
   # Use the implementation from batchnorm_expander.cc in XLA
   # Temporary variables have exactly the same names as in the C++ code
   elements_per_feature = constant(
-    divide(size(operand), dim(operand, feature_index)))
+    divide(num_elements(operand), dim(operand, feature_index)))
   i1 = multiply(
     grad_output,
     broadcast_in_dim(elements_per_feature, [], shape(operand)))
   i2 = broadcast_in_dim(
-    compute_sum(grad_output, feature_index),
+    compute_sum(grad_output),
     [feature_index], shape(operand))
   i3 = broadcast_in_dim(
     compute_sum(multiply(grad_output, centered_operand)),
     [feature_index], shape(operand))
   i4 = multiply(i3, centered_operand)
   i5 = divide(i4, add(variance_bcast, epsilon_bcast))
+  i6 = subtract(subtract(i1, i2), i5)
   grad_operand = multiply(
     divide(divide(scale_bcast, stddev), elements_per_feature),
-    subtract(subtract(i1, i2), i5))
+    i6)
   grad_scale = compute_sum(
-    multiply(grad_output, normalized_operand), feature_index)
+    multiply(grad_output, normalized_operand),
+    feature_index)
   grad_offset = compute_sum(grad_output, feature_index)
   return grad_operand, grad_scale, grad_offset
 ```
@@ -1117,8 +1119,8 @@ def batch_norm_grad(operand, scale, mean, variance, grad_output, epsilon, featur
 "stablehlo.batch_norm_grad"(%operand, %scale, %mean, %variance, %grad_output) {
   epsilon = 0.0 : f32,
   feature_index = 2 : i64
-} : (tensor<2x2x2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2xf32>,
-     tensor<2x2x2xf32>) -> (tensor<2x2x2xf32>, tensor<2xf32>, tensor<2xf32>)
+} : (tensor<2x2x2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>,
+     tensor<2x2x2xf64>) -> (tensor<2x2x2xf64>, tensor<2xf64>, tensor<2xf64>)
 // %grad_operand: [
 //                 [[0.0, 0.0], [0.0, 0.0]],
 //                 [[0.0, 0.0], [0.0, 0.0]]
@@ -1126,6 +1128,8 @@ def batch_norm_grad(operand, scale, mean, variance, grad_output, epsilon, featur
 // %grad_scale:  [0.0, 0.0]
 // %grad_offset: [0.4, 0.4]
 ```
+
+&nbsp;[More Examples](../stablehlo/tests/interpret_batch_norm_grad.mlir)
 
 ### batch_norm_inference
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -50,7 +50,7 @@ one of the following tracking labels.
 | all_to_all               | yes           | revisit      | yes            | no              | no          |
 | and                      | yes           | yes          | yes            | yes             | yes         |
 | atan2                    | yes           | yes          | yes            | yes             | yes         |
-| batch_norm_grad          | yes           | revisit      | yes            | no              | no          |
+| batch_norm_grad          | yes           | revisit      | yes            | no              | yes         |
 | batch_norm_inference     | yes           | revisit      | yes            | no              | yes         |
 | batch_norm_training      | yes           | revisit      | yes            | no              | yes         |
 | bitcast_convert          | yes           | yes          | infeasible     | yes             | no          |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1688,8 +1688,9 @@ def StableHLO_DynamicUpdateSliceOp: StableHLO_Op<"dynamic_update_slice",
 //===----------------------------------------------------------------------===//
 
 def StableHLO_BatchNormGradOp : StableHLO_Op<"batch_norm_grad", [Pure,
-    AllElementTypesMatch<["operand", "grad_operand", "grad_scale", "grad_offset"]>,
-    InferTensorType]> {
+    AllElementTypesMatch<["operand", "scale", "mean", "variance", "grad_output",
+    "grad_operand", "grad_scale", "grad_offset"] /*batch_norm_grad_c2*/>,
+    InferTensorType /*batch_norm_grad_c3, batch_norm_grad_c4*/]> {
   let summary = "BatchNormGrad operation";
   let description = [{
     Computes gradients of several inputs of BatchNormTrainingOp backpropagating
@@ -1705,19 +1706,19 @@ def StableHLO_BatchNormGradOp : StableHLO_Op<"batch_norm_grad", [Pure,
     "stablehlo.batch_norm_grad"(%operand, %scale, %mean, %variance, %grad_output) {
       epsilon = 0.0 : f32,
       feature_index = 2 : i64
-    } : (tensor<2x2x2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2xf32>,
-        tensor<2x2x2xf32>) -> (tensor<2x2x2xf32>, tensor<2xf32>, tensor<2xf32>)
+    } : (tensor<2x2x2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>,
+         tensor<2x2x2xf64>) -> (tensor<2x2x2xf64>, tensor<2xf64>, tensor<2xf64>)
     ```
   }];
 
   let arguments = (ins
-    RankedTensorOf<[HLO_Float]>:$operand,
-    1DTensorOf<[HLO_Float]>:$scale,
-    1DTensorOf<[HLO_Float]>:$mean,
-    1DTensorOf<[HLO_Float]>:$variance,
-    RankedTensorOf<[HLO_Float]>:$grad_output,
-    F32Attr:$epsilon,
-    I64Attr:$feature_index
+    RankedTensorOf<[HLO_Float]>:$operand, /*batch_norm_grad_i1*/
+    1DTensorOf<[HLO_Float]>:$scale, /*batch_norm_grad_i2*/
+    1DTensorOf<[HLO_Float]>:$mean, /*batch_norm_grad_i3*/
+    1DTensorOf<[HLO_Float]>:$variance, /*batch_norm_grad_i4*/
+    RankedTensorOf<[HLO_Float]>:$grad_output, /*batch_norm_grad_i5*/
+    F32Attr:$epsilon, /*batch_norm_grad_i6*/
+    I64Attr:$feature_index /*batch_norm_grad_i7*/
   );
 
   let results = (outs

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -219,19 +219,21 @@ LogicalResult verifyBatchNorm(std::optional<Location> location,
                               ValueRange multiDimOperands,
                               ValueRange singleDimOperands,
                               int64_t featureIndex) {
+  // batch_norm_grad_c3
   if (failed(verifyPairwiseCompatibleShapes(multiDimOperands.getTypes())))
     return emitOptionalError(
         location,
         "expects multi-dimensional operands to have compatible shapes.");
 
-  // batch_norm_inference_c3...batch_norm_inference_c6
+  // batch_norm_grad_c4, batch_norm_inference_c3...batch_norm_inference_c6,
+  // batch_norm_training_c3, batch_norm_training_c4
   if (failed(verifyPairwiseCompatibleShapes(singleDimOperands.getTypes())))
     return emitOptionalError(
         location,
         "expects single-dimensional operands to have compatible shapes.");
 
   auto multiDimType = multiDimOperands[0].getType().cast<RankedTensorType>();
-  // batch_norm_inference_c1, batch_norm_training_c1
+  // batch_norm_grad_c1, batch_norm_inference_c1, batch_norm_training_c1
   if (featureIndex >= multiDimType.getRank())
     return emitOptionalError(
         location,
@@ -239,7 +241,7 @@ LogicalResult verifyBatchNorm(std::optional<Location> location,
         "multi-dimensional operands; got featureIndex ",
         featureIndex, ", and rank ", multiDimType.getRank(), ".");
 
-  // batch_norm_inference_c1, batch_norm_training_c1
+  // batch_norm_grad_c1, batch_norm_inference_c1, batch_norm_training_c1
   if (featureIndex < 0)
     return emitOptionalError(location, "expects featureIndex to be a ",
                              "non-negative number, got ", featureIndex, ".");
@@ -248,8 +250,8 @@ LogicalResult verifyBatchNorm(std::optional<Location> location,
   const int64_t singleDimSize =
       singleDimOperands[0].getType().cast<RankedTensorType>().getDimSize(0);
 
-  // batch_norm_inference_c3...batch_norm_inference_c6, batch_norm_training_c3,
-  // batch_norm_training_c4
+  // batch_norm_grad_c5, batch_norm_inference_c3...batch_norm_inference_c6,
+  // batch_norm_training_c3, batch_norm_training_c4
   if (!verifyCompatibleDims(singleDimSize, featureCount))
     return emitOptionalError(
         location,
@@ -272,7 +274,7 @@ LogicalResult inferBatchNormOp(
 
   // Batch norm ops require operands to be ranked.
   auto multiDimType = multiDimOperands[0].getType().cast<RankedTensorType>();
-  // batch_norm_inference_c7, batch_norm_training_c7
+  // batch_norm_grad_c3, batch_norm_inference_c7, batch_norm_training_c7
   inferredReturnShapes.emplace_back(multiDimType.getShape(),
                                     multiDimType.getElementType(),
                                     multiDimType.getEncoding());
@@ -292,9 +294,9 @@ LogicalResult inferBatchNormOp(
       singleDimBounds.empty()
           ? nullptr
           : boundsToEncoding(multiDimType.getEncoding(), singleDimBounds));
-  // batch_norm_training_c5
+  // batch_norm_grad_c4, batch_norm_training_c5
   inferredReturnShapes.emplace_back(singleDimReturnShape);
-  // batch_norm_training_c6
+  // batch_norm_grad_c4, batch_norm_training_c6
   inferredReturnShapes.emplace_back(singleDimReturnShape);
   return success();
 }

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -31,6 +31,12 @@ Tensor evalAbsOp(const Tensor &operand, ShapedType resultType);
 Tensor evalAddOp(const Tensor &lhs, const Tensor &rhs, ShapedType resultType);
 Tensor evalAndOp(const Tensor &lhs, const Tensor &rhs, ShapedType resultType);
 Tensor evalAtan2Op(const Tensor &lhs, const Tensor &rhs, ShapedType resultType);
+SmallVector<Tensor> evalBatchNormGradOp(const Tensor &operand,
+                                        const Tensor &scale, const Tensor &mean,
+                                        const Tensor &variance,
+                                        const Tensor &gradOutput,
+                                        APFloat epsilon, Axis featureIndex,
+                                        ArrayRef<ShapedType> resultTypes);
 Tensor evalBatchNormInferenceOp(const Tensor &operand, const Tensor &scale,
                                 const Tensor &offset, const Tensor &mean,
                                 const Tensor &variance, APFloat epsilon,

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -256,11 +256,89 @@ func.func @fft(%arg0: tensor<3x9xcomplex<f32>>) -> tensor<3x9xindex> {
 
 // CHECK-LABEL: func @batch_norm_grad
 func.func @batch_norm_grad(%input: tensor<2x2x2x2xf32>, %scale: tensor<2xf32>, %mean: tensor<2xf32>, %variance: tensor<2xf32>, %grad_output: tensor<2x2x2x2xf32>) -> tensor<*xindex> {
-  %0:3 = "stablehlo.batch_norm_grad" (%input, %scale, %mean, %variance, %grad_output) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2x2x2x2xf32>) -> (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>)
+  %0:3 = "stablehlo.batch_norm_grad" (%input, %scale, %mean, %variance, %grad_output) {
+    epsilon = 0.001 : f32,
+    feature_index = 0 : i64
+  } : (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2x2x2x2xf32>) ->
+      (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>)
   // CHECK: types0 = tensor<2x2x2x2xf32>
   // CHECK-SAME: types1 = tensor<2xf32>
   // CHECK-SAME: types2 = tensor<2xf32>
   %1 = "hlo_test_infer.get_return_types"(%0#0) : (tensor<2x2x2x2xf32>) -> tensor<*xindex>
+  func.return %1 : tensor<*xindex>
+}
+
+// -----
+
+func.func @batch_norm_grad_c3(%input: tensor<2x2x2x2xf32>, %scale: tensor<2xf32>, %mean: tensor<2xf32>, %variance: tensor<2xf32>, %grad_output: tensor<2x2x2x2xf32>) -> tensor<*xindex> {
+  // expected-error@+2 {{failed to infer returned types}}
+  // expected-error@+1 {{inferred type(s) 'tensor<2x2x2x2xf32>', 'tensor<2xf32>', 'tensor<2xf32>' are incompatible with return type(s) of operation 'tensor<2x2x2xf32>', 'tensor<2xf32>', 'tensor<2xf32>'}}
+  %0:3 = "stablehlo.batch_norm_grad" (%input, %scale, %mean, %variance, %grad_output) {
+    epsilon = 0.001 : f32,
+    feature_index = 0 : i64
+  } : (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2x2x2x2xf32>) ->
+      (tensor<2x2x2xf32>, tensor<2xf32>, tensor<2xf32>)
+  %1 = "hlo_test_infer.get_return_types"(%0#0) : (tensor<2x2x2xf32>) -> tensor<*xindex>
+  func.return %1 : tensor<*xindex>
+}
+
+// -----
+
+func.func @batch_norm_grad_c4(%input: tensor<2x2x2x2xf32>, %scale: tensor<2xf32>, %mean: tensor<2xf32>, %variance: tensor<2xf32>, %grad_output: tensor<2x2x2x2xf32>) -> tensor<*xindex> {
+  // expected-error@+2 {{failed to infer returned types}}
+  // expected-error@+1 {{inferred type(s) 'tensor<2x2x2x2xf32>', 'tensor<2xf32>', 'tensor<2xf32>' are incompatible with return type(s) of operation 'tensor<2x2x2xf32>', 'tensor<3xf32>', 'tensor<2xf32>'}}
+  %0:3 = "stablehlo.batch_norm_grad" (%input, %scale, %mean, %variance, %grad_output) {
+    epsilon = 0.001 : f32,
+    feature_index = 0 : i64
+  } : (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2x2x2x2xf32>) ->
+      (tensor<2x2x2xf32>, tensor<3xf32>, tensor<2xf32>)
+  %1 = "hlo_test_infer.get_return_types"(%0#0) : (tensor<2x2x2xf32>) -> tensor<*xindex>
+  func.return %1 : tensor<*xindex>
+}
+
+// -----
+
+func.func @batch_norm_grad_c4(%input: tensor<2x2x2x2xf32>, %scale: tensor<2xf32>, %mean: tensor<2xf32>, %variance: tensor<2xf32>, %grad_output: tensor<2x2x2x2xf32>) -> tensor<*xindex> {
+  // expected-error@+2 {{failed to infer returned types}}
+  // expected-error@+1 {{inferred type(s) 'tensor<2x2x2x2xf32>', 'tensor<2xf32>', 'tensor<2xf32>' are incompatible with return type(s) of operation 'tensor<2x2x2xf32>', 'tensor<2xf32>', 'tensor<3xf32>'}}
+  %0:3 = "stablehlo.batch_norm_grad" (%input, %scale, %mean, %variance, %grad_output) {
+    epsilon = 0.001 : f32,
+    feature_index = 0 : i64
+  } : (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2x2x2x2xf32>) ->
+      (tensor<2x2x2xf32>, tensor<2xf32>, tensor<3xf32>)
+  %1 = "hlo_test_infer.get_return_types"(%0#0) : (tensor<2x2x2xf32>) -> tensor<*xindex>
+  func.return %1 : tensor<*xindex>
+}
+
+// -----
+
+// CHECK-LABEL: func @batch_norm_grad_bounds
+func.func @batch_norm_grad_bounds(
+  %input: tensor<2x?xf32, #stablehlo.bounds<?, 64>>,
+  %scale: tensor<?xf32, #stablehlo.bounds<64>>,
+  %mean: tensor<?xf32, #stablehlo.bounds<64>>,
+  %variance: tensor<?xf32, #stablehlo.bounds<64>>,
+  %grad_output: tensor<2x?xf32, #stablehlo.bounds<?, 64>>
+) -> tensor<*xindex> {
+  %0:3 = "stablehlo.batch_norm_grad" (%input, %scale, %mean, %variance, %grad_output) {
+    epsilon = 0.001 : f32,
+    feature_index = 1 : i64
+  } : (
+    tensor<2x?xf32, #stablehlo.bounds<?, 64>>,
+    tensor<?xf32, #stablehlo.bounds<64>>,
+    tensor<?xf32, #stablehlo.bounds<64>>,
+    tensor<?xf32, #stablehlo.bounds<64>>,
+    tensor<2x?xf32, #stablehlo.bounds<?, 64>>
+  ) ->
+    (
+    tensor<2x?xf32, #stablehlo.bounds<?, 64>>,
+    tensor<?xf32, #stablehlo.bounds<64>>,
+    tensor<?xf32, #stablehlo.bounds<64>>
+  )
+  // CHECK: types0 = tensor<2x?xf32, #stablehlo.bounds<?, 64>>
+  // CHECK-SAME: types1 = tensor<?xf32, #stablehlo.bounds<64>>
+  // CHECK-SAME: types2 = tensor<?xf32, #stablehlo.bounds<64>>
+  %1 = "hlo_test_infer.get_return_types"(%0#0) : (tensor<2x?xf32, #stablehlo.bounds<?, 64>>) -> tensor<*xindex>
   func.return %1 : tensor<*xindex>
 }
 
@@ -347,37 +425,6 @@ func.func @batch_norm_inference_bounds(
     } : (tensor<4x?xf32, #stablehlo.bounds<?, 64>>, tensor<?xf32>, tensor<?xf32>, tensor<?xf32>, tensor<?xf32>) -> tensor<4x?xf32, #stablehlo.bounds<?, 64>>
   // CHECK: types0 = tensor<4x?xf32, #stablehlo.bounds<?, 64>>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<4x?xf32, #stablehlo.bounds<?, 64>>) -> tensor<*xindex>
-  func.return %1 : tensor<*xindex>
-}
-
-// -----
-
-// CHECK-LABEL: func @batch_norm_grad_bounds
-func.func @batch_norm_grad_bounds(
-  %input: tensor<2x?xf32, #stablehlo.bounds<?, 64>>,
-  %scale: tensor<?xf32, #stablehlo.bounds<64>>,
-  %mean: tensor<?xf32, #stablehlo.bounds<64>>,
-  %variance: tensor<?xf32, #stablehlo.bounds<64>>,
-  %grad_output: tensor<2x?xf32, #stablehlo.bounds<?, 64>>
-) -> tensor<*xindex> {
-  %0:3 = "stablehlo.batch_norm_grad" (%input, %scale, %mean, %variance, %grad_output) {
-    epsilon = 0.001 : f32, feature_index = 1 : i64
-  } : (
-    tensor<2x?xf32, #stablehlo.bounds<?, 64>>,
-    tensor<?xf32, #stablehlo.bounds<64>>,
-    tensor<?xf32, #stablehlo.bounds<64>>,
-    tensor<?xf32, #stablehlo.bounds<64>>,
-    tensor<2x?xf32, #stablehlo.bounds<?, 64>>
-  ) ->
-    (
-    tensor<2x?xf32, #stablehlo.bounds<?, 64>>,
-    tensor<?xf32, #stablehlo.bounds<64>>,
-    tensor<?xf32, #stablehlo.bounds<64>>
-  )
-  // CHECK: types0 = tensor<2x?xf32, #stablehlo.bounds<?, 64>>
-  // CHECK-SAME: types1 = tensor<?xf32, #stablehlo.bounds<64>>
-  // CHECK-SAME: types2 = tensor<?xf32, #stablehlo.bounds<64>>
-  %1 = "hlo_test_infer.get_return_types"(%0#0) : (tensor<2x?xf32, #stablehlo.bounds<?, 64>>) -> tensor<*xindex>
   func.return %1 : tensor<*xindex>
 }
 

--- a/stablehlo/tests/interpret_batch_norm_grad.mlir
+++ b/stablehlo/tests/interpret_batch_norm_grad.mlir
@@ -1,0 +1,19 @@
+// RUN: stablehlo-translate --interpret -split-input-file %s
+
+func.func @batch_norm_grad() {
+  %operand = stablehlo.constant dense<[[[1.0, 2.0], [3.0, 4.0]],
+                                       [[3.0, 4.0], [1.0, 2.0]]]> : tensor<2x2x2xf64>
+  %scale = stablehlo.constant dense<[1.0, 1.0]> : tensor<2xf64>
+  %mean = stablehlo.constant dense<[2.0, 3.0]> : tensor<2xf64>
+  %variance = stablehlo.constant dense<[1.0, 1.0]> : tensor<2xf64>
+  %grad_output = stablehlo.constant dense<0.1> : tensor<2x2x2xf64>
+  %grad_operand, %grad_scale, %grad_offset = "stablehlo.batch_norm_grad"(%operand, %scale, %mean, %variance, %grad_output) {
+    epsilon = 0.0 : f32,
+    feature_index = 2 : i64
+  } : (tensor<2x2x2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>,
+       tensor<2x2x2xf64>) -> (tensor<2x2x2xf64>, tensor<2xf64>, tensor<2xf64>)
+  check.expect_almost_eq_const %grad_operand, dense<0.0> : tensor<2x2x2xf64>
+  check.expect_almost_eq_const %grad_scale, dense<[0.0, 0.0]> : tensor<2xf64>
+  check.expect_almost_eq_const %grad_offset, dense<[0.4, 0.4]> : tensor<2xf64>
+  func.return
+}

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -4860,8 +4860,6 @@ func.func @error_batch_norm_inference_c3_c4_c5_c6(%input: tensor<4x256xf32>, %sc
 
 // -----
 
-// stablehlo.batch_norm_grad
-
 // CHECK-LABEL: @batch_norm_grad
 func.func @batch_norm_grad(%input: tensor<2x2x2x2xf32>, %scale: tensor<2xf32>, %mean: tensor<2xf32>, %variance: tensor<2xf32>, %grad_output: tensor<2x2x2x2xf32>) -> tensor<2x2x2x2xf32> {
   %0:3 = "stablehlo.batch_norm_grad" (%input, %scale, %mean, %variance, %grad_output) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2x2x2x2xf32>) -> (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>)
@@ -4879,16 +4877,7 @@ func.func @batch_norm_grad_dynamic(%input: tensor<?x2x2x2xf32>, %scale: tensor<?
 
 // -----
 
-func.func @error_batch_norm_grad(%input: tensor<2x2x2x2xf32>, %scale: tensor<2xf32>, %mean: tensor<2xf32>, %variance: tensor<2xf32>, %grad_output: tensor<2x2x2x2xf32>) -> tensor<2x2x2x2xf32> {
-  // expected-error@+2 {{failed to infer returned types}}
-  // expected-error@+1 {{expects featureIndex to be smaller than the rank of multi-dimensional operands; got featureIndex 4, and rank 4.}}
-  %0:3 = "stablehlo.batch_norm_grad" (%input, %scale, %mean, %variance, %grad_output) {epsilon = 0.001 : f32, feature_index = 4 : i64} : (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2x2x2x2xf32>) -> (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>)
-  func.return %0#0 : tensor<2x2x2x2xf32>
-}
-
-// -----
-
-func.func @error_batch_norm_grad(%input: tensor<2x2x2x2xf32>, %scale: tensor<2xf32>, %mean: tensor<2xf32>, %variance: tensor<2xf32>, %grad_output: tensor<2x2x2x2xf32>) -> tensor<2x2x2x2xf32> {
+func.func @error_batch_norm_grad_c1(%input: tensor<2x2x2x2xf32>, %scale: tensor<2xf32>, %mean: tensor<2xf32>, %variance: tensor<2xf32>, %grad_output: tensor<2x2x2x2xf32>) -> tensor<2x2x2x2xf32> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{expects featureIndex to be a non-negative number, got -1.}}
   %0:3 = "stablehlo.batch_norm_grad" (%input, %scale, %mean, %variance, %grad_output) {epsilon = 0.001 : f32, feature_index = -1 : i64} : (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2x2x2x2xf32>) -> (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>)
@@ -4897,33 +4886,16 @@ func.func @error_batch_norm_grad(%input: tensor<2x2x2x2xf32>, %scale: tensor<2xf
 
 // -----
 
-func.func @error_batch_norm_grad(%input: tensor<2x2x2x2xf32>, %scale: tensor<4xf32>, %mean: tensor<4xf32>, %variance: tensor<4xf32>, %grad_output: tensor<2x2x2x2xf32>) -> tensor<2x2x2x2xf32> {
+func.func @error_batch_norm_grad_c1(%input: tensor<2x2x2x2xf32>, %scale: tensor<2xf32>, %mean: tensor<2xf32>, %variance: tensor<2xf32>, %grad_output: tensor<2x2x2x2xf32>) -> tensor<2x2x2x2xf32> {
   // expected-error@+2 {{failed to infer returned types}}
-  // expected-error@+1 {{expects the size of single-dimensional operands to be compatible with feature count, but the size of single-dimensional operands is 4 and the feature count is 2.}}
-  %0:3 = "stablehlo.batch_norm_grad" (%input, %scale, %mean, %variance, %grad_output) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<2x2x2x2xf32>, tensor<4xf32>, tensor<4xf32>, tensor<4xf32>, tensor<2x2x2x2xf32>) -> (tensor<2x2x2x2xf32>, tensor<4xf32>, tensor<4xf32>)
+  // expected-error@+1 {{expects featureIndex to be smaller than the rank of multi-dimensional operands; got featureIndex 4, and rank 4.}}
+  %0:3 = "stablehlo.batch_norm_grad" (%input, %scale, %mean, %variance, %grad_output) {epsilon = 0.001 : f32, feature_index = 4 : i64} : (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2x2x2x2xf32>) -> (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>)
   func.return %0#0 : tensor<2x2x2x2xf32>
 }
 
 // -----
 
-func.func @error_batch_norm_grad(%input: tensor<2x2x2x2xf32>, %scale: tensor<4xf32>, %mean: tensor<2xf32>, %variance: tensor<2xf32>, %grad_output: tensor<2x2x2x2xf32>) -> tensor<2x2x2x2xf32> {
-  // expected-error@+2 {{failed to infer returned types}}
-  // expected-error@+1 {{expects single-dimensional operands to have compatible shapes}}
-  %0:3 = "stablehlo.batch_norm_grad" (%input, %scale, %mean, %variance, %grad_output) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<2x2x2x2xf32>, tensor<4xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2x2x2x2xf32>) -> (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>)
-  func.return %0#0 : tensor<2x2x2x2xf32>
-}
-
-// -----
-
-func.func @error_batch_norm_grad(%input: tensor<2x2x2x2xi32>, %scale: tensor<2xf32>, %mean: tensor<2xf32>, %variance: tensor<2xf32>, %grad_output: tensor<2x2x2x2xf32>) -> tensor<2x2x2x2xf32> {
-  // expected-error@+1 {{operand #0 must be ranked tensor of f8E4M3B11FNUZ type or f8E4M3FN type or f8E4M3FNUZ type or f8E5M2 type or f8E5M2FNUZ type or 16-bit float or 32-bit float or 64-bit float or bfloat16 type values, but got 'tensor<2x2x2x2xi32>'}}
-  %0:3 = "stablehlo.batch_norm_grad" (%input, %scale, %mean, %variance, %grad_output) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<2x2x2x2xi32>, tensor<2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2x2x2x2xf32>) -> (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>)
-  func.return %0#0 : tensor<2x2x2x2xf32>
-}
-
-// -----
-
-func.func @error_batch_norm_grad(%input: tensor<2x2x2x2xf32>, %scale: tensor<2xf32>, %mean: tensor<2xf32>, %variance: tensor<2xf32>, %grad_output: tensor<2x2x2xf32>) -> tensor<2x2x2x2xf32> {
+func.func @error_batch_norm_grad_c3(%input: tensor<2x2x2x2xf32>, %scale: tensor<2xf32>, %mean: tensor<2xf32>, %variance: tensor<2xf32>, %grad_output: tensor<2x2x2xf32>) -> tensor<2x2x2x2xf32> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{expects multi-dimensional operands to have compatible shapes}}
   %0:3 = "stablehlo.batch_norm_grad" (%input, %scale, %mean, %variance, %grad_output) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2x2x2xf32>) -> (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>)
@@ -4932,34 +4904,38 @@ func.func @error_batch_norm_grad(%input: tensor<2x2x2x2xf32>, %scale: tensor<2xf
 
 // -----
 
-func.func @error_batch_norm_grad(%input: tensor<2x2x2x2xf32>, %scale: tensor<2xf32>, %mean: tensor<2xf32>, %variance: tensor<2xf32>, %grad_output: tensor<2x2x2x2xf32>) -> tensor<2x2x2x2xf32> {
-  // expected-error@+1 {{failed to verify that all of {operand, grad_operand, grad_scale, grad_offset} have same element type}}
-  %0:3 = "stablehlo.batch_norm_grad" (%input, %scale, %mean, %variance, %grad_output) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2x2x2x2xf32>) -> (tensor<2x2x2x2xf32>, tensor<2xf64>, tensor<2xf64>)
+func.func @error_batch_norm_grad_c4(%input: tensor<2x2x2x2xf32>, %scale: tensor<4xf32>, %mean: tensor<2xf32>, %variance: tensor<2xf32>, %grad_output: tensor<2x2x2x2xf32>) -> tensor<2x2x2x2xf32> {
+  // expected-error@+2 {{failed to infer returned types}}
+  // expected-error@+1 {{expects single-dimensional operands to have compatible shapes}}
+  %0:3 = "stablehlo.batch_norm_grad" (%input, %scale, %mean, %variance, %grad_output) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<2x2x2x2xf32>, tensor<4xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2x2x2x2xf32>) -> (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>)
   func.return %0#0 : tensor<2x2x2x2xf32>
 }
 
 // -----
 
-func.func @error_batch_norm_grad(%input: tensor<2x2x2x2xf32>, %scale: tensor<2xf32>, %mean: tensor<2xf32>, %variance: tensor<2xf32>, %grad_output: tensor<2x2x2x2xf32>) -> tensor<2x2x2x2xf64> {
-  // expected-error@+1 {{failed to verify that all of {operand, grad_operand, grad_scale, grad_offset} have same element type}}
-  %0:3 = "stablehlo.batch_norm_grad" (%input, %scale, %mean, %variance, %grad_output) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2x2x2x2xf32>) -> (tensor<2x2x2x2xf64>, tensor<2xf32>, tensor<2xf32>)
-  func.return %0#0 : tensor<2x2x2x2xf64>
-}
-
-// -----
-
-func.func @error_batch_norm_grad(%input: tensor<2x2x2x2xf32>, %scale: tensor<2xf32>, %mean: tensor<2xf32>, %variance: tensor<2xf32>, %grad_output: tensor<2x2x2x2xf32>) -> tensor<2x2x2x2xf32> {
-  // expected-error@+1 {{result #1 must be 1D tensor of f8E4M3B11FNUZ type or f8E4M3FN type or f8E4M3FNUZ type or f8E5M2 type or f8E5M2FNUZ type or 16-bit float or 32-bit float or 64-bit float or bfloat16 type values, but got 'tensor<2x2xf32>'}}
-  %0:3 = "stablehlo.batch_norm_grad" (%input, %scale, %mean, %variance, %grad_output) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2x2x2x2xf32>) -> (tensor<2x2x2x2xf32>, tensor<2x2xf32>, tensor<2xf32>)
+func.func @error_batch_norm_grad_c4(%input: tensor<2x2x2x2xf32>, %scale: tensor<2xf32>, %mean: tensor<4xf32>, %variance: tensor<2xf32>, %grad_output: tensor<2x2x2x2xf32>) -> tensor<2x2x2x2xf32> {
+  // expected-error@+2 {{failed to infer returned types}}
+  // expected-error@+1 {{expects single-dimensional operands to have compatible shapes}}
+  %0:3 = "stablehlo.batch_norm_grad" (%input, %scale, %mean, %variance, %grad_output) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<4xf32>, tensor<2xf32>, tensor<2x2x2x2xf32>) -> (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>)
   func.return %0#0 : tensor<2x2x2x2xf32>
 }
 
 // -----
 
-func.func @error_batch_norm_grad(%input: tensor<*xf32>, %scale: tensor<2xf32>, %mean: tensor<2xf32>, %variance: tensor<2xf32>, %grad_output: tensor<2x2x2x2xf32>) -> tensor<*xf32> {
-  // expected-error@+1 {{operand #0 must be ranked tensor of f8E4M3B11FNUZ type or f8E4M3FN type or f8E4M3FNUZ type or f8E5M2 type or f8E5M2FNUZ type or 16-bit float or 32-bit float or 64-bit float or bfloat16 type values, but got 'tensor<*xf32>'}}
-  %0:3 = "stablehlo.batch_norm_grad" (%input, %scale, %mean, %variance, %grad_output) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<*xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2x2x2x2xf32>) -> (tensor<*xf32>, tensor<2xf32>, tensor<2xf32>)
-  func.return %0#0 : tensor<*xf32>
+func.func @error_batch_norm_grad_c4(%input: tensor<2x2x2x2xf32>, %scale: tensor<2xf32>, %mean: tensor<2xf32>, %variance: tensor<4xf32>, %grad_output: tensor<2x2x2x2xf32>) -> tensor<2x2x2x2xf32> {
+  // expected-error@+2 {{failed to infer returned types}}
+  // expected-error@+1 {{expects single-dimensional operands to have compatible shapes}}
+  %0:3 = "stablehlo.batch_norm_grad" (%input, %scale, %mean, %variance, %grad_output) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<4xf32>, tensor<2x2x2x2xf32>) -> (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>)
+  func.return %0#0 : tensor<2x2x2x2xf32>
+}
+
+// -----
+
+func.func @error_batch_norm_grad_c5(%input: tensor<2x2x2x2xf32>, %scale: tensor<4xf32>, %mean: tensor<4xf32>, %variance: tensor<4xf32>, %grad_output: tensor<2x2x2x2xf32>) -> tensor<2x2x2x2xf32> {
+  // expected-error@+2 {{failed to infer returned types}}
+  // expected-error@+1 {{expects the size of single-dimensional operands to be compatible with feature count, but the size of single-dimensional operands is 4 and the feature count is 2.}}
+  %0:3 = "stablehlo.batch_norm_grad" (%input, %scale, %mean, %variance, %grad_output) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<2x2x2x2xf32>, tensor<4xf32>, tensor<4xf32>, tensor<4xf32>, tensor<2x2x2x2xf32>) -> (tensor<2x2x2x2xf32>, tensor<4xf32>, tensor<4xf32>)
+  func.return %0#0 : tensor<2x2x2x2xf32>
 }
 
 // -----


### PR DESCRIPTION
We have the following constraints in the spec:

```
(I1) `operand`: tensor of floating-point type.
(I2) `scale`: 1-dimensional tensor of floating-point type.
(I3) `mean`: 1-dimensional tensor of floating-point type.
(I4) `variance`: 1-dimensional tensor of floating-point type.
(I5) `grad_output`: tensor of floating-point type.
(I6) `epsilon`: constant of type `f32`.
(I7) `feature_index`: constant of type `si64`.
(C1) 0 <= `feature_index` < rank(`operand`).
(C2) `operand`, `scale`, `mean`, `variance`, `grad_output`, `grad_operand`
     `grad_scale` and `grad_offset` have the same element type.
(C3) `operand`, `grad_output` and `grad_operand` have the same shape.
(C4) `scale`, `mean`, `variance`, `grad_scale` and `grad_offset` have the
     same shape.
(C5) size(`scale`) = `dim(operand, feature_index)`.
```

These constraints will be comprehensively covered by the following tests:

```
I1: a) `operand` is not a tensor of floating-point type. (Covered by ODS).
I2: a) `scale` is not a 1-dimensional tensor. (Covered by ODS).
    b) `scale` is not a tensor of floating-point type. (Covered by ODS).
I3: a) `mean` is not a 1-dimensional tensor. (Covered by ODS).
    b) `mean` is not a tensor of floating-point type. (Covered by ODS).
I4: a) `variance` is not a 1-dimensional tensor. (Covered by ODS).
    b) `variance` is not a tensor of floating-point type. (Covered by ODS).
I5: a) `grad_output` is not a tensor of floating-point type. (Covered by ODS).
I6: a) `epsilon` is not a constant of type `f32`. (Covered by ODS).
I7: a) `feature_index` is not a constant of type `si64`. (Covered by ODS).
C1: a) `feature_index` < 0.
    b) `feature_index` >= rank(`operand`).
C2: a) element_type(`operand`) != element_type(`scale`). (Covered by ODS).
    b) element_type(`operand`) != element_type(`mean`). (Covered by ODS).
    c) element_type(`operand`) != element_type(`variance`). (Covered by ODS).
    d) element_type(`operand`) != element_type(`grad_output`). (Covered by ODS).
    e) element_type(`operand`) != element_type(`grad_operand`). (Covered by ODS).
    f) element_type(`operand`) != element_type(`grad_scale`). (Covered by ODS).
    g) element_type(`operand`) != element_type(`grad_offset`). (Covered by ODS).
C3: a) shape(`operand`) != shape(`grad_output`).
    b) shape(`operand`) != shape(`grad_operand`).
C4: a) shape(`scale`) != shape(`mean`).
    b) shape(`scale`) != shape(`variance`).
    c) shape(`scale`) != shape(`grad_scale`).
    d) shape(`scale`) != shape(`grad_offset`).
C5: a) size(`scale`) != dim(operand, feature_index).
```

If we drop the "Covered by ODS" pieces, this will leave us with the following test cases:

```
C1a: `feature_index` < 0.
C1b: `feature_index` >= rank(`operand`).
C3a: shape(`operand`) != shape(`grad_output`).
C3b: shape(`operand`) != shape(`grad_operand`).
C4a: shape(`scale`) != shape(`mean`).
C4b: shape(`scale`) != shape(`variance`).
C4c: shape(`scale`) != shape(`grad_scale`).
C4d: shape(`scale`) != shape(`grad_offset`).
C5a: size(`scale`) != dim(operand, feature_index).
```

Notes:
* Added `i6` in the spec to better align with the spec comments referring to [batchnorm_expander.cc](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/xla/service/batchnorm_expander.cc#L521-L524) in XLA.
* `size` -> `num_elements` to be consistent with what's written in `compute_mean` function.

closes #1121