### PR TITLE
Add interpreter for Log1pOp.

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3223,6 +3223,8 @@ produces a `result` tensor. Depending on the element type, does the following:
 // %result: [-nan, 0.0, -6.90776825, 2.07944155, 2.0, 2.77258873]
 ```
 
+&nbsp;[More Examples](../stablehlo/tests/interpret_log_plus_one.mlir)
+
 ### logistic
 
 #### Semantics

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3218,9 +3218,9 @@ produces a `result` tensor. Depending on the element type, does the following:
 #### Examples
 
 ```mlir
-// %operand: [-2.0, -0.0, -0.999, 7.0, 6.38905621, 15.0]
-%result = "stablehlo.log_plus_one"(%operand) : (tensor<6xf64>) -> tensor<6xf64>
-// %result: [-nan, 0.0, -6.90776825, 2.07944155, 2.0, 2.77258873]
+// %operand: [0.0, -0.999, 7.0, 6.38905621, 15.0]
+%result = "stablehlo.log_plus_one"(%operand) : (tensor<5xf64>) -> tensor<5xf64>
+// %result: [0.0, -6.90776825, 2.07944155, 2.0, 2.77258873]
 ```
 
 &nbsp;[More Examples](../stablehlo/tests/interpret_log_plus_one.mlir)

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3219,7 +3219,7 @@ produces a `result` tensor. Depending on the element type, does the following:
 
 ```mlir
 // %operand: [-2.0, -0.0, -0.999, 7.0, 6.38905621, 15.0]
-%result = "stablehlo.log_plus_one"(%operand) : (tensor<6xf32>) -> tensor<6xf32>
+%result = "stablehlo.log_plus_one"(%operand) : (tensor<6xf64>) -> tensor<6xf64>
 // %result: [-nan, 0.0, -6.90776825, 2.07944155, 2.0, 2.77258873]
 ```
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -100,7 +100,7 @@ one of the following tracking labels.
 | iota                     | yes           | yes          | infeasible     | yes             | yes         |
 | is_finite                | yes           | yes          | yes            | yes             | yes         |
 | log                      | yes           | yes          | yes            | yes             | yes         |
-| log_plus_one             | yes           | yes          | yes            | yes             | no          |
+| log_plus_one             | yes           | yes          | yes            | yes             | yes         |
 | logistic                 | yes           | yes          | yes            | yes             | yes         |
 | map                      | yes           | revisit      | yes            | no              | yes         |
 | maximum                  | yes           | yes          | yes            | yes             | yes         |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -430,7 +430,7 @@ def StableHLO_Log1pOp: StableHLO_UnaryElementwiseOp<"log_plus_one",
 
     Example:
     ```mlir
-    %result = stablehlo.log_plus_one %operand : tensor<6xf64>
+    %result = stablehlo.log_plus_one %operand : tensor<5xf64>
     ```
   }];
 }

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -419,7 +419,7 @@ def StableHLO_LogOp: StableHLO_UnaryElementwiseOp<"log",
 
 def StableHLO_Log1pOp: StableHLO_UnaryElementwiseOp<"log_plus_one",
     [Pure, HLO_CompatibleOperandsAndResultType /*log_plus_one_c1*/],
-	HLO_FpOrComplexTensor /*log_plus_one_i1*/> {
+    HLO_FpOrComplexTensor /*log_plus_one_i1*/> { /*log_plus_one_c1*/
   let summary = "Log1p operation";
   let description = [{
     Performs element-wise logarithm plus one operation on `operand` tensor and
@@ -430,7 +430,7 @@ def StableHLO_Log1pOp: StableHLO_UnaryElementwiseOp<"log_plus_one",
 
     Example:
     ```mlir
