### PR TITLE
Add Python Serialization APIs that operate on strings

### DIFF
--- a/stablehlo/dialect/Serialization.h
+++ b/stablehlo/dialect/Serialization.h
@@ -24,16 +24,56 @@ namespace mlir {
 namespace stablehlo {
 
 // Get current StableHLO version
+//
+// This value can be used as the `targetVersion` argument to
+// `serializePortableArtifact`.
+//
+// See `stablehlo/dialect/Version.h` for current version number.
 std::string getCurrentVersion();
 
 // Write a StableHLO program to a portable artifact
+// Writes a stable payload for `module` to `os`. If compatibility with a
+// previous version of StableHLO is required, provide the required version
+// string `#.#.#` for `targetVersion`.
+//
+// Can fail if `module` cannot be expressed in the `targetVersion` version of
+// StableHLO, e.g. if it's using new or removed features, or if it involves
+// unsupported dialects.
 LogicalResult serializePortableArtifact(ModuleOp module,
                                         StringRef targetVersion,
                                         raw_ostream& os);
 
+// Write a StableHLO program to a portable artifact
+//
+// This string overload of the above API is provided for Python bindings.
+// Python bindings expect all dialects to be compiled together. When this is not
+// possible, passing module bytecode as a string to this overload is safer.
+//
+// Can fail if `moduleStr` cannot be parsed, or if it cannot be expressed in the
+// `targetVersion` version of StableHLO, e.g. if it's using new or removed
+// features, or if it involves unsupported dialects.
+LogicalResult serializePortableArtifact(StringRef moduleStr,
+                                        StringRef targetVersion,
+                                        raw_ostream& os);
+
 // Read StableHLO portable artifact
+//
+// Can fail if `sourceStr` cannot be expressed in the current version of
+// StableHLO, e.g. if it's using incompatible features. Returns nullptr if
+// `sourceStr` is invalid or fails to deserialize.
 OwningOpRef<ModuleOp> deserializePortableArtifact(StringRef sourceStr,
                                                   MLIRContext* context);
+
+// Read a StableHLO program from a portable artifact, returning the module as
+// MLIR bytecode.
+//
+// This string overload of the above API is provided for Python bindings.
+// See the `serializePortableArtifact` `StringRef` overload for detail.
+//
+// Can fail if `sourceStr` cannot be expressed in the current version of
+// StableHLO, e.g. if it's using incompatible features. Returns failure if
+// `sourceStr` is invalid or fails to deserialize.
+FailureOr<std::string> deserializePortableArtifact(StringRef sourceStr);
 
 }  // namespace stablehlo
 }  // namespace mlir

--- a/stablehlo/dialect/Version.h
+++ b/stablehlo/dialect/Version.h
@@ -80,7 +80,7 @@ namespace stablehlo {
 
 /// Return the current version for StableHLO APIs.
 /// Increments on all C++/C/Python API changes
-inline int64_t getApiVersion() { return 1; }
+inline int64_t getApiVersion() { return 2; }
 
 }  // namespace stablehlo
 }  // namespace mlir

--- a/stablehlo/integrations/python/StablehloModule.cpp
+++ b/stablehlo/integrations/python/StablehloModule.cpp
@@ -493,6 +493,21 @@ PYBIND11_MODULE(_stablehlo, m) {
 
   m.def(
       "serialize_portable_artifact",
+      [](std::string module_str, std::string target) -> py::bytes {
+        std::string buffer;
+        llvm::raw_string_ostream os(buffer);
+        if (failed(mlir::stablehlo::serializePortableArtifact(module_str,
+                                                              target, os))) {
+          PyErr_SetString(PyExc_ValueError, "failed to serialize module");
+          return "";
+        }
+
+        return py::bytes(buffer);
+      },
+      py::arg("module_str"), py::arg("target"));
+
+  m.def(
+      "serialize_portable_artifact",
       [](MlirModule module, std::string target) -> py::bytes {
         std::string buffer;
         llvm::raw_string_ostream os(buffer);
@@ -505,6 +520,20 @@ PYBIND11_MODULE(_stablehlo, m) {
         return py::bytes(buffer);
       },
       py::arg("module"), py::arg("target"));
+
+  m.def(
+      "deserialize_portable_artifact",
+      [](std::string artifact) -> py::bytes {
+        auto moduleStr = mlir::stablehlo::deserializePortableArtifact(artifact);
+
+        if (failed(moduleStr)) {
+          PyErr_SetString(PyExc_ValueError, "failed to deserialize module");
+          return {};
+        }
+
+        return {moduleStr.value()};
+      },
+      py::arg("module_str"));
 
   m.def(
       "deserialize_portable_artifact",


### PR DESCRIPTION
More details on rationale in API comments of `stablehlo/dialect/Serialization.h`.

After learning more about Python bindings, unless build is set up in a specific way where all dialect extensions built together so type IDs are accurate, passing/returning strings is safer. These APIs give the option to do either.

Backport of https://github.com/tensorflow/mlir-hlo/commit/6d62e3157aec86d9a6c023595c1c7f89ecf928da

Closes #1361