### PR TITLE
Add interpreter for RoundOp

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4487,9 +4487,11 @@ the `roundToIntegralTiesToAway` operation from the IEEE-754 specification.
 
 ```mlir
 // %operand = [-2.5, 0.4, 0.5, 0.6, 2.5]
-%result = "stablehlo.round_nearest_afz"(%operand) : (tensor<5xf32>) -> tensor<5xf32>
+%result = "stablehlo.round_nearest_afz"(%operand) : (tensor<5xf64>) -> tensor<5xf64>
 // %result: [-3.0, 0.0, 1.0, 1.0, 3.0]
 ```
+
+&nbsp;[More Examples](../stablehlo/tests/interpret_round_nearest_afz.mlir)
 
 ### round_nearest_even
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -129,7 +129,7 @@ one of the following tracking labels.
 | reverse                  | yes           | yes          | yes            | yes             | yes         |
 | rng                      | yes           | yes          | yes            | yes             | no          |
 | rng_bit_generator        | yes           | revisit      | infeasible     | yes             | no          |
-| round_nearest_afz        | yes           | yes          | yes            | yes             | no          |
+| round_nearest_afz        | yes           | yes          | yes            | yes             | yes         |
 | round_nearest_even       | yes           | yes          | yes            | yes             | yes         |
 | rsqrt                    | yes           | yes          | yes            | yes             | yes         |
 | scatter                  | yes           | revisit      | yes            | no              | no          |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -522,7 +522,8 @@ def StableHLO_RealOp: StableHLO_UnaryElementwiseOp<"real",
 }
 
 def StableHLO_RoundOp: StableHLO_UnaryElementwiseOp<"round_nearest_afz",
-    [Pure, HLO_CompatibleOperandsAndResultType], HLO_FpTensor> {
+    [Pure, HLO_CompatibleOperandsAndResultType /*round_nearest_afz_c1*/],
+    HLO_FpTensor /*round_nearest_afz_i1*/> { /*round_nearest_afz_c1*/
   let summary = "Round operation";
   let description = [{
     Performs element-wise rounding towards the nearest integer, breaking ties
@@ -533,7 +534,7 @@ def StableHLO_RoundOp: StableHLO_UnaryElementwiseOp<"round_nearest_afz",
 
     Example:
     ```mlir
-    %result = stablehlo.round_nearest_afz %operand : tensor<5xf32>
+    %result = stablehlo.round_nearest_afz %operand : tensor<5xf64>
     ```
   }];
 }

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -765,6 +765,16 @@ Element rem(const Element &e1, const Element &e2) {
       });
 }
 
+Element roundNearestAfz(const Element &el) {
+  auto type = el.getType();
+  if (!isSupportedFloatType(type))
+    report_fatal_error(invalidArgument("Unsupported element type: %s",
+                                       debugString(type).c_str()));
+  auto val = el.getFloatValue();
+  val.roundToIntegral(llvm::RoundingMode::NearestTiesToAway);
+  return Element(type, val);
+}
+
 Element roundNearestEven(const Element &el) {
   auto type = el.getType();
   if (!isSupportedFloatType(type))

--- a/stablehlo/reference/Element.h
+++ b/stablehlo/reference/Element.h
@@ -194,6 +194,10 @@ Element real(const Element &e);
 /// Returns the remainder for two Element objects.
 Element rem(const Element &e1, const Element &e2);
 
+/// Returns the value rounded to the nearest integer, breaking ties away from
+/// zero, of Element object.
+Element roundNearestAfz(const Element &el);
+
 /// Returns the value rounded to nearest integer, breaking ties towards the
 /// even, of Element object.
 Element roundNearestEven(const Element &el);

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -259,6 +259,10 @@ SmallVector<Tensor> eval(
       Tensor runtimeResult =
           evalReverseOp(runtimeOperand, dimensions, reverseOp.getType());
       scope.add(op.getResults(), {runtimeResult});
+    } else if (auto roundOp = dyn_cast<RoundOp>(op)) {
+      Tensor runtimeOperand = scope.find(roundOp.getOperand());
+      Tensor runtimeResult = evalRoundOp(runtimeOperand, roundOp.getType());
+      scope.add(op.getResults(), {runtimeResult});
     } else if (auto roundNearestEvenOp = dyn_cast<RoundNearestEvenOp>(op)) {
       Tensor runtimeOperand = scope.find(roundNearestEvenOp.getOperand());
       Tensor runtimeResult =
@@ -728,6 +732,14 @@ Tensor evalReverseOp(const Tensor &operand, Axes dimensions,
       operandIdx[dim] = (resultShape[dim] - 1) - operandIdx[dim];
     result.set(*resultIt, operand.get(operandIdx));
   }
+  return result;
+}
+
+Tensor evalRoundOp(const Tensor &operand, ShapedType resultType) {
+  Tensor result(resultType);
+  for (auto resultIt = result.index_begin(); resultIt != result.index_end();
+       ++resultIt)
+    result.set(*resultIt, roundNearestAfz(operand.get(*resultIt)));
   return result;
 }
 

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -82,6 +82,7 @@ Tensor evalRemOp(const Tensor &lhs, const Tensor &rhs, ShapedType resultType);
 Tensor evalReshapeOp(const Tensor &operand, ShapedType resultType);
 Tensor evalReverseOp(const Tensor &operand, Axes dimensions,
                      ShapedType resultType);
+Tensor evalRoundOp(const Tensor &operand, ShapedType resultType);
 Tensor evalRoundNearestEvenOp(const Tensor &operand, ShapedType resultType);
 Tensor evalRsqrtOp(const Tensor &operand, ShapedType resultType);
 Tensor evalSelectOp(const Tensor &pred, const Tensor &onTrue,

--- a/stablehlo/testdata/round_dtypes_shape_bfloat16_100_100__roundingmethod_0.mlir
+++ b/stablehlo/testdata/round_dtypes_shape_bfloat16_100_100__roundingmethod_0.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/round_dtypes_shape_float16_100_100__roundingmethod_0.mlir
+++ b/stablehlo/testdata/round_dtypes_shape_float16_100_100__roundingmethod_0.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/round_dtypes_shape_float32_100_100__roundingmethod_0.mlir
+++ b/stablehlo/testdata/round_dtypes_shape_float32_100_100__roundingmethod_0.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/testdata/round_rounding_methods_shape_float32_2_5__roundingmethod_0.mlir
+++ b/stablehlo/testdata/round_rounding_methods_shape_float32_2_5__roundingmethod_0.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
+// RUN: stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt -inline | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --deserialize %s.0_9_0.bc | stablehlo-opt) <(stablehlo-opt %s)
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 

--- a/stablehlo/tests/interpret_round_nearest_afz.mlir
+++ b/stablehlo/tests/interpret_round_nearest_afz.mlir
@@ -1,0 +1,8 @@
+// RUN: stablehlo-translate --interpret -split-input-file %s
+
+func.func @round_nearest_afz_op_test_f64() {
+  %operand = stablehlo.constant dense<[-2.5, 0.4, 0.5, 0.6, 2.5]> : tensor<5xf64>
+  %result = stablehlo.round_nearest_afz %operand : tensor<5xf64>
+  check.expect_almost_eq_const %result, dense<[-3.0, 0.0, 1.0, 1.0, 3.0]> : tensor<5xf64>
+  func.return
+}


### PR DESCRIPTION
Here are the constraints for the RoundOp:
```
(I1) operand is a tensor of floating-point type.
(C1) `operand` and `result` have the same type.
```
I1 and C1 are covered by the ODS, so no additional tests are added.

closes #1110