### PR TITLE
Add interpreter for CholeskyOp

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1556,7 +1556,7 @@ matrix, then the behavior is undefined.
 //     ]
 %result = "stablehlo.cholesky"(%a) {
   lower = true
-} : (tensor<3x3xf32>) -> tensor<3x3xf32>
+} : (tensor<3x3xf32>) -> tensor<3x3xf64>
 // %result: [
 //           [1.0, 0.0, 0.0],
 //           [2.0, 4.0, 0.0],

--- a/docs/status.md
+++ b/docs/status.md
@@ -59,7 +59,7 @@ one of the following tracking labels.
 | case                     | yes           | revisit      | yes            | no              | yes         |
 | cbrt                     | yes           | yes          | yes            | yes             | yes         |
 | ceil                     | yes           | yes          | yes            | yes             | yes         |
-| cholesky                 | yes           | yes          | yes            | yes             | no          |
+| cholesky                 | yes           | yes          | yes            | yes             | yes         |
 | clamp                    | yes           | revisit      | yes            | yes             | yes         |
 | collective_permute       | yes           | revisit      | yes            | no              | no          |
 | compare                  | yes           | yes          | yes            | yes             | yes         |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1925,7 +1925,8 @@ def StableHLO_DynamicBroadcastInDimOp : StableHLO_ShapedInterfaceOp<
 // directly.
 
 def StableHLO_CholeskyOp : StableHLO_Op<"cholesky",
