### PR TITLE
Add interpreter for CbrtOp

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1471,9 +1471,11 @@ Performs element-wise cubic root operation on `operand` tensor and produces a
 
 ```mlir
 // %operand: [0.0, 1.0, 8.0, 27.0]
-%result = "stablehlo.cbrt"(%operand) : (tensor<4xf32>) -> tensor<4xf32>
+%result = "stablehlo.cbrt"(%operand) : (tensor<4xf64>) -> tensor<4xf64>
 // %result: [0.0, 1.0, 2.0, 3.0]
 ```
+
+&nbsp;[More Examples](../stablehlo/tests/interpret_cbrt.mlir)
 
 ### ceil
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -57,7 +57,7 @@ one of the following tracking labels.
 | broadcast                | no            | yes\*        | yes\*          | yes             | no          |
 | broadcast_in_dim         | yes           | yes          | infeasible     | yes             | yes         |
 | case                     | yes           | revisit      | yes            | no              | yes         |
-| cbrt                     | yes           | yes          | yes            | yes             | no          |
+| cbrt                     | yes           | yes          | yes            | yes             | yes         |
 | ceil                     | yes           | yes          | yes            | yes             | yes         |
 | cholesky                 | yes           | yes          | yes            | yes             | no          |
 | clamp                    | yes           | revisit      | yes            | yes             | yes         |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -218,7 +218,8 @@ def StableHLO_AbsOp: StableHLO_UnaryElementwiseOp<"abs",
 }
 
 def StableHLO_CbrtOp: StableHLO_UnaryElementwiseOp<"cbrt",
-    [Pure, HLO_CompatibleOperandsAndResultType], HLO_FpOrComplexTensor> {
+    [Pure, HLO_CompatibleOperandsAndResultType /*cbrt_c1*/],
+    HLO_FpOrComplexTensor /*cbrt_i1*/> { /*cbrt_c1*/
   let summary = "Cbrt operation";
   let description = [{
     Performs element-wise cubic root operation on `operand` tensor and produces
@@ -229,7 +230,7 @@ def StableHLO_CbrtOp: StableHLO_UnaryElementwiseOp<"cbrt",
 
     Example:
     ```mlir
-    %result = stablehlo.cbrt %operand : tensor<4xf32>
+    %result = stablehlo.cbrt %operand : tensor<4xf64>
     ```
   }];
 }

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -599,22 +599,14 @@ Element atan2(const Element &e1, const Element &e2) {
 }
 
 Element cbrt(const Element &el) {
-  auto type = el.getType();
-  if (isSupportedFloatType(type))
-    return Element(type, std::cbrt(el.getFloatValue().convertToDouble()));
-
-  if (isSupportedComplexType(type)) {
-    auto real = el.getComplexValue().real().convertToDouble();
-    auto imag = el.getComplexValue().imag().convertToDouble();
-    // cbrt(a + bi) = cbrt(sqrt(a^2 + b^2)) * (cos(1/3 * atan2(b, a)) + i *
-    // sin(1/3 * atan2(b, a)))
-    auto theta = std::atan2(imag, real) / 3.0;
-    return Element(
-        type, std::pow(std::pow(real, 2.0) + std::pow(imag, 2.0), 1.0 / 6.0) *
-                  std::complex<double>(std::cos(theta), std::sin(theta)));
-  }
-  report_fatal_error(invalidArgument("Unsupported element type: %s",
-                                     debugString(type).c_str()));
+  return mapWithUpcastToDouble(
+      el, [](double e) { return std::cbrt(e); },
+      [](std::complex<double> e) {
+        auto theta = std::atan2(e.imag(), e.real()) / 3.0;
+        return std::pow(std::pow(e.real(), 2.0) + std::pow(e.imag(), 2.0),
+                        1.0 / 6.0) *
+               std::complex<double>(std::cos(theta), std::sin(theta));
+      });
 }
 
 Element ceil(const Element &el) {

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -598,6 +598,25 @@ Element atan2(const Element &e1, const Element &e2) {
                                      debugString(type).c_str()));
 }
 
