### PR TITLE
Add interpreter for RoundNearestEvenOp

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4518,9 +4518,11 @@ specification.
 
 ```mlir
 // %operand = [-2.5, 0.4, 0.5, 0.6, 2.5]
-%result = "stablehlo.round_nearest_even"(%operand) : (tensor<5xf32>) -> tensor<5xf32>
+%result = "stablehlo.round_nearest_even"(%operand) : (tensor<5xf64>) -> tensor<5xf64>
 // %result: [-2.0, 0.0, 0.0, 1.0, 2.0]
 ```
+
+&nbsp;[More Examples](../stablehlo/tests/interpret_round_nearest_even.mlir)
 
 ### rsqrt
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -130,7 +130,7 @@ one of the following tracking labels.
 | rng                      | yes           | yes          | yes            | yes             | no          |
 | rng_bit_generator        | yes           | revisit      | infeasible     | yes             | no          |
 | round_nearest_afz        | yes           | yes          | yes            | yes             | no          |
-| round_nearest_even       | yes           | yes          | yes            | yes             | no          |
+| round_nearest_even       | yes           | yes          | yes            | yes             | yes         |
 | rsqrt                    | yes           | yes          | yes            | yes             | yes         |
 | scatter                  | yes           | revisit      | yes            | no              | no          |
 | select                   | yes           | yes          | yes            | yes             | yes         |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -538,7 +538,8 @@ def StableHLO_RoundOp: StableHLO_UnaryElementwiseOp<"round_nearest_afz",
 }
 
 def StableHLO_RoundNearestEvenOp: StableHLO_UnaryElementwiseOp<"round_nearest_even",
-    [Pure, HLO_CompatibleOperandsAndResultType], HLO_FpTensor> {
+    [Pure, HLO_CompatibleOperandsAndResultType /*round_nearest_even_c1*/],
+    HLO_FpTensor /*round_nearest_even_i1*/> { /*round_nearest_even_c1*/
   let summary = "RoundNearestEven operation";
   let description = [{
     Performs element-wise rounding towards the nearest integer, breaking ties
@@ -550,7 +551,7 @@ def StableHLO_RoundNearestEvenOp: StableHLO_UnaryElementwiseOp<"round_nearest_ev
 
     Example:
     ```mlir
-    %result = stablehlo.round_nearest_even %operand : tensor<5xf32>
+    %result = stablehlo.round_nearest_even %operand : tensor<5xf64>
     ```
   }];
 }

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -757,6 +757,16 @@ Element rem(const Element &e1, const Element &e2) {
       });
 }
 
+Element roundNearestEven(const Element &el) {
+  auto type = el.getType();
+  if (!isSupportedFloatType(type))
+    report_fatal_error(invalidArgument("Unsupported element type: %s",
+                                       debugString(type).c_str()));
+  auto val = el.getFloatValue();
+  val.roundToIntegral(llvm::RoundingMode::NearestTiesToEven);
+  return Element(type, val);
+}
+
 Element rsqrt(const Element &el) {
   return mapWithUpcastToDouble(
       el, [](double e) { return 1.0 / std::sqrt(e); },

--- a/stablehlo/reference/Element.h
+++ b/stablehlo/reference/Element.h
@@ -191,6 +191,9 @@ Element real(const Element &e);
 /// Returns the remainder for two Element objects.
 Element rem(const Element &e1, const Element &e2);
 
+/// Returns the value rounded to the nearest even of Element object.
+Element roundNearestEven(const Element &el);
+
 /// Returns reverse square root of Element object.
 Element rsqrt(const Element &e);
 

--- a/stablehlo/reference/Element.h
+++ b/stablehlo/reference/Element.h
@@ -191,7 +191,8 @@ Element real(const Element &e);
 /// Returns the remainder for two Element objects.
 Element rem(const Element &e1, const Element &e2);
 
-/// Returns the value rounded to the nearest even of Element object.
+/// Returns the value rounded to nearest integer, breaking ties towards the
+/// even, of Element object.
 Element roundNearestEven(const Element &el);
 
 /// Returns reverse square root of Element object.

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -254,6 +254,11 @@ SmallVector<Tensor> eval(
       Tensor runtimeResult =
           evalReverseOp(runtimeOperand, dimensions, reverseOp.getType());
       scope.add(op.getResults(), {runtimeResult});
+    } else if (auto roundNearestEvenOp = dyn_cast<RoundNearestEvenOp>(op)) {
+      Tensor runtimeOperand = scope.find(roundNearestEvenOp.getOperand());
+      Tensor runtimeResult =
+          evalRoundNearestEvenOp(runtimeOperand, roundNearestEvenOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
     } else if (auto rsqrtOp = dyn_cast<RsqrtOp>(op)) {
       Tensor runtimeOperand = scope.find(rsqrtOp.getOperand());
       Tensor runtimeResult = evalRsqrtOp(runtimeOperand, rsqrtOp.getType());
@@ -710,6 +715,14 @@ Tensor evalReverseOp(const Tensor &operand, Axes dimensions,
       operandIdx[dim] = (resultShape[dim] - 1) - operandIdx[dim];
     result.set(*resultIt, operand.get(operandIdx));
   }
+  return result;
+}
+
+Tensor evalRoundNearestEvenOp(const Tensor &operand, ShapedType resultType) {
+  Tensor result(resultType);
+  for (auto resultIt = result.index_begin(); resultIt != result.index_end();
+       ++resultIt)
+    result.set(*resultIt, roundNearestEven(operand.get(*resultIt)));
   return result;
 }
 

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -81,6 +81,7 @@ Tensor evalRemOp(const Tensor &lhs, const Tensor &rhs, ShapedType resultType);
 Tensor evalReshapeOp(const Tensor &operand, ShapedType resultType);
 Tensor evalReverseOp(const Tensor &operand, Axes dimensions,
                      ShapedType resultType);
+Tensor evalRoundNearestEvenOp(const Tensor &operand, ShapedType resultType);
 Tensor evalRsqrtOp(const Tensor &operand, ShapedType resultType);
 Tensor evalSelectOp(const Tensor &pred, const Tensor &onTrue,
                     const Tensor &onFalse, ShapedType resultType);

--- a/stablehlo/testdata/round_rounding_methods_shape_float32_2_5__roundingmethod_1.mlir
+++ b/stablehlo/testdata/round_rounding_methods_shape_float32_2_5__roundingmethod_1.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/tests/interpret_round_nearest_even.mlir
+++ b/stablehlo/tests/interpret_round_nearest_even.mlir
@@ -1,0 +1,8 @@
+// RUN: stablehlo-translate --interpret -split-input-file %s
+
+func.func @round_nearest_even_op_test_f64() {
+  %operand = stablehlo.constant dense<[-2.5, 0.4, 0.5, 0.6, 2.5]> : tensor<5xf64>
+  %result = stablehlo.round_nearest_even %operand : tensor<5xf64>
+  check.expect_almost_eq_const %result, dense<[-2.0, 0.0, 0.0, 1.0, 2.0]> : tensor<5xf64>
+  func.return
+}


### PR DESCRIPTION
Here are the constraints for the RoundNearestEvenOp:
```
(I1) operand is a tensor of floating-point type.
(C1) `operand` and `result` have the same type.
```
I1 and C1 are covered by the ODS, so no additional tests are added.

closes #1111