### PR TITLE
Split portable StableHLO APIs into separate file

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -697,7 +697,7 @@ cc_library(
 )
 
 cc_library(
-    name = "stablehlo_portable_cpp_api",
+    name = "stablehlo_portable_api",
     srcs = [
         "stablehlo/api/PortableApi.cpp",
     ],

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -708,6 +708,7 @@ cc_library(
     deps = [
         ":stablehlo_ops",
         ":stablehlo_serialization",
+        ":version",
         ":vhlo_ops",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:BytecodeWriter",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -21,6 +21,8 @@ package(
 exports_files([
     "LICENSE",
     "stablehlo/integrations/python/ChloModule.cpp",
+    "stablehlo/integrations/python/PortableApi.cpp",
+    "stablehlo/integrations/python/PortableApi.h",
     "stablehlo/integrations/python/StablehloModule.cpp",
     "stablehlo/integrations/python/VhloModule.cpp",
 ])
@@ -691,6 +693,28 @@ cc_library(
         "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:TransformUtils",
         "@llvm-project//mlir:Transforms",
+    ],
+)
+
+cc_library(
+    name = "stablehlo_portable_cpp_api",
+    srcs = [
+        "stablehlo/api/PortableApi.cpp",
+    ],
+    hdrs = [
+        "stablehlo/api/PortableApi.h",
+    ],
+    strip_include_prefix = ".",
+    deps = [
+        ":stablehlo_ops",
+        ":stablehlo_serialization",
+        ":vhlo_ops",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:BytecodeWriter",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Parser",
+        "@llvm-project//mlir:Support",
     ],
 )
 

--- a/stablehlo/api/CMakeLists.txt
+++ b/stablehlo/api/CMakeLists.txt
@@ -20,6 +20,7 @@ add_mlir_dialect_library(StablehloPortableApi
   ChloOps
   StablehloOps
   StablehloSerialization
+  Version
   VhloOps
   MLIRBytecodeWriter
   MLIRFuncDialect

--- a/stablehlo/api/CMakeLists.txt
+++ b/stablehlo/api/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2022 The StableHLO Authors.
+# Copyright 2023 The StableHLO Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,11 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(api)
-add_subdirectory(dialect)
-add_subdirectory(integrations)
-add_subdirectory(reference)
-add_subdirectory(tests)
-add_subdirectory(testdata)
-add_subdirectory(tools)
-add_subdirectory(transforms)
+add_mlir_dialect_library(StablehloPortableApi
+  PARTIAL_SOURCES_INTENDED
+  PortableApi.cpp
+
+  LINK_LIBS PUBLIC
+  ChloOps
+  StablehloOps
+  StablehloSerialization
+  VhloOps
+  MLIRBytecodeWriter
+  MLIRFuncDialect
+  MLIRIR
+)

--- a/stablehlo/api/PortableApi.cpp
+++ b/stablehlo/api/PortableApi.cpp
@@ -1,0 +1,61 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <string>
+
+#include "mlir/Bytecode/BytecodeWriter.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Parser/Parser.h"
+#include "stablehlo/dialect/Serialization.h"
+#include "stablehlo/dialect/StablehloOps.h"
+#include "stablehlo/dialect/VhloOps.h"
+
+namespace mlir {
+namespace stablehlo {
+namespace {
+void loadSerializationDialects(MLIRContext* context) {
+  context->loadDialect<mlir::func::FuncDialect>();
+  context->loadDialect<mlir::stablehlo::StablehloDialect>();
+  context->loadDialect<mlir::vhlo::VhloDialect>();
+}
+}  // namespace
+
+std::string getCurrentVersion() {
+  return mlir::vhlo::Version::getCurrentVersion().toString();
+}
+
+LogicalResult serializePortableArtifact(StringRef moduleStr,
+                                        StringRef targetVersion,
+                                        raw_ostream& os) {
+  MLIRContext context;
+  loadSerializationDialects(&context);
+  auto module = mlir::parseSourceString<mlir::ModuleOp>(moduleStr, &context);
+  if (!module || failed(module->verifyInvariants())) return failure();
+
+  return serializePortableArtifact(*module, targetVersion, os);
+}
+
+LogicalResult deserializePortableArtifact(StringRef artifactStr,
+                                          raw_ostream& os) {
+  MLIRContext context;
+  loadSerializationDialects(&context);
+  auto module = deserializePortableArtifact(artifactStr, &context);
+  if (!module) return failure();
+  return writeBytecodeToFile(*module, os);
+}
+
+}  // namespace stablehlo
+}  // namespace mlir

--- a/stablehlo/api/PortableApi.cpp
+++ b/stablehlo/api/PortableApi.cpp
@@ -21,6 +21,7 @@ limitations under the License.
 #include "mlir/Parser/Parser.h"
 #include "stablehlo/dialect/Serialization.h"
 #include "stablehlo/dialect/StablehloOps.h"
+#include "stablehlo/dialect/Version.h"
 #include "stablehlo/dialect/VhloOps.h"
 
 namespace mlir {

--- a/stablehlo/api/PortableApi.h
+++ b/stablehlo/api/PortableApi.h
@@ -1,0 +1,56 @@
+/* Copyright 2023 The StableHLO Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef STABLEHLO_API_PORTABLEAPI_H
+#define STABLEHLO_API_PORTABLEAPI_H
+
+#include <string>
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/raw_ostream.h"
+#include "mlir/Support/LogicalResult.h"
+#include "stablehlo/dialect/Serialization.h"
+
+namespace mlir {
+namespace stablehlo {
+
+/// Return the current version for portable API.
+/// Increments on all meaningful changes to this file.
+inline int64_t getApiVersion() { return 3; }
+
+// Get current StableHLO version.
+std::string getCurrentVersion();
+
+// Write a StableHLO program expressed as a string (either prettyprinted MLIR
+// module or MLIR bytecode) to a portable artifact.
+// Can fail if `moduleStr` cannot be parsed, or if it cannot be expressed in the
+// `targetVersion` version of StableHLO, e.g. if it's using new or removed
+// features, or if it involves unsupported dialects.
+LogicalResult serializePortableArtifact(StringRef moduleStr,
+                                        StringRef targetVersion,
+                                        raw_ostream& os);
+
+// Read a StableHLO program from a portable artifact, returning the module as
+// MLIR bytecode.
+// Can fail if `artifactStr` cannot be expressed in the current version of
+// StableHLO, e.g. if it's using incompatible features. Returns failure if
+// `artifactStr` is invalid or fails to deserialize.
+LogicalResult deserializePortableArtifact(StringRef artifactStr,
+                                          raw_ostream& os);
+
+}  // namespace stablehlo
+}  // namespace mlir
+
+#endif  // STABLEHLO_API_PORTABLEAPI_H

--- a/stablehlo/api/PortableApi.h
+++ b/stablehlo/api/PortableApi.h
@@ -30,7 +30,12 @@ namespace stablehlo {
 /// Increments on all meaningful changes to this file.
 inline int64_t getApiVersion() { return 3; }
 
-// Get current StableHLO version.
+// Get current StableHLO version
+//
+// This value can be used as the `targetVersion` argument to
+// `serializePortableArtifact`.
+//
+// See `stablehlo/dialect/Version.h` for current version number.
 std::string getCurrentVersion();
 
 // Write a StableHLO program expressed as a string (either prettyprinted MLIR

--- a/stablehlo/api/PortableApi.h
+++ b/stablehlo/api/PortableApi.h
@@ -30,7 +30,7 @@ namespace stablehlo {
 /// Increments on all meaningful changes to this file.
 inline int64_t getApiVersion() { return 3; }
 
-// Get current StableHLO version
+// Get the current StableHLO version.
 //
 // This value can be used as the `targetVersion` argument to
 // `serializePortableArtifact`.

--- a/stablehlo/api/PortableApi.h
+++ b/stablehlo/api/PortableApi.h
@@ -33,8 +33,6 @@ inline int64_t getApiVersion() { return 3; }
 //
 // This value can be used as the `targetVersion` argument to
 // `serializePortableArtifact`.
-//
-// See `stablehlo/dialect/Version.h` for current version number.
 std::string getCurrentVersion();
 
 // Write a StableHLO program expressed as a string (either prettyprinted MLIR

--- a/stablehlo/api/PortableApi.h
+++ b/stablehlo/api/PortableApi.h
@@ -21,7 +21,6 @@ limitations under the License.
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/raw_ostream.h"
 #include "mlir/Support/LogicalResult.h"
-#include "stablehlo/dialect/Serialization.h"
 
 namespace mlir {
 namespace stablehlo {

--- a/stablehlo/dialect/Serialization.cpp
+++ b/stablehlo/dialect/Serialization.cpp
@@ -15,27 +15,17 @@ limitations under the License.
 
 #include "stablehlo/dialect/Serialization.h"
 
-#include "llvm/Support/raw_ostream.h"
 #include "mlir/Bytecode/BytecodeWriter.h"
-#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/Parser/Parser.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Support/LogicalResult.h"
-#include "stablehlo/dialect/StablehloOps.h"
 #include "stablehlo/dialect/VhloOps.h"
 #include "stablehlo/transforms/Passes.h"
 
 namespace mlir {
 namespace stablehlo {
-namespace {
-void loadSerializationDialects(MLIRContext* context) {
-  context->loadDialect<mlir::func::FuncDialect>();
-  context->loadDialect<mlir::stablehlo::StablehloDialect>();
-  context->loadDialect<mlir::vhlo::VhloDialect>();
-}
-}  // namespace
 
 LogicalResult serializePortableArtifact(ModuleOp module,
                                         StringRef targetVersion,
@@ -68,17 +58,6 @@ LogicalResult serializePortableArtifact(ModuleOp module,
   return success();
 }
 
-LogicalResult serializePortableArtifact(StringRef moduleStr,
-                                        StringRef targetVersion,
-                                        raw_ostream& os) {
-  MLIRContext context;
-  loadSerializationDialects(&context);
-  auto module = mlir::parseSourceString<mlir::ModuleOp>(moduleStr, &context);
-  if (!module || failed(module->verifyInvariants())) return failure();
-
-  return serializePortableArtifact(*module, targetVersion, os);
-}
-
 OwningOpRef<ModuleOp> deserializePortableArtifact(StringRef sourceStr,
                                                   MLIRContext* context) {
   context->loadDialect<vhlo::VhloDialect>();
@@ -96,21 +75,6 @@ OwningOpRef<ModuleOp> deserializePortableArtifact(StringRef sourceStr,
   }
 
   return module;
-}
-
-FailureOr<std::string> deserializePortableArtifact(StringRef sourceStr) {
-  MLIRContext context;
-  loadSerializationDialects(&context);
-  auto module = deserializePortableArtifact(sourceStr, &context);
-  if (!module) return failure();
-  std::string buffer;
-  llvm::raw_string_ostream os(buffer);
-  (void)writeBytecodeToFile(*module, os);
-  return buffer;
-}
-
-std::string getCurrentVersion() {
-  return mlir::vhlo::Version::getCurrentVersion().toString();
 }
 
 }  // namespace stablehlo

--- a/stablehlo/dialect/Serialization.h
+++ b/stablehlo/dialect/Serialization.h
@@ -23,14 +23,6 @@ limitations under the License.
 namespace mlir {
 namespace stablehlo {
 
-// Get current StableHLO version
-//
-// This value can be used as the `targetVersion` argument to
-// `serializePortableArtifact`.
-//
-// See `stablehlo/dialect/Version.h` for current version number.
-std::string getCurrentVersion();
-
 // Write a StableHLO program to a portable artifact
 // Writes a stable payload for `module` to `os`. If compatibility with a
 // previous version of StableHLO is required, provide the required version
@@ -43,19 +35,6 @@ LogicalResult serializePortableArtifact(ModuleOp module,
                                         StringRef targetVersion,
                                         raw_ostream& os);
 
-// Write a StableHLO program to a portable artifact
-//
-// This string overload of the above API is provided for Python bindings.
-// Python bindings expect all dialects to be compiled together. When this is not
-// possible, passing module bytecode as a string to this overload is safer.
-//
-// Can fail if `moduleStr` cannot be parsed, or if it cannot be expressed in the
-// `targetVersion` version of StableHLO, e.g. if it's using new or removed
-// features, or if it involves unsupported dialects.
-LogicalResult serializePortableArtifact(StringRef moduleStr,
-                                        StringRef targetVersion,
-                                        raw_ostream& os);
-
 // Read StableHLO portable artifact
 //
 // Can fail if `sourceStr` cannot be expressed in the current version of
@@ -63,17 +42,6 @@ LogicalResult serializePortableArtifact(StringRef moduleStr,
 // `sourceStr` is invalid or fails to deserialize.
 OwningOpRef<ModuleOp> deserializePortableArtifact(StringRef sourceStr,
                                                   MLIRContext* context);
-
-// Read a StableHLO program from a portable artifact, returning the module as
-// MLIR bytecode.
-//
-// This string overload of the above API is provided for Python bindings.
-// See the `serializePortableArtifact` `StringRef` overload for detail.
-//
-// Can fail if `sourceStr` cannot be expressed in the current version of
-// StableHLO, e.g. if it's using incompatible features. Returns failure if
-// `sourceStr` is invalid or fails to deserialize.
-FailureOr<std::string> deserializePortableArtifact(StringRef sourceStr);
 
 }  // namespace stablehlo
 }  // namespace mlir

--- a/stablehlo/dialect/Version.h
+++ b/stablehlo/dialect/Version.h
@@ -75,14 +75,6 @@ mlir::Diagnostic& operator<<(mlir::Diagnostic& diag, const Version& version);
 llvm::raw_ostream& operator<<(llvm::raw_ostream& os, const Version& version);
 
 }  // namespace vhlo
-
-namespace stablehlo {
-
-/// Return the current version for StableHLO APIs.
-/// Increments on all C++/C/Python API changes
-inline int64_t getApiVersion() { return 2; }
-
-}  // namespace stablehlo
 }  // namespace mlir
 
 #endif  // STABLEHLO_DIALECT_VERSION_H

--- a/stablehlo/integrations/python/CMakeLists.txt
+++ b/stablehlo/integrations/python/CMakeLists.txt
@@ -86,7 +86,6 @@ declare_mlir_python_extension(StablehloPythonExtensions.Main
   PRIVATE_LINK_LIBS
     StablehloPortableApi
     StablehloSerialization
-    Version
     LLVMSupport
 )
 

--- a/stablehlo/integrations/python/CMakeLists.txt
+++ b/stablehlo/integrations/python/CMakeLists.txt
@@ -80,9 +80,11 @@ declare_mlir_python_extension(StablehloPythonExtensions.Main
   ADD_TO_PARENT StablehloPythonExtensions
   SOURCES
     StablehloModule.cpp
+    PortableApi.cpp
   EMBED_CAPI_LINK_LIBS
     StablehloCAPI
   PRIVATE_LINK_LIBS
+    StablehloPortableApi
     StablehloSerialization
     Version
     LLVMSupport

--- a/stablehlo/integrations/python/PortableApi.cpp
+++ b/stablehlo/integrations/python/PortableApi.cpp
@@ -1,0 +1,70 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "stablehlo/integrations/python/PortableApi.h"
+
+#include <string>
+
+#include "stablehlo/api/PortableApi.h"
+
+namespace py = pybind11;
+
+namespace mlir {
+namespace stablehlo {
+
+void AddPortableApi(py::module& m) {
+  //
+  // Utility APIs.
+  //
+
+  m.def("get_api_version", []() { return getApiVersion(); });
+
+  //
+  // Serialization APIs.
+  //
+
+  m.def("get_current_version", []() { return getCurrentVersion(); });
+
+  m.def(
+      "serialize_portable_artifact",
+      [](std::string moduleStr, std::string targetVersion) -> py::bytes {
+        std::string buffer;
+        llvm::raw_string_ostream os(buffer);
+        if (failed(serializePortableArtifact(moduleStr, targetVersion, os))) {
+          PyErr_SetString(PyExc_ValueError, "failed to serialize module");
+          return "";
+        }
+
+        return py::bytes(buffer);
+      },
+      py::arg("module_str"), py::arg("target_version"));
+
+  m.def(
+      "deserialize_portable_artifact",
+      [](std::string artifactStr) -> py::bytes {
+        std::string buffer;
+        llvm::raw_string_ostream os(buffer);
+        if (failed(deserializePortableArtifact(artifactStr, os))) {
+          PyErr_SetString(PyExc_ValueError, "failed to deserialize module");
+          return "";
+        }
+
+        return py::bytes(buffer);
+      },
+      py::arg("artifact_str"));
+}
+
+}  // namespace stablehlo
+}  // namespace mlir

--- a/stablehlo/integrations/python/PortableApi.h
+++ b/stablehlo/integrations/python/PortableApi.h
@@ -1,0 +1,31 @@
+/* Copyright 2023 The StableHLO Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef STABLEHLO_INTEGRATIONS_PYTHON_API_PORTABLEAPI_H
+#define STABLEHLO_INTEGRATIONS_PYTHON_API_PORTABLEAPI_H
+
+#include "pybind11/pybind11.h"
+
+namespace mlir {
+namespace stablehlo {
+
+// Add portable API to the pybind11 module.
+// Signatures of these APIs have no dependency on MLIR.
+void AddPortableApi(pybind11::module& m);
+
+}  // namespace stablehlo
+}  // namespace mlir
+
+#endif  // STABLEHLO_INTEGRATIONS_PYTHON_API_PORTABLEAPI_H

--- a/stablehlo/integrations/python/StablehloModule.cpp
+++ b/stablehlo/integrations/python/StablehloModule.cpp
@@ -15,7 +15,6 @@ limitations under the License.
 #include "mlir/Bindings/Python/PybindAdaptors.h"
 #include "mlir/CAPI/IR.h"
 #include "stablehlo/dialect/Serialization.h"
-#include "stablehlo/dialect/Version.h"
 #include "stablehlo/integrations/c/StablehloAttributes.h"
 #include "stablehlo/integrations/c/StablehloDialect.h"
 #include "stablehlo/integrations/c/StablehloTypes.h"

--- a/stablehlo/integrations/python/StablehloModule.cpp
+++ b/stablehlo/integrations/python/StablehloModule.cpp
@@ -19,6 +19,7 @@ limitations under the License.
 #include "stablehlo/integrations/c/StablehloAttributes.h"
 #include "stablehlo/integrations/c/StablehloDialect.h"
 #include "stablehlo/integrations/c/StablehloTypes.h"
+#include "stablehlo/integrations/python/PortableApi.h"
 
 namespace py = pybind11;
 
@@ -479,32 +480,13 @@ PYBIND11_MODULE(_stablehlo, m) {
       });
 
   //
-  // Utility APIs.
+  // Non-MLIR APIs
   //
-
-  m.def("get_api_version", []() { return mlir::stablehlo::getApiVersion(); });
+  mlir::stablehlo::AddPortableApi(m);
 
   //
   // Serialization APIs.
   //
-
-  m.def("get_current_version",
-        []() { return mlir::stablehlo::getCurrentVersion(); });
-
-  m.def(
-      "serialize_portable_artifact",
-      [](std::string module_str, std::string target) -> py::bytes {
-        std::string buffer;
-        llvm::raw_string_ostream os(buffer);
-        if (failed(mlir::stablehlo::serializePortableArtifact(module_str,
-                                                              target, os))) {
-          PyErr_SetString(PyExc_ValueError, "failed to serialize module");
-          return "";
-        }
-
-        return py::bytes(buffer);
-      },
-      py::arg("module_str"), py::arg("target"));
 
   m.def(
       "serialize_portable_artifact",
@@ -520,20 +502,6 @@ PYBIND11_MODULE(_stablehlo, m) {
         return py::bytes(buffer);
       },
       py::arg("module"), py::arg("target"));
-
-  m.def(
-      "deserialize_portable_artifact",
-      [](std::string artifact) -> py::bytes {
-        auto moduleStr = mlir::stablehlo::deserializePortableArtifact(artifact);
-
-        if (failed(moduleStr)) {
-          PyErr_SetString(PyExc_ValueError, "failed to deserialize module");
-          return {};
-        }
-
-        return {moduleStr.value()};
-      },
-      py::arg("module_str"));
 
   m.def(
       "deserialize_portable_artifact",

--- a/stablehlo/integrations/python/StablehloModule.cpp
+++ b/stablehlo/integrations/python/StablehloModule.cpp
@@ -479,7 +479,7 @@ PYBIND11_MODULE(_stablehlo, m) {
       });
 
   //
-  // Non-MLIR APIs
+  // Portable APIs
   //
   mlir::stablehlo::AddPortableApi(m);
 


### PR DESCRIPTION
Portable APIs are APIs with signatures that do not depend on MLIR. This provides a way to access some StableHLO APIs without needing an MLIR dependency/visibility at the call site.

These APIs also can be safer in cases where shared objects are used, as passing MLIR Context across shared objects can cause problems.