### PR TITLE
Add interpreter for PopulationCountOp

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3744,9 +3744,11 @@ and produces a `result` tensor.
 
 ```mlir
 // %operand: [0, 1, 2, 127]
-%result = "stablehlo.popcnt"(%operand) : (tensor<4xi8>) -> tensor<4xi8>
+%result = "stablehlo.popcnt"(%operand) : (tensor<4xi64>) -> tensor<4xi64>
 // %result: [0, 1, 1, 7]
 ```
+
+&nbsp;[More Examples](../stablehlo/tests/interpret_popcnt.mlir)
 
 ### power
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -113,7 +113,7 @@ one of the following tracking labels.
 | outfeed                  | yes           | yes          | yes            | no              | no          |
 | pad                      | yes           | yes          | yes            | yes             | yes         |
 | partition_id             | yes           | yes          | yes            | yes             | no          |
-| popcnt                   | yes           | yes          | yes            | yes             | no          |
+| popcnt                   | yes           | yes          | yes            | yes             | yes         |
 | power                    | yes           | yes          | yes            | yes             | yes         |
 | real                     | yes           | yes          | yes            | yes             | yes         |
 | real_dynamic_slice       | no            | revisit      | no             | yes             | no          |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -486,7 +486,8 @@ def StableHLO_NegOp: StableHLO_UnaryElementwiseOp<"negate",
 }
 
 def StableHLO_PopulationCountOp: StableHLO_UnaryElementwiseOp<"popcnt",
-    [Pure, HLO_CompatibleOperandsAndResultType], HLO_IntTensor> {
+    [Pure, HLO_CompatibleOperandsAndResultType /*popcnt_c1*/],
+    HLO_IntTensor /*popcnt_i1*/> { /*popcnt_c1*/
   let summary = "PopulationCount operation";
   let description = [{
     Performs element-wise count of the number of bits set in the `operand`
@@ -497,7 +498,7 @@ def StableHLO_PopulationCountOp: StableHLO_UnaryElementwiseOp<"popcnt",
 
     Example:
     ```mlir
-    %result = stablehlo.popcnt %operand : tensor<4xi8>
+    %result = stablehlo.popcnt %operand : tensor<4xi64>
     ```
   }];
 }

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -695,6 +695,14 @@ Element min(const Element &e1, const Element &e2) {
       });
 }
 
+Element popcnt(const Element &el) {
+  auto type = el.getType();
+  if (!isSupportedIntegerType(type))
+    report_fatal_error(invalidArgument("Unsupported element type: %s",
+                                       debugString(el.getType()).c_str()));
+  return Element(type, static_cast<int64_t>(el.getIntegerValue().popcount()));
+}
+
 Element power(const Element &e1, const Element &e2) {
   Type type = e1.getType();
 

--- a/stablehlo/reference/Element.h
+++ b/stablehlo/reference/Element.h
@@ -181,6 +181,9 @@ Element max(const Element &e1, const Element &e2);
 /// Returns the minimum between two Element objects.
 Element min(const Element &e1, const Element &e2);
 
+/// Returns the population count of Element object.
+Element popcnt(const Element &el);
+
 /// Returns the exponentiation of first element to the power of second element.
 Element power(const Element &e1, const Element &e2);
 

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -225,6 +225,11 @@ SmallVector<Tensor> eval(
           evalPadOp(runtimeOperand, runtimePaddingValue, edgePaddingLow,
                     interiorPadding, padOp.getType());
       scope.add(op.getResults(), {runtimeResult});
+    } else if (auto populationCountOp = dyn_cast<PopulationCountOp>(op)) {
+      Tensor runtimeOperand = scope.find(populationCountOp.getOperand());
+      Tensor runtimeResult =
+          evalPopulationCountOp(runtimeOperand, populationCountOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
     } else if (auto powerOp = dyn_cast<PowOp>(op)) {
       Tensor runtimeLhs = scope.find(powerOp.getLhs());
       Tensor runtimeRhs = scope.find(powerOp.getRhs());
@@ -666,6 +671,14 @@ Tensor evalPadOp(const Tensor &operand, const Tensor &paddingValue,
     if (resultIdx.inBounds(result.getShape()))
       result.set(resultIdx, operand.get(*operandIt));
   }
+  return result;
+}
+
+Tensor evalPopulationCountOp(const Tensor &operand, ShapedType resultType) {
+  Tensor result(resultType);
+  for (auto resultIt = result.index_begin(); resultIt != result.index_end();
+       ++resultIt)
+    result.set(*resultIt, popcnt(operand.get(*resultIt)));
   return result;
 }
 

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -75,6 +75,7 @@ Tensor evalOrOp(const Tensor &lhs, const Tensor &rhs, ShapedType resultType);
 Tensor evalPadOp(const Tensor &operand, const Tensor &paddingValue,
                  Sizes edgePaddingLow, Sizes interiorPadding,
                  ShapedType resultType);
+Tensor evalPopulationCountOp(const Tensor &operand, ShapedType resultType);
 Tensor evalPowerOp(const Tensor &lhs, const Tensor &rhs, ShapedType resultType);
 Tensor evalRealOp(const Tensor &operand, ShapedType resultType);
 Tensor evalRemOp(const Tensor &lhs, const Tensor &rhs, ShapedType resultType);

--- a/stablehlo/testdata/population_count_int16.mlir
+++ b/stablehlo/testdata/population_count_int16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/population_count_int32.mlir
+++ b/stablehlo/testdata/population_count_int32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/population_count_int8.mlir
+++ b/stablehlo/testdata/population_count_int8.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/population_count_uint16.mlir
+++ b/stablehlo/testdata/population_count_uint16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/population_count_uint32.mlir
+++ b/stablehlo/testdata/population_count_uint32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/population_count_uint8.mlir
+++ b/stablehlo/testdata/population_count_uint8.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/tests/interpret_popcnt.mlir
+++ b/stablehlo/tests/interpret_popcnt.mlir
@@ -1,0 +1,8 @@
+// RUN: stablehlo-translate --interpret -split-input-file %s
+
+func.func @popcnt_op_test_si64() {
+  %operand = stablehlo.constant dense<[0, 1, 2, 127]> : tensor<4xi64>
+  %result = stablehlo.popcnt %operand : tensor<4xi64>
+  check.expect_eq_const %result, dense<[0, 1, 1, 7]> : tensor<4xi64>
+  func.return
+}


### PR DESCRIPTION
Here are the constraints for the PopulationCountOp:
```
(I1) operand is a tensor of integer type.
(C1) `operand` and `result` have the same type.
```
I1 and C1 are covered by the ODS, so no additional tests are added.

closes #1107