### PR TITLE
Bump patch version 0.10.1 -> 0.10.2

### DIFF
--- a/stablehlo/dialect/Version.h
+++ b/stablehlo/dialect/Version.h
@@ -38,7 +38,7 @@ class Version {
   static FailureOr<Version> fromString(llvm::StringRef versionRef);
 
   /// Return a Version representing the current VHLO dialect version.
-  static Version getCurrentVersion() { return Version(0, 10, 1); }
+  static Version getCurrentVersion() { return Version(0, 10, 2); }
 
   /// Return a Version representing the minimum supported VHLO dialect version.
   static Version getMinimumVersion() { return Version(0, 9, 0); }


### PR DESCRIPTION
After a StableHLO release is integrated into OpenXLA ([openxla/xla](https://github.com/openxla/xla/tree/main/third_party/stablehlo)), we bump the patch version so HEAD remains ahead of the latest release.