### PR TITLE
Add interpreter for GetDimensionSizeOp

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2901,9 +2901,11 @@ Produces the size of the given `dimension` of the `operand`.
 // %operand: [[1, 2, 3], [4, 5, 6]]
 %result = "stablehlo.get_dimension_size"(%operand) {
   dimension = 1 : i64
-} : (tensor<2x3xf32>) -> tensor<i32>
+} : (tensor<2x3xi64>) -> tensor<i32>
 // %result: 3
 ```
+
+&nbsp;[More Examples](../stablehlo/tests/interpret_get_dimension_size.mlir)
 
 ### get_tuple_element
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -92,7 +92,7 @@ one of the following tracking labels.
 | fft                      | yes           | revisit      | yes            | yes             | no          |
 | floor                    | yes           | yes          | yes            | yes             | yes         |
 | gather                   | yes           | yes          | yes            | no              | no          |
-| get_dimension_size       | yes           | yes          | yes            | yes             | no          |
+| get_dimension_size       | yes           | yes          | yes            | yes             | yes         |
 | get_tuple_element        | yes           | yes          | yes            | yes             | no          |
 | if                       | yes           | revisit      | yes            | no              | yes         |
 | imag                     | yes           | yes          | yes            | yes             | yes         |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2351,22 +2351,22 @@ def StableHLO_GatherOp: StableHLO_Op<"gather", [InferTensorTypeWithReify, Pure]>
 }
 
 def StableHLO_GetDimensionSizeOp: StableHLO_Op<"get_dimension_size",
-      [Pure, InferTensorType]> {
+      [Pure, InferTensorType /*get_dimension_size_c1*/]> {
   let summary = "GetDimensionSize operation";
   let description = [{
     Produces the size of the given `dimension` of the `operand`.
 
-    See
+    See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec.md#get_dimension_size
 
     Example:
     ```mlir
