### PR TITLE
Bump patch to 0.10.1 after integrate

### DIFF
--- a/stablehlo/dialect/Version.h
+++ b/stablehlo/dialect/Version.h
@@ -38,7 +38,7 @@ class Version {
   static FailureOr<Version> fromString(llvm::StringRef versionRef);
 
   /// Return a Version representing the current VHLO dialect version.
-  static Version getCurrentVersion() { return Version(0, 10, 0); }
+  static Version getCurrentVersion() { return Version(0, 10, 1); }
 
   /// Return a Version representing the minimum supported VHLO dialect version.
   static Version getMinimumVersion() { return Version(0, 9, 0); }

--- a/stablehlo/integrations/python/tests/stablehlo.py
+++ b/stablehlo/integrations/python/tests/stablehlo.py
@@ -210,7 +210,9 @@ def test_api_version():
 @run
 def test_serialization_apis():
   curr_version = stablehlo.get_current_version()
-  assert curr_version == "0.10.1"
+  major_minor_patch = curr_version.split('.')
+  assert len(major_minor_patch) == 3
+  assert major_minor_patch[1] == "10"
 
   ASM = """
   func.func @test(%arg0: tensor<2xf32>) -> tensor<2xf32> {

--- a/stablehlo/integrations/python/tests/stablehlo.py
+++ b/stablehlo/integrations/python/tests/stablehlo.py
@@ -210,8 +210,8 @@ def test_api_version():
 @run
 def test_serialization_apis():
   curr_version = stablehlo.get_current_version()
-  assert curr_version == "0.10.0"
-  
+  assert curr_version == "0.10.1"
+
   ASM = """
   func.func @test(%arg0: tensor<2xf32>) -> tensor<2xf32> {
     %0 = stablehlo.add %arg0, %arg0 : (tensor<2xf32>, tensor<2xf32>) -> tensor<2xf32>

--- a/stablehlo/integrations/python/tests/stablehlo.py
+++ b/stablehlo/integrations/python/tests/stablehlo.py
@@ -211,7 +211,7 @@ def test_api_version():
 @run
 def test_serialization_apis():
   curr_version = stablehlo.get_current_version()
-  assert bool(re.match('\d+\.\d+\.\d+', curr_version))
+  assert re.match('^\d+\.\d+\.\d+$', curr_version)
 
   ASM = """
   func.func @test(%arg0: tensor<2xf32>) -> tensor<2xf32> {

--- a/stablehlo/integrations/python/tests/stablehlo.py
+++ b/stablehlo/integrations/python/tests/stablehlo.py
@@ -17,6 +17,7 @@
 
 # pylint: disable=wildcard-import,undefined-variable
 
+import re
 from mlir import ir
 from mlir.dialects import stablehlo
 
@@ -210,9 +211,7 @@ def test_api_version():
 @run
 def test_serialization_apis():
   curr_version = stablehlo.get_current_version()
-  major_minor_patch = curr_version.split('.')
-  assert len(major_minor_patch) == 3
-  assert major_minor_patch[1] == "10"
+  assert bool(re.match('\d+\.\d+\.\d+', curr_version))
 
   ASM = """
   func.func @test(%arg0: tensor<2xf32>) -> tensor<2xf32> {


### PR DESCRIPTION
After a StableHLO release is integrated into OpenXLA ([openxla/xla](https://github.com/openxla/xla/tree/main/third_party/stablehlo)), bump the patch version so HEAD remains ahead of the latest release.