### PR TITLE
Specification for quantized ConvolutionOp

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3668,17 +3668,17 @@ More formally, `result[result_index]` is defined as:
 
 | Label | Name                | Type                                         | Constraints   |
 |-------|---------------------|----------------------------------------------|---------------|
-| (I1)  | `operand`           | tensor or quantized tensor                   | (C1), (C3-C6) |
-| (I2)  | `padding_value`     | 0-dimensional tensor or quantized tensor     | (C4)          |
-| (I3)  | `edge_padding_low`  | 1-dimensional tensor constant of type `si64` | (C1), (C3)    |
-| (I4)  | `edge_padding_high` | 1-dimensional tensor constant of type `si64` | (C1), (C3)    |
-| (I5)  | `interior_padding`  | 1-dimensional tensor constant of type `si64` | (C1-C3)       |
+| (I1)  | `operand`           | tensor or quantized tensor                   | (C1-C2), (C4) |
+| (I2)  | `padding_value`     | 0-dimensional tensor or quantized tensor     | (C1)          |
+| (I3)  | `edge_padding_low`  | 1-dimensional tensor constant of type `si64` | (C2), (C4)    |
+| (I4)  | `edge_padding_high` | 1-dimensional tensor constant of type `si64` | (C2), (C4)    |
+| (I5)  | `interior_padding`  | 1-dimensional tensor constant of type `si64` | (C2-C4)       |
 
 #### Outputs
 
-| Name     | Type                       | Constraints   |
-|----------|----------------------------|---------------|
-| `result` | tensor or quantized tensor | (C3-C4), (C6) |
+| Name     | Type                       | Constraints |
+|----------|----------------------------|-------------|
+| `result` | tensor or quantized tensor | (C1)        |
 
 #### Constraints
 
@@ -4330,16 +4330,16 @@ and produces a `result` tensor. More formally,
 
 #### Inputs
 
-| Label | Name         | Type                                         | Constraints      |
-|-------|--------------|----------------------------------------------|------------------|
-| (I1)  | `operand`    | tensor   or quantized tensor                 | (C3-C8)          |
-| (I2)  | `dimensions` | 1-dimensional tensor constant of type `si64` | (C1-C2), (C7-C8) |
+| Label | Name         | Type                                         | Constraints |
+|-------|--------------|----------------------------------------------|-------------|
+| (I1)  | `operand`    | tensor   or quantized tensor                 | (C1), (C3)  |
+| (I2)  | `dimensions` | 1-dimensional tensor constant of type `si64` | (C2), (C3)  |
 
 #### Outputs
 
 | Name     | Type                       | Constraints |
 |----------|----------------------------|-------------|
-| `result` | tensor or quantized tensor | (C2-C8)     |
+| `result` | tensor or quantized tensor | (C1), (C3)  |
 
 #### Constraints
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3668,17 +3668,17 @@ More formally, `result[result_index]` is defined as:
 
 | Label | Name                | Type                                         | Constraints   |
 |-------|---------------------|----------------------------------------------|---------------|
-| (I1)  | `operand`           | tensor or quantized tensor                   | (C1-C2), (C4) |
-| (I2)  | `padding_value`     | 0-dimensional tensor or quantized tensor     | (C1)          |
-| (I3)  | `edge_padding_low`  | 1-dimensional tensor constant of type `si64` | (C2), (C4)    |
-| (I4)  | `edge_padding_high` | 1-dimensional tensor constant of type `si64` | (C2), (C4)    |
-| (I5)  | `interior_padding`  | 1-dimensional tensor constant of type `si64` | (C2-C4)       |
+| (I1)  | `operand`           | tensor or quantized tensor                   | (C1), (C3-C6) |
+| (I2)  | `padding_value`     | 0-dimensional tensor or quantized tensor     | (C4)          |
+| (I3)  | `edge_padding_low`  | 1-dimensional tensor constant of type `si64` | (C1), (C3)    |
+| (I4)  | `edge_padding_high` | 1-dimensional tensor constant of type `si64` | (C1), (C3)    |
+| (I5)  | `interior_padding`  | 1-dimensional tensor constant of type `si64` | (C1-C3)       |
 
 #### Outputs
 