-    %result = stablehlo.get_dimension_size %operand, dim = 1 : (tensor<2x3xf32>) -> tensor<i32>
+    %result = stablehlo.get_dimension_size %operand, dim = 1 : (tensor<2x3xi64>) -> tensor<i32>
     ```
   }];
   let arguments = (ins
-    HLO_Tensor:$operand,
-    I64Attr:$dimension
+    HLO_Tensor:$operand, /*get_dimension_size_i1*/
+    I64Attr:$dimension /*get_dimension_size_i2*/
   );
   // TODO(hinsu): Allow 64-bit result types once XLA HLO dialect based on the
   // XLA semantics is available. This limitation is because of the current XLA

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2351,7 +2351,7 @@ def StableHLO_GatherOp: StableHLO_Op<"gather", [InferTensorTypeWithReify, Pure]>
 }
 
 def StableHLO_GetDimensionSizeOp: StableHLO_Op<"get_dimension_size",
-      [Pure, InferTensorType /*get_dimension_size_c1*/]> {
+      [Pure, InferTensorType]> {
   let summary = "GetDimensionSize operation";
   let description = [{
     Produces the size of the given `dimension` of the `operand`.

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2304,6 +2304,7 @@ LogicalResult inferGatherOp(
 LogicalResult inferGetDimensionSizeOp(
     std::optional<Location> location, Type operandType, int64_t dimension,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
+  // get_dimension_size_c1
   if (failed(verifyDimInBounds(location, operandType.cast<ShapedType>(),
                                dimension)))
     return failure();

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -155,6 +155,12 @@ SmallVector<Tensor> eval(
       Tensor runtimeOperand = scope.find(floorOp.getOperand());
       Tensor runtimeResult = evalFloorOp(runtimeOperand, floorOp.getType());
       scope.add(op.getResults(), {runtimeResult});
+    } else if (auto getDimensionSizeOp = dyn_cast<GetDimensionSizeOp>(op)) {
+      Tensor runtimeOperand = scope.find(getDimensionSizeOp.getOperand());
+      auto runtimeResults = evalGetDimensionSizeOp(
+          runtimeOperand, getDimensionSizeOp.getDimension(),
+          getDimensionSizeOp.getType());
+      scope.add(op.getResults(), runtimeResults);
     } else if (auto ifOp = dyn_cast<IfOp>(op)) {
       Tensor runtimePred = scope.find(ifOp.getPred());
       auto runtimeResults = evalIfOp(runtimePred, ifOp.getTrueBranch(),
@@ -547,6 +553,14 @@ Tensor evalFloorOp(const Tensor &operand, ShapedType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, floor(operand.get(*it)));
+  return result;
+}
+
+Tensor evalGetDimensionSizeOp(const Tensor &operand, Axis dimension,
+                              ShapedType resultType) {
+  Tensor result(resultType);
+  result.set(
+      {}, Element(resultType.getElementType(), operand.getShape()[dimension]));
   return result;
 }
 

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -56,6 +56,8 @@ Tensor evalDynamicUpdateSliceOp(const Tensor &operand, const Tensor &update,
                                 ShapedType resultType);
 Tensor evalExponentialOp(const Tensor &operand, ShapedType resultType);
 Tensor evalFloorOp(const Tensor &operand, ShapedType resultType);
+Tensor evalGetDimensionSizeOp(const Tensor &operand, Axis dimension,
+                              ShapedType resultType);
 SmallVector<Tensor> evalIfOp(const Tensor &pred, Region &trueBranch,
                              Region &falseBranch, Scope &scope);
 Tensor evalImagOp(const Tensor &operand, ShapedType resultType);

--- a/stablehlo/tests/interpret_get_dimension_size.mlir
+++ b/stablehlo/tests/interpret_get_dimension_size.mlir
@@ -1,0 +1,8 @@
+// RUN: stablehlo-translate --interpret -split-input-file %s
+
+func.func @get_dimension_size_op_test_si64() {
+  %operand = stablehlo.constant dense<[[1, 2, 3], [4, 5, 6]]> : tensor<2x3xi64>
+  %result = stablehlo.get_dimension_size %operand, dim = 1 : (tensor<2x3xi64>) -> tensor<i32>
+  check.expect_eq_const %result, dense<3> : tensor<i32>
+  func.return
+}

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -4152,21 +4152,13 @@ func.func @dynamic_gather(%operand : tensor<*xi32>, %start_indices : tensor<?x?x
 // -----
 
 func.func @get_dimension_size(%I: tensor<1x128x512xf32>) -> tensor<i32> {
-  // expected-error@+1 {{requires dimension attribute in range [0, 3); found (3)}}
-  %size = "stablehlo.get_dimension_size"(%I) {dimension = 3 : i64} : (tensor<1x128x512xf32>) -> tensor<i32>
-  func.return %size : tensor<i32>
-}
-
-// -----
-
-func.func @get_dimension_size(%I: tensor<1x128x512xf32>) -> tensor<i32> {
   %size = "stablehlo.get_dimension_size"(%I) {dimension = 2 : i64} : (tensor<1x128x512xf32>) -> tensor<i32>
   func.return %size : tensor<i32>
 }
 
 // -----
 
-func.func @get_dimension_size_negative_dimension(%I: tensor<1x128x512xf32>) -> tensor<i32> {
+func.func @get_dimension_size_c1(%I: tensor<1x128x512xf32>) -> tensor<i32> {
   // expected-error@+1 {{requires non-negative dimension attribute; found (-1)}}
   %size = "stablehlo.get_dimension_size"(%I) {dimension = -1 : i64} : (tensor<1x128x512xf32>) -> tensor<i32>
   func.return %size : tensor<i32>
@@ -4174,7 +4166,7 @@ func.func @get_dimension_size_negative_dimension(%I: tensor<1x128x512xf32>) -> t
 
 // -----
 
-func.func @get_dimension_size_invalid_dimension(%I: tensor<1x128x512xf32>) -> tensor<i32> {
+func.func @get_dimension_size_c1(%I: tensor<1x128x512xf32>) -> tensor<i32> {
   // expected-error@+1 {{requires dimension attribute in range [0, 3); found (3)}}
   %size = "stablehlo.get_dimension_size"(%I) {dimension = 3 : i64} : (tensor<1x128x512xf32>) -> tensor<i32>
   func.return %size : tensor<i32>


### PR DESCRIPTION
Here are the constraints for the GetDimensionSizeOp:
```
(I1) operand is a tensor.
(I2) dimension is a constant of type `si64`.
(C1) 0 <= dimension < rank(operand).
```

These constraints will be comprehensively covered by the following tests:
```
I1: a) operand is not a tensor. (Covered by ODS).
I2: a) dimension is not a constant of type `si64`. (Covered by ODS).
C1: a) 0 < dimension.
    b) dimension < rank(operand).
```

If we drop the "Covered by ODS" pieces, this will leave us with the following test cases:
```
C1a: 0 < dimension.
C1b: dimension < rank(operand).
```

closes #1432