### PR TITLE
Fix issues identified during integrate

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -370,6 +370,7 @@ cc_library(
         ":reference_tensor",
         ":reference_types",
         ":stablehlo_ops",
+        ":stablehlo_type_inference",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:IR",

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -376,8 +376,8 @@ verifyWindowAttributesAndInferWindowDimensions(
 //            padding_high,
 //                         dilatedBound(window_shape[d]))
 //      where (padding_low, padding_high) is the padding-pair for d.
-SmallVector<int64_t> inferWindowOutputShape(
-    const ArrayRef<int64_t> baseShape, const ArrayRef<WindowDimension> window) {
+SmallVector<int64_t> inferWindowOutputShape(ArrayRef<int64_t> baseShape,
+                                            ArrayRef<WindowDimension> window) {
   assert(baseShape.size() == window.size() &&
          "Size of window dimensions must match the size of base shape.");
 
@@ -652,7 +652,7 @@ LogicalResult verifyReduceWindowOpInputsAndInferWindow(
     SmallVector<int64_t>& windowDims,
     SmallVector<WindowDimension>& inferredWindow) {
   // reduce_window_c1
-  if (inputArgTypes.size() < 1)
+  if (inputArgTypes.empty())
     return emitOptionalError(location, "requires at least 1 input value");
 
   // Check for unranked tensors in input operands.

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -76,8 +76,8 @@ verifyWindowAttributesAndInferWindowDimensions(
     ArrayRef<int64_t> lhsDilation, ArrayRef<int64_t> rhsDilation,
     ArrayRef<bool> windowReversal, std::optional<Location> loc);
 
-SmallVector<int64_t> inferWindowOutputShape(
-    const ArrayRef<int64_t> baseShape, const ArrayRef<WindowDimension> window);
+SmallVector<int64_t> inferWindowOutputShape(ArrayRef<int64_t> baseShape,
+                                            ArrayRef<WindowDimension> window);
 
 LogicalResult verifyReplicaGroups(std::optional<Location> location,
                                   DenseIntElementsAttr replicaGroups,
@@ -297,8 +297,8 @@ LogicalResult inferReplicaIdOp(MLIRContext* context, std::optional<Location>,
                                SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferReverseOp(
-    std::optional<Location> location, Type operands,
-    SmallVectorImpl<ShapedTypeComponents>& inferredReturnTypes);
+    std::optional<Location> location, Type operandType,
+    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferRngOp(
     std::optional<Location> location, Value a, Value b, Value shape,

--- a/stablehlo/integrations/python/tests/stablehlo.py
+++ b/stablehlo/integrations/python/tests/stablehlo.py
@@ -210,18 +210,22 @@ def test_api_version():
   assert type(api_version) == int
   assert api_version > 0
 
+
 def is_semver_format(version_str):
-  return re.match('^\d+\.\d+\.\d+$', version_str)
+  return re.match("^\d+\.\d+\.\d+$", version_str)
+
 
 @run
 def test_current_version():
   curr_version = stablehlo.get_current_version()
   assert is_semver_format(curr_version)
 
+
 @run
 def test_minimum_version():
   curr_version = stablehlo.get_minimum_version()
   assert is_semver_format(curr_version)
+
 
 ASM = """
 func.func @test(%arg0: tensor<2xf32>) -> tensor<2xf32> {

--- a/stablehlo/reference/CMakeLists.txt
+++ b/stablehlo/reference/CMakeLists.txt
@@ -90,4 +90,5 @@ add_mlir_library(StablehloReferenceOps
   StablehloReferenceScope
   StablehloReferenceSizes
   StablehloReferenceTensor
+  StablehloTypeInference
 )

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -62,10 +62,10 @@ SmallVector<Tensor> evalReduceOp(ArrayRef<Tensor> inputs,
                                  const Axes &dimensions, Region &body,
                                  Scope &scope) {
   SmallVector<Type> inputTypes;
-  for (auto input : inputs) inputTypes.push_back(input.getType());
+  for (const auto &input : inputs) inputTypes.push_back(input.getType());
 
   SmallVector<Type> initValueTypes;
-  for (auto initValue : initValues)
+  for (const auto &initValue : initValues)
     initValueTypes.push_back(initValue.getType());
 
   SmallVector<ShapedTypeComponents> inferredReduceTypes;
@@ -78,7 +78,7 @@ SmallVector<Tensor> evalReduceOp(ArrayRef<Tensor> inputs,
         invalidArgument("Could not infer ReduceOp's return type"));
 
   SmallVector<ShapedType> resultTypes;
-  for (auto inferredType : inferredReduceTypes) {
+  for (const auto &inferredType : inferredReduceTypes) {
     auto shapedType = hlo::createShapedType(inferredType);
     if (!shapedType)
       llvm::report_fatal_error("Could not infer ReduceOp's return type");
@@ -980,7 +980,7 @@ SmallVector<Tensor> evalReduceWindowOp(
        resultIt != results[0].index_end(); ++resultIt) {
     SmallVector<Tensor> windows;
     auto windowStart = (*resultIt) * windowStrides;
-    for (auto paddedInput : paddedInputs)
+    for (const auto &paddedInput : paddedInputs)
       windows.push_back(evalSliceOp(paddedInput, windowStart,
                                     windowStart + windowDimensions,
                                     windowDilations));
@@ -1108,7 +1108,7 @@ SmallVector<Tensor> evalSortOp(ArrayRef<Tensor> inputs, Axis dimension,
                                bool isStable, Region &comparator,
                                Scope &scope) {
   SmallVector<Tensor> results;
-  for (auto input : inputs) results.push_back(Tensor(input.getType()));
+  for (const auto &input : inputs) results.push_back(Tensor(input.getType()));
   auto adjustedDimension =
       dimension >= 0 ? dimension : dimension + inputs[0].getRank();
 

--- a/stablehlo/reference/Tensor.cpp
+++ b/stablehlo/reference/Tensor.cpp
@@ -93,11 +93,11 @@ Tensor::Tensor(ShapedType type)
 Tensor::Tensor(ShapedType type, AsmResourceBlob blob)
     : impl_(llvm::makeIntrusiveRefCnt<detail::Buffer>(type, std::move(blob))) {}
 
-Tensor::Tensor(ShapedType type, const Element &element)
+Tensor::Tensor(ShapedType type, const Element &initValue)
     : impl_(llvm::makeIntrusiveRefCnt<detail::Buffer>(type)) {
   for (auto indexIt = this->index_begin(); indexIt != this->index_end();
        ++indexIt)
-    this->set(*indexIt, element);
+    this->set(*indexIt, initValue);
 }
 
 Element Tensor::get(const Index &index) const {


### PR DESCRIPTION
  * BUILD.bazel & CMakeLists.txt: add a missing dependency.
  * stablehlo/dialect/TypeInference.cpp, stablehlo/dialect/TypeInference.h, stablehlo/reference/Ops.cpp, stablehlo/reference/Tensor.h: fix clang-tidy warnings.
  * stablehlo/integrations/python/tests/stablehlo.py: fix formatting.