-      [Pure, SameOperandsAndResultElementType, InferTensorType]> {
+      [Pure, SameOperandsAndResultElementType /*cholesky_c1*/,
+       InferTensorType /*cholesky_c1*/]> {
   let summary = "Cholesky operation";
   let description = [{
     Computes the Cholesky decomposition of a batch of matrices.
@@ -1935,7 +1936,7 @@ def StableHLO_CholeskyOp : StableHLO_Op<"cholesky",
 
     Example:
     ```mlir
-    %result = stablehlo.cholesky %a, lower = true : tensor<3x3xf32>
+    %result = stablehlo.cholesky %a, lower = true : tensor<3x3xf64>
     ```
   }];
   let arguments = (ins

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -1488,33 +1488,32 @@ LogicalResult inferCaseOp(std::optional<Location> location, Value index,
   return inferConditionalOp(location, index, branches, inferredReturnTypes);
 }
 
-// The following properties are already enforced by the ODS:
-//   P0. a.element_type is floating or complex
-// We intend to verify the following properties
-//   P1. The 'a' argument to Cholesky must have rank >= 2, got shape %s
-//   P2. The two minor dimensions of 'a' must have equal size, got %s.
 LogicalResult inferCholeskyOp(
     std::optional<Location> location, Value a,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   Type aType = a.getType();
   RankedTensorType aRankedType = aType.dyn_cast<RankedTensorType>();
   if (!aRankedType) {
+    // cholesky_c1
     inferredReturnShapes.emplace_back(
         aType.cast<ShapedType>().getElementType());
     return success();
   }
 
   ArrayRef<int64_t> aShape = aRankedType.getShape();
+  // cholesky_c2
   if (aShape.size() < 2)
     return emitOptionalError(
         location, "argument 'a' must have rank >= 2, got shape ", aShape, ".");
 
+  // cholesky_c3
   if (!verifyCompatibleDims(aShape[aShape.size() - 2],
                             aShape[aShape.size() - 1]))
     return emitOptionalError(
         location, "minor dimensions of 'a' must have equal size, got shape ",
         aShape, ".");
 
+  // cholesky_c1
   inferredReturnShapes.emplace_back(aRankedType.getShape(),
                                     aRankedType.getElementType(),
                                     aRankedType.getEncoding());

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -38,6 +38,7 @@ SmallVector<Tensor> evalCaseOp(const Tensor &index, RegionRange branches,
                                Scope &scope);
 Tensor evalCbrtOp(const Tensor &operand, ShapedType resultType);
 Tensor evalCeilOp(const Tensor &operand, ShapedType resultType);
+Tensor evalCholeskyOp(const Tensor &a, bool lower, ShapedType resultType);
 Tensor evalClampOp(const Tensor &min, const Tensor &operand, const Tensor &max,
                    ShapedType resultType);
 Tensor evalClzOp(const Tensor &operand, ShapedType resultType);

--- a/stablehlo/reference/Sizes.h
+++ b/stablehlo/reference/Sizes.h
@@ -32,6 +32,7 @@ class Sizes : public SmallVector<int64_t> {
   Sizes &operator=(const Sizes &other) = default;
 
   Sizes(std::initializer_list<int64_t> list) : SmallVector(list) {}
+  Sizes(iterator begin, iterator end) : SmallVector(begin, end) {}
   explicit Sizes(size_t size, int64_t element = 0)
       : SmallVector(size, element) {}
   explicit Sizes(ArrayRef<int64_t> array) : SmallVector(array) {}

--- a/stablehlo/tests/interpret_cholesky.mlir
+++ b/stablehlo/tests/interpret_cholesky.mlir
@@ -1,0 +1,66 @@
+// RUN: stablehlo-translate --interpret -split-input-file %s
+
+func.func @cholesky_op_test_f64() {
+  %a = stablehlo.constant dense<[[1.0, 2.0, 3.0],
+                                 [2.0, 20.0, 26.0],
+                                 [3.0, 26.0, 70.0]]> : tensor<3x3xf64>
+  %result = stablehlo.cholesky %a, lower = true : tensor<3x3xf64>
+  check.expect_almost_eq_const %result, dense<[[1.0, 0.0, 0.0],
+                                               [2.0, 4.0, 0.0],
+                                               [3.0, 5.0, 6.0]]> : tensor<3x3xf64>
+  func.return
+}
+
+// -----
+
+func.func @cholesky_op_test_f64() {
+  %a = stablehlo.constant dense<[[1.0, 2.0, 3.0],
+                                 [2.0, 20.0, 26.0],
+                                 [3.0, 26.0, 70.0]]> : tensor<3x3xf64>
+  %result = stablehlo.cholesky %a, lower = false : tensor<3x3xf64>
+  check.expect_almost_eq_const %result, dense<[[1.0, 2.0, 3.0],
+                                               [0.0, 4.0, 5.0],
+                                               [0.0, 0.0, 6.0]]> : tensor<3x3xf64>
+  func.return
+}
+
+// -----
+
+func.func @cholesky_op_test_f64_batching() {
+  %a = stablehlo.constant dense<[[[1.0, 2.0, 3.0],
+                                  [2.0, 20.0, 26.0],
+                                  [3.0, 26.0, 70.0]],
+                                 [[1.0, 2.0, 3.0],
+                                  [2.0, 20.0, 26.0],
+                                  [3.0, 26.0, 70.0]]]> : tensor<2x3x3xf64>
+  %result = stablehlo.cholesky %a, lower = true : tensor<2x3x3xf64>
+  check.expect_almost_eq_const %result, dense<[[[1.0, 0.0, 0.0],
+                                                [2.0, 4.0, 0.0],
+                                                [3.0, 5.0, 6.0]],
+                                               [[1.0, 0.0, 0.0],
+                                                [2.0, 4.0, 0.0],
+                                                [3.0, 5.0, 6.0]]]> : tensor<2x3x3xf64>
+  func.return
+}
+
+// -----
+
+func.func @cholesky_op_test_c128() {
+  %a = stablehlo.constant dense<[[(1.0, 0.0), (0.0, 2.0)],
+                                 [(0.0, -2.0), (5.0, 0.0)]]> : tensor<2x2xcomplex<f64>>
+  %result = stablehlo.cholesky %a, lower = true : tensor<2x2xcomplex<f64>>
+  check.expect_almost_eq_const %result, dense<[[(1.0, 0.0), (0.0, 0.0)],
+                                               [(0.0, -2.0), (1.0, 0.0)]]> : tensor<2x2xcomplex<f64>>
+  func.return
+}
+
+// -----
+
+func.func @cholesky_op_test_c128() {
+  %a = stablehlo.constant dense<[[(1.0, 0.0), (0.0, 2.0)],
+                                 [(0.0, -2.0), (5.0, 0.0)]]> : tensor<2x2xcomplex<f64>>
+  %result = stablehlo.cholesky %a, lower = false : tensor<2x2xcomplex<f64>>
+  check.expect_almost_eq_const %result, dense<[[(1.0, 0.0), (0.0, 2.0)],
+                                               [(0.0, 0.0), (1.0, 0.0)]]> : tensor<2x2xcomplex<f64>>
+  func.return
+}

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -1455,16 +1455,7 @@ func.func @cholesky(%arg0: tensor<1x2x2xf32>) -> tensor<1x2x2xf32> {
 
 // -----
 
-func.func @cholesky_error_nonsquare(%arg0: tensor<1x2x1xf32>) -> tensor<1x2x1xf32> {
-  // expected-error@+2 {{failed to infer returned types}}
-  // expected-error@+1 {{minor dimensions of 'a' must have equal size, got shape 1, 2, 1}}
-  %0 = "stablehlo.cholesky"(%arg0) { lower = true } : (tensor<1x2x1xf32>) -> tensor<1x2x1xf32>
-  func.return %0: tensor<1x2x1xf32>
-}
-
-// -----
-
-func.func @cholesky_invalid_rank(%arg0: tensor<1xf32>) -> tensor<1xf32> {
+func.func @cholesky_c2(%arg0: tensor<1xf32>) -> tensor<1xf32> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{argument 'a' must have rank >= 2, got shape 1}}
   %0 = "stablehlo.cholesky"(%arg0) { lower = true } : (tensor<1xf32>) -> tensor<1xf32>
@@ -1473,19 +1464,11 @@ func.func @cholesky_invalid_rank(%arg0: tensor<1xf32>) -> tensor<1xf32> {
 
 // -----
 
-func.func @cholesky_invalid_elt(%arg0: tensor<1x2x2xi32>) -> tensor<1x2x2xi32> {
-  // expected-error@+1 {{operand #0 must be tensor of f8E4M3B11FNUZ type or f8E4M3FN type or f8E4M3FNUZ type or f8E5M2 type or f8E5M2FNUZ type or 16-bit float or 32-bit float or 64-bit float or bfloat16 type or complex type with 32-bit float or 64-bit float elements values, but got 'tensor<1x2x2xi32>'}}
-  %0 = "stablehlo.cholesky"(%arg0) { lower = true } : (tensor<1x2x2xi32>) -> tensor<1x2x2xi32>
-  func.return %0: tensor<1x2x2xi32>
-}
-
-// -----
-
-func.func @cholesky_wrong_infer_shape(%arg0: tensor<1x2x2xf32>) -> tensor<1x2x2x2xf32> {
+func.func @cholesky_c3(%arg0: tensor<1x2x1xf32>) -> tensor<1x2x1xf32> {
   // expected-error@+2 {{failed to infer returned types}}
-  // expected-error@+1 {{'stablehlo.cholesky' op inferred type(s) 'tensor<1x2x2xf32>' are incompatible with return type(s) of operation 'tensor<1x2x2x2xf32>'}}
-  %0 = "stablehlo.cholesky"(%arg0) { lower = true } : (tensor<1x2x2xf32>) -> tensor<1x2x2x2xf32>
-  func.return %0: tensor<1x2x2x2xf32>
+  // expected-error@+1 {{minor dimensions of 'a' must have equal size, got shape 1, 2, 1}}
+  %0 = "stablehlo.cholesky"(%arg0) { lower = true } : (tensor<1x2x1xf32>) -> tensor<1x2x1xf32>
+  func.return %0: tensor<1x2x1xf32>
 }
 
 // -----


### PR DESCRIPTION
Here are the constraints for CholeskyOp:
```
(I1) `a` is a tensor of floating-point or complex type.
(I2) `lower` is a tensor constant of `i1` type.
(C1) `a` and `result` have the same type.
(C2) rank(`a`) >= 2.
(C3) dim(`a`, -2) = dim(`a`, -1).
```

These constraints will be comprehensively covered by the following tests:

```
I1: a) `a` is not a tensor of floating-point type or complex type. (Covered by ODS).
I2: a) `lower` is not a tensor constant of `i1` type. (Covered by ODS).
C1: a) type(a) != type(result).
C2: a) rank(a) < 2.
C3: a) dim(`a`, -2) != dim(`a`, -1).
```

If we drop the "Covered by ODS" pieces, this will leave us with the following test cases:

```
C1a: type(a) != type(result).
C2a: rank(a) < 2.
C3a: dim(`a`, -2) != dim(`a`, -1).
```

Notes:
* Implementation inspired by the [Cholesky–Banachiewicz algorithm](https://en.wikipedia.org/wiki/Cholesky_decomposition).

closes #1123