-    %result = stablehlo.log_plus_one %operand : tensor<6xf32>
+    %result = stablehlo.log_plus_one %operand : tensor<6xf64>
     ```
   }];
 }

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -418,7 +418,8 @@ def StableHLO_LogOp: StableHLO_UnaryElementwiseOp<"log",
 }
 
 def StableHLO_Log1pOp: StableHLO_UnaryElementwiseOp<"log_plus_one",
-    [Pure, HLO_CompatibleOperandsAndResultType], HLO_FpOrComplexTensor> {
+    [Pure, HLO_CompatibleOperandsAndResultType /*log_plus_one_c1*/],
+	HLO_FpOrComplexTensor /*log_plus_one_i1*/> {
   let summary = "Log1p operation";
   let description = [{
     Performs element-wise logarithm plus one operation on `operand` tensor and

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -659,16 +659,11 @@ Element log(const Element &el) {
       [](std::complex<double> e) { return std::log(e); });
 }
 
-Element log_plus_one(const Element &el) {
+Element logPlusOne(const Element &el) {
   return mapWithUpcastToDouble(
       el, [](double e) { return std::log1p(e); },
       [](std::complex<double> e) {
-        // log1p(a+bi) = log((a+1)+bi)
-        //             = 0.5 * log((a+1)^2 +  b^2) + i atan2(b, (a+1))
-        return std::complex<double>(
-            0.5 * std::log(std::pow(e.real() + 1.0, 2.0) +
-                           std::pow(e.imag(), 2.0)),
-            std::atan2(e.imag(), e.real() + 1.0));
+        return std::log(e + std::complex<double>(1.0));
       });
 }
 

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -659,6 +659,19 @@ Element log(const Element &el) {
       [](std::complex<double> e) { return std::log(e); });
 }
 
+Element log_plus_one(const Element &el) {
+  return mapWithUpcastToDouble(
+      el, [](double e) { return std::log1p(e); },
+      [](std::complex<double> e) {
+        // log1p(a+bi) = log((a+1)+bi)
+        //             = 0.5 * log((a+1)^2 +  b^2) + i atan2(b, (a+1))
+        return std::complex<double>(
+            0.5 * std::log(std::pow(e.real() + 1.0, 2.0) +
+                           std::pow(e.imag(), 2.0)),
+            std::atan2(e.imag(), e.real() + 1.0));
+      });
+}
+
 Element logistic(const Element &el) {
   auto one = Element(el.getType(), 1.0);
   return one / (one + exponential(-el));

--- a/stablehlo/reference/Element.h
+++ b/stablehlo/reference/Element.h
@@ -175,8 +175,8 @@ Element isFinite(const Element &el);
 /// Returns log of Element object.
 Element log(const Element &el);
 
-/// Returns logp1 of Element object.
-Element log_plus_one(const Element &el);
+/// Returns log1p of Element object.
+Element logPlusOne(const Element &el);
 
 /// Returns logistic of Element object.
 Element logistic(const Element &el);

--- a/stablehlo/reference/Element.h
+++ b/stablehlo/reference/Element.h
@@ -175,6 +175,9 @@ Element isFinite(const Element &el);
 /// Returns log of Element object.
 Element log(const Element &el);
 
+/// Returns logp1 of Element object.
+Element log_plus_one(const Element &el);
+
 /// Returns logistic of Element object.
 Element logistic(const Element &el);
 

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -620,17 +620,17 @@ Tensor evalIsFiniteOp(const Tensor &operand, ShapedType resultType) {
   return result;
 }
 
+Tensor evalLog1pOp(const Tensor &operand, ShapedType resultType) {
+  Tensor result(resultType);
+  for (auto it = result.index_begin(); it != result.index_end(); ++it)
+    result.set(*it, logPlusOne(operand.get(*it)));
+  return result;
+}
+
 Tensor evalLogOp(const Tensor &operand, ShapedType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, log(operand.get(*it)));
-  return result;
-}
-
-Tensor evalLog1pOp(const Tensor &operand, ShapedType resultType) {
-  Tensor result(resultType);
-  for (auto it = result.index_begin(); it != result.index_end(); ++it)
-    result.set(*it, log_plus_one(operand.get(*it)));
   return result;
 }
 

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -182,6 +182,10 @@ SmallVector<Tensor> eval(
       auto operand = scope.find(logOp.getOperand());
       auto result = evalLogOp(operand, logOp.getType());
       scope.add(op.getResults(), {result});
+    } else if (auto log1pOp = dyn_cast<Log1pOp>(op)) {
+      auto operand = scope.find(log1pOp.getOperand());
+      auto result = evalLog1pOp(operand, log1pOp.getType());
+      scope.add(op.getResults(), {result});
     } else if (auto logisticOp = dyn_cast<LogisticOp>(op)) {
       auto operand = scope.find(logisticOp.getOperand());
       auto result = evalLogisticOp(operand, logisticOp.getType());
@@ -620,6 +624,13 @@ Tensor evalLogOp(const Tensor &operand, ShapedType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, log(operand.get(*it)));
+  return result;
+}
+
+Tensor evalLog1pOp(const Tensor &operand, ShapedType resultType) {
+  Tensor result(resultType);
+  for (auto it = result.index_begin(); it != result.index_end(); ++it)
+    result.set(*it, log_plus_one(operand.get(*it)));
   return result;
 }
 

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -64,8 +64,8 @@ SmallVector<Tensor> evalIfOp(const Tensor &pred, Region &trueBranch,
 Tensor evalImagOp(const Tensor &operand, ShapedType resultType);
 Tensor evalIotaOp(Axis iotaDimension, ShapedType resultType);
 Tensor evalIsFiniteOp(const Tensor &operand, ShapedType resultType);
-Tensor evalLogOp(const Tensor &operand, ShapedType resultType);
 Tensor evalLog1pOp(const Tensor &operand, ShapedType resultType);
+Tensor evalLogOp(const Tensor &operand, ShapedType resultType);
 Tensor evalLogisticOp(const Tensor &operand, ShapedType resultType);
 Tensor evalMapOp(ArrayRef<Tensor> inputs, Region &computation, Scope &scope,
                  ShapedType resultType);

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -65,6 +65,7 @@ Tensor evalImagOp(const Tensor &operand, ShapedType resultType);
 Tensor evalIotaOp(Axis iotaDimension, ShapedType resultType);
 Tensor evalIsFiniteOp(const Tensor &operand, ShapedType resultType);
 Tensor evalLogOp(const Tensor &operand, ShapedType resultType);
+Tensor evalLog1pOp(const Tensor &operand, ShapedType resultType);
 Tensor evalLogisticOp(const Tensor &operand, ShapedType resultType);
 Tensor evalMapOp(ArrayRef<Tensor> inputs, Region &computation, Scope &scope,
                  ShapedType resultType);

--- a/stablehlo/testdata/atanh_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/atanh_shape_bfloat16_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/atanh_shape_float32_20_20.mlir
+++ b/stablehlo/testdata/atanh_shape_float32_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/cumlogsumexp_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumlogsumexp_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/cumlogsumexp_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_1_reverse_False.mlir
+++ b/stablehlo/testdata/cumlogsumexp_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_1_reverse_False.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/cumlogsumexp_axis_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumlogsumexp_axis_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/cumlogsumexp_axis_by_fun_shape_float32_8_9__axis_1_reverse_False.mlir
+++ b/stablehlo/testdata/cumlogsumexp_axis_by_fun_shape_float32_8_9__axis_1_reverse_False.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/cumlogsumexp_dtype_by_fun_shape_float16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumlogsumexp_dtype_by_fun_shape_float16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/cumlogsumexp_dtype_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumlogsumexp_dtype_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/cumlogsumexp_dtype_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumlogsumexp_dtype_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/cumlogsumexp_reverse_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_True.mlir
+++ b/stablehlo/testdata/cumlogsumexp_reverse_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_True.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/cumlogsumexp_reverse_shape_float32_8_9__axis_0_reverse_True.mlir
+++ b/stablehlo/testdata/cumlogsumexp_reverse_shape_float32_8_9__axis_0_reverse_True.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/digamma_shape_float32_20_20.mlir
+++ b/stablehlo/testdata/digamma_shape_float32_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/erf_inv_shape_float32_20_20.mlir
+++ b/stablehlo/testdata/erf_inv_shape_float32_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/lgamma_shape_float32_20_20.mlir
+++ b/stablehlo/testdata/lgamma_shape_float32_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/log1p_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/log1p_shape_bfloat16_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/log1p_shape_complex64_20_20.mlir
+++ b/stablehlo/testdata/log1p_shape_complex64_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/log1p_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/log1p_shape_float16_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/log1p_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/log1p_shape_float16_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED:: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/log1p_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/log1p_shape_float16_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN-DISABLED(#1278): stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/log1p_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/log1p_shape_float16_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED(#1278): stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN-DISABLED:: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/log1p_shape_float32_20_20.mlir
+++ b/stablehlo/testdata/log1p_shape_float32_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/tests/interpret_log_plus_one.mlir
+++ b/stablehlo/tests/interpret_log_plus_one.mlir
@@ -1,0 +1,22 @@
+// RUN: stablehlo-translate --interpret -split-input-file %s
+
+func.func @log_op_test_i64() {
+  %operand = stablehlo.constant dense<[-2.0, -0.0, -0.999, 7.0, 6.38905621, 15.0]> : tensor<6xf64>
+  %result = stablehlo.log_plus_one %operand : tensor<6xf64>
+  check.expect_almost_eq_const %result, dense<[0xFFFFFFFFFFFFFFFF, 0.0, -6.90776825, 2.07944155, 2.0, 2.77258873]> : tensor<6xf64>
+  func.return
+}
+
+// -----
+
+// func.func @log_op_test_c128() {
+//   %operand = stablehlo.constant dense<(1.0, 2.0)> : tensor<complex<f64>>
+//   %result = stablehlo.log %operand : tensor<complex<f64>>
+//   check.expect_almost_eq_const %result, dense<(0.80471895621705025, 1.1071487177940904)> : tensor<complex<f64>>
+//   func.return
+// }
+
+
+// %operand: 
+// %result = "stablehlo.log_plus_one"(%operand) : (tensor<6xf32>) -> tensor<6xf32>
+// %result: 

--- a/stablehlo/tests/interpret_log_plus_one.mlir
+++ b/stablehlo/tests/interpret_log_plus_one.mlir
@@ -1,9 +1,9 @@
 // RUN: stablehlo-translate --interpret -split-input-file %s
 
 func.func @log_plus_one_op_test_f64() {
-  %operand = stablehlo.constant dense<[-2.0, -0.0, -0.999, 7.0, 6.38905621, 15.0]> : tensor<6xf64>
-  %result = stablehlo.log_plus_one %operand : tensor<6xf64>
-  check.expect_almost_eq_const %result, dense<[0xFFFFFFFFFFFFFFFF, 0.0, -6.90776825, 2.07944155, 2.0, 2.77258873]> : tensor<6xf64>
+  %operand = stablehlo.constant dense<[0.0, -0.999, 7.0, 6.38905621, 15.0]> : tensor<5xf64>
+  %result = stablehlo.log_plus_one %operand : tensor<5xf64>
+  check.expect_almost_eq_const %result, dense<[0.0, -6.90776825, 2.07944155, 2.0, 2.77258873]> : tensor<5xf64>
   func.return
 }
 

--- a/stablehlo/tests/interpret_log_plus_one.mlir
+++ b/stablehlo/tests/interpret_log_plus_one.mlir
@@ -9,14 +9,13 @@ func.func @log_op_test_i64() {
 
 // -----
 
-// func.func @log_op_test_c128() {
-//   %operand = stablehlo.constant dense<(1.0, 2.0)> : tensor<complex<f64>>
-//   %result = stablehlo.log %operand : tensor<complex<f64>>
-//   check.expect_almost_eq_const %result, dense<(0.80471895621705025, 1.1071487177940904)> : tensor<complex<f64>>
-//   func.return
-// }
-
-
-// %operand: 
-// %result = "stablehlo.log_plus_one"(%operand) : (tensor<6xf32>) -> tensor<6xf32>
-// %result: 
+func.func @log_op_test_c128() {
+  %operand = stablehlo.constant dense<[(1.0, 2.0), (2.0, 1.0), (0.0, 0.0)]> : tensor<3xcomplex<f64>>
+  %result = stablehlo.log_plus_one %operand : tensor<3xcomplex<f64>>
+  check.expect_almost_eq_const %result, dense<[
+	(1.03972077083991, 0.78539816339744),
+	(1.15129254649702, 0.32175055439664),
+	(0.0, 0.0)
+  ]> : tensor<3xcomplex<f64>>
+  func.return
+}

--- a/stablehlo/tests/interpret_log_plus_one.mlir
+++ b/stablehlo/tests/interpret_log_plus_one.mlir
@@ -1,6 +1,6 @@
 // RUN: stablehlo-translate --interpret -split-input-file %s
 
-func.func @log_op_test_i64() {
+func.func @log_plus_one_op_test_f64() {
   %operand = stablehlo.constant dense<[-2.0, -0.0, -0.999, 7.0, 6.38905621, 15.0]> : tensor<6xf64>
   %result = stablehlo.log_plus_one %operand : tensor<6xf64>
   check.expect_almost_eq_const %result, dense<[0xFFFFFFFFFFFFFFFF, 0.0, -6.90776825, 2.07944155, 2.0, 2.77258873]> : tensor<6xf64>
@@ -9,7 +9,7 @@ func.func @log_op_test_i64() {
 
 // -----
 
-func.func @log_op_test_c128() {
+func.func @log_plus_one_op_test_c128() {
   %operand = stablehlo.constant dense<[(1.0, 2.0), (2.0, 1.0), (0.0, 0.0)]> : tensor<3xcomplex<f64>>
   %result = stablehlo.log_plus_one %operand : tensor<3xcomplex<f64>>
   check.expect_almost_eq_const %result, dense<[


### PR DESCRIPTION
closes #1105 

We have the following constraints in the spec:

```
(I1) operand is a tensor of floating-point or complex type.
(C1) operand and result have the same type.
```

These constraints are covered by the following tests

```
I1: a) operand is not a tensor of floating-point or complex type. (Covered by ODS).
C1: a) type(operand) != type(result). (Covered by ODS).
```