### PR TITLE
Add interpreter for ReducePrecisionOp

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4010,15 +4010,17 @@ More formally:
 #### Examples
 
 ```mlir
-// Logical values: -Inf, +Inf, NaN, ...
-// %operand: [0xFF800000, 0x7F800000, 0x7FFFFFFF, 0.0, 1000.0, 1000000.0]
+// Logical values: +Inf, NaN, +Denormal, 0.0, 65519.0, 65520.0
+// %operand: [0x7FF0000000000000, 0x7FFFFFFFFFFFFFFF, 0x0000000000000001, 0.0, 65519.0, 65520.0]
 %output = "stablehlo.reduce_precision"(%operand) {
   exponent_bits = 5 : i32,
-  mantissa_bits = 2 : i32
-} : (tensor<6xf32>) -> tensor<6xf32>
-// Logical values: -Inf, +Inf, NaN, NaN, 0.0, 1024.0, +Inf
-// %output: [0xFF800000, 0x7F800000, 0x7FFFFFFF, 0.0, 1024.0, 0x7F800000]
+  mantissa_bits = 10 : i32
+} : (tensor<6xf64>) -> tensor<6xf64>
+// Logical values: +Inf, NaN, 0.0, 0.0, 65504.0, +Inf
+// %output: [0x7FF0000000000000, 0x7FFFFFFFFFFFFFFF, 0.0, 0.0, 65504.0, 0x7FF0000000000000]
 ```
+
+&nbsp;[More Examples](../stablehlo/tests/interpret_reduce_precision.mlir)
 
 ### reduce_scatter
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -119,7 +119,7 @@ one of the following tracking labels.
 | real_dynamic_slice       | no            | revisit      | no             | yes             | no          |
 | recv                     | yes           | revisit      | infeasible     | no              | no          |
 | reduce                   | yes           | revisit      | yes            | revisit         | yes         |
-| reduce_precision         | yes           | yes          | yes            | yes             | no          |
+| reduce_precision         | yes           | yes          | yes            | yes             | yes         |
 | reduce_scatter           | yes           | revisit      | no             | no              | no          |
 | reduce_window            | yes           | revisit      | yes            | no              | yes         |
 | remainder                | yes           | yes          | yes            | yes             | yes         |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -3093,7 +3093,8 @@ def StableHLO_UniformDequantizeOp : StableHLO_UnaryElementwiseOp<"uniform_dequan
 }
 
 def StableHLO_ReducePrecisionOp :
