### PR TITLE
Introduce the specification of quantized type with multiplier and shift

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -174,8 +174,9 @@ following constraints:
 * (C10) `size(scales) = size(zero_points)`.
 * (C11) If `is_empty(quantization_dimension)`, then `size(scales) = 1`.
 * (C12) `0 <= quantization_dimension`.
-* (C13) `0 <= multipliers`.
-* (C14) `0 < shifts`.
+* (C13) `size(multipliers) = size(shifts) = size(zero_points)`.
+* (C14) `0 <= multipliers`.
+* (C15) `0 < shifts`.
 
 All quantized tensor types, in a given StableHLO operation, either
 use scales or multipliers and shifts. The `scales`, `multiplers` and `shifts`,

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -135,7 +135,7 @@ QuantizationParameters ::= QuantizationParameter
                          | '{' QuantizationParameter {',' QuantizationParameter} '}'
 QuantizationParameter ::= ( QuantizationScale | QuantizationMultiplierShift ) ':' QuantizationZeroPoint
 QuantizationScale ::= FloatConstant
-QuantizationMultiplierShift ::= '<' QuantizationMultiplier , QuantizationShift '>'
+QuantizationMultiplierShift ::= '<' QuantizationMultiplier ',' QuantizationShift '>'
 QuantizationMultiplier ::= IntegerConstant
 QuantizationShift ::= IntegerConstant
 QuantizationZeroPoint ::=  IntegerConstant
@@ -176,7 +176,7 @@ following constraints:
 
 In order to allow operation using only integer arithmetic, the floating-point
 `scale`, `S`, is realized using integer `multipler`, `M` and `shift` values each
