### PR TITLE
Add interpreter for Atan2Op

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -905,7 +905,7 @@ Performs element-wise atan2 operation on `lhs` and `rhs` tensor and produces a
 ```mlir
 // %lhs: [0.0, 1.0, -1.0]
 // %rhs: [0.0, 0.0, 0.0]
-%result = "stablehlo.atan2"(%lhs, %rhs) : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xf32>
+%result = "stablehlo.atan2"(%lhs, %rhs) : (tensor<3xf64>, tensor<3xf64>) -> tensor<3xf64>
 // %result: [0.0, 1.57079637, -1.57079637] // [0.0, pi/2, -pi/2]
 ```
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -909,6 +909,8 @@ Performs element-wise atan2 operation on `lhs` and `rhs` tensor and produces a
 // %result: [0.0, 1.57079637, -1.57079637] // [0.0, pi/2, -pi/2]
 ```
 
+&nbsp;[More Examples](../stablehlo/tests/interpret_atan2.mlir)
+
 ### batch_norm_grad
 
 #### Semantics

--- a/docs/status.md
+++ b/docs/status.md
@@ -49,7 +49,7 @@ one of the following tracking labels.
 | all_reduce               | yes           | revisit      | yes            | no              | no          |
 | all_to_all               | yes           | revisit      | yes            | no              | no          |
 | and                      | yes           | yes          | yes            | yes             | yes         |
-| atan2                    | yes           | yes          | yes            | yes             | no          |
+| atan2                    | yes           | yes          | yes            | yes             | yes         |
 | batch_norm_grad          | yes           | revisit      | yes            | no              | no          |
 | batch_norm_inference     | yes           | revisit      | yes            | no              | no          |
 | batch_norm_training      | yes           | revisit      | yes            | no              | no          |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -698,7 +698,8 @@ def StableHLO_AddOp : StableHLO_BinaryElementwiseOp<"add",
 }
 
 def StableHLO_Atan2Op : StableHLO_BinaryElementwiseOp<"atan2",
-      [Pure, HLO_CompatibleOperandsAndResultType], HLO_FpOrComplexTensor> {
+      [Pure, HLO_CompatibleOperandsAndResultType /*atan2_c1*/],
+      HLO_FpOrComplexTensor /*atan2_i1, atan2_i2*/> { /*atan2_c1*/
   let summary = "Atan2 operation";
   let description = [{
     Performs element-wise atan2 operation on `lhs` and `rhs` tensor and produces

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -710,7 +710,7 @@ def StableHLO_Atan2Op : StableHLO_BinaryElementwiseOp<"atan2",
 
     Example:
     ```mlir
