### PR TITLE
Refactor matchInts to use APSInt instead of APInt

### DIFF
--- a/stablehlo/transforms/StablehloCanonicalizeDynamism.cpp
+++ b/stablehlo/transforms/StablehloCanonicalizeDynamism.cpp
@@ -94,8 +94,7 @@ struct CanonicalizeDynamicBroadcastInDimOpPattern
     // with the result type.
     if (!op.getOperand().getType().hasStaticShape())
       return rewriter.notifyMatchFailure(op, "expected static operand type");
-    SmallVector<int64_t> outputDimensions;
-    if (!succeeded(hlo::matchInts(op.getOutputDimensions(), outputDimensions)))
+    if (!succeeded(hlo::matchInts(op.getOutputDimensions())))
       return rewriter.notifyMatchFailure(op,
                                          "expected static output_dimensions");
     if (!op.getType().hasStaticShape())
@@ -195,8 +194,7 @@ struct CanonicalizeDynamicReshapeOpPattern
                                 PatternRewriter& rewriter) const override {
     // This pattern ignores and discards the output_shape operand. We rely on
     // the verifier to make sure that its value is consistent with result type.
-    SmallVector<int64_t> outputShape;
-    if (!succeeded(hlo::matchInts(op.getOutputShape(), outputShape)))
+    if (!succeeded(hlo::matchInts(op.getOutputShape())))
       return rewriter.notifyMatchFailure(op, "expected static output_shape");
     if (!op.getType().hasStaticShape())
       return rewriter.notifyMatchFailure(op, "expected static result type");

--- a/stablehlo/transforms/StablehloRefineShapes.cpp
+++ b/stablehlo/transforms/StablehloRefineShapes.cpp
@@ -58,7 +58,7 @@ namespace {
 // DenseElementsAttr can be constructed from ArrayRef<APInt> but not from
 // ArrayRef<APSInt>. This helper bridges the gap.
 DenseIntElementsAttr getTensorAttr(ShapedType type, ArrayRef<APSInt> values) {
-  SmallVector<APInt> supportedValues(values.begin(), values.end());
+  SmallVector<APInt> supportedValues(values);
   return DenseIntElementsAttr::get(type, supportedValues);
 }
 

--- a/stablehlo/transforms/StablehloRefineShapes.cpp
+++ b/stablehlo/transforms/StablehloRefineShapes.cpp
@@ -58,10 +58,7 @@ namespace {
 // DenseElementsAttr can be constructed from ArrayRef<APInt> but not from
 // ArrayRef<APSInt>. This helper bridges the gap.
 DenseIntElementsAttr getTensorAttr(ShapedType type, ArrayRef<APSInt> values) {
-  SmallVector<APInt> supportedValues;
-  for (auto value : values) {
-    supportedValues.push_back(value);
-  }
+  SmallVector<APInt> supportedValues(values.begin(), values.end());
   return DenseIntElementsAttr::get(type, supportedValues);
 }
 
@@ -71,7 +68,7 @@ APSInt getAPSInt(Type type, uint64_t value) {
   if (auto integerType = type.dyn_cast<IntegerType>()) {
     numBits = integerType.getWidth();
     // Signless types are treated as signed, per StableHLO convention.
-    isUnsigned = integerType.getSignedness() == IntegerType::Unsigned;
+    isUnsigned = integerType.isUnsignedInteger();
   } else if (auto indexType = type.dyn_cast<IndexType>()) {
     numBits = IndexType::kInternalStorageBitWidth;
     isUnsigned = false;


### PR DESCRIPTION
As I was cleaning up the uses of matchInts, I figured I'd do the long-standing refactoring to switch to using APSInt.

This had the benefit of simplifying partial evaluation logic in --stablehlo-refine-shapes because with APSInts we no longer need to branch on whether the underlying APInts are signed or unsigned.