### PR TITLE
Streamline the pseudocode describing SignOp

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -5028,7 +5028,7 @@ def sign(x):
     return 1.0
   elif is_complex(x):
     if x.real is NaN or x.imag is NaN: return (NaN, NaN)
-    return divide(x, abs(x))
+    return divide(x, convert(abs(x), type(x)))
 ```
 
 #### Inputs

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -5022,9 +5022,9 @@ def sign(x):
     return 1
   elif is_float(x):
     if x is NaN: return NaN
-    if compare(x, 0.0, LT, FLOAT): return -1.0
     if compare(x, -0.0, EQ, FLOAT): return -0.0
     if compare(x, +0.0, EQ, FLOAT): return +0.0
+    if compare(x, 0.0, LT, FLOAT): return -1.0
     return 1.0
   elif is_complex(x):
     if x.real is NaN or x.imag is NaN: return (NaN, NaN)

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -5027,7 +5027,7 @@ def sign(x):
     if compare(x, +0.0, EQ, FLOAT): return +0.0
     return 1.0
   elif is_complex(x):
-    if x.real is NaN or x.imag is NaN: return NaN
+    if x.real is NaN or x.imag is NaN: return (NaN, NaN)
     return divide(x, abs(x))
 ```
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -5028,6 +5028,7 @@ def sign(x):
     return 1.0
   elif is_complex(x):
     if x.real is NaN or x.imag is NaN: return (NaN, NaN)
+    if compare(x, (0.0, 0.0), EQ, FLOAT): return (0.0, 0.0)
     return divide(x, convert(abs(x), type(x)))
 ```
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -5019,20 +5019,16 @@ def sign(x):
   if is_integer(x):
     if compare(x, 0, LT, SIGNED): return -1
     if compare(x, 0, EQ, SIGNED): return 0
-    if compare(x, 0, GT, SIGNED): return 1
+    return 1
   elif is_float(x):
-    if x is NaN:
-      return NaN
-    else:
-      if compare(x, 0.0, LT, FLOAT): return -1.0
-      if compare(x, -0.0, EQ, FLOAT): return -0.0
-      if compare(x, +0.0, EQ, FLOAT): return +0.0
-      if compare(x, 0.0, GT, FLOAT): return 1.0
+    if x is NaN: return NaN
+    if compare(x, 0.0, LT, FLOAT): return -1.0
+    if compare(x, -0.0, EQ, FLOAT): return -0.0
+    if compare(x, +0.0, EQ, FLOAT): return +0.0
+    return 1.0
   elif is_complex(x):
-    if x.real is NaN or x.imag is NaN:
-      return NaN
-    else:
-      return divide(x, abs(x))
+    if x.real is NaN or x.imag is NaN: return NaN
+    return divide(x, abs(x))
 ```
 
 #### Inputs

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -790,6 +790,11 @@ Element sign(const Element &el) {
       return Element(type, std::complex<APFloat>(APFloat::getNaN(elSemantics),
                                                  APFloat::getNaN(elSemantics)));
 
+    if (elVal.real().isZero() && elVal.imag().isZero())
+      return Element(type,
+                     std::complex<APFloat>(APFloat::getZero(elSemantics),
+                                           APFloat::getZero(elSemantics)));
+
     return el / Element(type, abs(el).getFloatValue().convertToDouble());
   }
 

--- a/stablehlo/testdata/sign_special_0_dtype_complex64.mlir
+++ b/stablehlo/testdata/sign_special_0_dtype_complex64.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/tests/interpret_sign.mlir
+++ b/stablehlo/tests/interpret_sign.mlir
@@ -23,13 +23,15 @@ func.func @sign_op_test_f64() {
 
 // CHECK-LABEL: Evaluated results of function: sign_op_test_c128
 func.func @sign_op_test_c128() {
-  // (+NaN, +0.0), (+0.0, +NaN), (0.0, 1.0)
+  // (+NaN, +0.0), (+0.0, +NaN), (0.0, 0.0), (0.0, 1.0)
   %operand = stablehlo.constant dense<[(0x7FF0000000000001, 0x0000000000000000),
                                        (0x0000000000000000, 0x7FF0000000000001),
-                                       (0.0, 1.0)]> : tensor<3xcomplex<f64>>
-  %result = stablehlo.sign %operand : tensor<3xcomplex<f64>>
+                                       (0.0, 0.0),
+                                       (0.0, 1.0)]> : tensor<4xcomplex<f64>>
+  %result = stablehlo.sign %operand : tensor<4xcomplex<f64>>
   check.expect_almost_eq_const %result, dense<[(0x7FF0000000000001, 0x7FF0000000000001),
                                                (0x7FF0000000000001, 0x7FF0000000000001),
-                                               (0.0, 1.0)]> : tensor<3xcomplex<f64>>
+                                               (0.0, 0.0),
+                                               (0.0, 1.0)]> : tensor<4xcomplex<f64>>
   func.return
 }


### PR DESCRIPTION
Inspired by #1382, this PR: 1) reduces nesting, 2) drops the final ifs from the is_integer and is_float code blocks, 3) makes it clear that the NaN case for complex numbers returns NaN for both real and imaginary components.