-    %result = stablehlo.atan2 %lhs, %rhs : tensor<3xf32>
+    %result = stablehlo.atan2 %lhs, %rhs : tensor<3xf64>
     ```
   }];
 }

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -585,6 +585,22 @@ Element areApproximatelyEqual(const Element &e1, const Element &e2) {
                                      debugString(type).c_str()));
 }
 
+Element atan2(const Element &e1, const Element &e2) {
+  auto type = e1.getType();
+  if (isSupportedFloatType(e1.getType()))
+    return Element(type, std::atan2(e1.getFloatValue().convertToDouble(),
+                                    e2.getFloatValue().convertToDouble()));
+
+  if (isSupportedComplexType(type)) {
+    // atan2(y, x) = -i * log((x + i * y) / sqrt(x**2+y**2))
+    auto i = Element(type, std::complex<double>(0.0, 1.0));
+    return -i * log((e2 + i * e1) / sqrt(e2 * e2 + e1 * e1));
+  }
+
+  report_fatal_error(invalidArgument("Unsupported element type: %s",
+                                     debugString(type).c_str()));
+}
+
 Element ceil(const Element &el) {
   APFloat val = el.getFloatValue();
   val.roundToIntegral(APFloat::rmTowardPositive);

--- a/stablehlo/reference/Element.h
+++ b/stablehlo/reference/Element.h
@@ -141,6 +141,9 @@ class Element {
 /// Returns abs of Element object.
 Element abs(const Element &e);
 
+/// Returns atan2 of Element object.
+Element atan2(const Element &e1, const Element &e2);
+
 /// For floating point type T, checks if two normal values f1 and f2 are equal
 /// within a tolerance given by 0.0001.
 /// For complex element type, checks if both real and imaginary parts are

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -66,6 +66,12 @@ SmallVector<Tensor> eval(
       Tensor runtimeRhs = scope.find(andOp.getRhs());
       Tensor runtimeResult = evalAndOp(runtimeLhs, runtimeRhs, andOp.getType());
       scope.add(op.getResults(), {runtimeResult});
+    } else if (auto atan2Op = dyn_cast<Atan2Op>(op)) {
+      Tensor runtimeLhs = scope.find(atan2Op.getLhs());
+      Tensor runtimeRhs = scope.find(atan2Op.getRhs());
+      Tensor runtimeResult =
+          evalAtan2Op(runtimeLhs, runtimeRhs, atan2Op.getType());
+      scope.add(op.getResults(), {runtimeResult});
     } else if (auto broadcastInDimOp = dyn_cast<BroadcastInDimOp>(op)) {
       Tensor runtimeOperand = scope.find(broadcastInDimOp.getOperand());
       auto broadcastDimensions =
@@ -325,6 +331,15 @@ Tensor evalAndOp(const Tensor &lhs, const Tensor &rhs, ShapedType resultType) {
   Tensor result(resultType);
   for (auto it = lhs.index_begin(); it != lhs.index_end(); ++it)
     result.set(*it, lhs.get(*it) & rhs.get(*it));
+  return result;
+}
+
+Tensor evalAtan2Op(const Tensor &lhs, const Tensor &rhs,
+                   ShapedType resultType) {
+  Tensor result(resultType);
+  for (auto resultIt = result.index_begin(); resultIt != result.index_end();
+       ++resultIt)
+    result.set(*resultIt, atan2(lhs.get(*resultIt), rhs.get(*resultIt)));
   return result;
 }
 

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -30,6 +30,7 @@ namespace stablehlo {
 Tensor evalAbsOp(const Tensor &operand, ShapedType resultType);
 Tensor evalAddOp(const Tensor &lhs, const Tensor &rhs, ShapedType resultType);
 Tensor evalAndOp(const Tensor &lhs, const Tensor &rhs, ShapedType resultType);
+Tensor evalAtan2Op(const Tensor &lhs, const Tensor &rhs, ShapedType resultType);
 Tensor evalBroadcastInDimOp(const Tensor &operand, Axes broadcastDimensions,
                             ShapedType resultType);
 SmallVector<Tensor> evalCaseOp(const Tensor &index, RegionRange branches,

--- a/stablehlo/testdata/acos_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/acos_shape_bfloat16_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/acos_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/acos_shape_float16_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/acos_shape_float32_20_20.mlir
+++ b/stablehlo/testdata/acos_shape_float32_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/asin_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/asin_shape_bfloat16_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/asin_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/asin_shape_float16_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/asin_shape_float32_20_20.mlir
+++ b/stablehlo/testdata/asin_shape_float32_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/atan2_broadcasting_lhs_float32_1_20__rhs_float32_20_20.mlir
+++ b/stablehlo/testdata/atan2_broadcasting_lhs_float32_1_20__rhs_float32_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/atan2_broadcasting_lhs_float32_20_20__rhs_float32_1_20.mlir
+++ b/stablehlo/testdata/atan2_broadcasting_lhs_float32_20_20__rhs_float32_1_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/atan2_dtypes_lhs_bfloat16_20_20__rhs_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/atan2_dtypes_lhs_bfloat16_20_20__rhs_bfloat16_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/atan2_dtypes_lhs_float16_20_20__rhs_float16_20_20.mlir
+++ b/stablehlo/testdata/atan2_dtypes_lhs_float16_20_20__rhs_float16_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/atan2_dtypes_lhs_float32_20_20__rhs_float32_20_20.mlir
+++ b/stablehlo/testdata/atan2_dtypes_lhs_float32_20_20__rhs_float32_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/atan_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/atan_shape_bfloat16_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/atan_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/atan_shape_float16_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/atan_shape_float32_20_20.mlir
+++ b/stablehlo/testdata/atan_shape_float32_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/tests/interpret_atan2.mlir
+++ b/stablehlo/tests/interpret_atan2.mlir
@@ -1,0 +1,21 @@
+// RUN: stablehlo-translate --interpret -split-input-file %s
+
+func.func @atan2_op_test_f64() {
+  %0 = stablehlo.constant dense<[0.0, 1.0, -1.0]> : tensor<3xf64>
+  %1 = stablehlo.constant dense<[0.0, 0.0, 0.0]> : tensor<3xf64>
+  %2 = stablehlo.atan2 %0, %1 : tensor<3xf64>
+  check.expect_almost_eq_const %2, dense<[0.0, 1.5707963267948966, -1.5707963267948966]> : tensor<3xf64>
+  func.return
+}
+
+// -----
+
+func.func @atan2_op_test_c128() {
+  %0 = stablehlo.constant dense<[(0.0, 0.0), (1.0, 0.0), (-1.0, 0.0)]> : tensor<3xcomplex<f64>>
+  %1 = stablehlo.constant dense<[(0.0, 0.0), (0.0, 0.0), (0.0, 0.0)]> : tensor<3xcomplex<f64>>
+  %2 = stablehlo.atan2 %0, %1 : tensor<3xcomplex<f64>>
+  check.expect_almost_eq_const %2, dense<[(0x7FF8000000000000, 0x7FF8000000000000),
+                                          (1.5707963267948966, -0.0),
+                                          (-1.5707963267948966, 0.0)]> : tensor<3xcomplex<f64>>
+  func.return
+}

--- a/stablehlo/tests/interpret_atan2.mlir
+++ b/stablehlo/tests/interpret_atan2.mlir
@@ -11,11 +11,10 @@ func.func @atan2_op_test_f64() {
 // -----
 
 func.func @atan2_op_test_c128() {
-  %0 = stablehlo.constant dense<[(0.0, 0.0), (1.0, 0.0), (-1.0, 0.0)]> : tensor<3xcomplex<f64>>
-  %1 = stablehlo.constant dense<[(0.0, 0.0), (0.0, 0.0), (0.0, 0.0)]> : tensor<3xcomplex<f64>>
-  %2 = stablehlo.atan2 %0, %1 : tensor<3xcomplex<f64>>
-  check.expect_almost_eq_const %2, dense<[(0x7FF8000000000000, 0x7FF8000000000000),
-                                          (1.5707963267948966, -0.0),
-                                          (-1.5707963267948966, 0.0)]> : tensor<3xcomplex<f64>>
+  %0 = stablehlo.constant dense<[(1.0, 0.0), (-1.0, 0.0)]> : tensor<2xcomplex<f64>>
+  %1 = stablehlo.constant dense<[(0.0, 0.0), (0.0, 0.0)]> : tensor<2xcomplex<f64>>
+  %2 = stablehlo.atan2 %0, %1 : tensor<2xcomplex<f64>>
+  check.expect_almost_eq_const %2, dense<[(1.5707963267948966, -0.0),
+                                          (-1.5707963267948966, 0.0)]> : tensor<2xcomplex<f64>>
   func.return
 }


### PR DESCRIPTION
Here are the following constraints:
```
(I1) `lhs` is a tensor of floating-point or complex type.
(I2) `rhs` is a tensor of floating-point or complex type.
(C1) `lhs`, `rhs`, and `result` have the same type.
```
I1, I2, and C1 are covered by the ODS, so no additional tests are added.

closes #1097