### PR TITLE
Account for operand_layouts in CustomCallOp canonicalization

### DIFF
--- a/stablehlo/tests/stablehlo_canonicalize_dynamism.mlir
+++ b/stablehlo/tests/stablehlo_canonicalize_dynamism.mlir
@@ -38,6 +38,24 @@ func.func @custom_call_success_mixed_positions(%arg0: tensor<4xf32>) -> (tensor<
 
 // -----
 
+// CHECK-LABEL: func @custom_call_success_mixed_positions_layouts
+func.func @custom_call_success_mixed_positions_layouts(%arg0: tensor<4x3xf32>) -> (tensor<1x2xf32>, tensor<3x4xf32>) {
+  //      CHECK: stablehlo.custom_call @foo(%arg0) {
+  // CHECK-SAME:   operand_layouts = [dense<[1, 0]> : tensor<2xindex>],
+  // CHECK-SAME:   result_layouts = [dense<[1, 0]> : tensor<2xindex>, dense<[1, 0]> : tensor<2xindex>]
+  // CHECK-SAME: } : (tensor<4x3xf32>) -> (tensor<1x2xf32>, tensor<3x4xf32>)
+  %0 = stablehlo.constant dense<[1, 2]> : tensor<2xi64>
+  %1 = stablehlo.constant dense<[3, 4]> : tensor<2xi64>
+  %2:2 = stablehlo.custom_call @foo(%0, %arg0, %1) {
+    indices_of_shape_operands = dense<[0, 2]> : tensor<2xi64>,
+    operand_layouts = [dense<[0]> : tensor<1xindex>, dense<[1, 0]> : tensor<2xindex>, dense<[0]> : tensor<1xindex>],
+    result_layouts = [dense<[1, 0]> : tensor<2xindex>, dense<[1, 0]> : tensor<2xindex>]
+  } : (tensor<2xi64>, tensor<4x3xf32>, tensor<2xi64>) -> (tensor<1x2xf32>, tensor<3x4xf32>)
+  return %2#0, %2#1 : tensor<1x2xf32>, tensor<3x4xf32>
+}
+
+// -----
+
 // CHECK-LABEL: func @custom_call_success_repeating_operands
 func.func @custom_call_success_repeating_operands(%arg0: tensor<4xf32>) -> (tensor<1x2xf32>, tensor<1x2xf32>) {
   // CHECK: stablehlo.custom_call @foo(%arg0) : (tensor<4xf32>) -> (tensor<1x2xf32>, tensor<1x2xf32>)

--- a/stablehlo/transforms/StablehloCanonicalizeDynamism.cpp
+++ b/stablehlo/transforms/StablehloCanonicalizeDynamism.cpp
@@ -56,6 +56,17 @@ struct CanonicalizeCustomCallOpPattern : public OpRewritePattern<CustomCallOp> {
     SmallVector<NamedAttribute> newAttrs;
     for (auto attr : op->getAttrs()) {
       if (attr.getName() == "indices_of_shape_operands") continue;
+      if (attr.getName() == "operand_layouts") {
+        // Drop the operand_layouts that correspond to indices_of_shape_operands
+        ArrayAttr operandLayouts = op.getOperandLayoutsAttr();
+        SmallVector<Attribute> newOperandLayouts;
+        for (unsigned i = 0; i < operandLayouts.size(); ++i) {
+          if (indices.contains(i)) continue;
+          newOperandLayouts.push_back(operandLayouts[i]);
+        }
+        attr = NamedAttribute(attr.getName(),
+                              rewriter.getArrayAttr(newOperandLayouts));
+      }
       newAttrs.push_back(attr);
     }
 


### PR DESCRIPTION
CustomCallOp canonicalization can delete operands called out in indices_of_shape_operands if certain conditions are met.

What I missed when implementing this is that this requires fixing up the operand_layouts attribute.

This has been originally implemented in https://github.com/tensorflow/mlir-hlo/commit/b35b237e77984ff8dd75f3a5a9f29b174d0e40c9 earlier today, and this PR backports that work.