-with bit width `W >= 2`, such that `round_nearest_even(S * 2^n) = M`, where `1
+with bit width `W >= 2`, such that `round_nearest_even(S * 2^n) == M`, where `1
 <= n <= 2*W - 2` and `0 <= M < 2^(W-1)`.
 
 The following demonstrates, using C++ code, a possible implementation of
@@ -204,7 +204,7 @@ floating-point scale `S` of type `f64`:
         adjustedMantissa = 0;
     }
 
-    // Saturate `adjustedMantissa`, if shift > 30,
+    // Saturate `adjustedMantissa`, if shift > 30.
     if (shift > 30) {
         shift = 30;
         adjustedMantissa = (1LL << 31) - 1;

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -178,7 +178,7 @@ following constraints:
 In a given StableHLO operation, all the quantized tensor types are either
 represented using floating-point scales, or integer scales, with multipliers and
 shifts. The floating-point scale `scale` value and the integer scale, with
-`multipler`, and `shift` values are related as: `round_nearest_even(scale *
+`multipler`, and `shift` values, are related as: `round_nearest_even(scale *
 2^shift) == multipler`.
 
 The following demonstrates, using C++ code, a possible implementation of

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -142,15 +142,17 @@ QuantizationShift ::= IntegerConstant
 QuantizationZeroPoint ::=  IntegerConstant
 ```
 
-| Name                     | Type                                        | Constraints                  |
-|--------------------------|---------------------------------------------|------------------------------|
-| `storage_type`           | integer type                                | (C1-C4), (C9)                |
-| `storage_min`            | integer constant                            | (C2), (C4), (C8)             |
-| `storage_max`            | integer constant                            | (C3), (C4), (C8)             |
-| `expressed_type`         | floating-point type                         | (C1), (C5)                   |
-| `quantization_dimension` | optional integer constant                   | (C11-C13)                    |
-| `scales`                 | variadic number of floating-point constants | (C5-C7), (C10), (C11), (C13) |
-| `zero_points`            | variadic number of integer constants        | (C8-C10)                     |
+| Name                     | Type                                        | Constraints        |
+|--------------------------|---------------------------------------------|--------------------|
+| `storage_type`           | integer type                                | (C1-C4), (C9)      |
+| `storage_min`            | integer constant                            | (C2), (C4), (C8)   |
+| `storage_max`            | integer constant                            | (C3), (C4), (C8)   |
+| `expressed_type`         | floating-point type                         | (C1), (C5)         |
+| `quantization_dimension` | optional integer constant                   | (C11-C12)          |
+| `scales`                 | variadic number of floating-point constants | (C5-C7), (C10-C11) |
+| `zero_points`            | variadic number of integer constants        | (C8-C10)           |
+| `multipliers`            | variadic number of integer constants        | (C13)              |
+| `shifts`                 | variadic number of integer constants        | (C14)              |
 
 **Quantized element types** represent integer values of a **storage type** in
 the range from `storage_min` to `storage_max` (inclusive) that correspond to
@@ -174,6 +176,8 @@ following constraints:
 * (C10) `size(scales) = size(zero_points)`.
 * (C11) If `is_empty(quantization_dimension)`, then `size(scales) = 1`.
 * (C12) `0 <= quantization_dimension`.
+* (C13) `0 <= multipliers < 2^(bitwidth(multiplers...) - 1)`.
+* (C14) `0 <= shifts < 2^(bitwidth(shifts...) - 1)`.
 
 In a given StableHLO operation, all the quantized tensor types are either
 represented using floating-point scales, or integer scales, with multipliers and
@@ -232,12 +236,8 @@ computations specified in the operational semantics using floating-point scales
 can be realized using integer scales with integer-only arithmetic. Refer to
 [dot_general](#dot_general) op for an example. The exact manner in which a
 computation involving floating-point scales is converted to a computation using
-integer scales for each individual operation is implementation-defined. Also,
-the bit width of the multiplier and shift, chosen for each operation, is
-implementation defined.
-
-For simplicity, we will only use floating-point scale when defining the
-operation specification, unless otherwise specified.
+integer scales for each individual operation is TBD. Also, the bit width of the
+multiplier and shift, chosen for each operation, is TBD.
 
 There is an ongoing discussion on the semantics of `QuantizationZeroPoint`,
 including the type, the values and whether there can be just one or

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -176,9 +176,7 @@ following constraints:
 
 In order to allow operation using only integer arithmetic, the floating-point
 `scale`, `S`, is realized using integer `multipler`, `M` and `shift` value,
-`n >= 0`, such that `round_nearest_integer(S) = (M + round)* 2^-n`, where
-`round` is added to recover the precision loss while deriving the values of
-`M` and `n` from `S`.
+`n >= 0`, such that `round_nearest_even(S * 2^n) = M`.
 
 The following demonstrates, using C++ code, a possible implementation of
 deriving the integer parameters `M` and `n` of type `i32` from a
@@ -218,11 +216,7 @@ relationship between the floating-point scale `S` and the integer parameters `M`
 and `n`.
 
 ```c++
-    int64_t round = static_cast<int64_t>(1) << (n - 1);
-    static_cast<int32_t>(std::floor(S + 0.5)) = clamp(
-                                    (static_cast<int64_t>(M) + round) >> n,
-                                    static_cast<int64_t>(std::numeric_limits<int32_t>::min()),
-                                    static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
+    static_cast<int32_t>(roundeven(M * std::pow(2, n))) = M;
 ```
 
 There is an ongoing discussion on the semantics of `QuantizationZeroPoint`,


### PR DESCRIPTION
Addresses https://github.com/openxla/stablehlo/issues/1404

The current PR does the followings:
1. Specifies grammar rules to introduce the integer multipler and shift  in `QuantizedElementType`. 
2. Informally defines the semantics of the multiplier and shift and demonstrates one possible implementation of deriving the values of multiplier and scale. 

There are a couple of open questions which I expect to resolve as part of the review:
1. Do the specification need to demonstrate an implementation (the one we current have using C++ code)? Maybe just the high level definition of multiplier and scale is fine. 
2.  Should the specification also need to explain, maybe using an example, how this new type enable integer-only computation?

Please let me know your feedback! 


**Update**
Based on the feedback received during the community meeting on 06/08/2023,  let me propose to limit this PR with (1) Introduction of multipliers and shifts in the type signature of QuantizedTensorType and (2) Specifying a conversion from floating-point scales to integer multipliers and shifts.

We will address the the specification of individual ops (like dot_general, add) with integers multipliers and shifts in a separate PR.