### PR TITLE
Add API to get minimum supported StableHLO version

### DIFF
--- a/stablehlo/api/PortableApi.cpp
+++ b/stablehlo/api/PortableApi.cpp
@@ -40,7 +40,7 @@ std::string getCurrentVersion() {
   return mlir::vhlo::Version::getCurrentVersion().toString();
 }
 
-std::string getMinimumSupportedVersion() {
+std::string getMinimumVersion() {
   return mlir::vhlo::Version::getMinimumVersion().toString();
 }
 

--- a/stablehlo/api/PortableApi.cpp
+++ b/stablehlo/api/PortableApi.cpp
@@ -13,6 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include "stablehlo/api/PortableApi.h"
+
 #include <string>
 
 #include "mlir/Bytecode/BytecodeWriter.h"
@@ -36,6 +38,10 @@ void loadSerializationDialects(MLIRContext* context) {
 
 std::string getCurrentVersion() {
   return mlir::vhlo::Version::getCurrentVersion().toString();
+}
+
+std::string getMinimumSupportedVersion() {
+  return mlir::vhlo::Version::getMinimumVersion().toString();
 }
 
 LogicalResult serializePortableArtifact(StringRef moduleStr,

--- a/stablehlo/api/PortableApi.h
+++ b/stablehlo/api/PortableApi.h
@@ -35,6 +35,14 @@ inline int64_t getApiVersion() { return 3; }
 // `serializePortableArtifact`.
 std::string getCurrentVersion();
 
+// Get the minimum supported StableHLO version.
+//
+// This value can be used as the `targetVersion` argument to
+// `serializePortableArtifact`.
+//
+// See `stablehlo/dialect/Version.h` for current version number.
+std::string getMinimumSupportedVersion();
+
 // Write a StableHLO program expressed as a string (either prettyprinted MLIR
 // module or MLIR bytecode) to a portable artifact.
 // Can fail if `moduleStr` cannot be parsed, or if it cannot be expressed in the

--- a/stablehlo/api/PortableApi.h
+++ b/stablehlo/api/PortableApi.h
@@ -27,7 +27,7 @@ namespace stablehlo {
 
 /// Return the current version for portable API.
 /// Increments on all meaningful changes to this file.
-inline int64_t getApiVersion() { return 3; }
+inline int64_t getApiVersion() { return 4; }
 
 // Get the current StableHLO version.
 //
@@ -41,7 +41,7 @@ std::string getCurrentVersion();
 // `serializePortableArtifact`.
 //
 // See `stablehlo/dialect/Version.h` for current version number.
-std::string getMinimumSupportedVersion();
+std::string getMinimumVersion();
 
 // Write a StableHLO program expressed as a string (either prettyprinted MLIR
 // module or MLIR bytecode) to a portable artifact.

--- a/stablehlo/integrations/python/PortableApi.cpp
+++ b/stablehlo/integrations/python/PortableApi.cpp
@@ -37,7 +37,7 @@ void AddPortableApi(py::module& m) {
 
   m.def("get_current_version", []() { return getCurrentVersion(); });
 
-  m.def("get_minimum_supported_version", []() { return getMinimumVersion(); });
+  m.def("get_minimum_version", []() { return getMinimumVersion(); });
 
   m.def(
       "serialize_portable_artifact",

--- a/stablehlo/integrations/python/PortableApi.cpp
+++ b/stablehlo/integrations/python/PortableApi.cpp
@@ -37,8 +37,7 @@ void AddPortableApi(py::module& m) {
 
   m.def("get_current_version", []() { return getCurrentVersion(); });
 
-  m.def("get_minimum_supported_version",
-        []() { return getMinimumSupportedVersion(); });
+  m.def("get_minimum_supported_version", []() { return getMinimumVersion(); });
 
   m.def(
       "serialize_portable_artifact",

--- a/stablehlo/integrations/python/PortableApi.cpp
+++ b/stablehlo/integrations/python/PortableApi.cpp
@@ -37,6 +37,9 @@ void AddPortableApi(py::module& m) {
 
   m.def("get_current_version", []() { return getCurrentVersion(); });
 
+  m.def("get_minimum_supported_version",
+        []() { return getMinimumSupportedVersion(); });
+
   m.def(
       "serialize_portable_artifact",
       [](std::string moduleStr, std::string targetVersion) -> py::bytes {

--- a/stablehlo/integrations/python/tests/stablehlo.py
+++ b/stablehlo/integrations/python/tests/stablehlo.py
@@ -210,10 +210,18 @@ def test_api_version():
   assert type(api_version) == int
   assert api_version > 0
 
+def is_semver_format(version_str):
+  return re.match('^\d+\.\d+\.\d+$', version_str)
+
 @run
 def test_current_version():
   curr_version = stablehlo.get_current_version()
-  assert re.match('^\d+\.\d+\.\d+$', curr_version)
+  assert is_semver_format(curr_version)
+
+@run
+def test_minimum_supported_version():
+  curr_version = stablehlo.get_minimum_supported_version()
+  assert is_semver_format(curr_version)
 
 ASM = """
 func.func @test(%arg0: tensor<2xf32>) -> tensor<2xf32> {

--- a/stablehlo/integrations/python/tests/stablehlo.py
+++ b/stablehlo/integrations/python/tests/stablehlo.py
@@ -219,8 +219,8 @@ def test_current_version():
   assert is_semver_format(curr_version)
 
 @run
-def test_minimum_supported_version():
-  curr_version = stablehlo.get_minimum_supported_version()
+def test_minimum_version():
+  curr_version = stablehlo.get_minimum_version()
   assert is_semver_format(curr_version)
 
 ASM = """


### PR DESCRIPTION
This is based on https://github.com/openxla/stablehlo/pull/1480