-| Name     | Type                       | Constraints |
-|----------|----------------------------|-------------|
-| `result` | tensor or quantized tensor | (C1)        |
+| Name     | Type                       | Constraints   |
+|----------|----------------------------|---------------|
+| `result` | tensor or quantized tensor | (C3-C4), (C6) |
 
 #### Constraints
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2006,8 +2006,8 @@ If `batch_group_count > 1`:
 
 | Label | Name                              | Type                                                         | Constraints                                     |
 |-------|-----------------------------------|--------------------------------------------------------------|-------------------------------------------------|
-| (I1)  | `lhs`                             | tensor or quantized tensor                                   | (C1), (C10-C11), (C14) (C25), (C27-C31), (C33)  |
-| (I2)  | `rhs`                             | tensor or quantized tensor                                   | (C1), (C14-C16), (C25), (C27-C32), (C34), (C36) |
+| (I1)  | `lhs`                             | tensor or quantized tensor                                   | (C1), (C10-C11), (C14) (C25), (C27-C32)         |
+| (I2)  | `rhs`                             | tensor or quantized tensor                                   | (C1), (C14-C16), (C25), (C27-C31), (C33), (C35) |
 | (I3)  | `window_strides`                  | 1-dimensional tensor constant of type `si64`                 | (C2), (C3), (C25)                               |
 | (I4)  | `padding`                         | 2-dimensional tensor constant of type `si64`                 | (C4), (C25)                                     |
 | (I5)  | `lhs_dilation`                    | 1-dimensional tensor constant of type `si64`                 | (C5), (C6), (C25)                               |
@@ -2017,7 +2017,7 @@ If `batch_group_count > 1`:
 | (I9)  | `input_feature_dimension`         | constant of type `si64`                                      | (C11), (C13), (C14)                             |
 | (I10) | `input_spatial_dimensions`        | 1-dimensional tensor constant of type `si64`                 | (C12), (C13), (C25)                             |
 | (I11) | `kernel_input_feature_dimension`  | constant of type `si64`                                      | (C14), (C18)                                    |
-| (I12) | `kernel_output_feature_dimension` | constant of type `si64`                                      | (C15), (C16), (C18), (C25), (C34)               |
+| (I12) | `kernel_output_feature_dimension` | constant of type `si64`                                      | (C15), (C16), (C18), (C25), (C33)               |
 | (I13) | `kernel_spatial_dimensions`       | 1-dimensional tensor constant of type `si64`                 | (C17), (C18), (C25)                             |
 | (I14) | `output_batch_dimension`          | constant of type `si64`                                      | (C20), (C25)                                    |
 | (I15) | `output_feature_dimension`        | constant of type `si64`                                      | (C20), (C25), (C35)                             |
@@ -2028,9 +2028,9 @@ If `batch_group_count > 1`:
 
 #### Outputs
 
-| Name     | Type                       | Constraints                            |
-|----------|----------------------------|----------------------------------------|
-| `result` | tensor or quantized tensor | (C25-C27), (C29), (C31-C33), (C37-C40) |
+| Name     | Type                       | Constraints                 |
+|----------|----------------------------|-----------------------------|
+| `result` | tensor or quantized tensor | (C25-C29), (C31), (C34-C35) |
 
 #### Constraints
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4330,16 +4330,16 @@ and produces a `result` tensor. More formally,
 
 #### Inputs
 
-| Label | Name         | Type                                         | Constraints |
-|-------|--------------|----------------------------------------------|-------------|
-| (I1)  | `operand`    | tensor   or quantized tensor                 | (C1), (C3)  |
-| (I2)  | `dimensions` | 1-dimensional tensor constant of type `si64` | (C2), (C3)  |
+| Label | Name         | Type                                         | Constraints      |
+|-------|--------------|----------------------------------------------|------------------|
+| (I1)  | `operand`    | tensor   or quantized tensor                 | (C3-C8)          |
+| (I2)  | `dimensions` | 1-dimensional tensor constant of type `si64` | (C1-C2), (C7-C8) |
 
 #### Outputs
 
 | Name     | Type                       | Constraints |
 |----------|----------------------------|-------------|
-| `result` | tensor or quantized tensor | (C1), (C3)  |
+| `result` | tensor or quantized tensor | (C2-C8)     |
 
 #### Constraints
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4331,14 +4331,14 @@ and produces a `result` tensor. More formally,
 
 | Label | Name         | Type                                         | Constraints |
 |-------|--------------|----------------------------------------------|-------------|
