### PR TITLE
Add type check to matchInts for shape refinement

### DIFF
--- a/stablehlo/dialect/Base.h
+++ b/stablehlo/dialect/Base.h
@@ -110,11 +110,23 @@ LogicalResult inferMostSpecificTypeComponents(
     std::optional<Location> location, TypeRange inputTypes,
     SmallVectorImpl<ShapedTypeComponents> &inferredReturnShapes);
 
+inline bool matchNumericType(DenseIntElementsAttr attr,
+                             SmallVector<int64_t> &result) {
+  // FIXME: Discuss if this should be signless 64?
+  return attr.getElementType().isSignlessInteger();
+}
+
+inline bool matchNumericType(DenseIntElementsAttr attr,
+                             SmallVector<APInt> &result) {
+  return attr.isa<IntegerType>();
+}
+
 // Matches a constant tensor with integer values into a 1-dimensional vector.
 template <typename T>
 LogicalResult matchInts(Value value, SmallVector<T> &result) {
   DenseIntElementsAttr attr;
   if (!matchPattern(value, m_Constant(&attr))) return failure();
+  if (!matchNumericType(attr, result)) return failure();
   for (auto element : attr.getValues<APInt>()) {
     if constexpr (std::is_same<T, int64_t>::value) {
       result.push_back(element.getSExtValue());

--- a/stablehlo/dialect/Base.h
+++ b/stablehlo/dialect/Base.h
@@ -110,15 +110,13 @@ LogicalResult inferMostSpecificTypeComponents(
     std::optional<Location> location, TypeRange inputTypes,
     SmallVectorImpl<ShapedTypeComponents> &inferredReturnShapes);
 
-inline bool matchNumericType(DenseIntElementsAttr attr,
-                             SmallVector<int64_t> &result) {
+inline bool matchNumericType(Type elementType, SmallVector<int64_t> &result) {
   // FIXME: Discuss if this should be signless 64?
-  return attr.getElementType().isSignlessInteger();
+  return elementType.isSignlessInteger();
 }
 
-inline bool matchNumericType(DenseIntElementsAttr attr,
-                             SmallVector<APInt> &result) {
-  return attr.isa<IntegerType>();
+inline bool matchNumericType(Type elementType, SmallVector<APInt> &result) {
+  return elementType.isa<IntegerType>();
 }
 
 // Matches a constant tensor with integer values into a 1-dimensional vector.
@@ -126,7 +124,7 @@ template <typename T>
 LogicalResult matchInts(Value value, SmallVector<T> &result) {
   DenseIntElementsAttr attr;
   if (!matchPattern(value, m_Constant(&attr))) return failure();
-  if (!matchNumericType(attr, result)) return failure();
+  if (!matchNumericType(attr.getElementType(), result)) return failure();
   for (auto element : attr.getValues<APInt>()) {
     if constexpr (std::is_same<T, int64_t>::value) {
       result.push_back(element.getSExtValue());

--- a/stablehlo/tests/stablehlo_refine_shapes.mlir
+++ b/stablehlo/tests/stablehlo_refine_shapes.mlir
@@ -312,6 +312,20 @@ func.func @eval_slice() -> tensor<2xi64> {
 
 // -----
 
+// CHECK-LABEL: func @eval_slice_uint
+func.func @eval_slice_uint() -> tensor<1xui64> {
+  // CHECK: stablehlo.slice
+  %0 = stablehlo.constant dense<[1, 2]> : tensor<2xui64>
+  %1 = "stablehlo.slice"(%0) {
+    start_indices = dense<0> : tensor<1xi64>,
+    limit_indices = dense<1> : tensor<1xi64>,
+    strides = dense<1> : tensor<1xi64>
+  } : (tensor<2xui64>) -> tensor<1xui64>
+  func.return %1 : tensor<1xui64>
+}
+
+// -----
+
 // CHECK-LABEL: func @eval_subtract
 func.func @eval_subtract() -> tensor<i64> {
   // CHECK-NOT: stablehlo.subtract

--- a/stablehlo/tests/stablehlo_refine_shapes.mlir
+++ b/stablehlo/tests/stablehlo_refine_shapes.mlir
@@ -312,8 +312,8 @@ func.func @eval_slice() -> tensor<2xi64> {
 
 // -----
 
-// CHECK-LABEL: func @eval_slice_uint
-func.func @eval_slice_uint() -> tensor<1xui64> {
+// CHECK-LABEL: func @eval_slice_uint_failure
+func.func @eval_slice_uint_failure() -> tensor<1xui64> {
   // CHECK: stablehlo.slice
   %0 = stablehlo.constant dense<[1, 2]> : tensor<2xui64>
   %1 = "stablehlo.slice"(%0) {


### PR DESCRIPTION
Converting to uint asserted when passing a `SmallVector<int64_t>` to `matchInts`. Add a check that the requested input type is valid for the element type of the tensor being matched.

Fixes #1328