+Element cbrt(const Element &el) {
+  auto type = el.getType();
+  if (isSupportedFloatType(type))
+    return Element(type, std::cbrt(el.getFloatValue().convertToDouble()));
+
+  if (isSupportedComplexType(type)) {
+    auto real = el.getComplexValue().real().convertToDouble();
+    auto imag = el.getComplexValue().imag().convertToDouble();
+    // cbrt(a + bi) = cbrt(sqrt(a^2 + b^2)) * (cos(1/3 * atan2(b, a)) + i *
+    // sin(1/3 * atan2(b, a)))
+    auto theta = std::atan2(imag, real) / 3.0;
+    return Element(
+        type, std::pow(std::pow(real, 2.0) + std::pow(imag, 2.0), 1.0 / 6.0) *
+                  std::complex<double>(std::cos(theta), std::sin(theta)));
+  }
+  report_fatal_error(invalidArgument("Unsupported element type: %s",
+                                     debugString(type).c_str()));
+}
+
 Element ceil(const Element &el) {
   APFloat val = el.getFloatValue();
   val.roundToIntegral(APFloat::rmTowardPositive);

--- a/stablehlo/reference/Element.h
+++ b/stablehlo/reference/Element.h
@@ -150,6 +150,9 @@ Element atan2(const Element &e1, const Element &e2);
 /// individually equal modulo the tolerance.
 Element areApproximatelyEqual(const Element &e1, const Element &e2);
 
+/// Returns cube root of Element object.
+Element cbrt(const Element &e);
+
 /// Returns ceil of Element object.
 Element ceil(const Element &e);
 

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -86,6 +86,10 @@ SmallVector<Tensor> eval(
       auto branches = caseOp.getBranches();
       auto results = evalCaseOp(index, branches, scope);
       scope.add(op.getResults(), {results});
+    } else if (auto cbrtOp = dyn_cast<CbrtOp>(op)) {
+      auto operand = scope.find(cbrtOp.getOperand());
+      auto result = evalCbrtOp(operand, cbrtOp.getType());
+      scope.add(op.getResults(), {result});
     } else if (auto ceilOp = dyn_cast<CeilOp>(op)) {
       auto operand = scope.find(ceilOp.getOperand());
       auto result = evalCeilOp(operand, ceilOp.getType());
@@ -406,6 +410,13 @@ SmallVector<Tensor> evalCaseOp(const Tensor &index, RegionRange branches,
   if (idx < 0 || idx >= static_cast<int64_t>(branches.size()))
     idx = branches.size() - 1;
   return eval(*branches[idx], {}, &scope);
+}
+
+Tensor evalCbrtOp(const Tensor &operand, ShapedType resultType) {
+  Tensor result(resultType);
+  for (auto it = result.index_begin(); it != result.index_end(); ++it)
+    result.set(*it, cbrt(operand.get(*it)));
+  return result;
 }
 
 Tensor evalCeilOp(const Tensor &operand, ShapedType resultType) {

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -35,6 +35,7 @@ Tensor evalBroadcastInDimOp(const Tensor &operand, Axes broadcastDimensions,
                             ShapedType resultType);
 SmallVector<Tensor> evalCaseOp(const Tensor &index, RegionRange branches,
                                Scope &scope);
+Tensor evalCbrtOp(const Tensor &operand, ShapedType resultType);
 Tensor evalCeilOp(const Tensor &operand, ShapedType resultType);
 Tensor evalClampOp(const Tensor &min, const Tensor &operand, const Tensor &max,
                    ShapedType resultType);

--- a/stablehlo/testdata/cbrt_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/cbrt_shape_bfloat16_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/cbrt_shape_float32_20_20.mlir
+++ b/stablehlo/testdata/cbrt_shape_float32_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/tests/interpret_cbrt.mlir
+++ b/stablehlo/tests/interpret_cbrt.mlir
@@ -1,0 +1,17 @@
+// RUN: stablehlo-translate --interpret -split-input-file %s
+
+func.func @cbrt_op_test_f64() {
+  %operand = stablehlo.constant dense<[0.0, 1.0, 8.0, 27.0]> : tensor<4xf64>
+  %result = stablehlo.cbrt %operand : tensor<4xf64>
+  check.expect_almost_eq_const %result, dense<[0.0, 1.0, 2.0, 3.0]> : tensor<4xf64>
+  func.return
+}
+
+// -----
+
+func.func @cbrt_op_test_c128() {
+  %operand = stablehlo.constant dense<(3.0, 4.0)> : tensor<complex<f64>>
+  %result = stablehlo.cbrt %operand : tensor<complex<f64>>
+  check.expect_almost_eq_const %result, dense<(1.6289371459221759, 0.5201745023045458)> : tensor<complex<f64>>
+  func.return
+}


### PR DESCRIPTION
Here are the constraints for CbrtOp:
```
(I1) operand is a tensor of floating-point or complex type.
(C1) `operand` and `result` have the same type.
```
I1 and C1 are covered by the ODS, so no additional tests are added.

Notes:
* The implementation is inspired from De Moivre's formula to calculate nth root of a complex number. k is assumed 0 for principal root. See: https://en.wikipedia.org/wiki/De_Moivre%27s_formula

closes #1099