-| (I1)  | `operand`    | tensor                                       | (C1)        |
+| (I1)  | `operand`    | tensor   or quantized tensor                 | (C1), (C3)  |
 | (I2)  | `dimensions` | 1-dimensional tensor constant of type `si64` | (C2), (C3)  |
 
 #### Outputs
 
-| Name     | Type   | Constraints |
-|----------|--------|-------------|
-| `result` | tensor | (C1), (C3)  |
+| Name     | Type                       | Constraints |
+|----------|----------------------------|-------------|
+| `result` | tensor or quantized tensor | (C1), (C3)  |
 
 #### Constraints
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -210,6 +210,19 @@ quantization parameters. Quantized tensor types have the following constraints:
   * (C12) `quantization_dimension < rank(self)`.
   * (C13) `dim(self, quantization_dimension) = size(scales)`.
 
+For simplicity, we only define individual operation semantics for per-tensor
+quantized type. Semantics of per-axis type, if supported by the op, can be
+derived as follows:
+
+Given an operation specification with per-tensor quantized type, let the
+semantics of the operation includes some application of the quantization
+parameters `zero_point` and `scale` to a tensor element`e` at index = `[i0, ...,
+id, ..., iR-1]`. The specification for the semantics of the same operation on
+tensor element `e`, with per-axis quantized type with quantization dimension `d`
+, would exactly be the same as the one with per-tensor type except that the
+`zero_point` and `scale` will be replaced with their per-axis counterparts,
+`zero_points[id]` and `scales[id]` resp.
+
 ```ebnf
 TokenType ::= 'token'
 ```
@@ -3652,19 +3665,19 @@ More formally, `result[result_index]` is defined as:
 
 #### Inputs
 
-| Label | Name                | Type                                         | Constraints      |
-|-------|---------------------|----------------------------------------------|------------------|
-| (I1)  | `operand`           | tensor                                       | (C1), (C2), (C4) |
-| (I2)  | `padding_value`     | 0-dimensional tensor                         | (C1)             |
-| (I3)  | `edge_padding_low`  | 1-dimensional tensor constant of type `si64` | (C2), (C4)       |
-| (I4)  | `edge_padding_high` | 1-dimensional tensor constant of type `si64` | (C2), (C4)       |
-| (I5)  | `interior_padding`  | 1-dimensional tensor constant of type `si64` | (C2-C4)          |
+| Label | Name                | Type                                         | Constraints   |
+|-------|---------------------|----------------------------------------------|---------------|
+| (I1)  | `operand`           | tensor or quantized tensor                   | (C1-C2), (C4) |
+| (I2)  | `padding_value`     | 0-dimensional tensor or quantized tensor     | (C1)          |
+| (I3)  | `edge_padding_low`  | 1-dimensional tensor constant of type `si64` | (C2), (C4)    |
+| (I4)  | `edge_padding_high` | 1-dimensional tensor constant of type `si64` | (C2), (C4)    |
+| (I5)  | `interior_padding`  | 1-dimensional tensor constant of type `si64` | (C2-C4)       |
 
 #### Outputs
 
-| Name     | Type   | Constraints |
-|----------|--------|-------------|
-| `result` | tensor | (C1)        |
+| Name     | Type                       | Constraints |
+|----------|----------------------------|-------------|
+| `result` | tensor or quantized tensor | (C1)        |
 
 #### Constraints
 


### PR DESCRIPTION
## Summary 
The PR proposes the specification for quantized convolution op along with the specifications for a few other ops on which the convolution specification depends on, for example, `pad`, `reverse`.

## A few details
1. Given `q = tensor with uniformed quantized type`, the PR covers the semantics of  static range quantized  `convolution(q, q)`. The specification is very similar to the earlier proposed [quantized dot_general op](https://github.com/openxla/stablehlo/blob/main/docs/spec.md#dot_general).

2. Given, that many ops support both per-tensor and per-axis quantization schemes, it might be redundant to specify for each op the semantics of the computation involved in both the scheme. To avoid that we decided that the op-level semantics will only specify the per-tensor semantics, whereas, semantics of per-axis computations will be described generally in one place.

Please let me know your review feedback.   