### PR TITLE
Document RFC status

### DIFF
--- a/rfcs/20230210-sparsity.md
+++ b/rfcs/20230210-sparsity.md
@@ -1,5 +1,8 @@
-﻿
-# Stable HLO Sparsity RFC
+﻿# Stable HLO Sparsity RFC
+
+Status: Reviewed<br/>
+Initial version: 2/10/2023<br/>
+Last updated: 4/12/2023
 
 ## Motivation
 

--- a/rfcs/20230309-e4m3b11.md
+++ b/rfcs/20230309-e4m3b11.md
@@ -1,5 +1,9 @@
 # RFC: E4M3B11FNUZ in XLA
 
+Status: Approved<br/>
+Initial version: 3/9/2023<br/>
+Last updated: 3/24/2023
+
 ## Summary
 
 Google has hardware which features a floating-point format similar to the one

--- a/rfcs/20230321-fp8_fnuz.md
+++ b/rfcs/20230321-fp8_fnuz.md
@@ -1,5 +1,9 @@
 # RFC: Float8E4M3FNUZ and Float8E5M2FNUZ
 
+Status: Approved<br/>
+Initial version: 3/21/2023<br/>
+Last updated: 4/5/2023
+
 ## Summary
 
 Graphcore, AMD, and Qualcomm have proposed two new FP8 types, Float8E4M3FNUZ


### PR DESCRIPTION
This adds status headers to all RFCs under rfcs/ to document their timeline and status.