### PR TITLE
Add interpreter for ComplexOp.

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1788,9 +1788,11 @@ imaginary values, `lhs` and `rhs`, and produces a `result` tensor.
 ```mlir
 // %lhs: [1.0, 3.0]
 // %rhs: [2.0, 4.0]
-%result = "stablehlo.complex"(%lhs, %rhs) : (tensor<2xf32>, tensor<2xf32>) -> tensor<2xcomplex<f32>>
+%result = "stablehlo.complex"(%lhs, %rhs) : (tensor<2xf64>, tensor<2xf64>) -> tensor<2xcomplex<f64>>
 // %result: [(1.0, 2.0), (3.0, 4.0)]
 ```
+
+&nbsp;[More Examples](../stablehlo/tests/interpret_complex.mlir)
 
 ### concatenate
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -63,7 +63,7 @@ one of the following tracking labels.
 | clamp                    | yes           | revisit      | yes            | yes             | yes         |
 | collective_permute       | yes           | revisit      | yes            | no              | no          |
 | compare                  | yes           | yes          | yes            | yes             | yes         |
-| complex                  | yes           | yes          | yes            | yes             | no          |
+| complex                  | yes           | yes          | yes            | yes             | yes         |
 | compute_reshape_shape    | no            | revisit      | no             | yes             | no          |
 | concatenate              | yes           | yes          | yes            | yes             | yes         |
 | constant                 | yes           | yes          | yes            | yes             | yes         |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -721,7 +721,7 @@ def StableHLO_Atan2Op : StableHLO_BinaryElementwiseOp<"atan2",
 
 def StableHLO_ComplexOp: StableHLO_BinaryElementwiseOp<"complex", [Pure,
     SameOperandsElementType /*complex_c1*/,
-	SameOperandsAndResultShape /*complex_c2*/,
+    SameOperandsAndResultShape /*complex_c2*/,
     DeclareOpInterfaceMethods<InferTypeOpInterface> /*complex_c3*/]> {
   let summary = "Complex operation";
   let description = [{

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -720,28 +720,26 @@ def StableHLO_Atan2Op : StableHLO_BinaryElementwiseOp<"atan2",
 }
 
 def StableHLO_ComplexOp: StableHLO_BinaryElementwiseOp<"complex", [Pure,
-    SameOperandsElementType /* complex_c1 */,
-	SameOperandsAndResultShape /* complex_c2 */,
-    DeclareOpInterfaceMethods<InferTypeOpInterface> /* complex_c3 */]> {
+    SameOperandsElementType /*complex_c1*/,
+	SameOperandsAndResultShape /*complex_c2*/,
+    DeclareOpInterfaceMethods<InferTypeOpInterface> /*complex_c3*/]> {
   let summary = "Complex operation";
   let description = [{
     Performs element-wise conversion to a complex value from a pair of real and
     imaginary values, `lhs` and `rhs`, and produces a `result` tensor.
-
     See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec.md#complex
-
     Example:
     ```mlir
-    %result = stablehlo.complex %lhs, %rhs : tensor<2xcomplex<f32>>
+    %result = stablehlo.complex %lhs, %rhs : tensor<2xcomplex<f64>>
     ```
   }];
   let arguments = (ins
-     HLO_Fp32Or64Tensor:$lhs /* complex_c1, complex_c2, complex_c3, complex_i1 */,
-     HLO_Fp32Or64Tensor:$rhs /* complex_c1, complex_i2 */
+     HLO_Fp32Or64Tensor:$lhs /*complex_i1*/,
+     HLO_Fp32Or64Tensor:$rhs /*complex_i2*/
   );
   let results = (outs
-     HLO_ComplexTensor:$result /* complex_c2, complex_c3 */
+     HLO_ComplexTensor:$result
   );
 
   let assemblyFormat = [{

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -720,8 +720,9 @@ def StableHLO_Atan2Op : StableHLO_BinaryElementwiseOp<"atan2",
 }
 
 def StableHLO_ComplexOp: StableHLO_BinaryElementwiseOp<"complex", [Pure,
-    SameOperandsElementType, SameOperandsAndResultShape,
-    DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
+    SameOperandsElementType /* complex_c1 */,
+	SameOperandsAndResultShape /* complex_c2 */,
+    DeclareOpInterfaceMethods<InferTypeOpInterface> /* complex_c3 */]> {
   let summary = "Complex operation";
   let description = [{
     Performs element-wise conversion to a complex value from a pair of real and
@@ -735,8 +736,13 @@ def StableHLO_ComplexOp: StableHLO_BinaryElementwiseOp<"complex", [Pure,
     %result = stablehlo.complex %lhs, %rhs : tensor<2xcomplex<f32>>
     ```
   }];
-  let arguments = (ins HLO_Fp32Or64Tensor:$lhs, HLO_Fp32Or64Tensor:$rhs);
-  let results = (outs HLO_ComplexTensor:$result);
+  let arguments = (ins
+     HLO_Fp32Or64Tensor:$lhs /* complex_c1, complex_c2, complex_c3, complex_i1 */,
+     HLO_Fp32Or64Tensor:$rhs /* complex_c1, complex_i2 */
+  );
+  let results = (outs
+     HLO_ComplexTensor:$result /* complex_c2, complex_c3 */
+  );
 
   let assemblyFormat = [{
     operands attr-dict

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -1597,7 +1597,9 @@ LogicalResult inferCompareOp(
 LogicalResult inferComplexOp(std::optional<Location> location, Value lhs,
                              SmallVectorImpl<Type>& inferredReturnTypes) {
   ShapedType operandType = lhs.getType().cast<ShapedType>();
+  // complex_c3
   ComplexType elementTy = ComplexType::get(operandType.getElementType());
+  // complex_c2
   inferredReturnTypes.push_back(getSameShapeTensorType(operandType, elementTy));
   return success();
 }

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -615,16 +615,14 @@ Element ceil(const Element &el) {
   return Element(el.getType(), val);
 }
 
-std::complex<double> complex(const Element &e1, const Element &e2) {
-  auto e1Type = e1.getType();
-  auto e2Type = e2.getType();
-  if (isSupportedFloatType(e1Type) && isSupportedFloatType(e2Type)) {
-    return std::complex<double>(e1.getFloatValue().convertToDouble(),
-                                e2.getFloatValue().convertToDouble());
-  }
-  report_fatal_error(invalidArgument("Unsupported element types: %s, %s",
-                                     debugString(e1Type).c_str(),
-                                     debugString(e2Type).c_str()));
+Element complex(const Element &e1, const Element &e2) {
+  auto type = e1.getType();
+  auto complexType = ComplexType::get(type);
+  if (isSupportedComplexType(complexType))
+    return Element(complexType, std::complex<APFloat>(e1.getFloatValue(),
+                                                      e2.getFloatValue()));
+  report_fatal_error(invalidArgument("Unsupported element type: %s",
+                                     debugString(complexType).c_str()));
 }
 
 Element exponential(const Element &el) {

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -615,6 +615,18 @@ Element ceil(const Element &el) {
   return Element(el.getType(), val);
 }
 
+std::complex<double> complex(const Element &e1, const Element &e2) {
+  auto e1Type = e1.getType();
+  auto e2Type = e2.getType();
+  if (isSupportedFloatType(e1Type) && isSupportedFloatType(e2Type)) {
+    return std::complex<double>(e1.getFloatValue().convertToDouble(),
+                                e2.getFloatValue().convertToDouble());
+  }
+  report_fatal_error(invalidArgument("Unsupported element types: %s, %s",
+                                     debugString(e1Type).c_str(),
+                                     debugString(e2Type).c_str()));
+}
+
 Element exponential(const Element &el) {
   return mapWithUpcastToDouble(
       el, [](double e) { return std::exp(e); },

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -616,8 +616,7 @@ Element ceil(const Element &el) {
 }
 
 Element complex(const Element &e1, const Element &e2) {
-  auto type = e1.getType();
-  auto complexType = ComplexType::get(type);
+  auto complexType = ComplexType::get(e1.getType());
   if (isSupportedComplexType(complexType))
     return Element(complexType, std::complex<APFloat>(e1.getFloatValue(),
                                                       e2.getFloatValue()));

--- a/stablehlo/reference/Element.h
+++ b/stablehlo/reference/Element.h
@@ -156,6 +156,9 @@ Element cbrt(const Element &e);
 /// Returns ceil of Element object.
 Element ceil(const Element &e);
 
+/// Returns a complex type Element.
+std::complex<double> complex(const Element &e1, const Element &e2);
+
 /// Returns cosine of Element object.
 Element cosine(const Element &e);
 

--- a/stablehlo/reference/Element.h
+++ b/stablehlo/reference/Element.h
@@ -156,8 +156,8 @@ Element cbrt(const Element &e);
 /// Returns ceil of Element object.
 Element ceil(const Element &e);
 
-/// Returns a complex type Element.
-std::complex<double> complex(const Element &e1, const Element &e2);
+/// Returns a complex type Element object.
+Element complex(const Element &e1, const Element &e2);
 
 /// Returns cosine of Element object.
 Element cosine(const Element &e);

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -110,6 +110,7 @@ SmallVector<Tensor> eval(
       auto comparisonDirection = compareOp.getComparisonDirection();
       auto result =
           evalCompareOp(lhs, rhs, comparisonDirection, compareOp.getType());
+      scope.add(op.getResults(), {result});
     } else if (auto complexOp = dyn_cast<ComplexOp>(op)) {
       auto lhs = scope.find(complexOp.getLhs());
       auto rhs = scope.find(complexOp.getRhs());

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -110,6 +110,10 @@ SmallVector<Tensor> eval(
       auto comparisonDirection = compareOp.getComparisonDirection();
       auto result =
           evalCompareOp(lhs, rhs, comparisonDirection, compareOp.getType());
+    } else if (auto complexOp = dyn_cast<ComplexOp>(op)) {
+      auto lhs = scope.find(complexOp.getLhs());
+      auto rhs = scope.find(complexOp.getRhs());
+      auto result = evalComplexOp(lhs, rhs, complexOp.getType());
       scope.add(op.getResults(), {result});
     } else if (auto concatenateOp = dyn_cast<ConcatenateOp>(op)) {
       auto operands = scope.find(concatenateOp.getOperands());
@@ -464,6 +468,15 @@ Tensor evalCompareOp(const Tensor &lhs, const Tensor &rhs,
         break;
     }
   }
+  return result;
+}
+
+Tensor evalComplexOp(const Tensor &lhs, const Tensor &rhs,
+                     ShapedType resultType) {
+  Tensor result(resultType);
+  for (auto it = result.index_begin(); it != result.index_end(); ++it)
+    result.set(*it, Element(resultType.getElementType(),
+                            complex(lhs.get(*it), rhs.get(*it))));
   return result;
 }
 

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -475,8 +475,7 @@ Tensor evalComplexOp(const Tensor &lhs, const Tensor &rhs,
                      ShapedType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
-    result.set(*it, Element(resultType.getElementType(),
-                            complex(lhs.get(*it), rhs.get(*it))));
+    result.set(*it, complex(lhs.get(*it), rhs.get(*it)));
   return result;
 }
 

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -43,6 +43,8 @@ Tensor evalClzOp(const Tensor &operand, ShapedType resultType);
 Tensor evalCompareOp(const Tensor &lhs, const Tensor &rhs,
                      ComparisonDirection comparisonDirection,
                      ShapedType resultType);
+Tensor evalComplexOp(const Tensor &lhs, const Tensor &rhs,
+                     ShapedType resultType);
 Tensor evalConcatenateOp(ArrayRef<Tensor> inputs, Axis dimension,
                          ShapedType resultType);
 Tensor evalConstantOp(ElementsAttr value);

--- a/stablehlo/testdata/complex_broadcast_lhs_float32_3_1__rhs_float32_3_2.mlir
+++ b/stablehlo/testdata/complex_broadcast_lhs_float32_3_1__rhs_float32_3_2.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/complex_broadcast_lhs_float32_3_2__rhs_float32_3_1.mlir
+++ b/stablehlo/testdata/complex_broadcast_lhs_float32_3_2__rhs_float32_3_1.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/complex_dtypes_lhs_float32_3_4__rhs_float32_3_4.mlir
+++ b/stablehlo/testdata/complex_dtypes_lhs_float32_3_4__rhs_float32_3_4.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -25,6 +25,16 @@ func.func @compare(%a : tensor<2x?xf32>, %b : tensor<2x?xf32>) -> tensor<2xindex
 
 // -----
 
+// CHECK-LABEL: @complex
+func.func @complex(%arg0: tensor<10x10xf32>, %arg1: tensor<10x10xf32>) -> tensor<10x10xindex> {
+  %0 = "stablehlo.complex"(%arg0, %arg1) {} : (tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<10x10xcomplex<f32>>
+  // CHECK: types0 = tensor<10x10xcomplex<f32>>
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<10x10xcomplex<f32>>) -> tensor<10x10xindex>
+  func.return %1 : tensor<10x10xindex>
+}
+
+// -----
+
 // CHECK-LABEL: @select
 func.func @select(%pred : tensor<i1>, %a : tensor<?x2x3xf32>, %b : tensor<1x?x3xf32>)
     -> tensor<1x2x3xindex> {

--- a/stablehlo/tests/interpret_complex.mlir
+++ b/stablehlo/tests/interpret_complex.mlir
@@ -1,18 +1,9 @@
 // RUN: stablehlo-translate --interpret -split-input-file %s
 
-func.func @add_op_test_f64() {
-  %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.14, 0x7FF0000000000000, 0.0]> : tensor<8xf64>
-  %1 = stablehlo.constant dense<[0.0, -0.0, 7.0, 0.75, 0.3, 3.14, 0.0, 0x7FF0000000000000]> : tensor<8xf64>
-  %2 = stablehlo.complex %0, %1 : tensor<8xcomplex<f64>>
-  check.expect_almost_eq_const %2, dense<[
-    (0.0, 0.0),
-    (-0.0, -0.0),
-    (1.0, 7.0),
-    (0.125, 0.75),
-    (0.1, 0.3),
-    (3.14, 3.14),
-    (0x7FF0000000000000, 0.0),
-    (0.0, 0x7FF0000000000000)
-  ]> : tensor<8xcomplex<f64>>
+func.func @complex_op_test_f64() {
+  %lhs = stablehlo.constant dense<[1.0, 3.0]> : tensor<2xf64>
+  %rhs = stablehlo.constant dense<[2.0, 4.0]> : tensor<2xf64>
+  %result = stablehlo.complex %lhs, %rhs : tensor<2xcomplex<f64>>
+  check.expect_almost_eq_const %result, dense<[(1.0, 2.0), (3.0, 4.0)]> : tensor<2xcomplex<f64>>
   func.return
 }

--- a/stablehlo/tests/interpret_complex.mlir
+++ b/stablehlo/tests/interpret_complex.mlir
@@ -1,0 +1,18 @@
+// RUN: stablehlo-translate --interpret -split-input-file %s
+
+func.func @add_op_test_f64() {
+  %0 = stablehlo.constant dense<[0.0, -0.0, 1.0, 0.125, 0.1, 3.14, 0x7FF0000000000000, 0.0]> : tensor<8xf64>
+  %1 = stablehlo.constant dense<[0.0, -0.0, 7.0, 0.75, 0.3, 3.14, 0.0, 0x7FF0000000000000]> : tensor<8xf64>
+  %2 = stablehlo.complex %0, %1 : tensor<8xcomplex<f64>>
+  check.expect_almost_eq_const %2, dense<[
+    (0.0, 0.0),
+    (-0.0, -0.0),
+    (1.0, 7.0),
+    (0.125, 0.75),
+    (0.1, 0.3),
+    (3.14, 3.14),
+    (0x7FF0000000000000, 0.0),
+    (0.0, 0x7FF0000000000000)
+  ]> : tensor<8xcomplex<f64>>
+  func.return
+}

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -5526,7 +5526,7 @@ func.func @complex(%arg0: tensor<10x10xf32>, %arg1: tensor<10x10xf32>) -> tensor
 
 // -----
 
-func.func @complex_int_input(%arg0: tensor<10x10xi32>, %arg1: tensor<10x10xi32>) -> tensor<10x10xcomplex<i32>> {
+func.func @complex_i1_i2(%arg0: tensor<10x10xi32>, %arg1: tensor<10x10xi32>) -> tensor<10x10xcomplex<i32>> {
   // expected-error@+1 {{operand #0 must be tensor of 32-bit float or 64-bit float values, but got 'tensor<10x10xi32>'}}
   %0 = "stablehlo.complex"(%arg0, %arg1) {} : (tensor<10x10xi32>, tensor<10x10xi32>) -> tensor<10x10xcomplex<i32>>
   func.return %0 : tensor<10x10xcomplex<i32>>
@@ -5534,7 +5534,7 @@ func.func @complex_int_input(%arg0: tensor<10x10xi32>, %arg1: tensor<10x10xi32>)
 
 // -----
 
-func.func @complex_f32_f64_mix_input(%arg0: tensor<10x10xf32>, %arg1: tensor<10x10xf64>) -> tensor<10x10xcomplex<f64>> {
+func.func @complex_c1(%arg0: tensor<10x10xf32>, %arg1: tensor<10x10xf64>) -> tensor<10x10xcomplex<f64>> {
   // expected-error@+1 {{requires the same element type for all operands}}
   %0 = "stablehlo.complex"(%arg0, %arg1) {} : (tensor<10x10xf32>, tensor<10x10xf64>) -> tensor<10x10xcomplex<f64>>
   func.return %0 : tensor<10x10xcomplex<f64>>
@@ -5542,7 +5542,7 @@ func.func @complex_f32_f64_mix_input(%arg0: tensor<10x10xf32>, %arg1: tensor<10x
 
 // -----
 
-func.func @complex_f16_input(%arg0: tensor<10x10xf16>, %arg1: tensor<10x10xf16>) -> tensor<10x10xcomplex<f16>> {
+func.func @complex_i1_i2(%arg0: tensor<10x10xf16>, %arg1: tensor<10x10xf16>) -> tensor<10x10xcomplex<f16>> {
   // expected-error@+1 {{operand #0 must be tensor of 32-bit float or 64-bit float values, but got 'tensor<10x10xf16>'}}
   %0 = "stablehlo.complex"(%arg0, %arg1) {} : (tensor<10x10xf16>, tensor<10x10xf16>) -> tensor<10x10xcomplex<f16>>
   func.return %0 : tensor<10x10xcomplex<f16>>
@@ -5550,7 +5550,7 @@ func.func @complex_f16_input(%arg0: tensor<10x10xf16>, %arg1: tensor<10x10xf16>)
 
 // -----
 
-func.func @complex_mismatch_return_element_type(%arg0: tensor<10x10xf32>, %arg1: tensor<10x10xf32>) -> tensor<10x10xcomplex<f64>> {
+func.func @complex_c3(%arg0: tensor<10x10xf32>, %arg1: tensor<10x10xf32>) -> tensor<10x10xcomplex<f64>> {
   // expected-error@+1 {{inferred type(s) 'tensor<10x10xcomplex<f32>>' are incompatible with return type(s) of operation 'tensor<10x10xcomplex<f64>>'}}
   %0 = "stablehlo.complex"(%arg0, %arg1) {} : (tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<10x10xcomplex<f64>>
   func.return %0 : tensor<10x10xcomplex<f64>>
@@ -5558,7 +5558,7 @@ func.func @complex_mismatch_return_element_type(%arg0: tensor<10x10xf32>, %arg1:
 
 // -----
 
-func.func @complex_mismatch_return_shape(%arg0: tensor<10x10xf32>, %arg1: tensor<10x10xf32>) -> tensor<5x5xcomplex<f32>> {
+func.func @complex_c2(%arg0: tensor<10x10xf32>, %arg1: tensor<10x10xf32>) -> tensor<5x5xcomplex<f32>> {
   // expected-error@+1 {{requires the same shape for all operands and results}}
   %0 = "stablehlo.complex"(%arg0, %arg1) {} : (tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<5x5xcomplex<f32>>
   func.return %0 : tensor<5x5xcomplex<f32>>

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -5526,46 +5526,6 @@ func.func @complex(%arg0: tensor<10x10xf32>, %arg1: tensor<10x10xf32>) -> tensor
 
 // -----
 
-func.func @complex_i1_i2(%arg0: tensor<10x10xi32>, %arg1: tensor<10x10xi32>) -> tensor<10x10xcomplex<i32>> {
-  // expected-error@+1 {{operand #0 must be tensor of 32-bit float or 64-bit float values, but got 'tensor<10x10xi32>'}}
-  %0 = "stablehlo.complex"(%arg0, %arg1) {} : (tensor<10x10xi32>, tensor<10x10xi32>) -> tensor<10x10xcomplex<i32>>
-  func.return %0 : tensor<10x10xcomplex<i32>>
-}
-
-// -----
-
-func.func @complex_c1(%arg0: tensor<10x10xf32>, %arg1: tensor<10x10xf64>) -> tensor<10x10xcomplex<f64>> {
-  // expected-error@+1 {{requires the same element type for all operands}}
-  %0 = "stablehlo.complex"(%arg0, %arg1) {} : (tensor<10x10xf32>, tensor<10x10xf64>) -> tensor<10x10xcomplex<f64>>
-  func.return %0 : tensor<10x10xcomplex<f64>>
-}
-
-// -----
-
-func.func @complex_i1_i2(%arg0: tensor<10x10xf16>, %arg1: tensor<10x10xf16>) -> tensor<10x10xcomplex<f16>> {
-  // expected-error@+1 {{operand #0 must be tensor of 32-bit float or 64-bit float values, but got 'tensor<10x10xf16>'}}
-  %0 = "stablehlo.complex"(%arg0, %arg1) {} : (tensor<10x10xf16>, tensor<10x10xf16>) -> tensor<10x10xcomplex<f16>>
-  func.return %0 : tensor<10x10xcomplex<f16>>
-}
-
-// -----
-
-func.func @complex_c3(%arg0: tensor<10x10xf32>, %arg1: tensor<10x10xf32>) -> tensor<10x10xcomplex<f64>> {
-  // expected-error@+1 {{inferred type(s) 'tensor<10x10xcomplex<f32>>' are incompatible with return type(s) of operation 'tensor<10x10xcomplex<f64>>'}}
-  %0 = "stablehlo.complex"(%arg0, %arg1) {} : (tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<10x10xcomplex<f64>>
-  func.return %0 : tensor<10x10xcomplex<f64>>
-}
-
-// -----
-
-func.func @complex_c2(%arg0: tensor<10x10xf32>, %arg1: tensor<10x10xf32>) -> tensor<5x5xcomplex<f32>> {
-  // expected-error@+1 {{requires the same shape for all operands and results}}
-  %0 = "stablehlo.complex"(%arg0, %arg1) {} : (tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<5x5xcomplex<f32>>
-  func.return %0 : tensor<5x5xcomplex<f32>>
-}
-
-// -----
-
 // CHECK-LABEL: func @is_finite
 func.func @is_finite(%arg0: tensor<3xf32>) -> tensor<3xi1> {
   %0 = "stablehlo.is_finite"(%arg0) {} : (tensor<3xf32>) -> tensor<3xi1>


### PR DESCRIPTION
Closes #1101 .

We have the following constraints in the spec:

```
(I1) lhs is a tensor of 32 bit floating-point or 64 bit floating-point.
(I2) rhs is a tensor of 32 bit floating-point or 64 bit floating-point.
(C1) lhs and rhs have the same type.
(C2) result and lhs have the same shape.
(C3) the return type should be a complex type of the element type of the lhs i.e. element_type(`result`) = complex_type(element_type(`lhs`)).
```

These constraints are covered by the following tests

```
I1: lhs is not a tensor of 32 bit floating-point or 64 bit floating-point. (ODS)
I2: rhs is not a tensor of 32 bit floating-point or 64 bit floating-point. (ODS)
C1: type(lhs) != type(rhs).
C2: shape(result) != shape(lhs).
C3: element_type(`result`) != complex_type(element_type(`lhs`)). (ODS)
```