### PR TITLE
Add missing dependency causing issues in google infra

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -671,6 +671,7 @@ cc_library(
     ],
     strip_include_prefix = ".",
     deps = [
+        ":base",
         ":chlo_ops",
         ":stablehlo_ops",
         ":stablehlo_ops_inc_gen",


### PR DESCRIPTION
Needed since `StablehloRefineShapes.cpp` includes `Base.h`:

https://github.com/openxla/stablehlo/blob/main/stablehlo/transforms/StablehloRefineShapes.cpp#L45