-    StableHLO_Op<"reduce_precision", [HLO_CompatibleOperandsAndResultType, Pure]> {
+    StableHLO_Op<"reduce_precision", [Pure,
+    HLO_CompatibleOperandsAndResultType /*reduce_precision_c1*/]> {
   let summary = "ReducePrecision operation";
   let description = [{
     Performs element-wise conversion of `operand` to another floating-point type
@@ -3105,13 +3106,13 @@ def StableHLO_ReducePrecisionOp :
 
     Example:
     ```mlir
-    %output = stablehlo.reduce_precision %operand, format = e5m2 : tensor<6xf32>
+    %output = stablehlo.reduce_precision %operand, format = e5m10 : tensor<6xf64>
     ```
   }];
   let arguments = (ins
-    HLO_FpTensor:$operand,
-    I32Attr:$exponent_bits,
-    I32Attr:$mantissa_bits
+    HLO_FpTensor:$operand, /*reduce_precision_i1*/
+    I32Attr:$exponent_bits, /*reduce_precision_i2*/
+    I32Attr:$mantissa_bits /*reduce_precision_i3*/
   );
   let hasVerifier = 1;
   let results = (outs HLO_FpTensor:$output);

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -3675,10 +3675,10 @@ LogicalResult verifyReduceOp(std::optional<Location> location,
 LogicalResult verifyReducePrecisionOp(std::optional<Location> location,
                                       int32_t exponentBits,
                                       int32_t mantissaBits) {
-  // (C2)
+  // reduce_precision_c2
   if (exponentBits < 1)
     return emitOptionalError(location, "exponent_bits must be at least 1.");
-  // (C3)
+  // reduce_precision_c3
   if (mantissaBits < 0)
     return emitOptionalError(location, "mantissa_bits must be at least 0.");
   return success();

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -856,6 +856,71 @@ Element real(const Element &el) {
                                      debugString(el.getType()).c_str()));
 }
 
+Element reducePrecision(const Element &el, uint32_t exponentBits,
+                        uint32_t mantissaBits) {
+  auto intVal = el.getFloatValue().bitcastToAPInt().getZExtValue();
+  auto type = el.getType().cast<FloatType>();
+  auto bitWidth = type.getWidth();
+
+  // Mantissa has an implicit leading 1 and binary point, hence subtracting one.
+  auto srcMantissaBits = type.getFPMantissaWidth() - 1;
+  auto destMantissaBits = mantissaBits;
+  if (destMantissaBits < srcMantissaBits) {
+    auto lastMantissaBitMask = 1UL << (srcMantissaBits - destMantissaBits);
+
+    // Compute rounding bias for round-to-nearest with ties to even.
+    auto baseRoundingBias = (lastMantissaBitMask >> 1) - 1;
+    auto xLastMantissaBit =
+        (intVal & lastMantissaBitMask) >> (srcMantissaBits - destMantissaBits);
+    auto xRoundingBias = xLastMantissaBit + baseRoundingBias;
+
+    // Add rounding bias, and mask out truncated bits.
+    auto truncationMask = ~(lastMantissaBitMask - 1);
+    intVal = intVal + xRoundingBias;
+    intVal = intVal & truncationMask;
+  }
+
+  // Exponent bit calculated by subtracting mantissa bits and sign bit.
+  auto srcExponentBits = bitWidth - srcMantissaBits - 1;
+  auto destExponentBits = exponentBits;
+  if (destExponentBits < srcExponentBits) {
+    auto signBitMask = 1UL << (bitWidth - 1);
+    auto expBitsMask = ((1UL << srcExponentBits) - 1) << srcMantissaBits;
+
+    // An exponent of 2^(n-1)-1 (i.e. 0b0111...) with 0 being the most
+    // significant bit is equal to 1.0f for all exponent sizes. Adding 2^(n-1)-1
+    // to this results in highest non-infinite exponent, and subtracting
+    // 2^(n-1)-1 results in lowest exponent (i.e. 0.0f) for a bit size of n.
+    auto exponentBias = (1UL << (srcExponentBits - 1)) - 1;
+    auto reducedExponentBias = (1UL << (destExponentBits - 1)) - 1;
+    auto reducedMaxExponent = exponentBias + reducedExponentBias;
+    auto reducedMinExponent = exponentBias - reducedExponentBias;
+
+    // Handle overflow or underflow.
+    auto xExponent = intVal & expBitsMask;
+    auto xOverflows = xExponent > (reducedMaxExponent << srcMantissaBits);
+    auto xUnderflows = xExponent <= (reducedMinExponent << srcMantissaBits);
+
+    // Compute appropriately-signed values of zero and infinity.
+    auto xSignedZero = intVal & signBitMask;
+    auto xSignedInf = xSignedZero | expBitsMask;
+
+    // Force to zero or infinity if overflow or underflow.
+    intVal = xOverflows ? xSignedInf : intVal;
+    intVal = xUnderflows ? xSignedZero : intVal;
+  }
+
+  Element reducedResult(
+      type, APFloat(type.getFloatSemantics(), APInt(bitWidth, intVal)));
+
+  if (el.getFloatValue().isNaN())
+    reducedResult = destMantissaBits > 0
+                        ? el
+                        : Element(type, reducedResult.getFloatValue().getInf(
+                                            type.getFloatSemantics()));
+  return reducedResult;
+}
+
 Element rem(const Element &e1, const Element &e2) {
   return map(
       e1, e2,

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -856,14 +856,14 @@ Element real(const Element &el) {
                                      debugString(el.getType()).c_str()));
 }
 
-Element reducePrecision(const Element &el, uint32_t exponentBits,
-                        uint32_t mantissaBits) {
+Element reducePrecision(const Element &el, int32_t exponentBits,
+                        int32_t mantissaBits) {
   auto intVal = el.getFloatValue().bitcastToAPInt().getZExtValue();
   auto type = el.getType().cast<FloatType>();
-  auto bitWidth = type.getWidth();
+  int32_t bitWidth = type.getWidth();
 
   // Mantissa has an implicit leading 1 and binary point, hence subtracting one.
-  auto srcMantissaBits = type.getFPMantissaWidth() - 1;
+  int32_t srcMantissaBits = type.getFPMantissaWidth() - 1;
   auto destMantissaBits = mantissaBits;
   if (destMantissaBits < srcMantissaBits) {
     auto lastMantissaBitMask = 1UL << (srcMantissaBits - destMantissaBits);

--- a/stablehlo/reference/Element.h
+++ b/stablehlo/reference/Element.h
@@ -247,8 +247,8 @@ Element power(const Element &e1, const Element &e2);
 Element real(const Element &e);
 
 /// Returns the Element object rounded to the specified precision type.
-Element reducePrecision(const Element &el, uint32_t exponentBits,
-                        uint32_t mantissaBits);
+Element reducePrecision(const Element &el, int32_t exponentBits,
+                        int32_t mantissaBits);
 
 /// Returns the remainder for two Element objects.
 Element rem(const Element &e1, const Element &e2);

--- a/stablehlo/reference/Element.h
+++ b/stablehlo/reference/Element.h
@@ -246,6 +246,10 @@ Element power(const Element &e1, const Element &e2);
 /// or complex type.
 Element real(const Element &e);
 
+/// Returns the Element object rounded to the specified precision type.
+Element reducePrecision(const Element &el, uint32_t exponentBits,
+                        uint32_t mantissaBits);
+
 /// Returns the remainder for two Element objects.
 Element rem(const Element &e1, const Element &e2);
 

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -1187,8 +1187,8 @@ SmallVector<Tensor> evalReduceOp(ArrayRef<Tensor> inputs,
   return results;
 }
 
-Tensor evalReducePrecisionOp(const Tensor &operand, uint32_t exponentBits,
-                             uint32_t mantissaBits, ShapedType resultType) {
+Tensor evalReducePrecisionOp(const Tensor &operand, int32_t exponentBits,
+                             int32_t mantissaBits, ShapedType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it,

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -197,7 +197,7 @@ SmallVector<InterpreterValue> eval(
       auto index = scope.findTensor(caseOp.getIndex());
       auto branches = caseOp.getBranches();
       auto results = evalCaseOp(index, branches, scope);
-      scope.add(op.getResults(), results);
+      scope.add(caseOp.getResults(), results);
     } else if (auto cbrtOp = dyn_cast<CbrtOp>(op)) {
       auto operand = scope.findTensor(cbrtOp.getOperand());
       auto result = evalCbrtOp(operand, cbrtOp.getType());
@@ -325,7 +325,7 @@ SmallVector<InterpreterValue> eval(
       auto &trueBranch = ifOp.getTrueBranch();
       auto &falseBranch = ifOp.getFalseBranch();
       auto results = evalIfOp(pred, trueBranch, falseBranch, scope);
-      scope.add(op.getResults(), results);
+      scope.add(ifOp.getResults(), results);
     } else if (auto imagOp = dyn_cast<ImagOp>(op)) {
       auto operand = scope.findTensor(imagOp.getOperand());
       auto result = evalImagOp(operand, imagOp.getType());
@@ -382,7 +382,7 @@ SmallVector<InterpreterValue> eval(
                    dyn_cast<OptimizationBarrierOp>(op)) {
       auto operand = scope.find(optimizationBarrierOp.getOperand());
       auto results = evalOptimizationBarrierOp(operand);
-      scope.add(op.getResults(), results);
+      scope.add(optimizationBarrierOp.getResults(), results);
     } else if (auto orOp = dyn_cast<OrOp>(op)) {
       auto lhs = scope.findTensor(orOp.getLhs());
       auto rhs = scope.findTensor(orOp.getRhs());
@@ -418,14 +418,14 @@ SmallVector<InterpreterValue> eval(
       auto results =
           evalReduceOp(inputs, initValues, Axes(reduceOp.getDimensions()),
                        reduceOp.getBody(), scope, resultTypes);
-      scope.add(op.getResults(), results);
+      scope.add(reduceOp.getResults(), results);
     } else if (auto reducePrecisionOp = dyn_cast<ReducePrecisionOp>(op)) {
-      auto operand = scope.find(reducePrecisionOp.getOperand());
-      auto exponentBits = reducePrecisionOp.getExponentBits();
-      auto mantissaBits = reducePrecisionOp.getMantissaBits();
+      auto operand = scope.findTensor(reducePrecisionOp.getOperand());
+      int32_t exponentBits = reducePrecisionOp.getExponentBits();
+      int32_t mantissaBits = reducePrecisionOp.getMantissaBits();
       auto result = evalReducePrecisionOp(operand, exponentBits, mantissaBits,
                                           reducePrecisionOp.getType());
-      scope.add(op.getResults(), {result});
+      scope.add(reducePrecisionOp.getResult(), result);
     } else if (auto reduceWindowOp = dyn_cast<ReduceWindowOp>(op)) {
       auto inputs = scope.findTensors(reduceWindowOp.getInputs());
       auto initValues = scope.findTensors(reduceWindowOp.getInitValues());
@@ -466,7 +466,7 @@ SmallVector<InterpreterValue> eval(
           inputs, initValues, Sizes(reduceWindowOp.getWindowDimensions()),
           windowStrides, baseDilations, windowDilations, paddingLow,
           paddingHigh, reduceWindowOp.getBody(), scope, resultTypes);
-      scope.add(op.getResults(), results);
+      scope.add(reduceWindowOp.getResults(), results);
     } else if (auto remOp = dyn_cast<RemOp>(op)) {
       auto lhs = scope.findTensor(remOp.getLhs());
       auto rhs = scope.findTensor(remOp.getRhs());
@@ -518,7 +518,7 @@ SmallVector<InterpreterValue> eval(
           evalScatterOp(inputs, scatterIndices, updates, updateWindowDims,
                         insertedWindowDims, scatterDimsToOperandDims,
                         indexVectorDim, updateComputation, scope, resultTypes);
-      scope.add(op.getResults(), results);
+      scope.add(scatterOp.getResults(), results);
     } else if (auto selectOp = dyn_cast<SelectOp>(op)) {
       auto pred = scope.findTensor(selectOp.getPred());
       auto onTrue = scope.findTensor(selectOp.getOnTrue());
@@ -598,7 +598,7 @@ SmallVector<InterpreterValue> eval(
       auto &comparator = sortOp.getComparator();
       auto results =
           evalSortOp(operands, dimension, isStable, comparator, scope);
-      scope.add(op.getResults(), results);
+      scope.add(sortOp.getResults(), results);
     } else if (auto sqrtOp = dyn_cast<SqrtOp>(op)) {
       auto operand = scope.findTensor(sqrtOp.getOperand());
       auto result = evalSqrtOp(operand, sqrtOp.getType());
@@ -631,7 +631,7 @@ SmallVector<InterpreterValue> eval(
       auto &cond = whileOp.getCond();
       auto &body = whileOp.getBody();
       auto results = evalWhileOp(operand, cond, body, scope);
-      scope.add(op.getResults(), results);
+      scope.add(whileOp.getResults(), results);
     } else if (auto xorOp = dyn_cast<XorOp>(op)) {
       auto lhs = scope.findTensor(xorOp.getLhs());
       auto rhs = scope.findTensor(xorOp.getRhs());

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -106,6 +106,8 @@ SmallVector<Tensor> evalReduceOp(ArrayRef<Tensor> inputs,
                                  const Axes &dimensions, Region &body,
                                  Scope &scope,
                                  ArrayRef<ShapedType> resultTypes);
+Tensor evalReducePrecisionOp(const Tensor &operand, uint32_t exponentBits,
+                             uint32_t mantissaBits, ShapedType resultType);
 SmallVector<Tensor> evalReduceWindowOp(
     ArrayRef<Tensor> inputs, ArrayRef<Tensor> initValues,
     const Sizes &windowDimensions, const Sizes &windowStrides,

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -106,8 +106,8 @@ SmallVector<Tensor> evalReduceOp(ArrayRef<Tensor> inputs,
                                  const Axes &dimensions, Region &body,
                                  Scope &scope,
                                  ArrayRef<ShapedType> resultTypes);
-Tensor evalReducePrecisionOp(const Tensor &operand, uint32_t exponentBits,
-                             uint32_t mantissaBits, ShapedType resultType);
+Tensor evalReducePrecisionOp(const Tensor &operand, int32_t exponentBits,
+                             int32_t mantissaBits, ShapedType resultType);
 SmallVector<Tensor> evalReduceWindowOp(
     ArrayRef<Tensor> inputs, ArrayRef<Tensor> initValues,
     const Sizes &windowDimensions, const Sizes &windowStrides,

--- a/stablehlo/testdata/reduce_precision_in_bfloat16_5_7__out_bfloat16_5_7.mlir
+++ b/stablehlo/testdata/reduce_precision_in_bfloat16_5_7__out_bfloat16_5_7.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/reduce_precision_in_bfloat16_5_7__out_float16_5_7.mlir
+++ b/stablehlo/testdata/reduce_precision_in_bfloat16_5_7__out_float16_5_7.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/reduce_precision_in_bfloat16_5_7__out_float32_5_7.mlir
+++ b/stablehlo/testdata/reduce_precision_in_bfloat16_5_7__out_float32_5_7.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/reduce_precision_in_bfloat16___out_bfloat16.mlir
+++ b/stablehlo/testdata/reduce_precision_in_bfloat16___out_bfloat16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/reduce_precision_in_bfloat16___out_float16.mlir
+++ b/stablehlo/testdata/reduce_precision_in_bfloat16___out_float16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/reduce_precision_in_bfloat16___out_float32.mlir
+++ b/stablehlo/testdata/reduce_precision_in_bfloat16___out_float32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/reduce_precision_in_float16_5_7__out_bfloat16_5_7.mlir
+++ b/stablehlo/testdata/reduce_precision_in_float16_5_7__out_bfloat16_5_7.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/reduce_precision_in_float16_5_7__out_float16_5_7.mlir
+++ b/stablehlo/testdata/reduce_precision_in_float16_5_7__out_float16_5_7.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/reduce_precision_in_float16_5_7__out_float32_5_7.mlir
+++ b/stablehlo/testdata/reduce_precision_in_float16_5_7__out_float32_5_7.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/reduce_precision_in_float16___out_bfloat16.mlir
+++ b/stablehlo/testdata/reduce_precision_in_float16___out_bfloat16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/reduce_precision_in_float16___out_float16.mlir
+++ b/stablehlo/testdata/reduce_precision_in_float16___out_float16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/reduce_precision_in_float16___out_float32.mlir
+++ b/stablehlo/testdata/reduce_precision_in_float16___out_float32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/reduce_precision_in_float32_5_7__out_bfloat16_5_7.mlir
+++ b/stablehlo/testdata/reduce_precision_in_float32_5_7__out_bfloat16_5_7.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/reduce_precision_in_float32_5_7__out_float16_5_7.mlir
+++ b/stablehlo/testdata/reduce_precision_in_float32_5_7__out_float16_5_7.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/reduce_precision_in_float32___out_bfloat16.mlir
+++ b/stablehlo/testdata/reduce_precision_in_float32___out_bfloat16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/reduce_precision_in_float32___out_float16.mlir
+++ b/stablehlo/testdata/reduce_precision_in_float32___out_float16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/reduce_precision_in_float32___out_float32.mlir
+++ b/stablehlo/testdata/reduce_precision_in_float32___out_float32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -873,6 +873,19 @@ func.func @reduce_c7(%arg0: tensor<?x?xf32>, %arg1 : tensor<f32>)
 
 // -----
 
+// CHECK-LABEL: func @reduce_precision_c1
+func.func @reduce_precision_c1(%arg: tensor<2x4xf32>) -> tensor<2x4xindex> {
+  %0 = "stablehlo.reduce_precision"(%arg) {
+    exponent_bits = 2 : i32,
+    mantissa_bits = 3 : i32
+  } : (tensor<2x4xf32>) -> tensor<2x4xf32>
+  // CHECK: types0 = tensor<2x4xf32>
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<2x4xf32>) -> tensor<2x4xindex>
+  func.return %1: tensor<2x4xindex>
+}
+
+// -----
+
 // CHECK-LABEL: func @reduce_window
 func.func @reduce_window(%arg0: tensor<4x2xf32>, %arg1: tensor<4x2xi32>,
                          %init0: tensor<f32>, %init1: tensor<i32>) ->

--- a/stablehlo/tests/interpret_reduce_precision.mlir
+++ b/stablehlo/tests/interpret_reduce_precision.mlir
@@ -1,0 +1,17 @@
+// RUN: stablehlo-translate --interpret -split-input-file %s
+
+func.func @reduce_precision_op_test_f64() {
+  %operand = stablehlo.constant dense<[0x7FF0000000000000, 0x7FFFFFFFFFFFFFFF, 0x0000000000000001, 0.0, 65505.0, 65520.0]> : tensor<6xf64>
+  %output = stablehlo.reduce_precision %operand, format = e5m10 : tensor<6xf64>
+  check.expect_almost_eq_const %output, dense<[0x7FF0000000000000, 0x7FFFFFFFFFFFFFFF, 0.0, 0.0, 65504.0, 0x7FF0000000000000]> : tensor<6xf64>
+  func.return
+}
+
+// -----
+
+func.func @reduce_precision_op_test_f64_zero_mantissa_bits() {
+  %operand = stablehlo.constant dense<0x7FFFFFFFFFFFFFFF> : tensor<f64>
+  %output = stablehlo.reduce_precision %operand, format = e5m0 : tensor<f64>
+  check.expect_almost_eq_const %output, dense<0x7FF0000000000000> : tensor<f64>
+  func.return
+}

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -3380,7 +3380,7 @@ func.func @reduce_precision(%arg: tensor<2x4xf32>) -> tensor<2x4xf32> {
 
 // -----
 
-func.func @reduce_precision_invalid_exponent(%arg: tensor<2x4xf32>) -> tensor<2x4xf32> {
+func.func @reduce_precision_c2(%arg: tensor<2x4xf32>) -> tensor<2x4xf32> {
   // expected-error @+1 {{exponent_bits must be at least 1.}}
   %0 = "stablehlo.reduce_precision"(%arg) {exponent_bits=0 : i32, mantissa_bits=3 : i32} : (tensor<2x4xf32>) -> tensor<2x4xf32>
   func.return %0 : tensor<2x4xf32>
@@ -3388,7 +3388,7 @@ func.func @reduce_precision_invalid_exponent(%arg: tensor<2x4xf32>) -> tensor<2x
 
 // -----
 
-func.func @reduce_precision_invalid_mantissa(%arg: tensor<2x4xf32>) -> tensor<2x4xf32> {
+func.func @reduce_precision_c3(%arg: tensor<2x4xf32>) -> tensor<2x4xf32> {
   // expected-error @+1 {{mantissa_bits must be at least 0.}}
   %0 = "stablehlo.reduce_precision"(%arg) {exponent_bits=1 : i32, mantissa_bits=-1 : i32} : (tensor<2x4xf32>) -> tensor<2x4xf32>
   func.return %0 : tensor<2x4xf32>


### PR DESCRIPTION
We have the following constraints in the spec:

```
(I1) `operand`: tensor of floating-point type.
(I2) `exponent_bits`: constant of type `si32`.
(I3) `mantissa_bits`: constant of type `si32`.
(C1) `operand` and `output` have the same type.
(C2) `exponent_bits` >= 1.
(C3) `mantissa_bits` >= 0.
```

These constraints will be comprehensively covered by the following tests:

```
(I1) `operand` is not a tensor of floating-point type. (Covered by ODS).
(I2) `exponent_bits` is not a constant of type `si32`. (Covered by ODS).
(I3) `mantissa_bits` is not a constant of type `si32`. (Covered by ODS).
(C1) type(`operand`) != type(`output`). (Covered by ODS).
(C2) `exponent_bits` < 1.
(C3) `mantissa_bits` < 0.
```

If we drop the "Covered by ODS" pieces, this will leave us with the following test cases:

```
(C2) `exponent_bits` < 1.
(C3) `mantissa_bits` < 0.
```

closes #1109