### PR TITLE
Add interpreter for ScatterOp

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4648,10 +4648,10 @@ More formally, for all `update_index` from the index space of `updates[0]`:
       `index_vector_dim` index, if `index_vector_dim` <
       `rank(scatter_indices)`.
   * `[scatter_indices[update_scatter_index]]` otherwise.
-* For `do` in `axes(inputs[0])`,
-  * `full_start_index[do]` = `start_index[ds]` if
-      `do = scatter_dims_to_operand_dims[ds]`.
-  * `full_start_index[do]` = `0` otherwise.
+* For `di` in `axes(inputs[0])`,
+  * `full_start_index[di]` = `start_index[dj]` if
+      `di = scatter_dims_to_operand_dims[dj]`.
+  * `full_start_index[di]` = `0` otherwise.
 * `update_window_index` = [`update_index[d]` for `d` in `update_window_dims`].
 * `full_window_index` = `[oi0, ..., 0, ..., oiN]` where `oi` are individual
   elements in `update_window_index`, and `0` is inserted at indices from
@@ -4721,7 +4721,7 @@ undefined.
    `update_scatter_dims` and `update_window_dim_sizes` at axes corresponding
    to `update_window_dims`.
 * (C5) N $=$ size(`inputs`) = size(`updates`) and N $\ge$ 1.
-* (C6) `element_type(updates[k]) = element_type(inputs[k])` for any k $\in$
+* (C6) `element_type(updates[k]) = element_type(inputs[k])` for all k $\in$
        [0, N).
 * (C7) All dimensions in `update_window_dims` are unique and sorted.
 * (C8) For all i $\in$ [0, size(`update_window_dims`)), $0 \le$
@@ -4737,8 +4737,8 @@ undefined.
       `scatter_dims_to_operand_dims`[i] $\lt$ rank(`inputs`[0]).
 * (C14) $0 \le$ `index_vector_dim` $\le$ rank(`scatter_indices`).
 * (C15) `update_computation` has type `(tensor<E0>, ..., tensor<EN-1>, tensor<E0>, ..., tensor<EN-1>) -> (tensor<E0>, ..., tensor<EN-1>)`
-        where `Ek = element_type(inputs[k])` for any k $\in$ [0, N).
-* (C16) `inputs[k]` and `result[k]` have the same type for any k $\in$ [0, N).
+        where `Ek = element_type(inputs[k])` for all k $\in$ [0, N).
+* (C16) `inputs[k]` and `result[k]` have the same type for all k $\in$ [0, N).
 <!-- markdownlint-enable line-length -->
 
 #### Examples
@@ -4755,24 +4755,26 @@ undefined.
 //           [[[1, 1], [1, 1]], [[1, 1], [1, 1]], [[1, 1], [1, 1]]]
 //          ]
 %result = "stablehlo.scatter"(%input, %scatter_indices, %update) ({
-  ^bb0(%arg0: tensor<i32>, %arg1: tensor<i32>):
-    %0 = "stablehlo.add"(%arg0, %arg1) : (tensor<i32>, tensor<i32>) -> tensor<i32>
-    "stablehlo.return"(%0) : (tensor<i32>) -> ()
+  ^bb0(%arg0: tensor<i64>, %arg1: tensor<i64>):
+    %0 = "stablehlo.add"(%arg0, %arg1) : (tensor<i64>, tensor<i64>) -> tensor<i64>
+    "stablehlo.return"(%0) : (tensor<i64>) -> ()
 }) {
   scatter_dimension_numbers = #stablehlo.scatter<
-    update_window_dims = [2,3],
+    update_window_dims = [2, 3],
     inserted_window_dims = [0],
     scatter_dims_to_operand_dims = [1, 0],
     index_vector_dim = 2>,
   indices_are_sorted = false,
   unique_indices = false
-} : (tensor<3x4x2xi32>, tensor<2x3x2xi64>, tensor<2x3x2x2xi32>) -> tensor<3x4x2xi32>
+} : (tensor<3x4x2xi64>, tensor<2x3x2xi64>, tensor<2x3x2x2xi64>) -> tensor<3x4x2xi64>
 // %result: [
 //           [[1, 2], [5, 6], [8, 9], [8, 9]],
 //           [[10, 11], [12, 13], [14, 15], [16, 17]],
 //           [[18, 19], [20, 21], [21, 22], [23, 24]]
 //          ]
 ```
+
+&nbsp;[More Examples](../stablehlo/tests/interpret_scatter.mlir)
 
 ### select
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4648,10 +4648,10 @@ More formally, for all `update_index` from the index space of `updates[0]`:
       `index_vector_dim` index, if `index_vector_dim` <
       `rank(scatter_indices)`.
   * `[scatter_indices[update_scatter_index]]` otherwise.
-* For `di` in `axes(inputs[0])`,
-  * `full_start_index[di]` = `start_index[dj]` if
-      `di = scatter_dims_to_operand_dims[dj]`.
-  * `full_start_index[di]` = `0` otherwise.
+* For `d_operand` in `axes(inputs[0])`,
+  * `full_start_index[d_operand]` = `start_index[d_start]` if
+      `d_operand = scatter_dims_to_operand_dims[d_start]`.
+  * `full_start_index[d_operand]` = `0` otherwise.
 * `update_window_index` = [`update_index[d]` for `d` in `update_window_dims`].
 * `full_window_index` = `[oi0, ..., 0, ..., oiN]` where `oi` are individual
   elements in `update_window_index`, and `0` is inserted at indices from

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4653,7 +4653,7 @@ More formally, for all `update_index` from the index space of `updates[0]`:
       `d_operand = scatter_dims_to_operand_dims[d_start]`.
   * `full_start_index[d_operand]` = `0` otherwise.
 * `update_window_index` = [`update_index[d]` for `d` in `update_window_dims`].
-* `full_window_index` = `[oi0, ..., 0, ..., oiN]` where `oi` are individual
+* `full_window_index` = `[wi0, ..., 0, ..., wiN]` where `wi` are individual
   elements in `update_window_index`, and `0` is inserted at indices from
   `inserted_window_dims`.
 * `result_index` = `add(full_start_index, full_window_index)`.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4648,10 +4648,10 @@ More formally, for all `update_index` from the index space of `updates[0]`:
       `index_vector_dim` index, if `index_vector_dim` <
       `rank(scatter_indices)`.
   * `[scatter_indices[update_scatter_index]]` otherwise.
-* For `d_operand` in `axes(inputs[0])`,
-  * `full_start_index[d_operand]` = `start_index[d_start]` if
-      `d_operand = scatter_dims_to_operand_dims[d_start]`.
-  * `full_start_index[d_operand]` = `0` otherwise.
+* For `d_input` in `axes(inputs[0])`,
+  * `full_start_index[d_input]` = `start_index[d_start]` if
+      `d_input = scatter_dims_to_operand_dims[d_start]`.
+  * `full_start_index[d_input]` = `0` otherwise.
 * `update_window_index` = [`update_index[d]` for `d` in `update_window_dims`].
 * `full_window_index` = `[wi0, ..., 0, ..., wiN]` where `wi` are individual
   elements in `update_window_index`, and `0` is inserted at indices from

--- a/docs/status.md
+++ b/docs/status.md
@@ -132,7 +132,7 @@ one of the following tracking labels.
 | round_nearest_afz        | yes           | yes          | yes            | yes             | yes         |
 | round_nearest_even       | yes           | yes          | yes            | yes             | yes         |
 | rsqrt                    | yes           | yes          | yes            | yes             | yes         |
-| scatter                  | yes           | revisit      | yes            | no              | no          |
+| scatter                  | yes           | revisit      | yes            | no              | yes         |
 | select                   | yes           | yes          | yes            | yes             | yes         |
 | select_and_scatter       | yes           | revisit      | yes            | no              | no          |
 | send                     | yes           | revisit      | yes            | no              | no          |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2470,7 +2470,7 @@ def StableHLO_DynamicReshapeOp: StableHLO_ShapedInterfaceOp<"dynamic_reshape", [
 }
 
 def StableHLO_ScatterOp: StableHLO_Op<"scatter", [RecursiveMemoryEffects,
-      SameVariadicOperandSize /*scatter_c1, scatter_c3, scatter_c5*/,
+      SameVariadicOperandSize /*scatter_c5*/,
       DeclareOpInterfaceMethods<InferTypeOpInterface> /*scatter_c16*/]> {
   let summary = "Scatter operation";
   let description = [{

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2469,9 +2469,9 @@ def StableHLO_DynamicReshapeOp: StableHLO_ShapedInterfaceOp<"dynamic_reshape", [
   let assemblyFormat = "operands attr-dict `:` functional-type(operands, results)";
 }
 
-def StableHLO_ScatterOp: StableHLO_Op<"scatter",
-      [SameVariadicOperandSize, RecursiveMemoryEffects,
-      DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
+def StableHLO_ScatterOp: StableHLO_Op<"scatter", [RecursiveMemoryEffects,
+      SameVariadicOperandSize /*scatter_c1, scatter_c3, scatter_c5*/,
+      DeclareOpInterfaceMethods<InferTypeOpInterface> /*scatter_c16*/]> {
   let summary = "Scatter operation";
   let description = [{
     Produces `results` tensors which are equal to `inputs` tensors except that
@@ -2482,33 +2482,32 @@ def StableHLO_ScatterOp: StableHLO_Op<"scatter",
     https://github.com/openxla/stablehlo/blob/main/docs/spec.md#scatter
 
    Example:
-
    ```mlir
    %result = "stablehlo.scatter"(%input, %scatter_indices, %update) ({
-     ^bb0(%arg0: tensor<i32>, %arg1: tensor<i32>):
-       %0 = stablehlo.add %arg0, %arg1 : tensor<i32>
-       stablehlo.return %0 : tensor<i32>
+     ^bb0(%arg0: tensor<i64>, %arg1: tensor<i64>):
+       %0 = stablehlo.add %arg0, %arg1 : tensor<i64>
+       stablehlo.return %0 : tensor<i64>
    }) {
      scatter_dimension_numbers = #stablehlo.scatter<
-       update_window_dims = [2,3],
+       update_window_dims = [2, 3],
        inserted_window_dims = [0],
        scatter_dims_to_operand_dims = [1, 0],
        index_vector_dim = 2>,
      indices_are_sorted = false,
      unique_indices = false
-   } : (tensor<3x4x2xi32>, tensor<2x3x2xi64>, tensor<2x3x2x2xi32>) -> tensor<3x4x2xi32>
+   } : (tensor<3x4x2xi64>, tensor<2x3x2xi64>, tensor<2x3x2x2xi64>) -> tensor<3x4x2xi64>
    ```
   }];
   let arguments = (ins
-    Variadic<HLO_Tensor>:$inputs,
-    TensorOf<[AnyInteger, Index]>:$scatter_indices,
-    Variadic<HLO_Tensor>:$updates,
-    StableHLO_ScatterDimensionNumbers:$scatter_dimension_numbers,
-    DefaultValuedOptionalAttr<BoolAttr, "false">:$indices_are_sorted,
-    DefaultValuedOptionalAttr<BoolAttr, "false">:$unique_indices
+    Variadic<HLO_Tensor>:$inputs, /*scatter_i1*/
+    TensorOf<[AnyInteger, Index]>:$scatter_indices, /*scatter_i2*/
+    Variadic<HLO_Tensor>:$updates, /*scatter_i3*/
+    StableHLO_ScatterDimensionNumbers:$scatter_dimension_numbers, /*scatter_i4...scatter_i7*/
+    DefaultValuedOptionalAttr<BoolAttr, "false">:$indices_are_sorted, /*scatter_i8*/
+    DefaultValuedOptionalAttr<BoolAttr, "false">:$unique_indices /*scatter_i9*/
   );
 
-  let regions = (region SizedRegion<1>:$update_computation);
+  let regions = (region SizedRegion<1>:$update_computation /*scatter_i10*/);
 
   let results = (outs Variadic<HLO_Tensor>);
 

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -1376,13 +1376,13 @@ SmallVector<Tensor> evalScatterOp(
     auto startIndex = evalIndex(evalSliceOp(scatterIndices, startIndicesIndex));
 
     Index fullStartIndex(inputs[0].getRank(), 0);
-    for (auto dOperand : inputs[0].getAxes()) {
-      if (llvm::find(scatterDimsToOperandDims, dOperand) ==
+    for (auto dInput : inputs[0].getAxes()) {
+      if (llvm::find(scatterDimsToOperandDims, dInput) ==
           scatterDimsToOperandDims.end())
         continue;
-      auto dStart = llvm::find(scatterDimsToOperandDims, dOperand) -
+      auto dStart = llvm::find(scatterDimsToOperandDims, dInput) -
                     scatterDimsToOperandDims.begin();
-      fullStartIndex[dOperand] = startIndex[dStart];
+      fullStartIndex[dInput] = startIndex[dStart];
     }
 
     Index updateWindowIndex;

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -125,6 +125,17 @@ Tensor evalReverseOp(const Tensor &operand, const Axes &dimensions,
 Tensor evalRoundOp(const Tensor &operand, ShapedType resultType);
 Tensor evalRoundNearestEvenOp(const Tensor &operand, ShapedType resultType);
 Tensor evalRsqrtOp(const Tensor &operand, ShapedType resultType);
+SmallVector<Tensor> evalScatterOp(
+    ArrayRef<Tensor> inputs, const Tensor &scatterIndices,
+    ArrayRef<Tensor> updates, const Axes &updateWindowDims,
+    const Axes &insertedWindowDims, const Axes &scatterDimsToOperandDims,
+    Axis indexVectorDim, Region &updateComputation, ShapedType resultType);
+SmallVector<Tensor> evalScatterOp(
+    ArrayRef<Tensor> inputs, const Tensor &scatterIndices,
+    ArrayRef<Tensor> updates, const Axes &updateWindowDims,
+    const Axes &insertedWindowDims, const Axes &scatterDimsToOperandDims,
+    Axis indexVectorDim, Region &updateComputation, Scope &scope,
+    ArrayRef<ShapedType> resultTypes);
 Tensor evalSelectOp(const Tensor &pred, const Tensor &onTrue,
                     const Tensor &onFalse, ShapedType resultType);
 Tensor evalShiftLeftOp(const Tensor &lhs, const Tensor &rhs,

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -129,11 +129,6 @@ SmallVector<Tensor> evalScatterOp(
     ArrayRef<Tensor> inputs, const Tensor &scatterIndices,
     ArrayRef<Tensor> updates, const Axes &updateWindowDims,
     const Axes &insertedWindowDims, const Axes &scatterDimsToOperandDims,
-    Axis indexVectorDim, Region &updateComputation, ShapedType resultType);
-SmallVector<Tensor> evalScatterOp(
-    ArrayRef<Tensor> inputs, const Tensor &scatterIndices,
-    ArrayRef<Tensor> updates, const Axes &updateWindowDims,
-    const Axes &insertedWindowDims, const Axes &scatterDimsToOperandDims,
     Axis indexVectorDim, Region &updateComputation, Scope &scope,
     ArrayRef<ShapedType> resultTypes);
 Tensor evalSelectOp(const Tensor &pred, const Tensor &onTrue,

--- a/stablehlo/testdata/scatter_add_dtypes_shape_bfloat16_5__scatterindices___0___2___updateshape__2___updatewindowdims____i3105365873972993397.mlir
+++ b/stablehlo/testdata/scatter_add_dtypes_shape_bfloat16_5__scatterindices___0___2___updateshape__2___updatewindowdims____i3105365873972993397.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_dtypes_shape_complex64_5__scatterindices___0___2___updateshape__2___updatewindowdims____6907187575661564349.mlir
+++ b/stablehlo/testdata/scatter_add_dtypes_shape_complex64_5__scatterindices___0___2___updateshape__2___updatewindowdims____6907187575661564349.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_dtypes_shape_float16_5__scatterindices___0___2___updateshape__2___updatewindowdims____in7460671499809967899.mlir
+++ b/stablehlo/testdata/scatter_add_dtypes_shape_float16_5__scatterindices___0___2___updateshape__2___updatewindowdims____in7460671499809967899.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_dtypes_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowdims____in6239340358948408549.mlir
+++ b/stablehlo/testdata/scatter_add_dtypes_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowdims____in6239340358948408549.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_dtypes_shape_int16_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse5866428584412663600.mlir
+++ b/stablehlo/testdata/scatter_add_dtypes_shape_int16_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse5866428584412663600.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_dtypes_shape_int32_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse3748619223488839328.mlir
+++ b/stablehlo/testdata/scatter_add_dtypes_shape_int32_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse3748619223488839328.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_dtypes_shape_int8_5__scatterindices___0___2___updateshape__2___updatewindowdims____inser6830291740956972723.mlir
+++ b/stablehlo/testdata/scatter_add_dtypes_shape_int8_5__scatterindices___0___2___updateshape__2___updatewindowdims____inser6830291740956972723.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_dtypes_shape_uint16_5__scatterindices___0___2___updateshape__2___updatewindowdims____ins-4520383806230198953.mlir
+++ b/stablehlo/testdata/scatter_add_dtypes_shape_uint16_5__scatterindices___0___2___updateshape__2___updatewindowdims____ins-4520383806230198953.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_dtypes_shape_uint32_5__scatterindices___0___2___updateshape__2___updatewindowdims____ins8809450043985603953.mlir
+++ b/stablehlo/testdata/scatter_add_dtypes_shape_uint32_5__scatterindices___0___2___updateshape__2___updatewindowdims____ins8809450043985603953.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_dtypes_shape_uint8_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse-4255998206634939686.mlir
+++ b/stablehlo/testdata/scatter_add_dtypes_shape_uint8_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse-4255998206634939686.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowd-348874080094627888.mlir
+++ b/stablehlo/testdata/scatter_add_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowd-348874080094627888.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowd7837153478809077655.mlir
+++ b/stablehlo/testdata/scatter_add_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowd7837153478809077655.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatewindow-8890984274374571387.mlir
+++ b/stablehlo/testdata/scatter_add_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatewindow-8890984274374571387.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatewindow5145962309437161874.mlir
+++ b/stablehlo/testdata/scatter_add_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatewindow5145962309437161874.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_bfloat16_1__scatterindices___0___0___updateshape__2___up-860494462789908425.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_bfloat16_1__scatterindices___0___0___updateshape__2___up-860494462789908425.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_bfloat16_1__scatterindices___0___0___updateshape__2___up7001784831726631490.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_bfloat16_1__scatterindices___0___0___updateshape__2___up7001784831726631490.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_bfloat16_2_3__scatterindices____2___2___2____updateshape-1496787690744292757.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_bfloat16_2_3__scatterindices____2___2___2____updateshape-1496787690744292757.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_bfloat16_2_3__scatterindices____2___2___2____updateshape-9089921811327946742.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_bfloat16_2_3__scatterindices____2___2___2____updateshape-9089921811327946742.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_bfloat16_3_5_40__scatterindices___1___1___updateshape__3-4274570454554491320.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_bfloat16_3_5_40__scatterindices___1___1___updateshape__3-4274570454554491320.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_bfloat16_3_5_40__scatterindices___1___1___updateshape__3137750960248060622.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_bfloat16_3_5_40__scatterindices___1___1___updateshape__3137750960248060622.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_bfloat16_3_5_4__scatterindices___1___1___updateshape__3_-4030463377469015899.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_bfloat16_3_5_4__scatterindices___1___1___updateshape__3_-4030463377469015899.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_bfloat16_3_5_4__scatterindices___1___1___updateshape__3_-889038016403856146.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_bfloat16_3_5_4__scatterindices___1___1___updateshape__3_-889038016403856146.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_bfloat16_3__scatterindices___1___0___1___updateshape__3_-1234331839929869546.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_bfloat16_3__scatterindices___1___0___1___updateshape__3_-1234331839929869546.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_bfloat16_3__scatterindices___1___0___1___updateshape__3_5983491590639358181.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_bfloat16_3__scatterindices___1___0___1___updateshape__3_5983491590639358181.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float16_1__scatterindices___0___0___updateshape__2___upd2891107003300082920.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float16_1__scatterindices___0___0___updateshape__2___upd2891107003300082920.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float16_1__scatterindices___0___0___updateshape__2___upd5362217514454606368.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float16_1__scatterindices___0___0___updateshape__2___upd5362217514454606368.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float16_2_3__scatterindices____2___2___2____updateshape_-3011851052689734097.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float16_2_3__scatterindices____2___2___2____updateshape_-3011851052689734097.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float16_2_3__scatterindices____2___2___2____updateshape_-8817597417694097826.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float16_2_3__scatterindices____2___2___2____updateshape_-8817597417694097826.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float16_3_5_40__scatterindices___1___1___updateshape__3_2912963089951762273.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float16_3_5_40__scatterindices___1___1___updateshape__3_2912963089951762273.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float16_3_5_40__scatterindices___1___1___updateshape__3_6681012509515424778.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float16_3_5_40__scatterindices___1___1___updateshape__3_6681012509515424778.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float16_3_5_4__scatterindices___1___1___updateshape__3_2-7988231109437691189.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float16_3_5_4__scatterindices___1___1___updateshape__3_2-7988231109437691189.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float16_3_5_4__scatterindices___1___1___updateshape__3_24396378064620439122.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float16_3_5_4__scatterindices___1___1___updateshape__3_24396378064620439122.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float16_3__scatterindices___1___0___1___updateshape__3__-6279399558626821175.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float16_3__scatterindices___1___0___1___updateshape__3__-6279399558626821175.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float16_3__scatterindices___1___0___1___updateshape__3__6927296407968934904.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float16_3__scatterindices___1___0___1___updateshape__3__6927296407968934904.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float32_1__scatterindices___0___0___updateshape__2___upd2596591008964205253.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float32_1__scatterindices___0___0___updateshape__2___upd2596591008964205253.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float32_1__scatterindices___0___0___updateshape__2___upd6619490232226873879.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float32_1__scatterindices___0___0___updateshape__2___upd6619490232226873879.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float32_2_3__scatterindices____2___2___2____updateshape_5036259221516710960.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float32_2_3__scatterindices____2___2___2____updateshape_5036259221516710960.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float32_2_3__scatterindices____2___2___2____updateshape_8345937081755116116.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float32_2_3__scatterindices____2___2___2____updateshape_8345937081755116116.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float32_3_5_40__scatterindices___1___1___updateshape__3_2951455025951434844.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float32_3_5_40__scatterindices___1___1___updateshape__3_2951455025951434844.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float32_3_5_40__scatterindices___1___1___updateshape__3_695726925484014410.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float32_3_5_40__scatterindices___1___1___updateshape__3_695726925484014410.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float32_3_5_4__scatterindices___1___1___updateshape__3_2-2774173445130720861.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float32_3_5_4__scatterindices___1___1___updateshape__3_2-2774173445130720861.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float32_3_5_4__scatterindices___1___1___updateshape__3_28218316950594479828.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float32_3_5_4__scatterindices___1___1___updateshape__3_28218316950594479828.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float32_3__scatterindices___1___0___1___updateshape__3__-4842756244488458473.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float32_3__scatterindices___1___0___1___updateshape__3__-4842756244488458473.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float32_3__scatterindices___1___0___1___updateshape__3__3611438175516175350.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float32_3__scatterindices___1___0___1___updateshape__3__3611438175516175350.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int16_1__scatterindices___0___0___updateshape__2___updat-7524018678144949761.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int16_1__scatterindices___0___0___updateshape__2___updat-7524018678144949761.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int16_1__scatterindices___0___0___updateshape__2___updat-9078878771811985072.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int16_1__scatterindices___0___0___updateshape__2___updat-9078878771811985072.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int16_2_3__scatterindices____2___2___2____updateshape__2-4916360558570014198.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int16_2_3__scatterindices____2___2___2____updateshape__2-4916360558570014198.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int16_2_3__scatterindices____2___2___2____updateshape__29001944072476716824.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int16_2_3__scatterindices____2___2___2____updateshape__29001944072476716824.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int16_3_5_40__scatterindices___1___1___updateshape__3_5_-3725043703956117426.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int16_3_5_40__scatterindices___1___1___updateshape__3_5_-3725043703956117426.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int16_3_5_40__scatterindices___1___1___updateshape__3_5_2656247344843304422.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int16_3_5_40__scatterindices___1___1___updateshape__3_5_2656247344843304422.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int16_3_5_4__scatterindices___1___1___updateshape__3_2_4-4264486373892608709.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int16_3_5_4__scatterindices___1___1___updateshape__3_2_4-4264486373892608709.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int16_3_5_4__scatterindices___1___1___updateshape__3_2_46479284842160210040.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int16_3_5_4__scatterindices___1___1___updateshape__3_2_46479284842160210040.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int16_3__scatterindices___1___0___1___updateshape__3___u-3591021005421900346.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int16_3__scatterindices___1___0___1___updateshape__3___u-3591021005421900346.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int16_3__scatterindices___1___0___1___updateshape__3___u-3594753372927687050.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int16_3__scatterindices___1___0___1___updateshape__3___u-3594753372927687050.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int32_1__scatterindices___0___0___updateshape__2___updat-354485824406248366.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int32_1__scatterindices___0___0___updateshape__2___updat-354485824406248366.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int32_1__scatterindices___0___0___updateshape__2___updat2266301288346060632.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int32_1__scatterindices___0___0___updateshape__2___updat2266301288346060632.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int32_2_3__scatterindices____2___2___2____updateshape__2-5393776790984240080.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int32_2_3__scatterindices____2___2___2____updateshape__2-5393776790984240080.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int32_2_3__scatterindices____2___2___2____updateshape__28847096142656084415.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int32_2_3__scatterindices____2___2___2____updateshape__28847096142656084415.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int32_3_5_40__scatterindices___1___1___updateshape__3_5_-7756335029081939712.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int32_3_5_40__scatterindices___1___1___updateshape__3_5_-7756335029081939712.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int32_3_5_40__scatterindices___1___1___updateshape__3_5_3678348900362642354.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int32_3_5_40__scatterindices___1___1___updateshape__3_5_3678348900362642354.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int32_3_5_4__scatterindices___1___1___updateshape__3_2_4-4098679572412113546.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int32_3_5_4__scatterindices___1___1___updateshape__3_2_4-4098679572412113546.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int32_3_5_4__scatterindices___1___1___updateshape__3_2_47476426858270645314.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int32_3_5_4__scatterindices___1___1___updateshape__3_2_47476426858270645314.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int32_3__scatterindices___1___0___1___updateshape__3___u-1822849126982343243.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int32_3__scatterindices___1___0___1___updateshape__3___u-1822849126982343243.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int32_3__scatterindices___1___0___1___updateshape__3___u3328846888780048830.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int32_3__scatterindices___1___0___1___updateshape__3___u3328846888780048830.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int8_1__scatterindices___0___0___updateshape__2___update1622126439350557293.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int8_1__scatterindices___0___0___updateshape__2___update1622126439350557293.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int8_1__scatterindices___0___0___updateshape__2___update3597746049988735779.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int8_1__scatterindices___0___0___updateshape__2___update3597746049988735779.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int8_2_3__scatterindices____2___2___2____updateshape__2_6362923774714678977.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int8_2_3__scatterindices____2___2___2____updateshape__2_6362923774714678977.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int8_2_3__scatterindices____2___2___2____updateshape__2_8103024994792774978.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int8_2_3__scatterindices____2___2___2____updateshape__2_8103024994792774978.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int8_3_5_40__scatterindices___1___1___updateshape__3_5_2-1988417011434006362.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int8_3_5_40__scatterindices___1___1___updateshape__3_5_2-1988417011434006362.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int8_3_5_40__scatterindices___1___1___updateshape__3_5_27199336242141289053.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int8_3_5_40__scatterindices___1___1___updateshape__3_5_27199336242141289053.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int8_3_5_4__scatterindices___1___1___updateshape__3_2_4_-3231048872442668326.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int8_3_5_4__scatterindices___1___1___updateshape__3_2_4_-3231048872442668326.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int8_3_5_4__scatterindices___1___1___updateshape__3_2_4_-4160837117599691199.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int8_3_5_4__scatterindices___1___1___updateshape__3_2_4_-4160837117599691199.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int8_3__scatterindices___1___0___1___updateshape__3___up-7917886033026925853.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int8_3__scatterindices___1___0___1___updateshape__3___up-7917886033026925853.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int8_3__scatterindices___1___0___1___updateshape__3___up2271924756491171274.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int8_3__scatterindices___1___0___1___updateshape__3___up2271924756491171274.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint16_1__scatterindices___0___0___updateshape__2___upda7888681396332677014.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint16_1__scatterindices___0___0___updateshape__2___upda7888681396332677014.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint16_1__scatterindices___0___0___updateshape__2___upda945060147471783225.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint16_1__scatterindices___0___0___updateshape__2___upda945060147471783225.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint16_2_3__scatterindices____2___2___2____updateshape__2510805737105385550.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint16_2_3__scatterindices____2___2___2____updateshape__2510805737105385550.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint16_2_3__scatterindices____2___2___2____updateshape__8091763406930871598.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint16_2_3__scatterindices____2___2___2____updateshape__8091763406930871598.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint16_3_5_40__scatterindices___1___1___updateshape__3_5-4926747791685884640.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint16_3_5_40__scatterindices___1___1___updateshape__3_5-4926747791685884640.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint16_3_5_40__scatterindices___1___1___updateshape__3_56146930483457941673.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint16_3_5_40__scatterindices___1___1___updateshape__3_56146930483457941673.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint16_3_5_4__scatterindices___1___1___updateshape__3_2_-4592846424164456833.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint16_3_5_4__scatterindices___1___1___updateshape__3_2_-4592846424164456833.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint16_3_5_4__scatterindices___1___1___updateshape__3_2_7666466305816482669.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint16_3_5_4__scatterindices___1___1___updateshape__3_2_7666466305816482669.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint16_3__scatterindices___1___0___1___updateshape__3___-3882386100438535526.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint16_3__scatterindices___1___0___1___updateshape__3___-3882386100438535526.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint16_3__scatterindices___1___0___1___updateshape__3___-5979552203502821981.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint16_3__scatterindices___1___0___1___updateshape__3___-5979552203502821981.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint32_1__scatterindices___0___0___updateshape__2___upda136913410679994980.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint32_1__scatterindices___0___0___updateshape__2___upda136913410679994980.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint32_1__scatterindices___0___0___updateshape__2___upda7842463203097941877.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint32_1__scatterindices___0___0___updateshape__2___upda7842463203097941877.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint32_2_3__scatterindices____2___2___2____updateshape__-1309214087076147471.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint32_2_3__scatterindices____2___2___2____updateshape__-1309214087076147471.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint32_2_3__scatterindices____2___2___2____updateshape__97537607199806852.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint32_2_3__scatterindices____2___2___2____updateshape__97537607199806852.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint32_3_5_40__scatterindices___1___1___updateshape__3_5-410985334763389823.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint32_3_5_40__scatterindices___1___1___updateshape__3_5-410985334763389823.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint32_3_5_40__scatterindices___1___1___updateshape__3_5-6577423887713838439.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint32_3_5_40__scatterindices___1___1___updateshape__3_5-6577423887713838439.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint32_3_5_4__scatterindices___1___1___updateshape__3_2_1623717598696775517.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint32_3_5_4__scatterindices___1___1___updateshape__3_2_1623717598696775517.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint32_3_5_4__scatterindices___1___1___updateshape__3_2_8309401109674874640.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint32_3_5_4__scatterindices___1___1___updateshape__3_2_8309401109674874640.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint32_3__scatterindices___1___0___1___updateshape__3___3455481995801809237.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint32_3__scatterindices___1___0___1___updateshape__3___3455481995801809237.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint32_3__scatterindices___1___0___1___updateshape__3___7498308269064318243.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint32_3__scatterindices___1___0___1___updateshape__3___7498308269064318243.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint8_1__scatterindices___0___0___updateshape__2___updat-9207802865953907581.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint8_1__scatterindices___0___0___updateshape__2___updat-9207802865953907581.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint8_1__scatterindices___0___0___updateshape__2___updat9140858870677867005.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint8_1__scatterindices___0___0___updateshape__2___updat9140858870677867005.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint8_2_3__scatterindices____2___2___2____updateshape__21352603121447941903.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint8_2_3__scatterindices____2___2___2____updateshape__21352603121447941903.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint8_2_3__scatterindices____2___2___2____updateshape__27480559985512445156.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint8_2_3__scatterindices____2___2___2____updateshape__27480559985512445156.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint8_3_5_40__scatterindices___1___1___updateshape__3_5_-6393488545608218666.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint8_3_5_40__scatterindices___1___1___updateshape__3_5_-6393488545608218666.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint8_3_5_40__scatterindices___1___1___updateshape__3_5_-92958002531278788.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint8_3_5_40__scatterindices___1___1___updateshape__3_5_-92958002531278788.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint8_3_5_4__scatterindices___1___1___updateshape__3_2_42856711317682290752.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint8_3_5_4__scatterindices___1___1___updateshape__3_2_42856711317682290752.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint8_3_5_4__scatterindices___1___1___updateshape__3_2_42902961225811021078.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint8_3_5_4__scatterindices___1___1___updateshape__3_2_42902961225811021078.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint8_3__scatterindices___1___0___1___updateshape__3___u4321644361351952093.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint8_3__scatterindices___1___0___1___updateshape__3___u4321644361351952093.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint8_3__scatterindices___1___0___1___updateshape__3___u5648339647004024495.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint8_3__scatterindices___1___0___1___updateshape__3___u5648339647004024495.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_125__scatterindices__0__updateshape__1___updatewi-8617159013234137769.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_125__scatterindices__0__updateshape__1___updatewi-8617159013234137769.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_125__scatterindices__0__updateshape__1___updatewi6144652360058557977.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_125__scatterindices__0__updateshape__1___updatewi6144652360058557977.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_1_1__scatterindices__0__updateshape__1_1__updatew-1556558392001991646.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_1_1__scatterindices__0__updateshape__1_1__updatew-1556558392001991646.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_1_1__scatterindices__0__updateshape__1_1__updatew-5987512261321349511.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_1_1__scatterindices__0__updateshape__1_1__updatew-5987512261321349511.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_1__scatterindices__0__updateshape__1___updatewind-5581034558494065018.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_1__scatterindices__0__updateshape__1___updatewind-5581034558494065018.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_1__scatterindices__0__updateshape__1___updatewind8373448553845026835.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_1__scatterindices__0__updateshape__1___updatewind8373448553845026835.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__0__updateshape__2_3__updatew-6019789563017120555.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__0__updateshape__2_3__updatew-6019789563017120555.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__0__updateshape__2_3__updatew9202089644754291152.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__0__updateshape__2_3__updatew9202089644754291152.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1_2__updateshape__1___update-2741684093322986342.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1_2__updateshape__1___update-2741684093322986342.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1_2__updateshape__1___update7075641444893981314.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1_2__updateshape__1___update7075641444893981314.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1__updateshape__1_3__updatew425803056863035771.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1__updateshape__1_3__updatew425803056863035771.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1__updateshape__1_3__updatew9110202218978731330.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1__updateshape__1_3__updatew9110202218978731330.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_50_3__scatterindices__32__updateshape__1_3__updat-6062071545452394866.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_50_3__scatterindices__32__updateshape__1_3__updat-6062071545452394866.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_50_3__scatterindices__32__updateshape__1_3__updat-8004672162355768985.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_50_3__scatterindices__32__updateshape__1_3__updat-8004672162355768985.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1__scatterindices__0__updateshape____updatewindowdi-828594468178229581.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1__scatterindices__0__updateshape____updatewindowdi-828594468178229581.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1__scatterindices__0__updateshape____updatewindowdi6429751923890686552.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1__scatterindices__0__updateshape____updatewindowdi6429751923890686552.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upd-6848840407727231745.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upd-6848840407727231745.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upd1861388025332688117.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upd1861388025332688117.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_4_2_3__scatterindices__3_2__updateshape__2___update-1982638209236671047.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_4_2_3__scatterindices__3_2__updateshape__2___update-1982638209236671047.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_4_2_3__scatterindices__3_2__updateshape__2___update2088472121195190538.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_4_2_3__scatterindices__3_2__updateshape__2___update2088472121195190538.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices___0_1___2_3___updateshape__2_-1093032740725682184.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices___0_1___2_3___updateshape__2_-1093032740725682184.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices___0_1___2_3___updateshape__2_-4922945492660867696.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices___0_1___2_3___updateshape__2_-4922945492660867696.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2___-7603903374362641006.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2___-7603903374362641006.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2___3435585015422911912.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2___3435585015422911912.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0___1_____2___3____updates7547332501918920602.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0___1_____2___3____updates7547332501918920602.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0___1_____2___3____updates8050165712147161814.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0___1_____2___3____updates8050165712147161814.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_125__scatterindices__0__updateshape__1___updatewin-4752489888149503617.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_125__scatterindices__0__updateshape__1___updatewin-4752489888149503617.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_125__scatterindices__0__updateshape__1___updatewin2053556689837356458.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_125__scatterindices__0__updateshape__1___updatewin2053556689837356458.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_1_1__scatterindices__0__updateshape__1_1__updatewi-3781116865999811871.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_1_1__scatterindices__0__updateshape__1_1__updatewi-3781116865999811871.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_1_1__scatterindices__0__updateshape__1_1__updatewi7533314707669860824.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_1_1__scatterindices__0__updateshape__1_1__updatewi7533314707669860824.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_1__scatterindices__0__updateshape__1___updatewindo-8488847812238110952.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_1__scatterindices__0__updateshape__1___updatewindo-8488847812238110952.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_1__scatterindices__0__updateshape__1___updatewindo4277266865564877965.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_1__scatterindices__0__updateshape__1___updatewindo4277266865564877965.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__0__updateshape__2_3__updatewi-5697591077233325860.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__0__updateshape__2_3__updatewi-5697591077233325860.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__0__updateshape__2_3__updatewi5753373379559669218.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__0__updateshape__2_3__updatewi5753373379559669218.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1_2__updateshape__1___updatew-1222690156116202003.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1_2__updateshape__1___updatew-1222690156116202003.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1_2__updateshape__1___updatew-7525130878030551788.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1_2__updateshape__1___updatew-7525130878030551788.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1__updateshape__1_3__updatewi1334311401954125279.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1__updateshape__1_3__updatewi1334311401954125279.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1__updateshape__1_3__updatewi628492442243500081.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1__updateshape__1_3__updatewi628492442243500081.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_50_3__scatterindices__32__updateshape__1_3__update-435478597733378491.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_50_3__scatterindices__32__updateshape__1_3__update-435478597733378491.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_50_3__scatterindices__32__updateshape__1_3__update2986102359662279142.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_50_3__scatterindices__32__updateshape__1_3__update2986102359662279142.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1__scatterindices__0__updateshape____updatewindowdim-4952504776566058822.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1__scatterindices__0__updateshape____updatewindowdim-4952504776566058822.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1__scatterindices__0__updateshape____updatewindowdim2796027074051456709.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1__scatterindices__0__updateshape____updatewindowdim2796027074051456709.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda-6311750605783993279.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda-6311750605783993279.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda4265363395406675305.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda4265363395406675305.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_4_2_3__scatterindices__3_2__updateshape__2___updatew-3203912789197849558.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_4_2_3__scatterindices__3_2__updateshape__2___updatew-3203912789197849558.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_4_2_3__scatterindices__3_2__updateshape__2___updatew-3643129952740408905.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_4_2_3__scatterindices__3_2__updateshape__2___updatew-3643129952740408905.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7-8563111457028476801.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7-8563111457028476801.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_5_6_7__scatterindices___0_1___2_3___updateshape__2_74870609094287397096.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_5_6_7__scatterindices___0_1___2_3___updateshape__2_74870609094287397096.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____-759744508599333163.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____-759744508599333163.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____1245777998526320213.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____1245777998526320213.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0___1_____2___3____updatesh-4249322870906831285.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0___1_____2___3____updatesh-4249322870906831285.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0___1_____2___3____updatesh-6156631391951242845.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0___1_____2___3____updatesh-6156631391951242845.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewin-304007529601890135.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewin-304007529601890135.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewin455400941778422949.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewin455400941778422949.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__updatewi-8477777432015844399.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__updatewi-8477777432015844399.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__updatewi7074773785138082609.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__updatewi7074773785138082609.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___updatewindo-8612627503936106700.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___updatewindo-8612627503936106700.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___updatewindo-9153118378468889125.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___updatewindo-9153118378468889125.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatewi5782516177151935046.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatewi5782516177151935046.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatewi9041188103475055130.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatewi9041188103475055130.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___updatew1689752114083955572.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___updatew1689752114083955572.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___updatew8693638238679832728.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___updatew8693638238679832728.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatewi-4551395605147325529.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatewi-4551395605147325529.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatewi7730408894793448812.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatewi7730408894793448812.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__update4174760181820348577.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__update4174760181820348577.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__update7900894070573682987.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__update7900894070573682987.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdim1751609735067905465.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdim1751609735067905465.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdim5673305870149119583.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdim5673305870149119583.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda-2469456288279167158.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda-2469456288279167158.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda4342698834420844442.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda4342698834420844442.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___updatew4175976412957549642.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___updatew4175976412957549642.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___updatew5768555911120390580.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___updatew5768555911120390580.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7-1676888133310209796.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7-1676888133310209796.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7-4402240353080601551.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7-4402240353080601551.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____5697733633172945226.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____5697733633172945226.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____8934238829712448896.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____8934238829712448896.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____updatesh3554705983460704021.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____updatesh3554705983460704021.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____updatesh6790731219354090899.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____updatesh6790731219354090899.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_125__scatterindices__0__updateshape__1___updatewindo2839844844000946233.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_125__scatterindices__0__updateshape__1___updatewindo2839844844000946233.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_125__scatterindices__0__updateshape__1___updatewindo4691533306572779958.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_125__scatterindices__0__updateshape__1___updatewindo4691533306572779958.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_1_1__scatterindices__0__updateshape__1_1__updatewind-4922517182425747675.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_1_1__scatterindices__0__updateshape__1_1__updatewind-4922517182425747675.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_1_1__scatterindices__0__updateshape__1_1__updatewind1681211343400286627.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_1_1__scatterindices__0__updateshape__1_1__updatewind1681211343400286627.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_1__scatterindices__0__updateshape__1___updatewindowd-420922130789298176.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_1__scatterindices__0__updateshape__1___updatewindowd-420922130789298176.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_1__scatterindices__0__updateshape__1___updatewindowd-4663183835276024253.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_1__scatterindices__0__updateshape__1___updatewindowd-4663183835276024253.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__0__updateshape__2_3__updatewind-5816799921830533789.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__0__updateshape__2_3__updatewind-5816799921830533789.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__0__updateshape__2_3__updatewind-887253207283244392.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__0__updateshape__2_3__updatewind-887253207283244392.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1_2__updateshape__1___updatewin-6105746935257438539.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1_2__updateshape__1___updatewin-6105746935257438539.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1_2__updateshape__1___updatewin368283231402400784.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1_2__updateshape__1___updatewin368283231402400784.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1__updateshape__1_3__updatewind-4833649072894316135.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1__updateshape__1_3__updatewind-4833649072894316135.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1__updateshape__1_3__updatewind-7325755528902790593.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1__updateshape__1_3__updatewind-7325755528902790593.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_50_3__scatterindices__32__updateshape__1_3__updatewi-9172264402326490364.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_50_3__scatterindices__32__updateshape__1_3__updatewi-9172264402326490364.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_50_3__scatterindices__32__updateshape__1_3__updatewi5722805357516891196.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_50_3__scatterindices__32__updateshape__1_3__updatewi5722805357516891196.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1__scatterindices__0__updateshape____updatewindowdims_3934064707146790949.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1__scatterindices__0__updateshape____updatewindowdims_3934064707146790949.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1__scatterindices__0__updateshape____updatewindowdims_8679781641694982610.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1__scatterindices__0__updateshape____updatewindowdims_8679781641694982610.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-8619458148601629175.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-8619458148601629175.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_4_2_3_5__scatterindices__0_4__updateshape__4_3__update1072636734502228327.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_4_2_3_5__scatterindices__0_4__updateshape__4_3__update1072636734502228327.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_4_2_3__scatterindices__3_2__updateshape__2___updatewin-2373040689244975897.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_4_2_3__scatterindices__3_2__updateshape__2___updatewin-2373040689244975897.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_4_2_3__scatterindices__3_2__updateshape__2___updatewin-7039533867993701.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_4_2_3__scatterindices__3_2__updateshape__2___updatewin-7039533867993701.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-5273540091416886440.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-5273540091416886440.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__520632053864570090.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__520632053864570090.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-5623848772288331181.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-5623848772288331181.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up500212622559178017.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up500212622559178017.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0___1_____2___3____updateshap-340960696335901665.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0___1_____2___3____updateshap-340960696335901665.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0___1_____2___3____updateshap-7634999522019619612.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0___1_____2___3____updateshap-7634999522019619612.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_125__scatterindices__0__updateshape__1___updatewindo-7971939317121945253.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_125__scatterindices__0__updateshape__1___updatewindo-7971939317121945253.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_125__scatterindices__0__updateshape__1___updatewindo4095517369750484142.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_125__scatterindices__0__updateshape__1___updatewindo4095517369750484142.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_1_1__scatterindices__0__updateshape__1_1__updatewind-3312424635250872014.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_1_1__scatterindices__0__updateshape__1_1__updatewind-3312424635250872014.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_1_1__scatterindices__0__updateshape__1_1__updatewind139215505656195790.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_1_1__scatterindices__0__updateshape__1_1__updatewind139215505656195790.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_1__scatterindices__0__updateshape__1___updatewindowd7342322526435903367.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_1__scatterindices__0__updateshape__1___updatewindowd7342322526435903367.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_1__scatterindices__0__updateshape__1___updatewindowd7553302737739030242.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_1__scatterindices__0__updateshape__1___updatewindowd7553302737739030242.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__0__updateshape__2_3__updatewind-5394744753228806123.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__0__updateshape__2_3__updatewind-5394744753228806123.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__0__updateshape__2_3__updatewind3630342298095974182.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__0__updateshape__2_3__updatewind3630342298095974182.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1_2__updateshape__1___updatewin2110578568797174599.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1_2__updateshape__1___updatewin2110578568797174599.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1_2__updateshape__1___updatewin309107136629663177.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1_2__updateshape__1___updatewin309107136629663177.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1__updateshape__1_3__updatewind6204710529394502514.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1__updateshape__1_3__updatewind6204710529394502514.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1__updateshape__1_3__updatewind6271891592308477634.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1__updateshape__1_3__updatewind6271891592308477634.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_50_3__scatterindices__32__updateshape__1_3__updatewi-1127081133223858940.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_50_3__scatterindices__32__updateshape__1_3__updatewi-1127081133223858940.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_50_3__scatterindices__32__updateshape__1_3__updatewi1698984474341869219.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_50_3__scatterindices__32__updateshape__1_3__updatewi1698984474341869219.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1__scatterindices__0__updateshape____updatewindowdims_-6540378403077330570.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1__scatterindices__0__updateshape____updatewindowdims_-6540378403077330570.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1__scatterindices__0__updateshape____updatewindowdims_-7397243544293713443.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1__scatterindices__0__updateshape____updatewindowdims_-7397243544293713443.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-10712058622206155.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-10712058622206155.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_4_2_3_5__scatterindices__0_4__updateshape__4_3__update2550571537627097938.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_4_2_3_5__scatterindices__0_4__updateshape__4_3__update2550571537627097938.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_4_2_3__scatterindices__3_2__updateshape__2___updatewin1479578082839246648.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_4_2_3__scatterindices__3_2__updateshape__2___updatewin1479578082839246648.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_4_2_3__scatterindices__3_2__updateshape__2___updatewin8686567596578332985.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_4_2_3__scatterindices__3_2__updateshape__2___updatewin8686567596578332985.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-4663429453766771963.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-4663429453766771963.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-7181773669694201441.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-7181773669694201441.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-2238527862024472151.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-2238527862024472151.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-2970555778160149333.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-2970555778160149333.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0___1_____2___3____updateshap1715785822546040830.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0___1_____2___3____updateshap1715785822546040830.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0___1_____2___3____updateshap6710213962241311232.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0___1_____2___3____updateshap6710213962241311232.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_125__scatterindices__0__updateshape__1___updatewindow-5741837050715739462.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_125__scatterindices__0__updateshape__1___updatewindow-5741837050715739462.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_125__scatterindices__0__updateshape__1___updatewindow6124594656634777346.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_125__scatterindices__0__updateshape__1___updatewindow6124594656634777346.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_1_1__scatterindices__0__updateshape__1_1__updatewindo-8135371938509125618.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_1_1__scatterindices__0__updateshape__1_1__updatewindo-8135371938509125618.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_1_1__scatterindices__0__updateshape__1_1__updatewindo7417675200334150160.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_1_1__scatterindices__0__updateshape__1_1__updatewindo7417675200334150160.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_1__scatterindices__0__updateshape__1___updatewindowdi-4489868158232826085.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_1__scatterindices__0__updateshape__1___updatewindowdi-4489868158232826085.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_1__scatterindices__0__updateshape__1___updatewindowdi-5808469219638001439.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_1__scatterindices__0__updateshape__1___updatewindowdi-5808469219638001439.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__0__updateshape__2_3__updatewindo-5441909635197723241.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__0__updateshape__2_3__updatewindo-5441909635197723241.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__0__updateshape__2_3__updatewindo-6720695980401733509.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__0__updateshape__2_3__updatewindo-6720695980401733509.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1_2__updateshape__1___updatewind-2808008445529984142.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1_2__updateshape__1___updatewind-2808008445529984142.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1_2__updateshape__1___updatewind4987595175184550066.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1_2__updateshape__1___updatewind4987595175184550066.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1__updateshape__1_3__updatewindo-1784469910841869456.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1__updateshape__1_3__updatewindo-1784469910841869456.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1__updateshape__1_3__updatewindo7538936333147709933.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1__updateshape__1_3__updatewindo7538936333147709933.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_50_3__scatterindices__32__updateshape__1_3__updatewin1508955844563568818.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_50_3__scatterindices__32__updateshape__1_3__updatewin1508955844563568818.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_50_3__scatterindices__32__updateshape__1_3__updatewin6067048107147913826.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_50_3__scatterindices__32__updateshape__1_3__updatewin6067048107147913826.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1__scatterindices__0__updateshape____updatewindowdims__-5061474144088218377.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1__scatterindices__0__updateshape____updatewindowdims__-5061474144088218377.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1__scatterindices__0__updateshape____updatewindowdims__7419933209394456505.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1__scatterindices__0__updateshape____updatewindowdims__7419933209394456505.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatew-475177265581722258.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatew-475177265581722258.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatew5568489650471049080.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatew5568489650471049080.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_4_2_3__scatterindices__3_2__updateshape__2___updatewind-8611891650160216261.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_4_2_3__scatterindices__3_2__updateshape__2___updatewind-8611891650160216261.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_4_2_3__scatterindices__3_2__updateshape__2___updatewind6985804078066516697.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_4_2_3__scatterindices__3_2__updateshape__2___updatewind6985804078066516697.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__u3771363404680848958.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__u3771363404680848958.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__u808523439608182752.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__u808523439608182752.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upd6531262831845641784.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upd6531262831845641784.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upd7351713410321533699.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upd7351713410321533699.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0___1_____2___3____updateshape3968639201026952742.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0___1_____2___3____updateshape3968639201026952742.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0___1_____2___3____updateshape6792664875203398695.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0___1_____2___3____updateshape6792664875203398695.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_125__scatterindices__0__updateshape__1___updatewind-2355530058007938589.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_125__scatterindices__0__updateshape__1___updatewind-2355530058007938589.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_125__scatterindices__0__updateshape__1___updatewind5899607047074806462.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_125__scatterindices__0__updateshape__1___updatewind5899607047074806462.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_1_1__scatterindices__0__updateshape__1_1__updatewin4255143736696256140.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_1_1__scatterindices__0__updateshape__1_1__updatewin4255143736696256140.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_1_1__scatterindices__0__updateshape__1_1__updatewin5355292897265078190.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_1_1__scatterindices__0__updateshape__1_1__updatewin5355292897265078190.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_1__scatterindices__0__updateshape__1___updatewindow-1865959740833351532.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_1__scatterindices__0__updateshape__1___updatewindow-1865959740833351532.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_1__scatterindices__0__updateshape__1___updatewindow3224571850859326572.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_1__scatterindices__0__updateshape__1___updatewindow3224571850859326572.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__0__updateshape__2_3__updatewin1928081368629774964.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__0__updateshape__2_3__updatewin1928081368629774964.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__0__updateshape__2_3__updatewin6027022332699736532.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__0__updateshape__2_3__updatewin6027022332699736532.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1_2__updateshape__1___updatewi222960814350783234.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1_2__updateshape__1___updatewi222960814350783234.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1_2__updateshape__1___updatewi5126588181291957161.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1_2__updateshape__1___updatewi5126588181291957161.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1__updateshape__1_3__updatewin7804651276816942207.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1__updateshape__1_3__updatewin7804651276816942207.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1__updateshape__1_3__updatewin7981612942392985245.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1__updateshape__1_3__updatewin7981612942392985245.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_50_3__scatterindices__32__updateshape__1_3__updatew-4754160280417932241.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_50_3__scatterindices__32__updateshape__1_3__updatew-4754160280417932241.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_50_3__scatterindices__32__updateshape__1_3__updatew-8872713435005673417.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_50_3__scatterindices__32__updateshape__1_3__updatew-8872713435005673417.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1__scatterindices__0__updateshape____updatewindowdims4804912606649857802.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1__scatterindices__0__updateshape____updatewindowdims4804912606649857802.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1__scatterindices__0__updateshape____updatewindowdims7558386364215168783.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1__scatterindices__0__updateshape____updatewindowdims7558386364215168783.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat-8274419980979350893.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat-8274419980979350893.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat1709061966807053836.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat1709061966807053836.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_4_2_3__scatterindices__3_2__updateshape__2___updatewi-6073099928643051906.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_4_2_3__scatterindices__3_2__updateshape__2___updatewi-6073099928643051906.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_4_2_3__scatterindices__3_2__updateshape__2___updatewi8179654881998250566.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_4_2_3__scatterindices__3_2__updateshape__2___updatewi8179654881998250566.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_-4324625212547377416.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_-4324625212547377416.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_492152019281825947.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_492152019281825947.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u-5201943969373002426.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u-5201943969373002426.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u8141856249510461351.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u8141856249510461351.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0___1_____2___3____updatesha-5032991910029426792.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0___1_____2___3____updatesha-5032991910029426792.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0___1_____2___3____updatesha-7026742454312175741.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0___1_____2___3____updatesha-7026742454312175741.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_125__scatterindices__0__updateshape__1___updatewind-2493932993191221377.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_125__scatterindices__0__updateshape__1___updatewind-2493932993191221377.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_125__scatterindices__0__updateshape__1___updatewind-4727333056025903092.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_125__scatterindices__0__updateshape__1___updatewind-4727333056025903092.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_1_1__scatterindices__0__updateshape__1_1__updatewin-6232381483023765460.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_1_1__scatterindices__0__updateshape__1_1__updatewin-6232381483023765460.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_1_1__scatterindices__0__updateshape__1_1__updatewin8781756429572856750.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_1_1__scatterindices__0__updateshape__1_1__updatewin8781756429572856750.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_1__scatterindices__0__updateshape__1___updatewindow5934522417062545132.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_1__scatterindices__0__updateshape__1___updatewindow5934522417062545132.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_1__scatterindices__0__updateshape__1___updatewindow868296633592529009.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_1__scatterindices__0__updateshape__1___updatewindow868296633592529009.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__0__updateshape__2_3__updatewin-1641133002030508080.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__0__updateshape__2_3__updatewin-1641133002030508080.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__0__updateshape__2_3__updatewin3285453687476766879.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__0__updateshape__2_3__updatewin3285453687476766879.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1_2__updateshape__1___updatewi-2627349516123329495.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1_2__updateshape__1___updatewi-2627349516123329495.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1_2__updateshape__1___updatewi5639421007566031063.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1_2__updateshape__1___updatewi5639421007566031063.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1__updateshape__1_3__updatewin-4024738447497901356.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1__updateshape__1_3__updatewin-4024738447497901356.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1__updateshape__1_3__updatewin-4196632273973579364.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1__updateshape__1_3__updatewin-4196632273973579364.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_50_3__scatterindices__32__updateshape__1_3__updatew-740047246519077104.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_50_3__scatterindices__32__updateshape__1_3__updatew-740047246519077104.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_50_3__scatterindices__32__updateshape__1_3__updatew8128135906735836974.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_50_3__scatterindices__32__updateshape__1_3__updatew8128135906735836974.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1__scatterindices__0__updateshape____updatewindowdims-8617825293348157163.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1__scatterindices__0__updateshape____updatewindowdims-8617825293348157163.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1__scatterindices__0__updateshape____updatewindowdims710391022991851600.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1__scatterindices__0__updateshape____updatewindowdims710391022991851600.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat6791897860392195051.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat6791897860392195051.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat7462471797269110173.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat7462471797269110173.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_4_2_3__scatterindices__3_2__updateshape__2___updatewi1477502061111573603.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_4_2_3__scatterindices__3_2__updateshape__2___updatewi1477502061111573603.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_4_2_3__scatterindices__3_2__updateshape__2___updatewi58247371151849691.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_4_2_3__scatterindices__3_2__updateshape__2___updatewi58247371151849691.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_-2789322176808458196.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_-2789322176808458196.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_-4274140649884019517.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_-4274140649884019517.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u-6441999524429153529.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u-6441999524429153529.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u8666094006939621915.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u8666094006939621915.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0___1_____2___3____updatesha-1250379279784296323.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0___1_____2___3____updatesha-1250379279784296323.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0___1_____2___3____updatesha-2476939433263809573.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0___1_____2___3____updatesha-2476939433263809573.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_125__scatterindices__0__updateshape__1___updatewindo2641506595458680540.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_125__scatterindices__0__updateshape__1___updatewindo2641506595458680540.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_125__scatterindices__0__updateshape__1___updatewindo534641495725659400.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_125__scatterindices__0__updateshape__1___updatewindo534641495725659400.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_1_1__scatterindices__0__updateshape__1_1__updatewind1604574441012752035.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_1_1__scatterindices__0__updateshape__1_1__updatewind1604574441012752035.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_1_1__scatterindices__0__updateshape__1_1__updatewind2731002153338747654.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_1_1__scatterindices__0__updateshape__1_1__updatewind2731002153338747654.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_1__scatterindices__0__updateshape__1___updatewindowd2284374715751213946.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_1__scatterindices__0__updateshape__1___updatewindowd2284374715751213946.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_1__scatterindices__0__updateshape__1___updatewindowd2505509251588462368.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_1__scatterindices__0__updateshape__1___updatewindowd2505509251588462368.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__0__updateshape__2_3__updatewind-3487018839623291285.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__0__updateshape__2_3__updatewind-3487018839623291285.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__0__updateshape__2_3__updatewind-8604484497256600253.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__0__updateshape__2_3__updatewind-8604484497256600253.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1_2__updateshape__1___updatewin1380415797906781469.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1_2__updateshape__1___updatewin1380415797906781469.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1_2__updateshape__1___updatewin6374287187271323238.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1_2__updateshape__1___updatewin6374287187271323238.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1__updateshape__1_3__updatewind-1305194734761190035.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1__updateshape__1_3__updatewind-1305194734761190035.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1__updateshape__1_3__updatewind1678143756998009091.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1__updateshape__1_3__updatewind1678143756998009091.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_50_3__scatterindices__32__updateshape__1_3__updatewi-8078915839645359058.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_50_3__scatterindices__32__updateshape__1_3__updatewi-8078915839645359058.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_50_3__scatterindices__32__updateshape__1_3__updatewi-9185061050524067474.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_50_3__scatterindices__32__updateshape__1_3__updatewi-9185061050524067474.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1__scatterindices__0__updateshape____updatewindowdims_-4251074730763850716.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1__scatterindices__0__updateshape____updatewindowdims_-4251074730763850716.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1__scatterindices__0__updateshape____updatewindowdims_-6837146777463778467.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1__scatterindices__0__updateshape____updatewindowdims_-6837146777463778467.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-2442629959164459302.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-2442629959164459302.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_4_2_3_5__scatterindices__0_4__updateshape__4_3__update252259578072299482.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_4_2_3_5__scatterindices__0_4__updateshape__4_3__update252259578072299482.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_4_2_3__scatterindices__3_2__updateshape__2___updatewin5304681254417113664.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_4_2_3__scatterindices__3_2__updateshape__2___updatewin5304681254417113664.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_4_2_3__scatterindices__3_2__updateshape__2___updatewin8751159257015308632.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_4_2_3__scatterindices__3_2__updateshape__2___updatewin8751159257015308632.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__2224374599205381727.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__2224374599205381727.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__3481253470408735801.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__3481253470408735801.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-2206320351948067066.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-2206320351948067066.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up6159067232391152621.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up6159067232391152621.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0___1_____2___3____updateshap-7004792914768066328.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0___1_____2___3____updateshap-7004792914768066328.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0___1_____2___3____updateshap-8827782002690829532.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0___1_____2___3____updateshap-8827782002690829532.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_dtypes_shape_bfloat16_5__scatterindices___0___2___updateshape__2___updatewindowdims____inser-2930277789604541476.mlir
+++ b/stablehlo/testdata/scatter_dtypes_shape_bfloat16_5__scatterindices___0___2___updateshape__2___updatewindowdims____inser-2930277789604541476.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_dtypes_shape_bool_5__scatterindices___0___2___updateshape__2___updatewindowdims____insertedw-7999209774018819546.mlir
+++ b/stablehlo/testdata/scatter_dtypes_shape_bool_5__scatterindices___0___2___updateshape__2___updatewindowdims____insertedw-7999209774018819546.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_dtypes_shape_complex64_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse360406677792545150.mlir
+++ b/stablehlo/testdata/scatter_dtypes_shape_complex64_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse360406677792545150.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_dtypes_shape_float16_5__scatterindices___0___2___updateshape__2___updatewindowdims____insert-6208401960821428700.mlir
+++ b/stablehlo/testdata/scatter_dtypes_shape_float16_5__scatterindices___0___2___updateshape__2___updatewindowdims____insert-6208401960821428700.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_dtypes_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowdims____insert-8815115321991225803.mlir
+++ b/stablehlo/testdata/scatter_dtypes_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowdims____insert-8815115321991225803.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_dtypes_shape_int16_5__scatterindices___0___2___updateshape__2___updatewindowdims____inserted-279814041569566222.mlir
+++ b/stablehlo/testdata/scatter_dtypes_shape_int16_5__scatterindices___0___2___updateshape__2___updatewindowdims____inserted-279814041569566222.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_dtypes_shape_int32_5__scatterindices___0___2___updateshape__2___updatewindowdims____inserted392539518372500492.mlir
+++ b/stablehlo/testdata/scatter_dtypes_shape_int32_5__scatterindices___0___2___updateshape__2___updatewindowdims____inserted392539518372500492.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_dtypes_shape_int8_5__scatterindices___0___2___updateshape__2___updatewindowdims____insertedw-8449960834207282352.mlir
+++ b/stablehlo/testdata/scatter_dtypes_shape_int8_5__scatterindices___0___2___updateshape__2___updatewindowdims____insertedw-8449960834207282352.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_dtypes_shape_uint16_5__scatterindices___0___2___updateshape__2___updatewindowdims____inserte2451184385895379567.mlir
+++ b/stablehlo/testdata/scatter_dtypes_shape_uint16_5__scatterindices___0___2___updateshape__2___updatewindowdims____inserte2451184385895379567.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_dtypes_shape_uint32_5__scatterindices___0___2___updateshape__2___updatewindowdims____inserte-2961744518792924699.mlir
+++ b/stablehlo/testdata/scatter_dtypes_shape_uint32_5__scatterindices___0___2___updateshape__2___updatewindowdims____inserte-2961744518792924699.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_dtypes_shape_uint8_5__scatterindices___0___2___updateshape__2___updatewindowdims____inserted1788240898021135728.mlir
+++ b/stablehlo/testdata/scatter_dtypes_shape_uint8_5__scatterindices___0___2___updateshape__2___updatewindowdims____inserted1788240898021135728.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_dtypes_shape_bfloat16_5__scatterindices___0___2___updateshape__2___updatewindowdims____i-392861041873938592.mlir
+++ b/stablehlo/testdata/scatter_max_dtypes_shape_bfloat16_5__scatterindices___0___2___updateshape__2___updatewindowdims____i-392861041873938592.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_dtypes_shape_bool_5__scatterindices___0___2___updateshape__2___updatewindowdims____inser5683702453722149665.mlir
+++ b/stablehlo/testdata/scatter_max_dtypes_shape_bool_5__scatterindices___0___2___updateshape__2___updatewindowdims____inser5683702453722149665.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_dtypes_shape_complex64_5__scatterindices___0___2___updateshape__2___updatewindowdims____-6396961326923825596.mlir
+++ b/stablehlo/testdata/scatter_max_dtypes_shape_complex64_5__scatterindices___0___2___updateshape__2___updatewindowdims____-6396961326923825596.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_dtypes_shape_float16_5__scatterindices___0___2___updateshape__2___updatewindowdims____in1336689541491778229.mlir
+++ b/stablehlo/testdata/scatter_max_dtypes_shape_float16_5__scatterindices___0___2___updateshape__2___updatewindowdims____in1336689541491778229.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_dtypes_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowdims____in5989306877217321302.mlir
+++ b/stablehlo/testdata/scatter_max_dtypes_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowdims____in5989306877217321302.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_dtypes_shape_int16_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse-5829043612105941797.mlir
+++ b/stablehlo/testdata/scatter_max_dtypes_shape_int16_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse-5829043612105941797.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_dtypes_shape_int32_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse2177675569692235609.mlir
+++ b/stablehlo/testdata/scatter_max_dtypes_shape_int32_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse2177675569692235609.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_dtypes_shape_int8_5__scatterindices___0___2___updateshape__2___updatewindowdims____inser2469995342507633075.mlir
+++ b/stablehlo/testdata/scatter_max_dtypes_shape_int8_5__scatterindices___0___2___updateshape__2___updatewindowdims____inser2469995342507633075.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_dtypes_shape_uint16_5__scatterindices___0___2___updateshape__2___updatewindowdims____ins8815963655942062891.mlir
+++ b/stablehlo/testdata/scatter_max_dtypes_shape_uint16_5__scatterindices___0___2___updateshape__2___updatewindowdims____ins8815963655942062891.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_dtypes_shape_uint32_5__scatterindices___0___2___updateshape__2___updatewindowdims____ins5453280543548493478.mlir
+++ b/stablehlo/testdata/scatter_max_dtypes_shape_uint32_5__scatterindices___0___2___updateshape__2___updatewindowdims____ins5453280543548493478.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_dtypes_shape_uint8_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse-8556092368691638686.mlir
+++ b/stablehlo/testdata/scatter_max_dtypes_shape_uint8_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse-8556092368691638686.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowd-4390078863631050283.mlir
+++ b/stablehlo/testdata/scatter_max_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowd-4390078863631050283.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowd3210884206065312593.mlir
+++ b/stablehlo/testdata/scatter_max_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowd3210884206065312593.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatewindow1025456038908883704.mlir
+++ b/stablehlo/testdata/scatter_max_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatewindow1025456038908883704.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatewindow3237573494961686018.mlir
+++ b/stablehlo/testdata/scatter_max_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatewindow3237573494961686018.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_bfloat16_1__scatterindices___0___0___updateshape__2___up-7839859950408934269.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_bfloat16_1__scatterindices___0___0___updateshape__2___up-7839859950408934269.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_bfloat16_1__scatterindices___0___0___updateshape__2___up6942369263525378132.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_bfloat16_1__scatterindices___0___0___updateshape__2___up6942369263525378132.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_bfloat16_2_3__scatterindices____2___2___2____updateshape-7756467163902878913.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_bfloat16_2_3__scatterindices____2___2___2____updateshape-7756467163902878913.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_bfloat16_2_3__scatterindices____2___2___2____updateshape2214961252790317124.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_bfloat16_2_3__scatterindices____2___2___2____updateshape2214961252790317124.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_bfloat16_3_5_40__scatterindices___1___1___updateshape__3-8026909858088384599.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_bfloat16_3_5_40__scatterindices___1___1___updateshape__3-8026909858088384599.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_bfloat16_3_5_40__scatterindices___1___1___updateshape__3807314941237875241.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_bfloat16_3_5_40__scatterindices___1___1___updateshape__3807314941237875241.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_bfloat16_3_5_4__scatterindices___1___1___updateshape__3_-488454440685315220.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_bfloat16_3_5_4__scatterindices___1___1___updateshape__3_-488454440685315220.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_bfloat16_3_5_4__scatterindices___1___1___updateshape__3_-6003342809812860302.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_bfloat16_3_5_4__scatterindices___1___1___updateshape__3_-6003342809812860302.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_bfloat16_3__scatterindices___1___0___1___updateshape__3_-3973973289357598622.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_bfloat16_3__scatterindices___1___0___1___updateshape__3_-3973973289357598622.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_bfloat16_3__scatterindices___1___0___1___updateshape__3_4256773944042201098.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_bfloat16_3__scatterindices___1___0___1___updateshape__3_4256773944042201098.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float16_1__scatterindices___0___0___updateshape__2___upd3204989355605098687.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float16_1__scatterindices___0___0___updateshape__2___upd3204989355605098687.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float16_1__scatterindices___0___0___updateshape__2___upd8022799176354603242.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float16_1__scatterindices___0___0___updateshape__2___upd8022799176354603242.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float16_2_3__scatterindices____2___2___2____updateshape_3719304099671093957.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float16_2_3__scatterindices____2___2___2____updateshape_3719304099671093957.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float16_2_3__scatterindices____2___2___2____updateshape_7082877253723391854.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float16_2_3__scatterindices____2___2___2____updateshape_7082877253723391854.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float16_3_5_40__scatterindices___1___1___updateshape__3_-7938565271035863995.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float16_3_5_40__scatterindices___1___1___updateshape__3_-7938565271035863995.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float16_3_5_40__scatterindices___1___1___updateshape__3_6570978612883412575.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float16_3_5_40__scatterindices___1___1___updateshape__3_6570978612883412575.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float16_3_5_4__scatterindices___1___1___updateshape__3_2-7773190694039022277.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float16_3_5_4__scatterindices___1___1___updateshape__3_2-7773190694039022277.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float16_3_5_4__scatterindices___1___1___updateshape__3_27849137539433517548.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float16_3_5_4__scatterindices___1___1___updateshape__3_27849137539433517548.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float16_3__scatterindices___1___0___1___updateshape__3__-4810395954883699510.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float16_3__scatterindices___1___0___1___updateshape__3__-4810395954883699510.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float16_3__scatterindices___1___0___1___updateshape__3__6571579309048280685.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float16_3__scatterindices___1___0___1___updateshape__3__6571579309048280685.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float32_1__scatterindices___0___0___updateshape__2___upd-1844039835433546582.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float32_1__scatterindices___0___0___updateshape__2___upd-1844039835433546582.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float32_1__scatterindices___0___0___updateshape__2___upd4721539826240850833.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float32_1__scatterindices___0___0___updateshape__2___upd4721539826240850833.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float32_2_3__scatterindices____2___2___2____updateshape_-6493859547791056291.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float32_2_3__scatterindices____2___2___2____updateshape_-6493859547791056291.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float32_2_3__scatterindices____2___2___2____updateshape_-9093868482978590861.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float32_2_3__scatterindices____2___2___2____updateshape_-9093868482978590861.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float32_3_5_40__scatterindices___1___1___updateshape__3_3101807958862616076.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float32_3_5_40__scatterindices___1___1___updateshape__3_3101807958862616076.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float32_3_5_40__scatterindices___1___1___updateshape__3_7771598417814736050.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float32_3_5_40__scatterindices___1___1___updateshape__3_7771598417814736050.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float32_3_5_4__scatterindices___1___1___updateshape__3_2-4088478221285117728.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float32_3_5_4__scatterindices___1___1___updateshape__3_2-4088478221285117728.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float32_3_5_4__scatterindices___1___1___updateshape__3_25732955927815578406.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float32_3_5_4__scatterindices___1___1___updateshape__3_25732955927815578406.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float32_3__scatterindices___1___0___1___updateshape__3__-6639842389483865163.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float32_3__scatterindices___1___0___1___updateshape__3__-6639842389483865163.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float32_3__scatterindices___1___0___1___updateshape__3__7830488357588033204.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float32_3__scatterindices___1___0___1___updateshape__3__7830488357588033204.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int16_1__scatterindices___0___0___updateshape__2___updat6963600156708085907.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int16_1__scatterindices___0___0___updateshape__2___updat6963600156708085907.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int16_1__scatterindices___0___0___updateshape__2___updat8878416149102138078.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int16_1__scatterindices___0___0___updateshape__2___updat8878416149102138078.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int16_2_3__scatterindices____2___2___2____updateshape__2-7314731004182888952.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int16_2_3__scatterindices____2___2___2____updateshape__2-7314731004182888952.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int16_2_3__scatterindices____2___2___2____updateshape__21821906852332500498.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int16_2_3__scatterindices____2___2___2____updateshape__21821906852332500498.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int16_3_5_40__scatterindices___1___1___updateshape__3_5_4499147356245180063.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int16_3_5_40__scatterindices___1___1___updateshape__3_5_4499147356245180063.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int16_3_5_40__scatterindices___1___1___updateshape__3_5_9025587788653182690.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int16_3_5_40__scatterindices___1___1___updateshape__3_5_9025587788653182690.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int16_3_5_4__scatterindices___1___1___updateshape__3_2_4-583937543846099786.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int16_3_5_4__scatterindices___1___1___updateshape__3_2_4-583937543846099786.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int16_3_5_4__scatterindices___1___1___updateshape__3_2_4-7084715015461268786.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int16_3_5_4__scatterindices___1___1___updateshape__3_2_4-7084715015461268786.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int16_3__scatterindices___1___0___1___updateshape__3___u-7412834368070813317.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int16_3__scatterindices___1___0___1___updateshape__3___u-7412834368070813317.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int16_3__scatterindices___1___0___1___updateshape__3___u-7485079511943524453.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int16_3__scatterindices___1___0___1___updateshape__3___u-7485079511943524453.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int32_1__scatterindices___0___0___updateshape__2___updat-2821015016578538976.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int32_1__scatterindices___0___0___updateshape__2___updat-2821015016578538976.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int32_1__scatterindices___0___0___updateshape__2___updat-4363515628628173317.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int32_1__scatterindices___0___0___updateshape__2___updat-4363515628628173317.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int32_2_3__scatterindices____2___2___2____updateshape__2-8552418276306640556.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int32_2_3__scatterindices____2___2___2____updateshape__2-8552418276306640556.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int32_2_3__scatterindices____2___2___2____updateshape__26232119252440644995.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int32_2_3__scatterindices____2___2___2____updateshape__26232119252440644995.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int32_3_5_40__scatterindices___1___1___updateshape__3_5_1762756447761634290.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int32_3_5_40__scatterindices___1___1___updateshape__3_5_1762756447761634290.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int32_3_5_40__scatterindices___1___1___updateshape__3_5_370064940315831604.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int32_3_5_40__scatterindices___1___1___updateshape__3_5_370064940315831604.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int32_3_5_4__scatterindices___1___1___updateshape__3_2_4-5091538715183112685.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int32_3_5_4__scatterindices___1___1___updateshape__3_2_4-5091538715183112685.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int32_3_5_4__scatterindices___1___1___updateshape__3_2_4-5230031465544313104.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int32_3_5_4__scatterindices___1___1___updateshape__3_2_4-5230031465544313104.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int32_3__scatterindices___1___0___1___updateshape__3___u745960711584405074.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int32_3__scatterindices___1___0___1___updateshape__3___u745960711584405074.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int32_3__scatterindices___1___0___1___updateshape__3___u7474826191716339973.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int32_3__scatterindices___1___0___1___updateshape__3___u7474826191716339973.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int8_1__scatterindices___0___0___updateshape__2___update-5394974141977995339.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int8_1__scatterindices___0___0___updateshape__2___update-5394974141977995339.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int8_1__scatterindices___0___0___updateshape__2___update3840665188349095112.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int8_1__scatterindices___0___0___updateshape__2___update3840665188349095112.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int8_2_3__scatterindices____2___2___2____updateshape__2_6576008549206823569.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int8_2_3__scatterindices____2___2___2____updateshape__2_6576008549206823569.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int8_2_3__scatterindices____2___2___2____updateshape__2_8145936191260086532.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int8_2_3__scatterindices____2___2___2____updateshape__2_8145936191260086532.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int8_3_5_40__scatterindices___1___1___updateshape__3_5_2-3817844005059537029.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int8_3_5_40__scatterindices___1___1___updateshape__3_5_2-3817844005059537029.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int8_3_5_40__scatterindices___1___1___updateshape__3_5_2454799236677986965.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int8_3_5_40__scatterindices___1___1___updateshape__3_5_2454799236677986965.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int8_3_5_4__scatterindices___1___1___updateshape__3_2_4_-704981458838703190.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int8_3_5_4__scatterindices___1___1___updateshape__3_2_4_-704981458838703190.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int8_3_5_4__scatterindices___1___1___updateshape__3_2_4_6593676401126510993.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int8_3_5_4__scatterindices___1___1___updateshape__3_2_4_6593676401126510993.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int8_3__scatterindices___1___0___1___updateshape__3___up-1167360532793909946.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int8_3__scatterindices___1___0___1___updateshape__3___up-1167360532793909946.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int8_3__scatterindices___1___0___1___updateshape__3___up-8298869919665076145.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int8_3__scatterindices___1___0___1___updateshape__3___up-8298869919665076145.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint16_1__scatterindices___0___0___updateshape__2___upda161921840649824051.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint16_1__scatterindices___0___0___updateshape__2___upda161921840649824051.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint16_1__scatterindices___0___0___updateshape__2___upda3735630494581482059.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint16_1__scatterindices___0___0___updateshape__2___upda3735630494581482059.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint16_2_3__scatterindices____2___2___2____updateshape__2688714887801807388.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint16_2_3__scatterindices____2___2___2____updateshape__2688714887801807388.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint16_2_3__scatterindices____2___2___2____updateshape__8361960485238181174.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint16_2_3__scatterindices____2___2___2____updateshape__8361960485238181174.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint16_3_5_40__scatterindices___1___1___updateshape__3_5-5809831560180248311.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint16_3_5_40__scatterindices___1___1___updateshape__3_5-5809831560180248311.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint16_3_5_40__scatterindices___1___1___updateshape__3_56857962009318709386.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint16_3_5_40__scatterindices___1___1___updateshape__3_56857962009318709386.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint16_3_5_4__scatterindices___1___1___updateshape__3_2_-2304007480951039088.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint16_3_5_4__scatterindices___1___1___updateshape__3_2_-2304007480951039088.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint16_3_5_4__scatterindices___1___1___updateshape__3_2_5459370073862717448.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint16_3_5_4__scatterindices___1___1___updateshape__3_2_5459370073862717448.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint16_3__scatterindices___1___0___1___updateshape__3___-4638989347349221305.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint16_3__scatterindices___1___0___1___updateshape__3___-4638989347349221305.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint16_3__scatterindices___1___0___1___updateshape__3___5197437071204231332.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint16_3__scatterindices___1___0___1___updateshape__3___5197437071204231332.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint32_1__scatterindices___0___0___updateshape__2___upda-5033170067209841298.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint32_1__scatterindices___0___0___updateshape__2___upda-5033170067209841298.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint32_1__scatterindices___0___0___updateshape__2___upda3405531792482433818.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint32_1__scatterindices___0___0___updateshape__2___upda3405531792482433818.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint32_2_3__scatterindices____2___2___2____updateshape__-3874832709047427655.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint32_2_3__scatterindices____2___2___2____updateshape__-3874832709047427655.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint32_2_3__scatterindices____2___2___2____updateshape__-6809006410571346051.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint32_2_3__scatterindices____2___2___2____updateshape__-6809006410571346051.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint32_3_5_40__scatterindices___1___1___updateshape__3_5-8087282932593150333.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint32_3_5_40__scatterindices___1___1___updateshape__3_5-8087282932593150333.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint32_3_5_40__scatterindices___1___1___updateshape__3_53752717208774607143.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint32_3_5_40__scatterindices___1___1___updateshape__3_53752717208774607143.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint32_3_5_4__scatterindices___1___1___updateshape__3_2_-9119104572226652429.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint32_3_5_4__scatterindices___1___1___updateshape__3_2_-9119104572226652429.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint32_3_5_4__scatterindices___1___1___updateshape__3_2_9027081709691489580.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint32_3_5_4__scatterindices___1___1___updateshape__3_2_9027081709691489580.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint32_3__scatterindices___1___0___1___updateshape__3___-2824440249156885329.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint32_3__scatterindices___1___0___1___updateshape__3___-2824440249156885329.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint32_3__scatterindices___1___0___1___updateshape__3___4204330477043591502.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint32_3__scatterindices___1___0___1___updateshape__3___4204330477043591502.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint8_1__scatterindices___0___0___updateshape__2___updat-1928048275487284072.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint8_1__scatterindices___0___0___updateshape__2___updat-1928048275487284072.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint8_1__scatterindices___0___0___updateshape__2___updat-5645493756063806586.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint8_1__scatterindices___0___0___updateshape__2___updat-5645493756063806586.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint8_2_3__scatterindices____2___2___2____updateshape__2-4849279551096494062.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint8_2_3__scatterindices____2___2___2____updateshape__2-4849279551096494062.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint8_2_3__scatterindices____2___2___2____updateshape__2-5015570983650787750.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint8_2_3__scatterindices____2___2___2____updateshape__2-5015570983650787750.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint8_3_5_40__scatterindices___1___1___updateshape__3_5_-6488793373393055668.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint8_3_5_40__scatterindices___1___1___updateshape__3_5_-6488793373393055668.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint8_3_5_40__scatterindices___1___1___updateshape__3_5_2876137255340148048.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint8_3_5_40__scatterindices___1___1___updateshape__3_5_2876137255340148048.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint8_3_5_4__scatterindices___1___1___updateshape__3_2_4-5468250991339657190.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint8_3_5_4__scatterindices___1___1___updateshape__3_2_4-5468250991339657190.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint8_3_5_4__scatterindices___1___1___updateshape__3_2_46597706213966163723.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint8_3_5_4__scatterindices___1___1___updateshape__3_2_46597706213966163723.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint8_3__scatterindices___1___0___1___updateshape__3___u8008517684702321245.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint8_3__scatterindices___1___0___1___updateshape__3___u8008517684702321245.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint8_3__scatterindices___1___0___1___updateshape__3___u8952013310211685863.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint8_3__scatterindices___1___0___1___updateshape__3___u8952013310211685863.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_125__scatterindices__0__updateshape__1___updatewi-7951316018913039515.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_125__scatterindices__0__updateshape__1___updatewi-7951316018913039515.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_125__scatterindices__0__updateshape__1___updatewi6702824425361821392.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_125__scatterindices__0__updateshape__1___updatewi6702824425361821392.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_1_1__scatterindices__0__updateshape__1_1__updatew-5972702966998148248.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_1_1__scatterindices__0__updateshape__1_1__updatew-5972702966998148248.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_1_1__scatterindices__0__updateshape__1_1__updatew1407841965061306462.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_1_1__scatterindices__0__updateshape__1_1__updatew1407841965061306462.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_1__scatterindices__0__updateshape__1___updatewind-3943852519473722017.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_1__scatterindices__0__updateshape__1___updatewind-3943852519473722017.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_1__scatterindices__0__updateshape__1___updatewind127580504216186793.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_1__scatterindices__0__updateshape__1___updatewind127580504216186793.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__0__updateshape__2_3__updatew-7506540865680037479.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__0__updateshape__2_3__updatew-7506540865680037479.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__0__updateshape__2_3__updatew5584184258335034500.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__0__updateshape__2_3__updatew5584184258335034500.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1_2__updateshape__1___update-4251555005392764840.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1_2__updateshape__1___update-4251555005392764840.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1_2__updateshape__1___update-5229134625950574353.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1_2__updateshape__1___update-5229134625950574353.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1__updateshape__1_3__updatew-3961914136394634324.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1__updateshape__1_3__updatew-3961914136394634324.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1__updateshape__1_3__updatew3401137719720140593.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1__updateshape__1_3__updatew3401137719720140593.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_50_3__scatterindices__32__updateshape__1_3__updat2982281935440931080.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_50_3__scatterindices__32__updateshape__1_3__updat2982281935440931080.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_50_3__scatterindices__32__updateshape__1_3__updat3084121004419047144.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_50_3__scatterindices__32__updateshape__1_3__updat3084121004419047144.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1__scatterindices__0__updateshape____updatewindowdi2750489734415423653.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1__scatterindices__0__updateshape____updatewindowdi2750489734415423653.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1__scatterindices__0__updateshape____updatewindowdi5124668511842850918.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1__scatterindices__0__updateshape____updatewindowdi5124668511842850918.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upd-6081757470381034206.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upd-6081757470381034206.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upd3885288221741258848.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upd3885288221741258848.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_4_2_3__scatterindices__3_2__updateshape__2___update7364310318843531288.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_4_2_3__scatterindices__3_2__updateshape__2___update7364310318843531288.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_4_2_3__scatterindices__3_2__updateshape__2___update8372352202104151718.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_4_2_3__scatterindices__3_2__updateshape__2___update8372352202104151718.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices___0_1___2_3___updateshape__2_-6857933840613967855.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices___0_1___2_3___updateshape__2_-6857933840613967855.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices___0_1___2_3___updateshape__2_1854402682370088797.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices___0_1___2_3___updateshape__2_1854402682370088797.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2___-4664842944644532288.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2___-4664842944644532288.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2___-4912124039036857606.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2___-4912124039036857606.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0___1_____2___3____updates8425066511028864359.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0___1_____2___3____updates8425066511028864359.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0___1_____2___3____updates9039479434269282771.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0___1_____2___3____updates9039479434269282771.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_125__scatterindices__0__updateshape__1___updatewin-8731115509034630074.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_125__scatterindices__0__updateshape__1___updatewin-8731115509034630074.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_125__scatterindices__0__updateshape__1___updatewin5456048288023940070.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_125__scatterindices__0__updateshape__1___updatewin5456048288023940070.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_1_1__scatterindices__0__updateshape__1_1__updatewi-7461026489300552530.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_1_1__scatterindices__0__updateshape__1_1__updatewi-7461026489300552530.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_1_1__scatterindices__0__updateshape__1_1__updatewi7584067801932672436.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_1_1__scatterindices__0__updateshape__1_1__updatewi7584067801932672436.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_1__scatterindices__0__updateshape__1___updatewindo6262511284222583383.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_1__scatterindices__0__updateshape__1___updatewindo6262511284222583383.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_1__scatterindices__0__updateshape__1___updatewindo826934003937973373.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_1__scatterindices__0__updateshape__1___updatewindo826934003937973373.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__0__updateshape__2_3__updatewi-413052865564151320.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__0__updateshape__2_3__updatewi-413052865564151320.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__0__updateshape__2_3__updatewi4461960695973448237.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__0__updateshape__2_3__updatewi4461960695973448237.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1_2__updateshape__1___updatew-5801480997889705312.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1_2__updateshape__1___updatew-5801480997889705312.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1_2__updateshape__1___updatew8160063217424680651.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1_2__updateshape__1___updatew8160063217424680651.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1__updateshape__1_3__updatewi-2327934312904943306.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1__updateshape__1_3__updatewi-2327934312904943306.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1__updateshape__1_3__updatewi-5939485743090244293.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1__updateshape__1_3__updatewi-5939485743090244293.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_50_3__scatterindices__32__updateshape__1_3__update-6025244686982047499.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_50_3__scatterindices__32__updateshape__1_3__update-6025244686982047499.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_50_3__scatterindices__32__updateshape__1_3__update3446534180989259789.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_50_3__scatterindices__32__updateshape__1_3__update3446534180989259789.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1__scatterindices__0__updateshape____updatewindowdim-5250745436348551263.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1__scatterindices__0__updateshape____updatewindowdim-5250745436348551263.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1__scatterindices__0__updateshape____updatewindowdim7739733770160348375.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1__scatterindices__0__updateshape____updatewindowdim7739733770160348375.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda-3538272321874794861.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda-3538272321874794861.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda-392663043202175784.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda-392663043202175784.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_4_2_3__scatterindices__3_2__updateshape__2___updatew-2440309485513542178.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_4_2_3__scatterindices__3_2__updateshape__2___updatew-2440309485513542178.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_4_2_3__scatterindices__3_2__updateshape__2___updatew7426129206573115753.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_4_2_3__scatterindices__3_2__updateshape__2___updatew7426129206573115753.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7-159451342797418259.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7-159451342797418259.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7-5578923499037233624.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7-5578923499037233624.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____-2444622237702936986.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____-2444622237702936986.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____-7757199019071415531.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____-7757199019071415531.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0___1_____2___3____updatesh-3136091413228841764.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0___1_____2___3____updatesh-3136091413228841764.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0___1_____2___3____updatesh-6758286671672048533.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0___1_____2___3____updatesh-6758286671672048533.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewin6630480169388456900.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewin6630480169388456900.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewin8572492367628107196.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewin8572492367628107196.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__updatewi-7371943639734852459.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__updatewi-7371943639734852459.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__updatewi4068384492096779511.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__updatewi4068384492096779511.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___updatewindo-2154616836031129399.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___updatewindo-2154616836031129399.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___updatewindo8211732968977781634.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___updatewindo8211732968977781634.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatewi1964705741470670687.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatewi1964705741470670687.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatewi8565875730962467804.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatewi8565875730962467804.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___updatew-404205633388340906.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___updatew-404205633388340906.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___updatew3237864401487247669.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___updatew3237864401487247669.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatewi-2067769420489394878.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatewi-2067769420489394878.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatewi-6579002509224460796.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatewi-6579002509224460796.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__update-2859679405862166530.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__update-2859679405862166530.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__update-7634215713295217725.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__update-7634215713295217725.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdim-8284545332321621723.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdim-8284545332321621723.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdim2552856992181958030.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdim2552856992181958030.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda-2412234970495546907.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda-2412234970495546907.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda453838035690433383.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda453838035690433383.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___updatew-7533059538631912228.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___updatew-7533059538631912228.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___updatew3375484086611496655.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___updatew3375484086611496655.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7-3920948015976371115.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7-3920948015976371115.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7-7515156318392282609.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7-7515156318392282609.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____-1170955320691764183.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____-1170955320691764183.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____2313902312206829190.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____2313902312206829190.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____updatesh-7684033199204675714.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____updatesh-7684033199204675714.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____updatesh3178105627475464119.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____updatesh3178105627475464119.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_125__scatterindices__0__updateshape__1___updatewindo-3654291814679525556.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_125__scatterindices__0__updateshape__1___updatewindo-3654291814679525556.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_125__scatterindices__0__updateshape__1___updatewindo-871221408395309914.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_125__scatterindices__0__updateshape__1___updatewindo-871221408395309914.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_1_1__scatterindices__0__updateshape__1_1__updatewind-1266270276664743071.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_1_1__scatterindices__0__updateshape__1_1__updatewind-1266270276664743071.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_1_1__scatterindices__0__updateshape__1_1__updatewind7510692379337228912.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_1_1__scatterindices__0__updateshape__1_1__updatewind7510692379337228912.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_1__scatterindices__0__updateshape__1___updatewindowd-5539344497814516958.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_1__scatterindices__0__updateshape__1___updatewindowd-5539344497814516958.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_1__scatterindices__0__updateshape__1___updatewindowd628686664965122633.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_1__scatterindices__0__updateshape__1___updatewindowd628686664965122633.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__0__updateshape__2_3__updatewind-7281596825748537654.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__0__updateshape__2_3__updatewind-7281596825748537654.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__0__updateshape__2_3__updatewind343624490879144246.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__0__updateshape__2_3__updatewind343624490879144246.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1_2__updateshape__1___updatewin-9130298215407344948.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1_2__updateshape__1___updatewin-9130298215407344948.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1_2__updateshape__1___updatewin29170760427750106.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1_2__updateshape__1___updatewin29170760427750106.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1__updateshape__1_3__updatewind6199941392158014970.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1__updateshape__1_3__updatewind6199941392158014970.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1__updateshape__1_3__updatewind7584387903479037346.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1__updateshape__1_3__updatewind7584387903479037346.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_50_3__scatterindices__32__updateshape__1_3__updatewi645749440987017403.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_50_3__scatterindices__32__updateshape__1_3__updatewi645749440987017403.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_50_3__scatterindices__32__updateshape__1_3__updatewi7756715673163114539.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_50_3__scatterindices__32__updateshape__1_3__updatewi7756715673163114539.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1__scatterindices__0__updateshape____updatewindowdims_-3679121800625812234.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1__scatterindices__0__updateshape____updatewindowdims_-3679121800625812234.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1__scatterindices__0__updateshape____updatewindowdims_-8475013276026304217.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1__scatterindices__0__updateshape____updatewindowdims_-8475013276026304217.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_4_2_3_5__scatterindices__0_4__updateshape__4_3__update5145103864147144487.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_4_2_3_5__scatterindices__0_4__updateshape__4_3__update5145103864147144487.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_4_2_3_5__scatterindices__0_4__updateshape__4_3__update5305151552116457906.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_4_2_3_5__scatterindices__0_4__updateshape__4_3__update5305151552116457906.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_4_2_3__scatterindices__3_2__updateshape__2___updatewin6273731547009376844.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_4_2_3__scatterindices__3_2__updateshape__2___updatewin6273731547009376844.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_4_2_3__scatterindices__3_2__updateshape__2___updatewin942858064976496756.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_4_2_3__scatterindices__3_2__updateshape__2___updatewin942858064976496756.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-3444864293038376401.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-3444864293038376401.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-7188394306654795863.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-7188394306654795863.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up7107157064561570510.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up7107157064561570510.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up7387677201127024645.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up7387677201127024645.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0___1_____2___3____updateshap-8046792862695677092.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0___1_____2___3____updateshap-8046792862695677092.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0___1_____2___3____updateshap6673711492997861910.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0___1_____2___3____updateshap6673711492997861910.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_125__scatterindices__0__updateshape__1___updatewindo4656103149856539072.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_125__scatterindices__0__updateshape__1___updatewindo4656103149856539072.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_125__scatterindices__0__updateshape__1___updatewindo6174606093632257094.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_125__scatterindices__0__updateshape__1___updatewindo6174606093632257094.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_1_1__scatterindices__0__updateshape__1_1__updatewind7605846626881629019.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_1_1__scatterindices__0__updateshape__1_1__updatewind7605846626881629019.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_1_1__scatterindices__0__updateshape__1_1__updatewind8480432924465288348.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_1_1__scatterindices__0__updateshape__1_1__updatewind8480432924465288348.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_1__scatterindices__0__updateshape__1___updatewindowd-1521835621444368318.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_1__scatterindices__0__updateshape__1___updatewindowd-1521835621444368318.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_1__scatterindices__0__updateshape__1___updatewindowd-169679448021614044.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_1__scatterindices__0__updateshape__1___updatewindowd-169679448021614044.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__0__updateshape__2_3__updatewind8659525051222717199.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__0__updateshape__2_3__updatewind8659525051222717199.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__0__updateshape__2_3__updatewind9221825623425246191.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__0__updateshape__2_3__updatewind9221825623425246191.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1_2__updateshape__1___updatewin-1243305172105270209.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1_2__updateshape__1___updatewin-1243305172105270209.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1_2__updateshape__1___updatewin2903989190550323920.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1_2__updateshape__1___updatewin2903989190550323920.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1__updateshape__1_3__updatewind8114183208411738953.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1__updateshape__1_3__updatewind8114183208411738953.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1__updateshape__1_3__updatewind9011474719121171092.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1__updateshape__1_3__updatewind9011474719121171092.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_50_3__scatterindices__32__updateshape__1_3__updatewi-1609030670137173878.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_50_3__scatterindices__32__updateshape__1_3__updatewi-1609030670137173878.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_50_3__scatterindices__32__updateshape__1_3__updatewi3133214799466578856.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_50_3__scatterindices__32__updateshape__1_3__updatewi3133214799466578856.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1__scatterindices__0__updateshape____updatewindowdims_-1135572076354273511.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1__scatterindices__0__updateshape____updatewindowdims_-1135572076354273511.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1__scatterindices__0__updateshape____updatewindowdims_-3604859808534884877.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1__scatterindices__0__updateshape____updatewindowdims_-3604859808534884877.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_4_2_3_5__scatterindices__0_4__updateshape__4_3__update4471163082483622438.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_4_2_3_5__scatterindices__0_4__updateshape__4_3__update4471163082483622438.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_4_2_3_5__scatterindices__0_4__updateshape__4_3__update6384155601706297380.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_4_2_3_5__scatterindices__0_4__updateshape__4_3__update6384155601706297380.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_4_2_3__scatterindices__3_2__updateshape__2___updatewin-4610183090425207438.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_4_2_3__scatterindices__3_2__updateshape__2___updatewin-4610183090425207438.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_4_2_3__scatterindices__3_2__updateshape__2___updatewin-8061986652111493245.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_4_2_3__scatterindices__3_2__updateshape__2___updatewin-8061986652111493245.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-163470273381609128.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-163470273381609128.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-18573880227059666.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-18573880227059666.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-3276982532932579518.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-3276982532932579518.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-4337912569205295127.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-4337912569205295127.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0___1_____2___3____updateshap-464904247894401737.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0___1_____2___3____updateshap-464904247894401737.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0___1_____2___3____updateshap164430147412181105.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0___1_____2___3____updateshap164430147412181105.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_125__scatterindices__0__updateshape__1___updatewindow-8386886293990609168.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_125__scatterindices__0__updateshape__1___updatewindow-8386886293990609168.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_125__scatterindices__0__updateshape__1___updatewindow6998811498039155782.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_125__scatterindices__0__updateshape__1___updatewindow6998811498039155782.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_1_1__scatterindices__0__updateshape__1_1__updatewindo-166998336338534843.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_1_1__scatterindices__0__updateshape__1_1__updatewindo-166998336338534843.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_1_1__scatterindices__0__updateshape__1_1__updatewindo4171420055510686488.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_1_1__scatterindices__0__updateshape__1_1__updatewindo4171420055510686488.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_1__scatterindices__0__updateshape__1___updatewindowdi2814190485852129409.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_1__scatterindices__0__updateshape__1___updatewindowdi2814190485852129409.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_1__scatterindices__0__updateshape__1___updatewindowdi3666386104836301017.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_1__scatterindices__0__updateshape__1___updatewindowdi3666386104836301017.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__0__updateshape__2_3__updatewindo-4820753800701744168.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__0__updateshape__2_3__updatewindo-4820753800701744168.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__0__updateshape__2_3__updatewindo6247082404024764138.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__0__updateshape__2_3__updatewindo6247082404024764138.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1_2__updateshape__1___updatewind-4394756924061263821.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1_2__updateshape__1___updatewind-4394756924061263821.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1_2__updateshape__1___updatewind8730101061849356499.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1_2__updateshape__1___updatewind8730101061849356499.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1__updateshape__1_3__updatewindo-229339135565173539.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1__updateshape__1_3__updatewindo-229339135565173539.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1__updateshape__1_3__updatewindo1356973389398030785.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1__updateshape__1_3__updatewindo1356973389398030785.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_50_3__scatterindices__32__updateshape__1_3__updatewin-2721867853299623403.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_50_3__scatterindices__32__updateshape__1_3__updatewin-2721867853299623403.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_50_3__scatterindices__32__updateshape__1_3__updatewin-8208861813110223290.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_50_3__scatterindices__32__updateshape__1_3__updatewin-8208861813110223290.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1__scatterindices__0__updateshape____updatewindowdims__-6373449430230855376.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1__scatterindices__0__updateshape____updatewindowdims__-6373449430230855376.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1__scatterindices__0__updateshape____updatewindowdims__7302486127658143934.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1__scatterindices__0__updateshape____updatewindowdims__7302486127658143934.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatew360761962830156288.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatew360761962830156288.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatew8812456315477330015.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatew8812456315477330015.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_4_2_3__scatterindices__3_2__updateshape__2___updatewind-78009980723520832.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_4_2_3__scatterindices__3_2__updateshape__2___updatewind-78009980723520832.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_4_2_3__scatterindices__3_2__updateshape__2___updatewind231526804584745672.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_4_2_3__scatterindices__3_2__updateshape__2___updatewind231526804584745672.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__u3069527597941492880.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__u3069527597941492880.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__u6138003060915204942.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__u6138003060915204942.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upd-3453535066437865765.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upd-3453535066437865765.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upd7484757335449695351.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upd7484757335449695351.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0___1_____2___3____updateshape2008502797251229853.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0___1_____2___3____updateshape2008502797251229853.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0___1_____2___3____updateshape9059928969943241058.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0___1_____2___3____updateshape9059928969943241058.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_125__scatterindices__0__updateshape__1___updatewind-6752944464245862548.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_125__scatterindices__0__updateshape__1___updatewind-6752944464245862548.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_125__scatterindices__0__updateshape__1___updatewind-6808379694680963614.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_125__scatterindices__0__updateshape__1___updatewind-6808379694680963614.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_1_1__scatterindices__0__updateshape__1_1__updatewin1465340387020024301.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_1_1__scatterindices__0__updateshape__1_1__updatewin1465340387020024301.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_1_1__scatterindices__0__updateshape__1_1__updatewin5254831785028503037.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_1_1__scatterindices__0__updateshape__1_1__updatewin5254831785028503037.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_1__scatterindices__0__updateshape__1___updatewindow-6162849774345350374.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_1__scatterindices__0__updateshape__1___updatewindow-6162849774345350374.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_1__scatterindices__0__updateshape__1___updatewindow2124728795437520929.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_1__scatterindices__0__updateshape__1___updatewindow2124728795437520929.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__0__updateshape__2_3__updatewin2617421260401081730.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__0__updateshape__2_3__updatewin2617421260401081730.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__0__updateshape__2_3__updatewin8448822445776111624.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__0__updateshape__2_3__updatewin8448822445776111624.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1_2__updateshape__1___updatewi-4016152869797095665.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1_2__updateshape__1___updatewi-4016152869797095665.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1_2__updateshape__1___updatewi2385945470013585710.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1_2__updateshape__1___updatewi2385945470013585710.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1__updateshape__1_3__updatewin2679635985562700073.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1__updateshape__1_3__updatewin2679635985562700073.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1__updateshape__1_3__updatewin7808601965039850272.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1__updateshape__1_3__updatewin7808601965039850272.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_50_3__scatterindices__32__updateshape__1_3__updatew-1160369651841163817.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_50_3__scatterindices__32__updateshape__1_3__updatew-1160369651841163817.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_50_3__scatterindices__32__updateshape__1_3__updatew2441965319563582007.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_50_3__scatterindices__32__updateshape__1_3__updatew2441965319563582007.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1__scatterindices__0__updateshape____updatewindowdims-4284546542326456679.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1__scatterindices__0__updateshape____updatewindowdims-4284546542326456679.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1__scatterindices__0__updateshape____updatewindowdims-4941197402186890645.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1__scatterindices__0__updateshape____updatewindowdims-4941197402186890645.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat5717897549646019228.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat5717897549646019228.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat8983247923438467165.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat8983247923438467165.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_4_2_3__scatterindices__3_2__updateshape__2___updatewi-1489473092002645628.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_4_2_3__scatterindices__3_2__updateshape__2___updatewi-1489473092002645628.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_4_2_3__scatterindices__3_2__updateshape__2___updatewi4907939457090036648.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_4_2_3__scatterindices__3_2__updateshape__2___updatewi4907939457090036648.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_-231979961555022713.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_-231979961555022713.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_8754120654496972949.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_8754120654496972949.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u6156571203190694208.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u6156571203190694208.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u7653219651823671808.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u7653219651823671808.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0___1_____2___3____updatesha3560960001983197772.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0___1_____2___3____updatesha3560960001983197772.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0___1_____2___3____updatesha6359168246041175228.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0___1_____2___3____updatesha6359168246041175228.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_125__scatterindices__0__updateshape__1___updatewind-3688988568462201922.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_125__scatterindices__0__updateshape__1___updatewind-3688988568462201922.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_125__scatterindices__0__updateshape__1___updatewind2534325557785002654.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_125__scatterindices__0__updateshape__1___updatewind2534325557785002654.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_1_1__scatterindices__0__updateshape__1_1__updatewin-8530351583768892932.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_1_1__scatterindices__0__updateshape__1_1__updatewin-8530351583768892932.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_1_1__scatterindices__0__updateshape__1_1__updatewin2336848997200141272.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_1_1__scatterindices__0__updateshape__1_1__updatewin2336848997200141272.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_1__scatterindices__0__updateshape__1___updatewindow-1949369266602443161.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_1__scatterindices__0__updateshape__1___updatewindow-1949369266602443161.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_1__scatterindices__0__updateshape__1___updatewindow1516144548387135784.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_1__scatterindices__0__updateshape__1___updatewindow1516144548387135784.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__0__updateshape__2_3__updatewin-312996440089190260.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__0__updateshape__2_3__updatewin-312996440089190260.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__0__updateshape__2_3__updatewin-3855556489712161194.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__0__updateshape__2_3__updatewin-3855556489712161194.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1_2__updateshape__1___updatewi1703169112067469677.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1_2__updateshape__1___updatewi1703169112067469677.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1_2__updateshape__1___updatewi618583376894179380.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1_2__updateshape__1___updatewi618583376894179380.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1__updateshape__1_3__updatewin-5501066061188023133.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1__updateshape__1_3__updatewin-5501066061188023133.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1__updateshape__1_3__updatewin8255429920127766752.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1__updateshape__1_3__updatewin8255429920127766752.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_50_3__scatterindices__32__updateshape__1_3__updatew-3145522822460544824.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_50_3__scatterindices__32__updateshape__1_3__updatew-3145522822460544824.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_50_3__scatterindices__32__updateshape__1_3__updatew8234721788552425508.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_50_3__scatterindices__32__updateshape__1_3__updatew8234721788552425508.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1__scatterindices__0__updateshape____updatewindowdims-7729688490175977200.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1__scatterindices__0__updateshape____updatewindowdims-7729688490175977200.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1__scatterindices__0__updateshape____updatewindowdims4711489216670640103.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1__scatterindices__0__updateshape____updatewindowdims4711489216670640103.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat6275639048557222837.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat6275639048557222837.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat6576522988704498337.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat6576522988704498337.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_4_2_3__scatterindices__3_2__updateshape__2___updatewi2066102519051268717.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_4_2_3__scatterindices__3_2__updateshape__2___updatewi2066102519051268717.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_4_2_3__scatterindices__3_2__updateshape__2___updatewi6905061648456258990.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_4_2_3__scatterindices__3_2__updateshape__2___updatewi6905061648456258990.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_-4268300808812953018.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_-4268300808812953018.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_-9153478667077725183.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_-9153478667077725183.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u-6157939275883288533.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u-6157939275883288533.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u8511265051077457043.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u8511265051077457043.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0___1_____2___3____updatesha-2091136672711357126.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0___1_____2___3____updatesha-2091136672711357126.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0___1_____2___3____updatesha796353546737293148.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0___1_____2___3____updatesha796353546737293148.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_125__scatterindices__0__updateshape__1___updatewindo2689091551362511366.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_125__scatterindices__0__updateshape__1___updatewindo2689091551362511366.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_125__scatterindices__0__updateshape__1___updatewindo3624303292444803106.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_125__scatterindices__0__updateshape__1___updatewindo3624303292444803106.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_1_1__scatterindices__0__updateshape__1_1__updatewind-8504773445311031845.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_1_1__scatterindices__0__updateshape__1_1__updatewind-8504773445311031845.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_1_1__scatterindices__0__updateshape__1_1__updatewind8076236772147644448.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_1_1__scatterindices__0__updateshape__1_1__updatewind8076236772147644448.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_1__scatterindices__0__updateshape__1___updatewindowd-1579650891753513969.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_1__scatterindices__0__updateshape__1___updatewindowd-1579650891753513969.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_1__scatterindices__0__updateshape__1___updatewindowd6935007064526363979.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_1__scatterindices__0__updateshape__1___updatewindowd6935007064526363979.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__0__updateshape__2_3__updatewind-2961218062536580227.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__0__updateshape__2_3__updatewind-2961218062536580227.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__0__updateshape__2_3__updatewind2771680170207766950.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__0__updateshape__2_3__updatewind2771680170207766950.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1_2__updateshape__1___updatewin1983890828044820225.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1_2__updateshape__1___updatewin1983890828044820225.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1_2__updateshape__1___updatewin62016766260514297.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1_2__updateshape__1___updatewin62016766260514297.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1__updateshape__1_3__updatewind-692020949637620008.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1__updateshape__1_3__updatewind-692020949637620008.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1__updateshape__1_3__updatewind7583448234884642512.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1__updateshape__1_3__updatewind7583448234884642512.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_50_3__scatterindices__32__updateshape__1_3__updatewi373097052078385741.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_50_3__scatterindices__32__updateshape__1_3__updatewi373097052078385741.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_50_3__scatterindices__32__updateshape__1_3__updatewi5387246296885867613.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_50_3__scatterindices__32__updateshape__1_3__updatewi5387246296885867613.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1__scatterindices__0__updateshape____updatewindowdims_-6261381946082163628.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1__scatterindices__0__updateshape____updatewindowdims_-6261381946082163628.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1__scatterindices__0__updateshape____updatewindowdims_8998606905763508495.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1__scatterindices__0__updateshape____updatewindowdims_8998606905763508495.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_4_2_3_5__scatterindices__0_4__updateshape__4_3__update37168508320117536.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_4_2_3_5__scatterindices__0_4__updateshape__4_3__update37168508320117536.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_4_2_3_5__scatterindices__0_4__updateshape__4_3__update4396915468484087491.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_4_2_3_5__scatterindices__0_4__updateshape__4_3__update4396915468484087491.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_4_2_3__scatterindices__3_2__updateshape__2___updatewin-3224467062420307614.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_4_2_3__scatterindices__3_2__updateshape__2___updatewin-3224467062420307614.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_4_2_3__scatterindices__3_2__updateshape__2___updatewin3891239180403390738.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_4_2_3__scatterindices__3_2__updateshape__2___updatewin3891239180403390738.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-2151910845188751696.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-2151910845188751696.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-2404637618845325000.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-2404637618845325000.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-572190243029509453.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-572190243029509453.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up7668301934060675915.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up7668301934060675915.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0___1_____2___3____updateshap-115477283981442116.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0___1_____2___3____updateshap-115477283981442116.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0___1_____2___3____updateshap-3395923389630413235.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0___1_____2___3____updateshap-3395923389630413235.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_dtypes_shape_bfloat16_5__scatterindices___0___2___updateshape__2___updatewindowdims____i1719900046009157333.mlir
+++ b/stablehlo/testdata/scatter_min_dtypes_shape_bfloat16_5__scatterindices___0___2___updateshape__2___updatewindowdims____i1719900046009157333.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_dtypes_shape_bool_5__scatterindices___0___2___updateshape__2___updatewindowdims____inser1719862287393275076.mlir
+++ b/stablehlo/testdata/scatter_min_dtypes_shape_bool_5__scatterindices___0___2___updateshape__2___updatewindowdims____inser1719862287393275076.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_dtypes_shape_complex64_5__scatterindices___0___2___updateshape__2___updatewindowdims____4352046343394697159.mlir
+++ b/stablehlo/testdata/scatter_min_dtypes_shape_complex64_5__scatterindices___0___2___updateshape__2___updatewindowdims____4352046343394697159.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_dtypes_shape_float16_5__scatterindices___0___2___updateshape__2___updatewindowdims____in3400391015131318119.mlir
+++ b/stablehlo/testdata/scatter_min_dtypes_shape_float16_5__scatterindices___0___2___updateshape__2___updatewindowdims____in3400391015131318119.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_dtypes_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowdims____in-3152158342664535743.mlir
+++ b/stablehlo/testdata/scatter_min_dtypes_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowdims____in-3152158342664535743.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_dtypes_shape_int16_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse7721631736843667759.mlir
+++ b/stablehlo/testdata/scatter_min_dtypes_shape_int16_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse7721631736843667759.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_dtypes_shape_int32_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse4043667791730656744.mlir
+++ b/stablehlo/testdata/scatter_min_dtypes_shape_int32_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse4043667791730656744.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_dtypes_shape_int8_5__scatterindices___0___2___updateshape__2___updatewindowdims____inser7141706196654897674.mlir
+++ b/stablehlo/testdata/scatter_min_dtypes_shape_int8_5__scatterindices___0___2___updateshape__2___updatewindowdims____inser7141706196654897674.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_dtypes_shape_uint16_5__scatterindices___0___2___updateshape__2___updatewindowdims____ins9124514689364773013.mlir
+++ b/stablehlo/testdata/scatter_min_dtypes_shape_uint16_5__scatterindices___0___2___updateshape__2___updatewindowdims____ins9124514689364773013.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_dtypes_shape_uint32_5__scatterindices___0___2___updateshape__2___updatewindowdims____ins-4863845320241037762.mlir
+++ b/stablehlo/testdata/scatter_min_dtypes_shape_uint32_5__scatterindices___0___2___updateshape__2___updatewindowdims____ins-4863845320241037762.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_dtypes_shape_uint8_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse534852232021846945.mlir
+++ b/stablehlo/testdata/scatter_min_dtypes_shape_uint8_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse534852232021846945.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_indices_are_sorted_shape_float32_5__scatterindices___0___2___updateshape__2___updatewind5825509085618127810.mlir
+++ b/stablehlo/testdata/scatter_min_indices_are_sorted_shape_float32_5__scatterindices___0___2___updateshape__2___updatewind5825509085618127810.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowd-4280126132222170601.mlir
+++ b/stablehlo/testdata/scatter_min_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowd-4280126132222170601.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowd-7030084515635948913.mlir
+++ b/stablehlo/testdata/scatter_min_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowd-7030084515635948913.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatewindow-6977587035204418846.mlir
+++ b/stablehlo/testdata/scatter_min_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatewindow-6977587035204418846.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatewindow794294539857980968.mlir
+++ b/stablehlo/testdata/scatter_min_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatewindow794294539857980968.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_bfloat16_1__scatterindices___0___0___updateshape__2___up-6655058111581649220.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_bfloat16_1__scatterindices___0___0___updateshape__2___up-6655058111581649220.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_bfloat16_1__scatterindices___0___0___updateshape__2___up257011455004234925.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_bfloat16_1__scatterindices___0___0___updateshape__2___up257011455004234925.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_bfloat16_2_3__scatterindices____2___2___2____updateshape-2249289855259825998.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_bfloat16_2_3__scatterindices____2___2___2____updateshape-2249289855259825998.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_bfloat16_2_3__scatterindices____2___2___2____updateshape3597514414725498598.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_bfloat16_2_3__scatterindices____2___2___2____updateshape3597514414725498598.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_bfloat16_3_5_40__scatterindices___1___1___updateshape__3-5074117366129902401.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_bfloat16_3_5_40__scatterindices___1___1___updateshape__3-5074117366129902401.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_bfloat16_3_5_40__scatterindices___1___1___updateshape__34933250815520880524.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_bfloat16_3_5_40__scatterindices___1___1___updateshape__34933250815520880524.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_bfloat16_3_5_4__scatterindices___1___1___updateshape__3_6244259100277537568.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_bfloat16_3_5_4__scatterindices___1___1___updateshape__3_6244259100277537568.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_bfloat16_3_5_4__scatterindices___1___1___updateshape__3_7096135450420072774.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_bfloat16_3_5_4__scatterindices___1___1___updateshape__3_7096135450420072774.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_bfloat16_3__scatterindices___1___0___1___updateshape__3_-2390111683147858631.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_bfloat16_3__scatterindices___1___0___1___updateshape__3_-2390111683147858631.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_bfloat16_3__scatterindices___1___0___1___updateshape__3_6371101921313517982.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_bfloat16_3__scatterindices___1___0___1___updateshape__3_6371101921313517982.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float16_1__scatterindices___0___0___updateshape__2___upd-6220627124317296940.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float16_1__scatterindices___0___0___updateshape__2___upd-6220627124317296940.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float16_1__scatterindices___0___0___updateshape__2___upd4569219469464053131.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float16_1__scatterindices___0___0___updateshape__2___upd4569219469464053131.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float16_2_3__scatterindices____2___2___2____updateshape_4356686229420019100.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float16_2_3__scatterindices____2___2___2____updateshape_4356686229420019100.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float16_2_3__scatterindices____2___2___2____updateshape_8694718717423353139.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float16_2_3__scatterindices____2___2___2____updateshape_8694718717423353139.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float16_3_5_40__scatterindices___1___1___updateshape__3_-8316221048643743799.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float16_3_5_40__scatterindices___1___1___updateshape__3_-8316221048643743799.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float16_3_5_40__scatterindices___1___1___updateshape__3_-857194216228152443.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float16_3_5_40__scatterindices___1___1___updateshape__3_-857194216228152443.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float16_3_5_4__scatterindices___1___1___updateshape__3_2-714900388043421455.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float16_3_5_4__scatterindices___1___1___updateshape__3_2-714900388043421455.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float16_3_5_4__scatterindices___1___1___updateshape__3_294168853516180589.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float16_3_5_4__scatterindices___1___1___updateshape__3_294168853516180589.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float16_3__scatterindices___1___0___1___updateshape__3__-1592233629693916822.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float16_3__scatterindices___1___0___1___updateshape__3__-1592233629693916822.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float16_3__scatterindices___1___0___1___updateshape__3__-4570510485399197673.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float16_3__scatterindices___1___0___1___updateshape__3__-4570510485399197673.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float32_1__scatterindices___0___0___updateshape__2___upd-8091195660655238031.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float32_1__scatterindices___0___0___updateshape__2___upd-8091195660655238031.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float32_1__scatterindices___0___0___updateshape__2___upd3680312855999364491.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float32_1__scatterindices___0___0___updateshape__2___upd3680312855999364491.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float32_2_3__scatterindices____2___2___2____updateshape_-3099664615390500206.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float32_2_3__scatterindices____2___2___2____updateshape_-3099664615390500206.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float32_2_3__scatterindices____2___2___2____updateshape_4115365008761471583.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float32_2_3__scatterindices____2___2___2____updateshape_4115365008761471583.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float32_3_5_40__scatterindices___1___1___updateshape__3_-2626246477929477630.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float32_3_5_40__scatterindices___1___1___updateshape__3_-2626246477929477630.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float32_3_5_40__scatterindices___1___1___updateshape__3_5421303431107764636.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float32_3_5_40__scatterindices___1___1___updateshape__3_5421303431107764636.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float32_3_5_4__scatterindices___1___1___updateshape__3_2-4098451780701630155.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float32_3_5_4__scatterindices___1___1___updateshape__3_2-4098451780701630155.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float32_3_5_4__scatterindices___1___1___updateshape__3_2-4943527707746498712.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float32_3_5_4__scatterindices___1___1___updateshape__3_2-4943527707746498712.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float32_3__scatterindices___1___0___1___updateshape__3__-3971564147856755499.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float32_3__scatterindices___1___0___1___updateshape__3__-3971564147856755499.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float32_3__scatterindices___1___0___1___updateshape__3__7215406999342465565.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float32_3__scatterindices___1___0___1___updateshape__3__7215406999342465565.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int16_1__scatterindices___0___0___updateshape__2___updat-2407133498544979633.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int16_1__scatterindices___0___0___updateshape__2___updat-2407133498544979633.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int16_1__scatterindices___0___0___updateshape__2___updat707246471925448235.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int16_1__scatterindices___0___0___updateshape__2___updat707246471925448235.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int16_2_3__scatterindices____2___2___2____updateshape__2-3082733421359615550.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int16_2_3__scatterindices____2___2___2____updateshape__2-3082733421359615550.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int16_2_3__scatterindices____2___2___2____updateshape__21853808655309087749.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int16_2_3__scatterindices____2___2___2____updateshape__21853808655309087749.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int16_3_5_40__scatterindices___1___1___updateshape__3_5_-3168049263500542045.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int16_3_5_40__scatterindices___1___1___updateshape__3_5_-3168049263500542045.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int16_3_5_40__scatterindices___1___1___updateshape__3_5_-4612044676003355777.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int16_3_5_40__scatterindices___1___1___updateshape__3_5_-4612044676003355777.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int16_3_5_4__scatterindices___1___1___updateshape__3_2_44884154015831063889.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int16_3_5_4__scatterindices___1___1___updateshape__3_2_44884154015831063889.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int16_3_5_4__scatterindices___1___1___updateshape__3_2_46191447577027647775.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int16_3_5_4__scatterindices___1___1___updateshape__3_2_46191447577027647775.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int16_3__scatterindices___1___0___1___updateshape__3___u6262865648268185343.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int16_3__scatterindices___1___0___1___updateshape__3___u6262865648268185343.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int16_3__scatterindices___1___0___1___updateshape__3___u8732534266313544978.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int16_3__scatterindices___1___0___1___updateshape__3___u8732534266313544978.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int32_1__scatterindices___0___0___updateshape__2___updat-7343798520741133620.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int32_1__scatterindices___0___0___updateshape__2___updat-7343798520741133620.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int32_1__scatterindices___0___0___updateshape__2___updat8346955452553751621.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int32_1__scatterindices___0___0___updateshape__2___updat8346955452553751621.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int32_2_3__scatterindices____2___2___2____updateshape__21575384273124453539.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int32_2_3__scatterindices____2___2___2____updateshape__21575384273124453539.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int32_2_3__scatterindices____2___2___2____updateshape__29049572619063429077.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int32_2_3__scatterindices____2___2___2____updateshape__29049572619063429077.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int32_3_5_40__scatterindices___1___1___updateshape__3_5_-4492180260379123575.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int32_3_5_40__scatterindices___1___1___updateshape__3_5_-4492180260379123575.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int32_3_5_40__scatterindices___1___1___updateshape__3_5_-6804281654964710260.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int32_3_5_40__scatterindices___1___1___updateshape__3_5_-6804281654964710260.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int32_3_5_4__scatterindices___1___1___updateshape__3_2_4-8085552538497462086.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int32_3_5_4__scatterindices___1___1___updateshape__3_2_4-8085552538497462086.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int32_3_5_4__scatterindices___1___1___updateshape__3_2_48915394162869716664.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int32_3_5_4__scatterindices___1___1___updateshape__3_2_48915394162869716664.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int32_3__scatterindices___1___0___1___updateshape__3___u-4091295550652669529.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int32_3__scatterindices___1___0___1___updateshape__3___u-4091295550652669529.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int32_3__scatterindices___1___0___1___updateshape__3___u549801763074919359.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int32_3__scatterindices___1___0___1___updateshape__3___u549801763074919359.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int8_1__scatterindices___0___0___updateshape__2___update-1360754318140092109.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int8_1__scatterindices___0___0___updateshape__2___update-1360754318140092109.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int8_1__scatterindices___0___0___updateshape__2___update-6651041623792386111.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int8_1__scatterindices___0___0___updateshape__2___update-6651041623792386111.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int8_2_3__scatterindices____2___2___2____updateshape__2_-2225969877503185882.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int8_2_3__scatterindices____2___2___2____updateshape__2_-2225969877503185882.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int8_2_3__scatterindices____2___2___2____updateshape__2_-3742461097496387086.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int8_2_3__scatterindices____2___2___2____updateshape__2_-3742461097496387086.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int8_3_5_40__scatterindices___1___1___updateshape__3_5_2-7764254308842032551.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int8_3_5_40__scatterindices___1___1___updateshape__3_5_2-7764254308842032551.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int8_3_5_40__scatterindices___1___1___updateshape__3_5_23450775816481210993.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int8_3_5_40__scatterindices___1___1___updateshape__3_5_23450775816481210993.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int8_3_5_4__scatterindices___1___1___updateshape__3_2_4_-6591631366574437153.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int8_3_5_4__scatterindices___1___1___updateshape__3_2_4_-6591631366574437153.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int8_3_5_4__scatterindices___1___1___updateshape__3_2_4_-8706909794187844482.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int8_3_5_4__scatterindices___1___1___updateshape__3_2_4_-8706909794187844482.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int8_3__scatterindices___1___0___1___updateshape__3___up-1297660150798520786.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int8_3__scatterindices___1___0___1___updateshape__3___up-1297660150798520786.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int8_3__scatterindices___1___0___1___updateshape__3___up6318457899351731724.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int8_3__scatterindices___1___0___1___updateshape__3___up6318457899351731724.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint16_1__scatterindices___0___0___updateshape__2___upda5207510223195637833.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint16_1__scatterindices___0___0___updateshape__2___upda5207510223195637833.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint16_1__scatterindices___0___0___updateshape__2___upda6262798125151336282.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint16_1__scatterindices___0___0___updateshape__2___upda6262798125151336282.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint16_2_3__scatterindices____2___2___2____updateshape__-8656143665335338128.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint16_2_3__scatterindices____2___2___2____updateshape__-8656143665335338128.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint16_2_3__scatterindices____2___2___2____updateshape__8667165760414880574.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint16_2_3__scatterindices____2___2___2____updateshape__8667165760414880574.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint16_3_5_40__scatterindices___1___1___updateshape__3_5-4608489474011168533.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint16_3_5_40__scatterindices___1___1___updateshape__3_5-4608489474011168533.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint16_3_5_40__scatterindices___1___1___updateshape__3_54655453964880485515.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint16_3_5_40__scatterindices___1___1___updateshape__3_54655453964880485515.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint16_3_5_4__scatterindices___1___1___updateshape__3_2_-8520820431443740876.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint16_3_5_4__scatterindices___1___1___updateshape__3_2_-8520820431443740876.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint16_3_5_4__scatterindices___1___1___updateshape__3_2_3572500993044654711.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint16_3_5_4__scatterindices___1___1___updateshape__3_2_3572500993044654711.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint16_3__scatterindices___1___0___1___updateshape__3___-7867920288811157954.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint16_3__scatterindices___1___0___1___updateshape__3___-7867920288811157954.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint16_3__scatterindices___1___0___1___updateshape__3___8720268492036459268.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint16_3__scatterindices___1___0___1___updateshape__3___8720268492036459268.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint32_1__scatterindices___0___0___updateshape__2___upda-2091068717007306664.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint32_1__scatterindices___0___0___updateshape__2___upda-2091068717007306664.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint32_1__scatterindices___0___0___updateshape__2___upda8120988465709075289.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint32_1__scatterindices___0___0___updateshape__2___upda8120988465709075289.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint32_2_3__scatterindices____2___2___2____updateshape__-8786096591665500031.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint32_2_3__scatterindices____2___2___2____updateshape__-8786096591665500031.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint32_2_3__scatterindices____2___2___2____updateshape__1436396732987470658.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint32_2_3__scatterindices____2___2___2____updateshape__1436396732987470658.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint32_3_5_40__scatterindices___1___1___updateshape__3_5-138328594848753004.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint32_3_5_40__scatterindices___1___1___updateshape__3_5-138328594848753004.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint32_3_5_40__scatterindices___1___1___updateshape__3_5-823404253934322853.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint32_3_5_40__scatterindices___1___1___updateshape__3_5-823404253934322853.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint32_3_5_4__scatterindices___1___1___updateshape__3_2_-7530330949824434259.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint32_3_5_4__scatterindices___1___1___updateshape__3_2_-7530330949824434259.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint32_3_5_4__scatterindices___1___1___updateshape__3_2_5820078437345868748.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint32_3_5_4__scatterindices___1___1___updateshape__3_2_5820078437345868748.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint32_3__scatterindices___1___0___1___updateshape__3___-129985155865775457.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint32_3__scatterindices___1___0___1___updateshape__3___-129985155865775457.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint32_3__scatterindices___1___0___1___updateshape__3___2343539028412553554.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint32_3__scatterindices___1___0___1___updateshape__3___2343539028412553554.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint8_1__scatterindices___0___0___updateshape__2___updat-1272592393935837253.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint8_1__scatterindices___0___0___updateshape__2___updat-1272592393935837253.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint8_1__scatterindices___0___0___updateshape__2___updat4425389787711593969.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint8_1__scatterindices___0___0___updateshape__2___updat4425389787711593969.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint8_2_3__scatterindices____2___2___2____updateshape__2-3410694954850677544.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint8_2_3__scatterindices____2___2___2____updateshape__2-3410694954850677544.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint8_2_3__scatterindices____2___2___2____updateshape__29203764322210362910.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint8_2_3__scatterindices____2___2___2____updateshape__29203764322210362910.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint8_3_5_40__scatterindices___1___1___updateshape__3_5_-7295488856326444060.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint8_3_5_40__scatterindices___1___1___updateshape__3_5_-7295488856326444060.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint8_3_5_40__scatterindices___1___1___updateshape__3_5_3070699946697361877.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint8_3_5_40__scatterindices___1___1___updateshape__3_5_3070699946697361877.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint8_3_5_4__scatterindices___1___1___updateshape__3_2_4-5549751385104158980.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint8_3_5_4__scatterindices___1___1___updateshape__3_2_4-5549751385104158980.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint8_3_5_4__scatterindices___1___1___updateshape__3_2_4-5718248314471681435.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint8_3_5_4__scatterindices___1___1___updateshape__3_2_4-5718248314471681435.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint8_3__scatterindices___1___0___1___updateshape__3___u-5425130638233748095.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint8_3__scatterindices___1___0___1___updateshape__3___u-5425130638233748095.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint8_3__scatterindices___1___0___1___updateshape__3___u-6732484422315882264.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint8_3__scatterindices___1___0___1___updateshape__3___u-6732484422315882264.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_125__scatterindices__0__updateshape__1___updatewi-8455060674813840089.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_125__scatterindices__0__updateshape__1___updatewi-8455060674813840089.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_125__scatterindices__0__updateshape__1___updatewi6988113685815211566.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_125__scatterindices__0__updateshape__1___updatewi6988113685815211566.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_1_1__scatterindices__0__updateshape__1_1__updatew6079948891887161857.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_1_1__scatterindices__0__updateshape__1_1__updatew6079948891887161857.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_1_1__scatterindices__0__updateshape__1_1__updatew6549659875295259688.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_1_1__scatterindices__0__updateshape__1_1__updatew6549659875295259688.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_1__scatterindices__0__updateshape__1___updatewind3824046247028131474.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_1__scatterindices__0__updateshape__1___updatewind3824046247028131474.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_1__scatterindices__0__updateshape__1___updatewind7836302535510859558.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_1__scatterindices__0__updateshape__1___updatewind7836302535510859558.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__0__updateshape__2_3__updatew-2507891561465170673.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__0__updateshape__2_3__updatew-2507891561465170673.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__0__updateshape__2_3__updatew-4606238653677723928.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__0__updateshape__2_3__updatew-4606238653677723928.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1_2__updateshape__1___update3838801698297708086.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1_2__updateshape__1___update3838801698297708086.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1_2__updateshape__1___update8582144022432454162.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1_2__updateshape__1___update8582144022432454162.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1__updateshape__1_3__updatew-3499019506028152780.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1__updateshape__1_3__updatew-3499019506028152780.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1__updateshape__1_3__updatew-5731561847796673736.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1__updateshape__1_3__updatew-5731561847796673736.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_50_3__scatterindices__32__updateshape__1_3__updat9063298096984913623.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_50_3__scatterindices__32__updateshape__1_3__updat9063298096984913623.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_50_3__scatterindices__32__updateshape__1_3__updat9081076048855731653.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_50_3__scatterindices__32__updateshape__1_3__updat9081076048855731653.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1__scatterindices__0__updateshape____updatewindowdi4014730839607642488.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1__scatterindices__0__updateshape____updatewindowdi4014730839607642488.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1__scatterindices__0__updateshape____updatewindowdi6405466108572526127.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1__scatterindices__0__updateshape____updatewindowdi6405466108572526127.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upd3563814370155075944.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upd3563814370155075944.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upd8749611313497629157.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upd8749611313497629157.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_4_2_3__scatterindices__3_2__updateshape__2___update3767757828594658078.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_4_2_3__scatterindices__3_2__updateshape__2___update3767757828594658078.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_4_2_3__scatterindices__3_2__updateshape__2___update3837990416671658082.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_4_2_3__scatterindices__3_2__updateshape__2___update3837990416671658082.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices___0_1___2_3___updateshape__2_-7532755016762737811.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices___0_1___2_3___updateshape__2_-7532755016762737811.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices___0_1___2_3___updateshape__2_8460571233850253931.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices___0_1___2_3___updateshape__2_8460571233850253931.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2___-3281381171658143616.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2___-3281381171658143616.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2___7895186756503018450.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2___7895186756503018450.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0___1_____2___3____updates-7133135434776847571.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0___1_____2___3____updates-7133135434776847571.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0___1_____2___3____updates1992556058291306227.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0___1_____2___3____updates1992556058291306227.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_125__scatterindices__0__updateshape__1___updatewin-7219620919170275402.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_125__scatterindices__0__updateshape__1___updatewin-7219620919170275402.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_125__scatterindices__0__updateshape__1___updatewin2019808635615422103.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_125__scatterindices__0__updateshape__1___updatewin2019808635615422103.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_1_1__scatterindices__0__updateshape__1_1__updatewi-1154839571289251294.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_1_1__scatterindices__0__updateshape__1_1__updatewi-1154839571289251294.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_1_1__scatterindices__0__updateshape__1_1__updatewi5444842911984533710.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_1_1__scatterindices__0__updateshape__1_1__updatewi5444842911984533710.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_1__scatterindices__0__updateshape__1___updatewindo-2950411685828876999.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_1__scatterindices__0__updateshape__1___updatewindo-2950411685828876999.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_1__scatterindices__0__updateshape__1___updatewindo1094744759700233541.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_1__scatterindices__0__updateshape__1___updatewindo1094744759700233541.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__0__updateshape__2_3__updatewi3333288523443268181.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__0__updateshape__2_3__updatewi3333288523443268181.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__0__updateshape__2_3__updatewi422102818376078865.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__0__updateshape__2_3__updatewi422102818376078865.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1_2__updateshape__1___updatew-6181263443370822618.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1_2__updateshape__1___updatew-6181263443370822618.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1_2__updateshape__1___updatew-6433087509074096220.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1_2__updateshape__1___updatew-6433087509074096220.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1__updateshape__1_3__updatewi-2252964348354275925.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1__updateshape__1_3__updatewi-2252964348354275925.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1__updateshape__1_3__updatewi7411317443831486478.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1__updateshape__1_3__updatewi7411317443831486478.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_50_3__scatterindices__32__updateshape__1_3__update-5100689976626851558.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_50_3__scatterindices__32__updateshape__1_3__update-5100689976626851558.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_50_3__scatterindices__32__updateshape__1_3__update9033995531765975800.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_50_3__scatterindices__32__updateshape__1_3__update9033995531765975800.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1__scatterindices__0__updateshape____updatewindowdim-7066819620180239285.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1__scatterindices__0__updateshape____updatewindowdim-7066819620180239285.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1__scatterindices__0__updateshape____updatewindowdim-7801774742063109687.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1__scatterindices__0__updateshape____updatewindowdim-7801774742063109687.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda630720772185460788.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda630720772185460788.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda678556358992363704.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda678556358992363704.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_4_2_3__scatterindices__3_2__updateshape__2___updatew6849606337113289247.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_4_2_3__scatterindices__3_2__updateshape__2___updatew6849606337113289247.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_4_2_3__scatterindices__3_2__updateshape__2___updatew7952926376746779189.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_4_2_3__scatterindices__3_2__updateshape__2___updatew7952926376746779189.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7-1846790892893359733.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7-1846790892893359733.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_5_6_7__scatterindices___0_1___2_3___updateshape__2_77771727832633254392.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_5_6_7__scatterindices___0_1___2_3___updateshape__2_77771727832633254392.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____3311700604022838238.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____3311700604022838238.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____6631360807004031578.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____6631360807004031578.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0___1_____2___3____updatesh-2441375675325881794.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0___1_____2___3____updatesh-2441375675325881794.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0___1_____2___3____updatesh4339301259731857950.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0___1_____2___3____updatesh4339301259731857950.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewin3434837777651772019.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewin3434837777651772019.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewin6626096260784457491.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewin6626096260784457491.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__updatewi4187542989145136011.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__updatewi4187542989145136011.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__updatewi7379173832243563380.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__updatewi7379173832243563380.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___updatewindo-6873417748702292701.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___updatewindo-6873417748702292701.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___updatewindo6832112543129542117.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___updatewindo6832112543129542117.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatewi-1913261295690793592.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatewi-1913261295690793592.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatewi2385003291164847436.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatewi2385003291164847436.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___updatew2151281305958059125.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___updatew2151281305958059125.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___updatew3832905097368469483.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___updatew3832905097368469483.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatewi-3362430168774037732.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatewi-3362430168774037732.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatewi106994944400262570.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatewi106994944400262570.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__update-577545178140062831.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__update-577545178140062831.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__update-6011850232913338927.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__update-6011850232913338927.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdim-3256607664589015350.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdim-3256607664589015350.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdim-7327087540068455882.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdim-7327087540068455882.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda-6616585842710565767.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda-6616585842710565767.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda-7864195232735747393.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda-7864195232735747393.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___updatew-7199475041378945992.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___updatew-7199475041378945992.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___updatew-8839460156077137232.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___updatew-8839460156077137232.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape__2_71141133607715404040.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape__2_71141133607715404040.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape__2_74444378811213684451.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape__2_74444378811213684451.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____-1929229371068995825.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____-1929229371068995825.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____7796631715486587555.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____7796631715486587555.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____updatesh-4864067830661700007.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____updatesh-4864067830661700007.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____updatesh-8078869473627428624.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____updatesh-8078869473627428624.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_125__scatterindices__0__updateshape__1___updatewindo-4048898580210518923.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_125__scatterindices__0__updateshape__1___updatewindo-4048898580210518923.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_125__scatterindices__0__updateshape__1___updatewindo2663632515478957534.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_125__scatterindices__0__updateshape__1___updatewindo2663632515478957534.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_1_1__scatterindices__0__updateshape__1_1__updatewind-4872233943325429746.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_1_1__scatterindices__0__updateshape__1_1__updatewind-4872233943325429746.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_1_1__scatterindices__0__updateshape__1_1__updatewind-5131798970918347525.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_1_1__scatterindices__0__updateshape__1_1__updatewind-5131798970918347525.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_1__scatterindices__0__updateshape__1___updatewindowd-5817743396570967462.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_1__scatterindices__0__updateshape__1___updatewindowd-5817743396570967462.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_1__scatterindices__0__updateshape__1___updatewindowd-9101122120036262009.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_1__scatterindices__0__updateshape__1___updatewindowd-9101122120036262009.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__0__updateshape__2_3__updatewind4956717948692458560.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__0__updateshape__2_3__updatewind4956717948692458560.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__0__updateshape__2_3__updatewind6488415553946838757.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__0__updateshape__2_3__updatewind6488415553946838757.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1_2__updateshape__1___updatewin-2311893409916309480.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1_2__updateshape__1___updatewin-2311893409916309480.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1_2__updateshape__1___updatewin5443007369435740914.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1_2__updateshape__1___updatewin5443007369435740914.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1__updateshape__1_3__updatewind139047943743357621.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1__updateshape__1_3__updatewind139047943743357621.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1__updateshape__1_3__updatewind2569505830733396853.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1__updateshape__1_3__updatewind2569505830733396853.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_50_3__scatterindices__32__updateshape__1_3__updatewi-4522415576264482421.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_50_3__scatterindices__32__updateshape__1_3__updatewi-4522415576264482421.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_50_3__scatterindices__32__updateshape__1_3__updatewi-6751549191563984126.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_50_3__scatterindices__32__updateshape__1_3__updatewi-6751549191563984126.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1__scatterindices__0__updateshape____updatewindowdims_-4184954724394605776.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1__scatterindices__0__updateshape____updatewindowdims_-4184954724394605776.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1__scatterindices__0__updateshape____updatewindowdims_2909575980966412820.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1__scatterindices__0__updateshape____updatewindowdims_2909575980966412820.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-6850199035370975979.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-6850199035370975979.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_4_2_3_5__scatterindices__0_4__updateshape__4_3__update2307656599037197652.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_4_2_3_5__scatterindices__0_4__updateshape__4_3__update2307656599037197652.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_4_2_3__scatterindices__3_2__updateshape__2___updatewin3937406258051021731.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_4_2_3__scatterindices__3_2__updateshape__2___updatewin3937406258051021731.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_4_2_3__scatterindices__3_2__updateshape__2___updatewin4671330445293080617.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_4_2_3__scatterindices__3_2__updateshape__2___updatewin4671330445293080617.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-6823698740828894740.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-6823698740828894740.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__8116338334848718103.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__8116338334848718103.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up1897490814391211893.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up1897490814391211893.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up3955050749775670123.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up3955050749775670123.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0___1_____2___3____updateshap-2669360800802260213.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0___1_____2___3____updateshap-2669360800802260213.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0___1_____2___3____updateshap-5300422118746435442.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0___1_____2___3____updateshap-5300422118746435442.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_125__scatterindices__0__updateshape__1___updatewindo-5773493145779110529.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_125__scatterindices__0__updateshape__1___updatewindo-5773493145779110529.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_125__scatterindices__0__updateshape__1___updatewindo-6306854691638577587.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_125__scatterindices__0__updateshape__1___updatewindo-6306854691638577587.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_1_1__scatterindices__0__updateshape__1_1__updatewind4521601090946723752.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_1_1__scatterindices__0__updateshape__1_1__updatewind4521601090946723752.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_1_1__scatterindices__0__updateshape__1_1__updatewind8113619835508400365.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_1_1__scatterindices__0__updateshape__1_1__updatewind8113619835508400365.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_1__scatterindices__0__updateshape__1___updatewindowd-3469160267547152989.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_1__scatterindices__0__updateshape__1___updatewindowd-3469160267547152989.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_1__scatterindices__0__updateshape__1___updatewindowd-4485215942239891048.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_1__scatterindices__0__updateshape__1___updatewindowd-4485215942239891048.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__0__updateshape__2_3__updatewind-4157173160933560839.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__0__updateshape__2_3__updatewind-4157173160933560839.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__0__updateshape__2_3__updatewind-8276893021528647212.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__0__updateshape__2_3__updatewind-8276893021528647212.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1_2__updateshape__1___updatewin-3907920868952273498.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1_2__updateshape__1___updatewin-3907920868952273498.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1_2__updateshape__1___updatewin-5829009328670546117.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1_2__updateshape__1___updatewin-5829009328670546117.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1__updateshape__1_3__updatewind-1880838265011712149.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1__updateshape__1_3__updatewind-1880838265011712149.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1__updateshape__1_3__updatewind-711642015244088147.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1__updateshape__1_3__updatewind-711642015244088147.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_50_3__scatterindices__32__updateshape__1_3__updatewi-1976704082280904433.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_50_3__scatterindices__32__updateshape__1_3__updatewi-1976704082280904433.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_50_3__scatterindices__32__updateshape__1_3__updatewi1744785575307162204.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_50_3__scatterindices__32__updateshape__1_3__updatewi1744785575307162204.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1__scatterindices__0__updateshape____updatewindowdims_3989505911331951517.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1__scatterindices__0__updateshape____updatewindowdims_3989505911331951517.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1__scatterindices__0__updateshape____updatewindowdims_5832033282227399517.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1__scatterindices__0__updateshape____updatewindowdims_5832033282227399517.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-300910068295299136.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-300910068295299136.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-4635129519501855715.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-4635129519501855715.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_4_2_3__scatterindices__3_2__updateshape__2___updatewin-4972159876752712758.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_4_2_3__scatterindices__3_2__updateshape__2___updatewin-4972159876752712758.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_4_2_3__scatterindices__3_2__updateshape__2___updatewin-5028247379765118510.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_4_2_3__scatterindices__3_2__updateshape__2___updatewin-5028247379765118510.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__3328729301052536943.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__3328729301052536943.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__4304361855510301002.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__4304361855510301002.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-618963719957585263.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-618963719957585263.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up9163082647035002694.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up9163082647035002694.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0___1_____2___3____updateshap-2358744188387002594.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0___1_____2___3____updateshap-2358744188387002594.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0___1_____2___3____updateshap1996461387154660185.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0___1_____2___3____updateshap1996461387154660185.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_125__scatterindices__0__updateshape__1___updatewindow-2164897151381856441.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_125__scatterindices__0__updateshape__1___updatewindow-2164897151381856441.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_125__scatterindices__0__updateshape__1___updatewindow-2961561519251948998.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_125__scatterindices__0__updateshape__1___updatewindow-2961561519251948998.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_1_1__scatterindices__0__updateshape__1_1__updatewindo-8020988861111988180.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_1_1__scatterindices__0__updateshape__1_1__updatewindo-8020988861111988180.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_1_1__scatterindices__0__updateshape__1_1__updatewindo4881717839749137459.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_1_1__scatterindices__0__updateshape__1_1__updatewindo4881717839749137459.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_1__scatterindices__0__updateshape__1___updatewindowdi-1401586037954451478.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_1__scatterindices__0__updateshape__1___updatewindowdi-1401586037954451478.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_1__scatterindices__0__updateshape__1___updatewindowdi-3299551669044129890.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_1__scatterindices__0__updateshape__1___updatewindowdi-3299551669044129890.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__0__updateshape__2_3__updatewindo-482045768683493515.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__0__updateshape__2_3__updatewindo-482045768683493515.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__0__updateshape__2_3__updatewindo3010445502852181464.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__0__updateshape__2_3__updatewindo3010445502852181464.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1_2__updateshape__1___updatewind1932062239427915429.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1_2__updateshape__1___updatewind1932062239427915429.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1_2__updateshape__1___updatewind6959809007312719819.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1_2__updateshape__1___updatewind6959809007312719819.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1__updateshape__1_3__updatewindo6234545826659136216.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1__updateshape__1_3__updatewindo6234545826659136216.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1__updateshape__1_3__updatewindo6651601235066092967.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1__updateshape__1_3__updatewindo6651601235066092967.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_50_3__scatterindices__32__updateshape__1_3__updatewin-8494262652049039261.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_50_3__scatterindices__32__updateshape__1_3__updatewin-8494262652049039261.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_50_3__scatterindices__32__updateshape__1_3__updatewin-9177737518976100433.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_50_3__scatterindices__32__updateshape__1_3__updatewin-9177737518976100433.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1__scatterindices__0__updateshape____updatewindowdims__-1308981154281318723.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1__scatterindices__0__updateshape____updatewindowdims__-1308981154281318723.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1__scatterindices__0__updateshape____updatewindowdims__-6584724419750600150.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1__scatterindices__0__updateshape____updatewindowdims__-6584724419750600150.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatew-8355771186641774244.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatew-8355771186641774244.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatew8744947161230796126.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatew8744947161230796126.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_4_2_3__scatterindices__3_2__updateshape__2___updatewind-3464400292317216201.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_4_2_3__scatterindices__3_2__updateshape__2___updatewind-3464400292317216201.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_4_2_3__scatterindices__3_2__updateshape__2___updatewind8789432491710657866.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_4_2_3__scatterindices__3_2__updateshape__2___updatewind8789432491710657866.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__u-4379412217277116514.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__u-4379412217277116514.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__u-4620022713790399524.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__u-4620022713790399524.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upd-528608027875306388.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upd-528608027875306388.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upd2543776539875068957.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upd2543776539875068957.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0___1_____2___3____updateshape-6662304895221129059.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0___1_____2___3____updateshape-6662304895221129059.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0___1_____2___3____updateshape1379091125016347204.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0___1_____2___3____updateshape1379091125016347204.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_125__scatterindices__0__updateshape__1___updatewind6104678372056570904.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_125__scatterindices__0__updateshape__1___updatewind6104678372056570904.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_125__scatterindices__0__updateshape__1___updatewind8951713881198357282.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_125__scatterindices__0__updateshape__1___updatewind8951713881198357282.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_1_1__scatterindices__0__updateshape__1_1__updatewin-2293786845320776475.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_1_1__scatterindices__0__updateshape__1_1__updatewin-2293786845320776475.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_1_1__scatterindices__0__updateshape__1_1__updatewin-825491026465492200.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_1_1__scatterindices__0__updateshape__1_1__updatewin-825491026465492200.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_1__scatterindices__0__updateshape__1___updatewindow-3748161403226128671.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_1__scatterindices__0__updateshape__1___updatewindow-3748161403226128671.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_1__scatterindices__0__updateshape__1___updatewindow-5452883222867681143.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_1__scatterindices__0__updateshape__1___updatewindow-5452883222867681143.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__0__updateshape__2_3__updatewin-4983694071830808263.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__0__updateshape__2_3__updatewin-4983694071830808263.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__0__updateshape__2_3__updatewin-922800980968193647.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__0__updateshape__2_3__updatewin-922800980968193647.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1_2__updateshape__1___updatewi-7628752331345613625.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1_2__updateshape__1___updatewi-7628752331345613625.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1_2__updateshape__1___updatewi7087372310607227699.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1_2__updateshape__1___updatewi7087372310607227699.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1__updateshape__1_3__updatewin-4238276651709682367.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1__updateshape__1_3__updatewin-4238276651709682367.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1__updateshape__1_3__updatewin2574239198136190332.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1__updateshape__1_3__updatewin2574239198136190332.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_50_3__scatterindices__32__updateshape__1_3__updatew-7448424536125729420.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_50_3__scatterindices__32__updateshape__1_3__updatew-7448424536125729420.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_50_3__scatterindices__32__updateshape__1_3__updatew1534887604859550305.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_50_3__scatterindices__32__updateshape__1_3__updatew1534887604859550305.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1__scatterindices__0__updateshape____updatewindowdims-7120094586284358384.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1__scatterindices__0__updateshape____updatewindowdims-7120094586284358384.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1__scatterindices__0__updateshape____updatewindowdims-8557503002565537042.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1__scatterindices__0__updateshape____updatewindowdims-8557503002565537042.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat-2855550188487489879.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat-2855550188487489879.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat-6858799924904399445.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat-6858799924904399445.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_4_2_3__scatterindices__3_2__updateshape__2___updatewi3842920200244835884.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_4_2_3__scatterindices__3_2__updateshape__2___updatewi3842920200244835884.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_4_2_3__scatterindices__3_2__updateshape__2___updatewi531814443214012646.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_4_2_3__scatterindices__3_2__updateshape__2___updatewi531814443214012646.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_-2203453677154150371.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_-2203453677154150371.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_1680898793278744290.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_1680898793278744290.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u-5568333888604383669.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u-5568333888604383669.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u-7686200927978297073.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u-7686200927978297073.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0___1_____2___3____updatesha-8261153333685108720.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0___1_____2___3____updatesha-8261153333685108720.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0___1_____2___3____updatesha8897516788227473093.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0___1_____2___3____updatesha8897516788227473093.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_125__scatterindices__0__updateshape__1___updatewind5324299034178680984.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_125__scatterindices__0__updateshape__1___updatewind5324299034178680984.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_125__scatterindices__0__updateshape__1___updatewind8053525223274197913.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_125__scatterindices__0__updateshape__1___updatewind8053525223274197913.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_1_1__scatterindices__0__updateshape__1_1__updatewin-3919347360338486161.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_1_1__scatterindices__0__updateshape__1_1__updatewin-3919347360338486161.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_1_1__scatterindices__0__updateshape__1_1__updatewin557265926019113997.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_1_1__scatterindices__0__updateshape__1_1__updatewin557265926019113997.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_1__scatterindices__0__updateshape__1___updatewindow-530097313420603595.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_1__scatterindices__0__updateshape__1___updatewindow-530097313420603595.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_1__scatterindices__0__updateshape__1___updatewindow5540511942877021843.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_1__scatterindices__0__updateshape__1___updatewindow5540511942877021843.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__0__updateshape__2_3__updatewin-7921085769571620715.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__0__updateshape__2_3__updatewin-7921085769571620715.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__0__updateshape__2_3__updatewin5516599741785648027.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__0__updateshape__2_3__updatewin5516599741785648027.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1_2__updateshape__1___updatewi-3890715224454106690.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1_2__updateshape__1___updatewi-3890715224454106690.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1_2__updateshape__1___updatewi2451467265301592276.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1_2__updateshape__1___updatewi2451467265301592276.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1__updateshape__1_3__updatewin-6835298325160753158.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1__updateshape__1_3__updatewin-6835298325160753158.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1__updateshape__1_3__updatewin5907199364789461624.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1__updateshape__1_3__updatewin5907199364789461624.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_50_3__scatterindices__32__updateshape__1_3__updatew3599289276786300260.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_50_3__scatterindices__32__updateshape__1_3__updatew3599289276786300260.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_50_3__scatterindices__32__updateshape__1_3__updatew5573174805555653228.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_50_3__scatterindices__32__updateshape__1_3__updatew5573174805555653228.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1__scatterindices__0__updateshape____updatewindowdims3891969193358125108.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1__scatterindices__0__updateshape____updatewindowdims3891969193358125108.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1__scatterindices__0__updateshape____updatewindowdims6728519843519579187.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1__scatterindices__0__updateshape____updatewindowdims6728519843519579187.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat1875016188276619820.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat1875016188276619820.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat2832033142102107345.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat2832033142102107345.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_4_2_3__scatterindices__3_2__updateshape__2___updatewi4541439119239315328.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_4_2_3__scatterindices__3_2__updateshape__2___updatewi4541439119239315328.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_4_2_3__scatterindices__3_2__updateshape__2___updatewi6249915064913725474.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_4_2_3__scatterindices__3_2__updateshape__2___updatewi6249915064913725474.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_4998849318336846036.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_4998849318336846036.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_8808245818971476835.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_8808245818971476835.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u-1847282675845561838.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u-1847282675845561838.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u-7307692730245064305.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u-7307692730245064305.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0___1_____2___3____updatesha-8377372164247774274.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0___1_____2___3____updatesha-8377372164247774274.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0___1_____2___3____updatesha101657976520010788.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0___1_____2___3____updatesha101657976520010788.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_125__scatterindices__0__updateshape__1___updatewindo-7267870577026374491.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_125__scatterindices__0__updateshape__1___updatewindo-7267870577026374491.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_125__scatterindices__0__updateshape__1___updatewindo-7831274120441572214.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_125__scatterindices__0__updateshape__1___updatewindo-7831274120441572214.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_1_1__scatterindices__0__updateshape__1_1__updatewind-4364353834884633969.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_1_1__scatterindices__0__updateshape__1_1__updatewind-4364353834884633969.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_1_1__scatterindices__0__updateshape__1_1__updatewind95337174995502651.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_1_1__scatterindices__0__updateshape__1_1__updatewind95337174995502651.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_1__scatterindices__0__updateshape__1___updatewindowd-4401939044538948194.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_1__scatterindices__0__updateshape__1___updatewindowd-4401939044538948194.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_1__scatterindices__0__updateshape__1___updatewindowd7374118277642078703.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_1__scatterindices__0__updateshape__1___updatewindowd7374118277642078703.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__0__updateshape__2_3__updatewind-4320742272598554972.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__0__updateshape__2_3__updatewind-4320742272598554972.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__0__updateshape__2_3__updatewind-5647768797625277636.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__0__updateshape__2_3__updatewind-5647768797625277636.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1_2__updateshape__1___updatewin-2598259718380766207.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1_2__updateshape__1___updatewin-2598259718380766207.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1_2__updateshape__1___updatewin-4507202267474985982.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1_2__updateshape__1___updatewin-4507202267474985982.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1__updateshape__1_3__updatewind-282272057526996412.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1__updateshape__1_3__updatewind-282272057526996412.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1__updateshape__1_3__updatewind5289939932728021031.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1__updateshape__1_3__updatewind5289939932728021031.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_50_3__scatterindices__32__updateshape__1_3__updatewi-1911855998223034084.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_50_3__scatterindices__32__updateshape__1_3__updatewi-1911855998223034084.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_50_3__scatterindices__32__updateshape__1_3__updatewi-8788238066019617104.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_50_3__scatterindices__32__updateshape__1_3__updatewi-8788238066019617104.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1__scatterindices__0__updateshape____updatewindowdims_1435654138527556962.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1__scatterindices__0__updateshape____updatewindowdims_1435654138527556962.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1__scatterindices__0__updateshape____updatewindowdims_4791307863228181924.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1__scatterindices__0__updateshape____updatewindowdims_4791307863228181924.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-3631479775757131866.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-3631479775757131866.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_4_2_3_5__scatterindices__0_4__updateshape__4_3__update8304920547383840732.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_4_2_3_5__scatterindices__0_4__updateshape__4_3__update8304920547383840732.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_4_2_3__scatterindices__3_2__updateshape__2___updatewin-4726102016836464664.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_4_2_3__scatterindices__3_2__updateshape__2___updatewin-4726102016836464664.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_4_2_3__scatterindices__3_2__updateshape__2___updatewin6504664932451562272.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_4_2_3__scatterindices__3_2__updateshape__2___updatewin6504664932451562272.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-1521424101927027807.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-1521424101927027807.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-7210161950186348637.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-7210161950186348637.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-1488261666750715563.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-1488261666750715563.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-347543453836881210.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-347543453836881210.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0___1_____2___3____updateshap-5935271915580022048.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0___1_____2___3____updateshap-5935271915580022048.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0___1_____2___3____updateshap8601300616414390880.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0___1_____2___3____updateshap8601300616414390880.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_shapes_and_dimension_numbers_shape_float32_10_5__scatterindices___0___2___1___updateshap2046588017570464208.mlir
+++ b/stablehlo/testdata/scatter_min_shapes_and_dimension_numbers_shape_float32_10_5__scatterindices___0___2___1___updateshap2046588017570464208.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_min_shapes_and_dimension_numbers_shape_float32_10__scatterindices___0___0___0___updateshape_7540184139313307643.mlir
+++ b/stablehlo/testdata/scatter_min_shapes_and_dimension_numbers_shape_float32_10__scatterindices___0___0___0___updateshape_7540184139313307643.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowdims_-8447536616241837701.mlir
+++ b/stablehlo/testdata/scatter_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowdims_-8447536616241837701.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowdims_-9193453681395924655.mlir
+++ b/stablehlo/testdata/scatter_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowdims_-9193453681395924655.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatewindowdims-8163468306341242010.mlir
+++ b/stablehlo/testdata/scatter_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatewindowdims-8163468306341242010.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatewindowdims1979005098091914037.mlir
+++ b/stablehlo/testdata/scatter_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatewindowdims1979005098091914037.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_dtypes_shape_bfloat16_5__scatterindices___0___2___updateshape__2___updatewindowdims____i-8818140716242942777.mlir
+++ b/stablehlo/testdata/scatter_mul_dtypes_shape_bfloat16_5__scatterindices___0___2___updateshape__2___updatewindowdims____i-8818140716242942777.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_dtypes_shape_complex64_5__scatterindices___0___2___updateshape__2___updatewindowdims____2849053335900351376.mlir
+++ b/stablehlo/testdata/scatter_mul_dtypes_shape_complex64_5__scatterindices___0___2___updateshape__2___updatewindowdims____2849053335900351376.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_dtypes_shape_float16_5__scatterindices___0___2___updateshape__2___updatewindowdims____in6295346331202233422.mlir
+++ b/stablehlo/testdata/scatter_mul_dtypes_shape_float16_5__scatterindices___0___2___updateshape__2___updatewindowdims____in6295346331202233422.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_dtypes_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowdims____in3461545776928786403.mlir
+++ b/stablehlo/testdata/scatter_mul_dtypes_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowdims____in3461545776928786403.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_dtypes_shape_int16_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse-946010944284495501.mlir
+++ b/stablehlo/testdata/scatter_mul_dtypes_shape_int16_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse-946010944284495501.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_dtypes_shape_int32_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse7107969741003160690.mlir
+++ b/stablehlo/testdata/scatter_mul_dtypes_shape_int32_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse7107969741003160690.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_dtypes_shape_int8_5__scatterindices___0___2___updateshape__2___updatewindowdims____inser5257149825007736758.mlir
+++ b/stablehlo/testdata/scatter_mul_dtypes_shape_int8_5__scatterindices___0___2___updateshape__2___updatewindowdims____inser5257149825007736758.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_dtypes_shape_uint16_5__scatterindices___0___2___updateshape__2___updatewindowdims____ins-6272450472772319521.mlir
+++ b/stablehlo/testdata/scatter_mul_dtypes_shape_uint16_5__scatterindices___0___2___updateshape__2___updatewindowdims____ins-6272450472772319521.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_dtypes_shape_uint32_5__scatterindices___0___2___updateshape__2___updatewindowdims____ins2853409422886604297.mlir
+++ b/stablehlo/testdata/scatter_mul_dtypes_shape_uint32_5__scatterindices___0___2___updateshape__2___updatewindowdims____ins2853409422886604297.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_dtypes_shape_uint8_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse-6082089585072626272.mlir
+++ b/stablehlo/testdata/scatter_mul_dtypes_shape_uint8_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse-6082089585072626272.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowd-5874148103768417641.mlir
+++ b/stablehlo/testdata/scatter_mul_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowd-5874148103768417641.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowd6195566175507190160.mlir
+++ b/stablehlo/testdata/scatter_mul_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowd6195566175507190160.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatewindow-3409624153632020317.mlir
+++ b/stablehlo/testdata/scatter_mul_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatewindow-3409624153632020317.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatewindow-8783135513137066974.mlir
+++ b/stablehlo/testdata/scatter_mul_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatewindow-8783135513137066974.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_bfloat16_1__scatterindices___0___0___updateshape__2___up-5884834123805549505.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_bfloat16_1__scatterindices___0___0___updateshape__2___up-5884834123805549505.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_bfloat16_1__scatterindices___0___0___updateshape__2___up8705143908452656300.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_bfloat16_1__scatterindices___0___0___updateshape__2___up8705143908452656300.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_bfloat16_2_3__scatterindices____2___2___2____updateshape-7803826843619021591.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_bfloat16_2_3__scatterindices____2___2___2____updateshape-7803826843619021591.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_bfloat16_2_3__scatterindices____2___2___2____updateshape6701127154102155436.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_bfloat16_2_3__scatterindices____2___2___2____updateshape6701127154102155436.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_bfloat16_3_5_40__scatterindices___1___1___updateshape__35129282179707517658.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_bfloat16_3_5_40__scatterindices___1___1___updateshape__35129282179707517658.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_bfloat16_3_5_40__scatterindices___1___1___updateshape__35867807482160217870.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_bfloat16_3_5_40__scatterindices___1___1___updateshape__35867807482160217870.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_bfloat16_3_5_4__scatterindices___1___1___updateshape__3_-6622735777596271264.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_bfloat16_3_5_4__scatterindices___1___1___updateshape__3_-6622735777596271264.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_bfloat16_3_5_4__scatterindices___1___1___updateshape__3_4553474462917028659.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_bfloat16_3_5_4__scatterindices___1___1___updateshape__3_4553474462917028659.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_bfloat16_3__scatterindices___1___0___1___updateshape__3_-145760181962938805.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_bfloat16_3__scatterindices___1___0___1___updateshape__3_-145760181962938805.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_bfloat16_3__scatterindices___1___0___1___updateshape__3_-8371739205776775064.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_bfloat16_3__scatterindices___1___0___1___updateshape__3_-8371739205776775064.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float16_1__scatterindices___0___0___updateshape__2___upd322742675240437040.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float16_1__scatterindices___0___0___updateshape__2___upd322742675240437040.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float16_1__scatterindices___0___0___updateshape__2___upd733684278547254401.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float16_1__scatterindices___0___0___updateshape__2___upd733684278547254401.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float16_2_3__scatterindices____2___2___2____updateshape_-6140700220738729259.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float16_2_3__scatterindices____2___2___2____updateshape_-6140700220738729259.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float16_2_3__scatterindices____2___2___2____updateshape_-8345408382580861067.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float16_2_3__scatterindices____2___2___2____updateshape_-8345408382580861067.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float16_3_5_40__scatterindices___1___1___updateshape__3_-7757659907667194445.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float16_3_5_40__scatterindices___1___1___updateshape__3_-7757659907667194445.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float16_3_5_40__scatterindices___1___1___updateshape__3_197919947003228826.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float16_3_5_40__scatterindices___1___1___updateshape__3_197919947003228826.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float16_3_5_4__scatterindices___1___1___updateshape__3_2-7947552070747803171.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float16_3_5_4__scatterindices___1___1___updateshape__3_2-7947552070747803171.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float16_3_5_4__scatterindices___1___1___updateshape__3_25570052255445993142.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float16_3_5_4__scatterindices___1___1___updateshape__3_25570052255445993142.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float16_3__scatterindices___1___0___1___updateshape__3__-3382522699924592203.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float16_3__scatterindices___1___0___1___updateshape__3__-3382522699924592203.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float16_3__scatterindices___1___0___1___updateshape__3__-4211286303940773681.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float16_3__scatterindices___1___0___1___updateshape__3__-4211286303940773681.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float32_1__scatterindices___0___0___updateshape__2___upd-4240085725628378496.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float32_1__scatterindices___0___0___updateshape__2___upd-4240085725628378496.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float32_1__scatterindices___0___0___updateshape__2___upd8296829068770047821.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float32_1__scatterindices___0___0___updateshape__2___upd8296829068770047821.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float32_2_3__scatterindices____2___2___2____updateshape_-1153956390855415424.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float32_2_3__scatterindices____2___2___2____updateshape_-1153956390855415424.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float32_2_3__scatterindices____2___2___2____updateshape_-5918800170200989140.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float32_2_3__scatterindices____2___2___2____updateshape_-5918800170200989140.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float32_3_5_40__scatterindices___1___1___updateshape__3_-7580188922100577254.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float32_3_5_40__scatterindices___1___1___updateshape__3_-7580188922100577254.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float32_3_5_40__scatterindices___1___1___updateshape__3_5775500666699308696.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float32_3_5_40__scatterindices___1___1___updateshape__3_5775500666699308696.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float32_3_5_4__scatterindices___1___1___updateshape__3_2-7239115346209951984.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float32_3_5_4__scatterindices___1___1___updateshape__3_2-7239115346209951984.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float32_3_5_4__scatterindices___1___1___updateshape__3_2-7654327717305556714.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float32_3_5_4__scatterindices___1___1___updateshape__3_2-7654327717305556714.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float32_3__scatterindices___1___0___1___updateshape__3__-2072492453741906856.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float32_3__scatterindices___1___0___1___updateshape__3__-2072492453741906856.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float32_3__scatterindices___1___0___1___updateshape__3__-689434329673296.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float32_3__scatterindices___1___0___1___updateshape__3__-689434329673296.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int16_1__scatterindices___0___0___updateshape__2___updat-3529340748184752289.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int16_1__scatterindices___0___0___updateshape__2___updat-3529340748184752289.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int16_1__scatterindices___0___0___updateshape__2___updat561594413493909078.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int16_1__scatterindices___0___0___updateshape__2___updat561594413493909078.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int16_2_3__scatterindices____2___2___2____updateshape__2-2688753720662318550.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int16_2_3__scatterindices____2___2___2____updateshape__2-2688753720662318550.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int16_2_3__scatterindices____2___2___2____updateshape__2-377529509809056652.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int16_2_3__scatterindices____2___2___2____updateshape__2-377529509809056652.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int16_3_5_40__scatterindices___1___1___updateshape__3_5_-7710644996687728757.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int16_3_5_40__scatterindices___1___1___updateshape__3_5_-7710644996687728757.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int16_3_5_40__scatterindices___1___1___updateshape__3_5_2970487491126707417.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int16_3_5_40__scatterindices___1___1___updateshape__3_5_2970487491126707417.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int16_3_5_4__scatterindices___1___1___updateshape__3_2_4-6292020326763356426.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int16_3_5_4__scatterindices___1___1___updateshape__3_2_4-6292020326763356426.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int16_3_5_4__scatterindices___1___1___updateshape__3_2_46232449216193599633.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int16_3_5_4__scatterindices___1___1___updateshape__3_2_46232449216193599633.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int16_3__scatterindices___1___0___1___updateshape__3___u-5457944352225901292.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int16_3__scatterindices___1___0___1___updateshape__3___u-5457944352225901292.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int16_3__scatterindices___1___0___1___updateshape__3___u-6947452231428007930.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int16_3__scatterindices___1___0___1___updateshape__3___u-6947452231428007930.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int32_1__scatterindices___0___0___updateshape__2___updat-7831187107835337863.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int32_1__scatterindices___0___0___updateshape__2___updat-7831187107835337863.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int32_1__scatterindices___0___0___updateshape__2___updat3013699399251572191.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int32_1__scatterindices___0___0___updateshape__2___updat3013699399251572191.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int32_2_3__scatterindices____2___2___2____updateshape__2-2568914706362044844.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int32_2_3__scatterindices____2___2___2____updateshape__2-2568914706362044844.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int32_2_3__scatterindices____2___2___2____updateshape__21379637257835652405.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int32_2_3__scatterindices____2___2___2____updateshape__21379637257835652405.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int32_3_5_40__scatterindices___1___1___updateshape__3_5_-6397860387266378208.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int32_3_5_40__scatterindices___1___1___updateshape__3_5_-6397860387266378208.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int32_3_5_40__scatterindices___1___1___updateshape__3_5_-8425013369710626776.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int32_3_5_40__scatterindices___1___1___updateshape__3_5_-8425013369710626776.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int32_3_5_4__scatterindices___1___1___updateshape__3_2_4-1354491335324461437.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int32_3_5_4__scatterindices___1___1___updateshape__3_2_4-1354491335324461437.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int32_3_5_4__scatterindices___1___1___updateshape__3_2_44517803174587004329.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int32_3_5_4__scatterindices___1___1___updateshape__3_2_44517803174587004329.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int32_3__scatterindices___1___0___1___updateshape__3___u-8298357739460833153.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int32_3__scatterindices___1___0___1___updateshape__3___u-8298357739460833153.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int32_3__scatterindices___1___0___1___updateshape__3___u2992424440995594389.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int32_3__scatterindices___1___0___1___updateshape__3___u2992424440995594389.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int8_1__scatterindices___0___0___updateshape__2___update-6155816636504228609.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int8_1__scatterindices___0___0___updateshape__2___update-6155816636504228609.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int8_1__scatterindices___0___0___updateshape__2___update5958272776881116115.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int8_1__scatterindices___0___0___updateshape__2___update5958272776881116115.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int8_2_3__scatterindices____2___2___2____updateshape__2_-273914920177501008.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int8_2_3__scatterindices____2___2___2____updateshape__2_-273914920177501008.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int8_2_3__scatterindices____2___2___2____updateshape__2_-6476029564649474413.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int8_2_3__scatterindices____2___2___2____updateshape__2_-6476029564649474413.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int8_3_5_40__scatterindices___1___1___updateshape__3_5_2-1853547627817211597.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int8_3_5_40__scatterindices___1___1___updateshape__3_5_2-1853547627817211597.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int8_3_5_40__scatterindices___1___1___updateshape__3_5_22695725104585857772.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int8_3_5_40__scatterindices___1___1___updateshape__3_5_22695725104585857772.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int8_3_5_4__scatterindices___1___1___updateshape__3_2_4_-2838624526001024835.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int8_3_5_4__scatterindices___1___1___updateshape__3_2_4_-2838624526001024835.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int8_3_5_4__scatterindices___1___1___updateshape__3_2_4_7685550097225305461.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int8_3_5_4__scatterindices___1___1___updateshape__3_2_4_7685550097225305461.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int8_3__scatterindices___1___0___1___updateshape__3___up-1361580417478478018.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int8_3__scatterindices___1___0___1___updateshape__3___up-1361580417478478018.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int8_3__scatterindices___1___0___1___updateshape__3___up-6118132633872574782.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int8_3__scatterindices___1___0___1___updateshape__3___up-6118132633872574782.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint16_1__scatterindices___0___0___updateshape__2___upda2503261450963630172.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint16_1__scatterindices___0___0___updateshape__2___upda2503261450963630172.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint16_1__scatterindices___0___0___updateshape__2___upda5093204510233506868.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint16_1__scatterindices___0___0___updateshape__2___upda5093204510233506868.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint16_2_3__scatterindices____2___2___2____updateshape__-1750143131007774592.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint16_2_3__scatterindices____2___2___2____updateshape__-1750143131007774592.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint16_2_3__scatterindices____2___2___2____updateshape__-5500787063730751651.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint16_2_3__scatterindices____2___2___2____updateshape__-5500787063730751651.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint16_3_5_40__scatterindices___1___1___updateshape__3_5-5919758369527735070.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint16_3_5_40__scatterindices___1___1___updateshape__3_5-5919758369527735070.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint16_3_5_40__scatterindices___1___1___updateshape__3_57458529555874971234.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint16_3_5_40__scatterindices___1___1___updateshape__3_57458529555874971234.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint16_3_5_4__scatterindices___1___1___updateshape__3_2_-636077671172413854.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint16_3_5_4__scatterindices___1___1___updateshape__3_2_-636077671172413854.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint16_3_5_4__scatterindices___1___1___updateshape__3_2_8211125442785068895.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint16_3_5_4__scatterindices___1___1___updateshape__3_2_8211125442785068895.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint16_3__scatterindices___1___0___1___updateshape__3___-2867485987227787074.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint16_3__scatterindices___1___0___1___updateshape__3___-2867485987227787074.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint16_3__scatterindices___1___0___1___updateshape__3___381164792639576333.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint16_3__scatterindices___1___0___1___updateshape__3___381164792639576333.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint32_1__scatterindices___0___0___updateshape__2___upda-2795949964342122630.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint32_1__scatterindices___0___0___updateshape__2___upda-2795949964342122630.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint32_1__scatterindices___0___0___updateshape__2___upda2250736341764409016.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint32_1__scatterindices___0___0___updateshape__2___upda2250736341764409016.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint32_2_3__scatterindices____2___2___2____updateshape__-1690059249365063935.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint32_2_3__scatterindices____2___2___2____updateshape__-1690059249365063935.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint32_2_3__scatterindices____2___2___2____updateshape__-7198034765269814555.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint32_2_3__scatterindices____2___2___2____updateshape__-7198034765269814555.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint32_3_5_40__scatterindices___1___1___updateshape__3_5-5318382943476393861.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint32_3_5_40__scatterindices___1___1___updateshape__3_5-5318382943476393861.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint32_3_5_40__scatterindices___1___1___updateshape__3_57035426037223572327.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint32_3_5_40__scatterindices___1___1___updateshape__3_57035426037223572327.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint32_3_5_4__scatterindices___1___1___updateshape__3_2_-4101621119111344638.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint32_3_5_4__scatterindices___1___1___updateshape__3_2_-4101621119111344638.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint32_3_5_4__scatterindices___1___1___updateshape__3_2_-6343906009227681817.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint32_3_5_4__scatterindices___1___1___updateshape__3_2_-6343906009227681817.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint32_3__scatterindices___1___0___1___updateshape__3___-3922149894643362258.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint32_3__scatterindices___1___0___1___updateshape__3___-3922149894643362258.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint32_3__scatterindices___1___0___1___updateshape__3___-6180249292673263141.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint32_3__scatterindices___1___0___1___updateshape__3___-6180249292673263141.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint8_1__scatterindices___0___0___updateshape__2___updat4024776412691488168.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint8_1__scatterindices___0___0___updateshape__2___updat4024776412691488168.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint8_1__scatterindices___0___0___updateshape__2___updat5272633470443816471.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint8_1__scatterindices___0___0___updateshape__2___updat5272633470443816471.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint8_2_3__scatterindices____2___2___2____updateshape__24766134113834505929.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint8_2_3__scatterindices____2___2___2____updateshape__24766134113834505929.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint8_2_3__scatterindices____2___2___2____updateshape__25513192764788487323.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint8_2_3__scatterindices____2___2___2____updateshape__25513192764788487323.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint8_3_5_40__scatterindices___1___1___updateshape__3_5_-8174486124717837339.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint8_3_5_40__scatterindices___1___1___updateshape__3_5_-8174486124717837339.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint8_3_5_40__scatterindices___1___1___updateshape__3_5_1143847998952290388.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint8_3_5_40__scatterindices___1___1___updateshape__3_5_1143847998952290388.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint8_3_5_4__scatterindices___1___1___updateshape__3_2_41873808453015829452.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint8_3_5_4__scatterindices___1___1___updateshape__3_2_41873808453015829452.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint8_3_5_4__scatterindices___1___1___updateshape__3_2_4746412150290416873.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint8_3_5_4__scatterindices___1___1___updateshape__3_2_4746412150290416873.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint8_3__scatterindices___1___0___1___updateshape__3___u-5426271295044320436.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint8_3__scatterindices___1___0___1___updateshape__3___u-5426271295044320436.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint8_3__scatterindices___1___0___1___updateshape__3___u-6108961382462025285.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint8_3__scatterindices___1___0___1___updateshape__3___u-6108961382462025285.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_125__scatterindices__0__updateshape__1___updatewi-3360477254955707104.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_125__scatterindices__0__updateshape__1___updatewi-3360477254955707104.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_125__scatterindices__0__updateshape__1___updatewi-7946346305990918934.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_125__scatterindices__0__updateshape__1___updatewi-7946346305990918934.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_1_1__scatterindices__0__updateshape__1_1__updatew-4215525067889211598.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_1_1__scatterindices__0__updateshape__1_1__updatew-4215525067889211598.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_1_1__scatterindices__0__updateshape__1_1__updatew6431305253276105236.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_1_1__scatterindices__0__updateshape__1_1__updatew6431305253276105236.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_1__scatterindices__0__updateshape__1___updatewind-2780272603278834227.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_1__scatterindices__0__updateshape__1___updatewind-2780272603278834227.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_1__scatterindices__0__updateshape__1___updatewind4104176976515763082.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_1__scatterindices__0__updateshape__1___updatewind4104176976515763082.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__0__updateshape__2_3__updatew2559860308944517111.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__0__updateshape__2_3__updatew2559860308944517111.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__0__updateshape__2_3__updatew8742465151666686826.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__0__updateshape__2_3__updatew8742465151666686826.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1_2__updateshape__1___update-1881389378983648424.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1_2__updateshape__1___update-1881389378983648424.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1_2__updateshape__1___update-6387272614647063159.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1_2__updateshape__1___update-6387272614647063159.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1__updateshape__1_3__updatew-335502595080908761.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1__updateshape__1_3__updatew-335502595080908761.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1__updateshape__1_3__updatew5647609707928580429.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1__updateshape__1_3__updatew5647609707928580429.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_50_3__scatterindices__32__updateshape__1_3__updat-5889877709785329052.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_50_3__scatterindices__32__updateshape__1_3__updat-5889877709785329052.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_50_3__scatterindices__32__updateshape__1_3__updat3688725826103030188.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_50_3__scatterindices__32__updateshape__1_3__updat3688725826103030188.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1__scatterindices__0__updateshape____updatewindowdi8099031119810233793.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1__scatterindices__0__updateshape____updatewindowdi8099031119810233793.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1__scatterindices__0__updateshape____updatewindowdi8325755295697371291.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1__scatterindices__0__updateshape____updatewindowdi8325755295697371291.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upd3417738498369290757.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upd3417738498369290757.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upd9109906871151307668.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upd9109906871151307668.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_4_2_3__scatterindices__3_2__updateshape__2___update-4702680586383969660.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_4_2_3__scatterindices__3_2__updateshape__2___update-4702680586383969660.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_4_2_3__scatterindices__3_2__updateshape__2___update-8795005146239087129.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_4_2_3__scatterindices__3_2__updateshape__2___update-8795005146239087129.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices___0_1___2_3___updateshape__2_-6656881674249389345.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices___0_1___2_3___updateshape__2_-6656881674249389345.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices___0_1___2_3___updateshape__2_2316509734154499027.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices___0_1___2_3___updateshape__2_2316509734154499027.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2___-7981361882450982124.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2___-7981361882450982124.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2___1647529870284745307.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2___1647529870284745307.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0___1_____2___3____updates1467080413083166032.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0___1_____2___3____updates1467080413083166032.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0___1_____2___3____updates3651937655910732508.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0___1_____2___3____updates3651937655910732508.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_125__scatterindices__0__updateshape__1___updatewin-1705989900307999079.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_125__scatterindices__0__updateshape__1___updatewin-1705989900307999079.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_125__scatterindices__0__updateshape__1___updatewin-246492594110861908.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_125__scatterindices__0__updateshape__1___updatewin-246492594110861908.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_1_1__scatterindices__0__updateshape__1_1__updatewi-4346732979607199533.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_1_1__scatterindices__0__updateshape__1_1__updatewi-4346732979607199533.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_1_1__scatterindices__0__updateshape__1_1__updatewi-5946980796241614660.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_1_1__scatterindices__0__updateshape__1_1__updatewi-5946980796241614660.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_1__scatterindices__0__updateshape__1___updatewindo-306016717615730660.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_1__scatterindices__0__updateshape__1___updatewindo-306016717615730660.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_1__scatterindices__0__updateshape__1___updatewindo3890941391873863717.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_1__scatterindices__0__updateshape__1___updatewindo3890941391873863717.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__0__updateshape__2_3__updatewi1839078693190890993.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__0__updateshape__2_3__updatewi1839078693190890993.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__0__updateshape__2_3__updatewi5761561957537694476.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__0__updateshape__2_3__updatewi5761561957537694476.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1_2__updateshape__1___updatew6252979626325873169.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1_2__updateshape__1___updatew6252979626325873169.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1_2__updateshape__1___updatew7494928465242488531.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1_2__updateshape__1___updatew7494928465242488531.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1__updateshape__1_3__updatewi-3584544566206542049.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1__updateshape__1_3__updatewi-3584544566206542049.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1__updateshape__1_3__updatewi-7572000476884458861.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1__updateshape__1_3__updatewi-7572000476884458861.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_50_3__scatterindices__32__updateshape__1_3__update-598301403947229232.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_50_3__scatterindices__32__updateshape__1_3__update-598301403947229232.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_50_3__scatterindices__32__updateshape__1_3__update8652299584681040983.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_50_3__scatterindices__32__updateshape__1_3__update8652299584681040983.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1__scatterindices__0__updateshape____updatewindowdim-7668310686109821516.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1__scatterindices__0__updateshape____updatewindowdim-7668310686109821516.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1__scatterindices__0__updateshape____updatewindowdim439772284860314777.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1__scatterindices__0__updateshape____updatewindowdim439772284860314777.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda-8229569663899407117.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda-8229569663899407117.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda1985329647950112572.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda1985329647950112572.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_4_2_3__scatterindices__3_2__updateshape__2___updatew-8523218113249752123.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_4_2_3__scatterindices__3_2__updateshape__2___updatew-8523218113249752123.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_4_2_3__scatterindices__3_2__updateshape__2___updatew6735558503942351692.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_4_2_3__scatterindices__3_2__updateshape__2___updatew6735558503942351692.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7-4258334668196109132.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7-4258334668196109132.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_5_6_7__scatterindices___0_1___2_3___updateshape__2_76621240554816602630.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_5_6_7__scatterindices___0_1___2_3___updateshape__2_76621240554816602630.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____-2362187331049583053.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____-2362187331049583053.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____-5820826746249069089.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____-5820826746249069089.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0___1_____2___3____updatesh-8865046078508563898.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0___1_____2___3____updatesh-8865046078508563898.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0___1_____2___3____updatesh3362558007660062089.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0___1_____2___3____updatesh3362558007660062089.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewin-6464005931074999144.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewin-6464005931074999144.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewin1632551694578966009.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewin1632551694578966009.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__updatewi-4057511293439628981.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__updatewi-4057511293439628981.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__updatewi465178004043834746.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__updatewi465178004043834746.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___updatewindo3601856020145074869.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___updatewindo3601856020145074869.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___updatewindo4848867162453427424.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___updatewindo4848867162453427424.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatewi5803760535453716447.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatewi5803760535453716447.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatewi676591662531539119.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatewi676591662531539119.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___updatew-6954106673892958067.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___updatew-6954106673892958067.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___updatew6445319413769660340.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___updatew6445319413769660340.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatewi7109546237705646979.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatewi7109546237705646979.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatewi8953743155862854282.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatewi8953743155862854282.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__update2709164478077877077.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__update2709164478077877077.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__update6879970989976731825.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__update6879970989976731825.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdim-2705209602339395263.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdim-2705209602339395263.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdim-4975626822862635303.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdim-4975626822862635303.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda-8979056223101967933.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda-8979056223101967933.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda7605760556573737631.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda7605760556573737631.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___updatew-7612717851277605180.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___updatew-7612717851277605180.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___updatew3278581319799892390.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___updatew3278581319799892390.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7-2031264665322592657.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7-2031264665322592657.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape__2_76375060216127585701.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape__2_76375060216127585701.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____-5359808417426891675.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____-5359808417426891675.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____2501261658899671469.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____2501261658899671469.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____updatesh4730208024092888126.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____updatesh4730208024092888126.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____updatesh979978458744744089.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____updatesh979978458744744089.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_125__scatterindices__0__updateshape__1___updatewindo-894643363405551362.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_125__scatterindices__0__updateshape__1___updatewindo-894643363405551362.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_125__scatterindices__0__updateshape__1___updatewindo2210039802490704290.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_125__scatterindices__0__updateshape__1___updatewindo2210039802490704290.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_1_1__scatterindices__0__updateshape__1_1__updatewind4564339569477160634.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_1_1__scatterindices__0__updateshape__1_1__updatewind4564339569477160634.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_1_1__scatterindices__0__updateshape__1_1__updatewind7066681658393563090.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_1_1__scatterindices__0__updateshape__1_1__updatewind7066681658393563090.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_1__scatterindices__0__updateshape__1___updatewindowd1131523970815717172.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_1__scatterindices__0__updateshape__1___updatewindowd1131523970815717172.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_1__scatterindices__0__updateshape__1___updatewindowd7341461832802061798.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_1__scatterindices__0__updateshape__1___updatewindowd7341461832802061798.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__0__updateshape__2_3__updatewind5115612453657169070.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__0__updateshape__2_3__updatewind5115612453657169070.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__0__updateshape__2_3__updatewind8686182913507257521.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__0__updateshape__2_3__updatewind8686182913507257521.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1_2__updateshape__1___updatewin3357486422049699870.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1_2__updateshape__1___updatewin3357486422049699870.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1_2__updateshape__1___updatewin5579100838365427816.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1_2__updateshape__1___updatewin5579100838365427816.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1__updateshape__1_3__updatewind-5330481510598916239.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1__updateshape__1_3__updatewind-5330481510598916239.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1__updateshape__1_3__updatewind6212760972741628489.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1__updateshape__1_3__updatewind6212760972741628489.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_50_3__scatterindices__32__updateshape__1_3__updatewi-4661087241743951708.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_50_3__scatterindices__32__updateshape__1_3__updatewi-4661087241743951708.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_50_3__scatterindices__32__updateshape__1_3__updatewi2227239171340197214.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_50_3__scatterindices__32__updateshape__1_3__updatewi2227239171340197214.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1__scatterindices__0__updateshape____updatewindowdims_-3022424246807224585.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1__scatterindices__0__updateshape____updatewindowdims_-3022424246807224585.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1__scatterindices__0__updateshape____updatewindowdims_6495970254371841842.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1__scatterindices__0__updateshape____updatewindowdims_6495970254371841842.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-4024893389875354515.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-4024893389875354515.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-5668681648500657011.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-5668681648500657011.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_4_2_3__scatterindices__3_2__updateshape__2___updatewin-9105649694610227047.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_4_2_3__scatterindices__3_2__updateshape__2___updatewin-9105649694610227047.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_4_2_3__scatterindices__3_2__updateshape__2___updatewin6073515528611323777.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_4_2_3__scatterindices__3_2__updateshape__2___updatewin6073515528611323777.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-3882476055472377626.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-3882476055472377626.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-513754655167866318.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-513754655167866318.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-8966013931511561723.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-8966013931511561723.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up391128158965102141.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up391128158965102141.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0___1_____2___3____updateshap-9078196501509989682.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0___1_____2___3____updateshap-9078196501509989682.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0___1_____2___3____updateshap5700558581733748335.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0___1_____2___3____updateshap5700558581733748335.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_125__scatterindices__0__updateshape__1___updatewindo-6562225039484538740.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_125__scatterindices__0__updateshape__1___updatewindo-6562225039484538740.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_125__scatterindices__0__updateshape__1___updatewindo8232220520292271211.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_125__scatterindices__0__updateshape__1___updatewindo8232220520292271211.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_1_1__scatterindices__0__updateshape__1_1__updatewind-7916337849519059432.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_1_1__scatterindices__0__updateshape__1_1__updatewind-7916337849519059432.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_1_1__scatterindices__0__updateshape__1_1__updatewind761967631948328949.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_1_1__scatterindices__0__updateshape__1_1__updatewind761967631948328949.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_1__scatterindices__0__updateshape__1___updatewindowd-5359430482089778863.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_1__scatterindices__0__updateshape__1___updatewindowd-5359430482089778863.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_1__scatterindices__0__updateshape__1___updatewindowd5240083812117045369.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_1__scatterindices__0__updateshape__1___updatewindowd5240083812117045369.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__0__updateshape__2_3__updatewind-3880842726960184803.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__0__updateshape__2_3__updatewind-3880842726960184803.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__0__updateshape__2_3__updatewind-849743020913739099.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__0__updateshape__2_3__updatewind-849743020913739099.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1_2__updateshape__1___updatewin-1988034303685772822.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1_2__updateshape__1___updatewin-1988034303685772822.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1_2__updateshape__1___updatewin217957902070723668.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1_2__updateshape__1___updatewin217957902070723668.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1__updateshape__1_3__updatewind-1045259206755100465.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1__updateshape__1_3__updatewind-1045259206755100465.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1__updateshape__1_3__updatewind-2163171530325055090.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1__updateshape__1_3__updatewind-2163171530325055090.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_50_3__scatterindices__32__updateshape__1_3__updatewi-6750428638558261011.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_50_3__scatterindices__32__updateshape__1_3__updatewi-6750428638558261011.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_50_3__scatterindices__32__updateshape__1_3__updatewi3312930273958637148.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_50_3__scatterindices__32__updateshape__1_3__updatewi3312930273958637148.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1__scatterindices__0__updateshape____updatewindowdims_-2160631094585953130.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1__scatterindices__0__updateshape____updatewindowdims_-2160631094585953130.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1__scatterindices__0__updateshape____updatewindowdims_5211705405518386156.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1__scatterindices__0__updateshape____updatewindowdims_5211705405518386156.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-8648264117507005007.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-8648264117507005007.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_4_2_3_5__scatterindices__0_4__updateshape__4_3__update6159597994996988558.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_4_2_3_5__scatterindices__0_4__updateshape__4_3__update6159597994996988558.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_4_2_3__scatterindices__3_2__updateshape__2___updatewin3292662860220954186.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_4_2_3__scatterindices__3_2__updateshape__2___updatewin3292662860220954186.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_4_2_3__scatterindices__3_2__updateshape__2___updatewin8363876055077466091.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_4_2_3__scatterindices__3_2__updateshape__2___updatewin8363876055077466091.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__1300960516346061501.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__1300960516346061501.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__8366371928875377100.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__8366371928875377100.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up1636569897511669512.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up1636569897511669512.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up3340198020277021599.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up3340198020277021599.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0___1_____2___3____updateshap-8225746493159059601.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0___1_____2___3____updateshap-8225746493159059601.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0___1_____2___3____updateshap4011951321233696206.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0___1_____2___3____updateshap4011951321233696206.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_125__scatterindices__0__updateshape__1___updatewindow-111981570719861577.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_125__scatterindices__0__updateshape__1___updatewindow-111981570719861577.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_125__scatterindices__0__updateshape__1___updatewindow3372628312255323136.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_125__scatterindices__0__updateshape__1___updatewindow3372628312255323136.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_1_1__scatterindices__0__updateshape__1_1__updatewindo3534973217554270585.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_1_1__scatterindices__0__updateshape__1_1__updatewindo3534973217554270585.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_1_1__scatterindices__0__updateshape__1_1__updatewindo4155173732612390224.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_1_1__scatterindices__0__updateshape__1_1__updatewindo4155173732612390224.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_1__scatterindices__0__updateshape__1___updatewindowdi2887914144604862218.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_1__scatterindices__0__updateshape__1___updatewindowdi2887914144604862218.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_1__scatterindices__0__updateshape__1___updatewindowdi4469707123732510219.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_1__scatterindices__0__updateshape__1___updatewindowdi4469707123732510219.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__0__updateshape__2_3__updatewindo-1464735832931959797.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__0__updateshape__2_3__updatewindo-1464735832931959797.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__0__updateshape__2_3__updatewindo991080895202624293.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__0__updateshape__2_3__updatewindo991080895202624293.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1_2__updateshape__1___updatewind-5869849077510288141.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1_2__updateshape__1___updatewind-5869849077510288141.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1_2__updateshape__1___updatewind4714892237262590743.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1_2__updateshape__1___updatewind4714892237262590743.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1__updateshape__1_3__updatewindo-2821247655828279221.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1__updateshape__1_3__updatewindo-2821247655828279221.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1__updateshape__1_3__updatewindo5883765822750344543.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1__updateshape__1_3__updatewindo5883765822750344543.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_50_3__scatterindices__32__updateshape__1_3__updatewin3890704783693838053.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_50_3__scatterindices__32__updateshape__1_3__updatewin3890704783693838053.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_50_3__scatterindices__32__updateshape__1_3__updatewin5926764019743641747.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_50_3__scatterindices__32__updateshape__1_3__updatewin5926764019743641747.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1__scatterindices__0__updateshape____updatewindowdims__1254005676560697655.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1__scatterindices__0__updateshape____updatewindowdims__1254005676560697655.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1__scatterindices__0__updateshape____updatewindowdims__2042027638374529727.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1__scatterindices__0__updateshape____updatewindowdims__2042027638374529727.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatew-3294582951459358199.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatew-3294582951459358199.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatew8954133149842640533.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatew8954133149842640533.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_4_2_3__scatterindices__3_2__updateshape__2___updatewind-2950263105139370261.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_4_2_3__scatterindices__3_2__updateshape__2___updatewind-2950263105139370261.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_4_2_3__scatterindices__3_2__updateshape__2___updatewind-4707753359265092675.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_4_2_3__scatterindices__3_2__updateshape__2___updatewind-4707753359265092675.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__u-5932100710693672352.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__u-5932100710693672352.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__u533406235125782564.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__u533406235125782564.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upd-345864373339151471.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upd-345864373339151471.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upd1553916274230136318.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upd1553916274230136318.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0___1_____2___3____updateshape4285133721288375655.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0___1_____2___3____updateshape4285133721288375655.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0___1_____2___3____updateshape4507876843873845780.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0___1_____2___3____updateshape4507876843873845780.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_125__scatterindices__0__updateshape__1___updatewind-1667807402137901181.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_125__scatterindices__0__updateshape__1___updatewind-1667807402137901181.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_125__scatterindices__0__updateshape__1___updatewind821217668492272078.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_125__scatterindices__0__updateshape__1___updatewind821217668492272078.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_1_1__scatterindices__0__updateshape__1_1__updatewin3418850834955662541.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_1_1__scatterindices__0__updateshape__1_1__updatewin3418850834955662541.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_1_1__scatterindices__0__updateshape__1_1__updatewin4201243891161652134.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_1_1__scatterindices__0__updateshape__1_1__updatewin4201243891161652134.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_1__scatterindices__0__updateshape__1___updatewindow3680904523812281099.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_1__scatterindices__0__updateshape__1___updatewindow3680904523812281099.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_1__scatterindices__0__updateshape__1___updatewindow4781847233955898769.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_1__scatterindices__0__updateshape__1___updatewindow4781847233955898769.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__0__updateshape__2_3__updatewin-322681613942851425.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__0__updateshape__2_3__updatewin-322681613942851425.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__0__updateshape__2_3__updatewin2126778553061836798.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__0__updateshape__2_3__updatewin2126778553061836798.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1_2__updateshape__1___updatewi-6766913623160416458.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1_2__updateshape__1___updatewi-6766913623160416458.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1_2__updateshape__1___updatewi1162864048077847697.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1_2__updateshape__1___updatewi1162864048077847697.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1__updateshape__1_3__updatewin-113788717369935348.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1__updateshape__1_3__updatewin-113788717369935348.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1__updateshape__1_3__updatewin8975737341944237165.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1__updateshape__1_3__updatewin8975737341944237165.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_50_3__scatterindices__32__updateshape__1_3__updatew-8407979194831241665.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_50_3__scatterindices__32__updateshape__1_3__updatew-8407979194831241665.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_50_3__scatterindices__32__updateshape__1_3__updatew1896497151505034933.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_50_3__scatterindices__32__updateshape__1_3__updatew1896497151505034933.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1__scatterindices__0__updateshape____updatewindowdims-6732567000122109466.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1__scatterindices__0__updateshape____updatewindowdims-6732567000122109466.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1__scatterindices__0__updateshape____updatewindowdims8369315150788296177.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1__scatterindices__0__updateshape____updatewindowdims8369315150788296177.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat1872239608779336173.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat1872239608779336173.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat7331007253302672627.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat7331007253302672627.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_4_2_3__scatterindices__3_2__updateshape__2___updatewi-6289641638059328425.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_4_2_3__scatterindices__3_2__updateshape__2___updatewi-6289641638059328425.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_4_2_3__scatterindices__3_2__updateshape__2___updatewi6894674836177418052.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_4_2_3__scatterindices__3_2__updateshape__2___updatewi6894674836177418052.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_-4801225886434282536.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_-4801225886434282536.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_3972516982325290392.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_3972516982325290392.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u-377631690596425522.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u-377631690596425522.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u6860646687466945699.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u6860646687466945699.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0___1_____2___3____updatesha-4251669814050383889.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0___1_____2___3____updatesha-4251669814050383889.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0___1_____2___3____updatesha-8858309163784542992.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0___1_____2___3____updatesha-8858309163784542992.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_125__scatterindices__0__updateshape__1___updatewind-1704453188135452065.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_125__scatterindices__0__updateshape__1___updatewind-1704453188135452065.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_125__scatterindices__0__updateshape__1___updatewind3660954273200353020.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_125__scatterindices__0__updateshape__1___updatewind3660954273200353020.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_1_1__scatterindices__0__updateshape__1_1__updatewin-4234295038244077699.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_1_1__scatterindices__0__updateshape__1_1__updatewin-4234295038244077699.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_1_1__scatterindices__0__updateshape__1_1__updatewin7679086674395570535.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_1_1__scatterindices__0__updateshape__1_1__updatewin7679086674395570535.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_1__scatterindices__0__updateshape__1___updatewindow-110325613177501848.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_1__scatterindices__0__updateshape__1___updatewindow-110325613177501848.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_1__scatterindices__0__updateshape__1___updatewindow8551599803177390565.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_1__scatterindices__0__updateshape__1___updatewindow8551599803177390565.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__0__updateshape__2_3__updatewin-1859429760712290799.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__0__updateshape__2_3__updatewin-1859429760712290799.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__0__updateshape__2_3__updatewin3387081657127263646.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__0__updateshape__2_3__updatewin3387081657127263646.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1_2__updateshape__1___updatewi-2449112500337245365.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1_2__updateshape__1___updatewi-2449112500337245365.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1_2__updateshape__1___updatewi4744761297352104237.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1_2__updateshape__1___updatewi4744761297352104237.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1__updateshape__1_3__updatewin1307550907639424494.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1__updateshape__1_3__updatewin1307550907639424494.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1__updateshape__1_3__updatewin6567349431661793525.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1__updateshape__1_3__updatewin6567349431661793525.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_50_3__scatterindices__32__updateshape__1_3__updatew-8119964461084363759.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_50_3__scatterindices__32__updateshape__1_3__updatew-8119964461084363759.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_50_3__scatterindices__32__updateshape__1_3__updatew3673094684779122943.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_50_3__scatterindices__32__updateshape__1_3__updatew3673094684779122943.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1__scatterindices__0__updateshape____updatewindowdims1969687651635792397.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1__scatterindices__0__updateshape____updatewindowdims1969687651635792397.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1__scatterindices__0__updateshape____updatewindowdims2696056147646221299.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1__scatterindices__0__updateshape____updatewindowdims2696056147646221299.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat-542804495611746280.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat-542804495611746280.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat9217932344131399686.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat9217932344131399686.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_4_2_3__scatterindices__3_2__updateshape__2___updatewi-5713978486446818932.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_4_2_3__scatterindices__3_2__updateshape__2___updatewi-5713978486446818932.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_4_2_3__scatterindices__3_2__updateshape__2___updatewi5259753196347630593.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_4_2_3__scatterindices__3_2__updateshape__2___updatewi5259753196347630593.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_-7053757109840106619.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_-7053757109840106619.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_4871342495677478541.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_4871342495677478541.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u2457362189692860874.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u2457362189692860874.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u6188014052084615117.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u6188014052084615117.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0___1_____2___3____updatesha4248940963503671441.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0___1_____2___3____updatesha4248940963503671441.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0___1_____2___3____updatesha6868272512651083334.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0___1_____2___3____updatesha6868272512651083334.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_125__scatterindices__0__updateshape__1___updatewindo-1910154477968116386.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_125__scatterindices__0__updateshape__1___updatewindo-1910154477968116386.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_125__scatterindices__0__updateshape__1___updatewindo8260422791672786393.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_125__scatterindices__0__updateshape__1___updatewindo8260422791672786393.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_1_1__scatterindices__0__updateshape__1_1__updatewind-5161385092992564727.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_1_1__scatterindices__0__updateshape__1_1__updatewind-5161385092992564727.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_1_1__scatterindices__0__updateshape__1_1__updatewind7864482691090263849.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_1_1__scatterindices__0__updateshape__1_1__updatewind7864482691090263849.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_1__scatterindices__0__updateshape__1___updatewindowd-3673649132944055118.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_1__scatterindices__0__updateshape__1___updatewindowd-3673649132944055118.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_1__scatterindices__0__updateshape__1___updatewindowd7995333100578489040.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_1__scatterindices__0__updateshape__1___updatewindowd7995333100578489040.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__0__updateshape__2_3__updatewind-3849831729354064929.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__0__updateshape__2_3__updatewind-3849831729354064929.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__0__updateshape__2_3__updatewind-3919994019662167690.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__0__updateshape__2_3__updatewind-3919994019662167690.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1_2__updateshape__1___updatewin-8230579987754338924.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1_2__updateshape__1___updatewin-8230579987754338924.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1_2__updateshape__1___updatewin6410318316600411775.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1_2__updateshape__1___updatewin6410318316600411775.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1__updateshape__1_3__updatewind-18644883834479203.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1__updateshape__1_3__updatewind-18644883834479203.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1__updateshape__1_3__updatewind1471471209202151261.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1__updateshape__1_3__updatewind1471471209202151261.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_50_3__scatterindices__32__updateshape__1_3__updatewi-3494775986942929214.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_50_3__scatterindices__32__updateshape__1_3__updatewi-3494775986942929214.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_50_3__scatterindices__32__updateshape__1_3__updatewi4960596588736335712.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_50_3__scatterindices__32__updateshape__1_3__updatewi4960596588736335712.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1__scatterindices__0__updateshape____updatewindowdims_7030611960189158297.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1__scatterindices__0__updateshape____updatewindowdims_7030611960189158297.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1__scatterindices__0__updateshape____updatewindowdims_987589972778068218.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1__scatterindices__0__updateshape____updatewindowdims_987589972778068218.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-6688911708365296131.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-6688911708365296131.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_4_2_3_5__scatterindices__0_4__updateshape__4_3__update8221209685807053597.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_4_2_3_5__scatterindices__0_4__updateshape__4_3__update8221209685807053597.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_4_2_3__scatterindices__3_2__updateshape__2___updatewin-1390584555678624339.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_4_2_3__scatterindices__3_2__updateshape__2___updatewin-1390584555678624339.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_4_2_3__scatterindices__3_2__updateshape__2___updatewin-4833110851173867022.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_4_2_3__scatterindices__3_2__updateshape__2___updatewin-4833110851173867022.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-3139063086521215457.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-3139063086521215457.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-4201352065835320077.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-4201352065835320077.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up1751444907009857893.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up1751444907009857893.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up7676739352108892783.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up7676739352108892783.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0___1_____2___3____updateshap-2761376882161010530.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0___1_____2___3____updateshap-2761376882161010530.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0___1_____2___3____updateshap-3709788139329733973.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0___1_____2___3____updateshap-3709788139329733973.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_125__scatterindices__0__updateshape__1___updatewindow1533954122127809733.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_125__scatterindices__0__updateshape__1___updatewindow1533954122127809733.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_125__scatterindices__0__updateshape__1___updatewindow2212334345328524560.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_125__scatterindices__0__updateshape__1___updatewindow2212334345328524560.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_1_1__scatterindices__0__updateshape__1_1__updatewindo-5515472226926612209.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_1_1__scatterindices__0__updateshape__1_1__updatewindo-5515472226926612209.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_1_1__scatterindices__0__updateshape__1_1__updatewindo-5746832321951146741.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_1_1__scatterindices__0__updateshape__1_1__updatewindo-5746832321951146741.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_1__scatterindices__0__updateshape__1___updatewindowdi-4275631455928422701.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_1__scatterindices__0__updateshape__1___updatewindowdi-4275631455928422701.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_1__scatterindices__0__updateshape__1___updatewindowdi880223842074782525.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_1__scatterindices__0__updateshape__1___updatewindowdi880223842074782525.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__0__updateshape__2_3__updatewindo-6921631478747710153.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__0__updateshape__2_3__updatewindo-6921631478747710153.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__0__updateshape__2_3__updatewindo7169358858965434835.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__0__updateshape__2_3__updatewindo7169358858965434835.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1_2__updateshape__1___updatewind-8327222120113615417.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1_2__updateshape__1___updatewind-8327222120113615417.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1_2__updateshape__1___updatewind3214235195966616342.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1_2__updateshape__1___updatewind3214235195966616342.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1__updateshape__1_3__updatewindo-748528918597234818.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1__updateshape__1_3__updatewindo-748528918597234818.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1__updateshape__1_3__updatewindo4827717327284223529.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1__updateshape__1_3__updatewindo4827717327284223529.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_50_3__scatterindices__32__updateshape__1_3__updatewin-811004303319833014.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_50_3__scatterindices__32__updateshape__1_3__updatewin-811004303319833014.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_50_3__scatterindices__32__updateshape__1_3__updatewin-8968797547817646506.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_50_3__scatterindices__32__updateshape__1_3__updatewin-8968797547817646506.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1__scatterindices__0__updateshape____updatewindowdims__803457496356836485.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1__scatterindices__0__updateshape____updatewindowdims__803457496356836485.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1__scatterindices__0__updateshape____updatewindowdims__8767377410188178831.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1__scatterindices__0__updateshape____updatewindowdims__8767377410188178831.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatew2557353525546824738.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatew2557353525546824738.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatew4970676801450038327.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatew4970676801450038327.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_4_2_3__scatterindices__3_2__updateshape__2___updatewind-4730266098010714399.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_4_2_3__scatterindices__3_2__updateshape__2___updatewind-4730266098010714399.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_4_2_3__scatterindices__3_2__updateshape__2___updatewind4163324590869984089.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_4_2_3__scatterindices__3_2__updateshape__2___updatewind4163324590869984089.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__u6903743958365226192.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__u6903743958365226192.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__u851653131651182203.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__u851653131651182203.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upd-4211788900756011514.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upd-4211788900756011514.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upd-567013946010987568.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upd-567013946010987568.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0___1_____2___3____updateshape-2470723896364236739.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0___1_____2___3____updateshape-2470723896364236739.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0___1_____2___3____updateshape-2777750282793909638.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0___1_____2___3____updateshape-2777750282793909638.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_125__scatterindices__0__updateshape__1___updatewindowd-7931172523670735374.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_125__scatterindices__0__updateshape__1___updatewindowd-7931172523670735374.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_125__scatterindices__0__updateshape__1___updatewindowd-7993092849982844884.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_125__scatterindices__0__updateshape__1___updatewindowd-7993092849982844884.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_1_1__scatterindices__0__updateshape__1_1__updatewindow-5898398544245547889.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_1_1__scatterindices__0__updateshape__1_1__updatewindow-5898398544245547889.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_1_1__scatterindices__0__updateshape__1_1__updatewindow9167193204831340500.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_1_1__scatterindices__0__updateshape__1_1__updatewindow9167193204831340500.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_1__scatterindices__0__updateshape__1___updatewindowdim-6697600837644775619.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_1__scatterindices__0__updateshape__1___updatewindowdim-6697600837644775619.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_1__scatterindices__0__updateshape__1___updatewindowdim-8696271625363789640.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_1__scatterindices__0__updateshape__1___updatewindowdim-8696271625363789640.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__0__updateshape__2_3__updatewindow-4892701647612422962.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__0__updateshape__2_3__updatewindow-4892701647612422962.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__0__updateshape__2_3__updatewindow2596278087494014499.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__0__updateshape__2_3__updatewindow2596278087494014499.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1_2__updateshape__1___updatewindo-8075241794635431733.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1_2__updateshape__1___updatewindo-8075241794635431733.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1_2__updateshape__1___updatewindo1273402148187748210.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1_2__updateshape__1___updatewindo1273402148187748210.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1__updateshape__1_3__updatewindow2449512720322872831.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1__updateshape__1_3__updatewindow2449512720322872831.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1__updateshape__1_3__updatewindow5376840236682189212.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1__updateshape__1_3__updatewindow5376840236682189212.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_50_3__scatterindices__32__updateshape__1_3__updatewind-4988232798612003322.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_50_3__scatterindices__32__updateshape__1_3__updatewind-4988232798612003322.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_50_3__scatterindices__32__updateshape__1_3__updatewind-5971616284794195597.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_50_3__scatterindices__32__updateshape__1_3__updatewind-5971616284794195597.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1__scatterindices__0__updateshape____updatewindowdims___-1581882056067495630.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1__scatterindices__0__updateshape____updatewindowdims___-1581882056067495630.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1__scatterindices__0__updateshape____updatewindowdims___6931141976005902227.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1__scatterindices__0__updateshape____updatewindowdims___6931141976005902227.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewi-4440686757305113217.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewi-4440686757305113217.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewi6177149507061095935.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewi6177149507061095935.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_4_2_3__scatterindices__3_2__updateshape__2___updatewindo-6702992408726250105.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_4_2_3__scatterindices__3_2__updateshape__2___updatewindo-6702992408726250105.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_4_2_3__scatterindices__3_2__updateshape__2___updatewindo9003353866223854776.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_4_2_3__scatterindices__3_2__updateshape__2___updatewindo9003353866223854776.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__up-3915391758544634424.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__up-3915391758544634424.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__up5091440795627112933.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__up5091440795627112933.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upda-3895422969289538715.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upda-3895422969289538715.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upda-8607484419178884934.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upda-8607484419178884934.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0___1_____2___3____updateshape_-3264758681388995130.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0___1_____2___3____updateshape_-3264758681388995130.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0___1_____2___3____updateshape_-4145200395049429998.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0___1_____2___3____updateshape_-4145200395049429998.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewindowd-5032394219303006330.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewindowd-5032394219303006330.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewindowd-6124250000237564558.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewindowd-6124250000237564558.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__updatewindow-1166308964052795389.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__updatewindow-1166308964052795389.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__updatewindow6146376150855278773.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__updatewindow6146376150855278773.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___updatewindowdim-5224563014099850559.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___updatewindowdim-5224563014099850559.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___updatewindowdim5902876704179291364.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___updatewindowdim5902876704179291364.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatewindow-1359298270164992119.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatewindow-1359298270164992119.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatewindow4638245368204258251.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatewindow4638245368204258251.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___updatewindo-6952903215068308375.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___updatewindo-6952903215068308375.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___updatewindo8098655806184711956.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___updatewindo8098655806184711956.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatewindow-3166175301749478603.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatewindow-3166175301749478603.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatewindow-8091553558886532801.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatewindow-8091553558886532801.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__updatewind-4592039499336222183.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__updatewind-4592039499336222183.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__updatewind551072783988540586.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__updatewind551072783988540586.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdims___-6627904546511788292.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdims___-6627904546511788292.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdims___-7236496705769878027.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdims___-7236496705769878027.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewi-1035527451504575367.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewi-1035527451504575367.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewi8957927086497228610.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewi8957927086497228610.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___updatewindo-6250034927652667738.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___updatewindo-6250034927652667738.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___updatewindo3872250257123715336.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___updatewindo3872250257123715336.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__up-769885505866663214.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__up-769885505866663214.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__up8042376641814452391.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__up8042376641814452391.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upda2948120356280440177.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upda2948120356280440177.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upda5974274183341077107.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upda5974274183341077107.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____updateshape_-5296991456639355529.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____updateshape_-5296991456639355529.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____updateshape_4632684866950503328.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____updateshape_4632684866950503328.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_125__scatterindices__0__updateshape__1___updatewindowdim-8698108769819920525.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_125__scatterindices__0__updateshape__1___updatewindowdim-8698108769819920525.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_125__scatterindices__0__updateshape__1___updatewindowdim8087846058922533087.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_125__scatterindices__0__updateshape__1___updatewindowdim8087846058922533087.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_1_1__scatterindices__0__updateshape__1_1__updatewindowdi1276220733139075642.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_1_1__scatterindices__0__updateshape__1_1__updatewindowdi1276220733139075642.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_1_1__scatterindices__0__updateshape__1_1__updatewindowdi4078443036999630362.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_1_1__scatterindices__0__updateshape__1_1__updatewindowdi4078443036999630362.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_1__scatterindices__0__updateshape__1___updatewindowdims_-3629977247342632200.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_1__scatterindices__0__updateshape__1___updatewindowdims_-3629977247342632200.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_1__scatterindices__0__updateshape__1___updatewindowdims_-4115071638028730798.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_1__scatterindices__0__updateshape__1___updatewindowdims_-4115071638028730798.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__0__updateshape__2_3__updatewindowdi-3883231357575282014.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__0__updateshape__2_3__updatewindowdi-3883231357575282014.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__0__updateshape__2_3__updatewindowdi1978913595889693225.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__0__updateshape__2_3__updatewindowdi1978913595889693225.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1_2__updateshape__1___updatewindowd-3566369876500629401.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1_2__updateshape__1___updatewindowd-3566369876500629401.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1_2__updateshape__1___updatewindowd4618097380212176823.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1_2__updateshape__1___updatewindowd4618097380212176823.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1__updateshape__1_3__updatewindowdi2436397930943635512.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1__updateshape__1_3__updatewindowdi2436397930943635512.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1__updateshape__1_3__updatewindowdi8827461135262261632.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1__updateshape__1_3__updatewindowdi8827461135262261632.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_50_3__scatterindices__32__updateshape__1_3__updatewindow-4109071485922139713.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_50_3__scatterindices__32__updateshape__1_3__updatewindow-4109071485922139713.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_50_3__scatterindices__32__updateshape__1_3__updatewindow960323707474477742.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_50_3__scatterindices__32__updateshape__1_3__updatewindow960323707474477742.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1__scatterindices__0__updateshape____updatewindowdims____i2590786440408111957.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1__scatterindices__0__updateshape____updatewindowdims____i2590786440408111957.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1__scatterindices__0__updateshape____updatewindowdims____i3309142488687098958.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1__scatterindices__0__updateshape____updatewindowdims____i3309142488687098958.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewind-2387065130740248241.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewind-2387065130740248241.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewind-6857143018353430914.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewind-6857143018353430914.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_4_2_3__scatterindices__3_2__updateshape__2___updatewindowd-9078145034046701277.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_4_2_3__scatterindices__3_2__updateshape__2___updatewindowd-9078145034046701277.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_4_2_3__scatterindices__3_2__updateshape__2___updatewindowd7657914062383838323.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_4_2_3__scatterindices__3_2__updateshape__2___updatewindowd7657914062383838323.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__upda-5685031293975477435.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__upda-5685031293975477435.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__upda8137745118639757527.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__upda8137745118639757527.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____update-4929832496997222980.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____update-4929832496997222980.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____update-8287342731327426887.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____update-8287342731327426887.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0___1_____2___3____updateshape__5-3903744609433253284.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0___1_____2___3____updateshape__5-3903744609433253284.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0___1_____2___3____updateshape__5-6179391706430955564.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0___1_____2___3____updateshape__5-6179391706430955564.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_125__scatterindices__0__updateshape__1___updatewindowdim-8041961560498277574.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_125__scatterindices__0__updateshape__1___updatewindowdim-8041961560498277574.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_125__scatterindices__0__updateshape__1___updatewindowdim1732450095990130954.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_125__scatterindices__0__updateshape__1___updatewindowdim1732450095990130954.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_1_1__scatterindices__0__updateshape__1_1__updatewindowdi7713226170430967235.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_1_1__scatterindices__0__updateshape__1_1__updatewindowdi7713226170430967235.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_1_1__scatterindices__0__updateshape__1_1__updatewindowdi8543119104200808925.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_1_1__scatterindices__0__updateshape__1_1__updatewindowdi8543119104200808925.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_1__scatterindices__0__updateshape__1___updatewindowdims_3272632314613488541.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_1__scatterindices__0__updateshape__1___updatewindowdims_3272632314613488541.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_1__scatterindices__0__updateshape__1___updatewindowdims_5182742344668572861.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_1__scatterindices__0__updateshape__1___updatewindowdims_5182742344668572861.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__0__updateshape__2_3__updatewindowdi-2517998333183107903.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__0__updateshape__2_3__updatewindowdi-2517998333183107903.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__0__updateshape__2_3__updatewindowdi8478884336016351970.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__0__updateshape__2_3__updatewindowdi8478884336016351970.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1_2__updateshape__1___updatewindowd66591961499526895.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1_2__updateshape__1___updatewindowd66591961499526895.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1_2__updateshape__1___updatewindowd8972423980274079564.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1_2__updateshape__1___updatewindowd8972423980274079564.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1__updateshape__1_3__updatewindowdi-4913757608281705160.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1__updateshape__1_3__updatewindowdi-4913757608281705160.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1__updateshape__1_3__updatewindowdi-6020693450791392005.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1__updateshape__1_3__updatewindowdi-6020693450791392005.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_50_3__scatterindices__32__updateshape__1_3__updatewindow-3607337236459034612.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_50_3__scatterindices__32__updateshape__1_3__updatewindow-3607337236459034612.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_50_3__scatterindices__32__updateshape__1_3__updatewindow8217929817648577925.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_50_3__scatterindices__32__updateshape__1_3__updatewindow8217929817648577925.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1__scatterindices__0__updateshape____updatewindowdims____i-5238184922794335713.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1__scatterindices__0__updateshape____updatewindowdims____i-5238184922794335713.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1__scatterindices__0__updateshape____updatewindowdims____i-8501313456125247071.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1__scatterindices__0__updateshape____updatewindowdims____i-8501313456125247071.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewind2339814497718031510.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewind2339814497718031510.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewind6454648953224456034.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewind6454648953224456034.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_4_2_3__scatterindices__3_2__updateshape__2___updatewindowd-8777987494929121958.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_4_2_3__scatterindices__3_2__updateshape__2___updatewindowd-8777987494929121958.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_4_2_3__scatterindices__3_2__updateshape__2___updatewindowd757110069171395288.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_4_2_3__scatterindices__3_2__updateshape__2___updatewindowd757110069171395288.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__upda3661825465707905512.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__upda3661825465707905512.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__upda4401317640487384848.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__upda4401317640487384848.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____update-2801117496105208640.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____update-2801117496105208640.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____update3039220554070550341.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____update3039220554070550341.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0___1_____2___3____updateshape__54475812850829447254.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0___1_____2___3____updateshape__54475812850829447254.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0___1_____2___3____updateshape__57345062635922761033.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0___1_____2___3____updateshape__57345062635922761033.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_125__scatterindices__0__updateshape__1___updatewindowdims-128018089031167.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_125__scatterindices__0__updateshape__1___updatewindowdims-128018089031167.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_125__scatterindices__0__updateshape__1___updatewindowdims1150961019743390834.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_125__scatterindices__0__updateshape__1___updatewindowdims1150961019743390834.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_1_1__scatterindices__0__updateshape__1_1__updatewindowdim-3128990905478656943.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_1_1__scatterindices__0__updateshape__1_1__updatewindowdim-3128990905478656943.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_1_1__scatterindices__0__updateshape__1_1__updatewindowdim-5697043038146688684.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_1_1__scatterindices__0__updateshape__1_1__updatewindowdim-5697043038146688684.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_1__scatterindices__0__updateshape__1___updatewindowdims__-1957699880279094704.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_1__scatterindices__0__updateshape__1___updatewindowdims__-1957699880279094704.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_1__scatterindices__0__updateshape__1___updatewindowdims__4463659161859160997.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_1__scatterindices__0__updateshape__1___updatewindowdims__4463659161859160997.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__0__updateshape__2_3__updatewindowdim-7930785710990024243.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__0__updateshape__2_3__updatewindowdim-7930785710990024243.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__0__updateshape__2_3__updatewindowdim-8041675212181463870.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__0__updateshape__2_3__updatewindowdim-8041675212181463870.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1_2__updateshape__1___updatewindowdi-5778987303411786884.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1_2__updateshape__1___updatewindowdi-5778987303411786884.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1_2__updateshape__1___updatewindowdi8444350783812761590.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1_2__updateshape__1___updatewindowdi8444350783812761590.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1__updateshape__1_3__updatewindowdim-3408679425006372114.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1__updateshape__1_3__updatewindowdim-3408679425006372114.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1__updateshape__1_3__updatewindowdim-364356374783506979.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1__updateshape__1_3__updatewindowdim-364356374783506979.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_50_3__scatterindices__32__updateshape__1_3__updatewindowd-356627360969227147.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_50_3__scatterindices__32__updateshape__1_3__updatewindowd-356627360969227147.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_50_3__scatterindices__32__updateshape__1_3__updatewindowd-8666680446554792979.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_50_3__scatterindices__32__updateshape__1_3__updatewindowd-8666680446554792979.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1__scatterindices__0__updateshape____updatewindowdims____in-5906452100205584348.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1__scatterindices__0__updateshape____updatewindowdims____in-5906452100205584348.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1__scatterindices__0__updateshape____updatewindowdims____in1050596572800058400.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1__scatterindices__0__updateshape____updatewindowdims____in1050596572800058400.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewindo-3571976316732823693.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewindo-3571976316732823693.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewindo-6191603219336322807.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewindo-6191603219336322807.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_4_2_3__scatterindices__3_2__updateshape__2___updatewindowdi-3048175578679534780.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_4_2_3__scatterindices__3_2__updateshape__2___updatewindowdi-3048175578679534780.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_4_2_3__scatterindices__3_2__updateshape__2___updatewindowdi6315664052372191509.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_4_2_3__scatterindices__3_2__updateshape__2___updatewindowdi6315664052372191509.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__updat1387116752558094332.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__updat1387116752558094332.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__updat4589862969700926488.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__updat4589862969700926488.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____updates-5157275558322390602.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____updates-5157275558322390602.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____updates-5895939879477908360.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____updates-5895939879477908360.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0___1_____2___3____updateshape__5_-9119330590615599912.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0___1_____2___3____updateshape__5_-9119330590615599912.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0___1_____2___3____updateshape__5_7518604883535774282.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0___1_____2___3____updateshape__5_7518604883535774282.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_125__scatterindices__0__updateshape__1___updatewindowdi1709719826830415272.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_125__scatterindices__0__updateshape__1___updatewindowdi1709719826830415272.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_125__scatterindices__0__updateshape__1___updatewindowdi6949094029620369112.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_125__scatterindices__0__updateshape__1___updatewindowdi6949094029620369112.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_1_1__scatterindices__0__updateshape__1_1__updatewindowd-565426276648605539.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_1_1__scatterindices__0__updateshape__1_1__updatewindowd-565426276648605539.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_1_1__scatterindices__0__updateshape__1_1__updatewindowd4334829496169821059.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_1_1__scatterindices__0__updateshape__1_1__updatewindowd4334829496169821059.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_1__scatterindices__0__updateshape__1___updatewindowdims-1853568041871720165.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_1__scatterindices__0__updateshape__1___updatewindowdims-1853568041871720165.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_1__scatterindices__0__updateshape__1___updatewindowdims-2800941818176172076.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_1__scatterindices__0__updateshape__1___updatewindowdims-2800941818176172076.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__0__updateshape__2_3__updatewindowd-1896253718340167045.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__0__updateshape__2_3__updatewindowd-1896253718340167045.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__0__updateshape__2_3__updatewindowd6150403469595319224.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__0__updateshape__2_3__updatewindowd6150403469595319224.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1_2__updateshape__1___updatewindow-1202610202676547172.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1_2__updateshape__1___updatewindow-1202610202676547172.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1_2__updateshape__1___updatewindow8092064714204763665.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1_2__updateshape__1___updatewindow8092064714204763665.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1__updateshape__1_3__updatewindowd-1196552373318079471.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1__updateshape__1_3__updatewindowd-1196552373318079471.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1__updateshape__1_3__updatewindowd-6481532818920122396.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1__updateshape__1_3__updatewindowd-6481532818920122396.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_50_3__scatterindices__32__updateshape__1_3__updatewindo-1828674518234095434.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_50_3__scatterindices__32__updateshape__1_3__updatewindo-1828674518234095434.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_50_3__scatterindices__32__updateshape__1_3__updatewindo-7943737821179902950.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_50_3__scatterindices__32__updateshape__1_3__updatewindo-7943737821179902950.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1__scatterindices__0__updateshape____updatewindowdims____-6957864214876146366.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1__scatterindices__0__updateshape____updatewindowdims____-6957864214876146366.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1__scatterindices__0__updateshape____updatewindowdims____8521511291519361452.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1__scatterindices__0__updateshape____updatewindowdims____8521511291519361452.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewin-7577335397410040091.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewin-7577335397410040091.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewin420305544559759402.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewin420305544559759402.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_4_2_3__scatterindices__3_2__updateshape__2___updatewindow-4211987635293399389.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_4_2_3__scatterindices__3_2__updateshape__2___updatewindow-4211987635293399389.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_4_2_3__scatterindices__3_2__updateshape__2___updatewindow8431377997243514204.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_4_2_3__scatterindices__3_2__updateshape__2___updatewindow8431377997243514204.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__upd-1763064319475721773.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__upd-1763064319475721773.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__upd7192867830617648292.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__upd7192867830617648292.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____updat-2972694197857005228.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____updat-2972694197857005228.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____updat5898339477728515111.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____updat5898339477728515111.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0___1_____2___3____updateshape__2602811564001695677.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0___1_____2___3____updateshape__2602811564001695677.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0___1_____2___3____updateshape__500166362744140911.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0___1_____2___3____updateshape__500166362744140911.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_125__scatterindices__0__updateshape__1___updatewindowdi-1688302901246251983.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_125__scatterindices__0__updateshape__1___updatewindowdi-1688302901246251983.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_125__scatterindices__0__updateshape__1___updatewindowdi-7403433579795086737.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_125__scatterindices__0__updateshape__1___updatewindowdi-7403433579795086737.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_1_1__scatterindices__0__updateshape__1_1__updatewindowd124765762738191335.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_1_1__scatterindices__0__updateshape__1_1__updatewindowd124765762738191335.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_1_1__scatterindices__0__updateshape__1_1__updatewindowd781473145886613309.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_1_1__scatterindices__0__updateshape__1_1__updatewindowd781473145886613309.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_1__scatterindices__0__updateshape__1___updatewindowdims-8211810013263470528.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_1__scatterindices__0__updateshape__1___updatewindowdims-8211810013263470528.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_1__scatterindices__0__updateshape__1___updatewindowdims7129685623957404554.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_1__scatterindices__0__updateshape__1___updatewindowdims7129685623957404554.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__0__updateshape__2_3__updatewindowd5320211669957695973.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__0__updateshape__2_3__updatewindowd5320211669957695973.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__0__updateshape__2_3__updatewindowd5461774889517582963.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__0__updateshape__2_3__updatewindowd5461774889517582963.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1_2__updateshape__1___updatewindow-163652940973155099.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1_2__updateshape__1___updatewindow-163652940973155099.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1_2__updateshape__1___updatewindow8184019343288996738.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1_2__updateshape__1___updatewindow8184019343288996738.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1__updateshape__1_3__updatewindowd2672684945363288763.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1__updateshape__1_3__updatewindowd2672684945363288763.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1__updateshape__1_3__updatewindowd5354314623131050500.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1__updateshape__1_3__updatewindowd5354314623131050500.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_50_3__scatterindices__32__updateshape__1_3__updatewindo1868587186902615224.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_50_3__scatterindices__32__updateshape__1_3__updatewindo1868587186902615224.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_50_3__scatterindices__32__updateshape__1_3__updatewindo6837170408141216480.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_50_3__scatterindices__32__updateshape__1_3__updatewindo6837170408141216480.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1__scatterindices__0__updateshape____updatewindowdims____-3546209324335573385.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1__scatterindices__0__updateshape____updatewindowdims____-3546209324335573385.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1__scatterindices__0__updateshape____updatewindowdims____-3671700194875203478.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1__scatterindices__0__updateshape____updatewindowdims____-3671700194875203478.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewin-2522674721507997761.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewin-2522674721507997761.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewin-2758232658412626325.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewin-2758232658412626325.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_4_2_3__scatterindices__3_2__updateshape__2___updatewindow-1940630927273973679.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_4_2_3__scatterindices__3_2__updateshape__2___updatewindow-1940630927273973679.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_4_2_3__scatterindices__3_2__updateshape__2___updatewindow-6965913679939402575.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_4_2_3__scatterindices__3_2__updateshape__2___updatewindow-6965913679939402575.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__upd-8712709380021038962.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__upd-8712709380021038962.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__upd4449301830185425735.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__upd4449301830185425735.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____updat-4293316453503330429.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____updat-4293316453503330429.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____updat7893343186085503986.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____updat7893343186085503986.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0___1_____2___3____updateshape__4842477100420295985.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0___1_____2___3____updateshape__4842477100420295985.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0___1_____2___3____updateshape__8225012549892341281.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0___1_____2___3____updateshape__8225012549892341281.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_125__scatterindices__0__updateshape__1___updatewindowdim4897701391840007208.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_125__scatterindices__0__updateshape__1___updatewindowdim4897701391840007208.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_125__scatterindices__0__updateshape__1___updatewindowdim6232235312107433645.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_125__scatterindices__0__updateshape__1___updatewindowdim6232235312107433645.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_1_1__scatterindices__0__updateshape__1_1__updatewindowdi-36899100055995107.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_1_1__scatterindices__0__updateshape__1_1__updatewindowdi-36899100055995107.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_1_1__scatterindices__0__updateshape__1_1__updatewindowdi1177948157318465368.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_1_1__scatterindices__0__updateshape__1_1__updatewindowdi1177948157318465368.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_1__scatterindices__0__updateshape__1___updatewindowdims_-5834322957039009125.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_1__scatterindices__0__updateshape__1___updatewindowdims_-5834322957039009125.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_1__scatterindices__0__updateshape__1___updatewindowdims_8219644983733290724.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_1__scatterindices__0__updateshape__1___updatewindowdims_8219644983733290724.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__0__updateshape__2_3__updatewindowdi-5861384246211432114.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__0__updateshape__2_3__updatewindowdi-5861384246211432114.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__0__updateshape__2_3__updatewindowdi1584703602367340481.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__0__updateshape__2_3__updatewindowdi1584703602367340481.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1_2__updateshape__1___updatewindowd-1546876755771932966.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1_2__updateshape__1___updatewindowd-1546876755771932966.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1_2__updateshape__1___updatewindowd-4537251676254979075.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1_2__updateshape__1___updatewindowd-4537251676254979075.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1__updateshape__1_3__updatewindowdi-2704631236776867428.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1__updateshape__1_3__updatewindowdi-2704631236776867428.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1__updateshape__1_3__updatewindowdi8717625349561755806.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1__updateshape__1_3__updatewindowdi8717625349561755806.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_50_3__scatterindices__32__updateshape__1_3__updatewindow-2069691074413654165.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_50_3__scatterindices__32__updateshape__1_3__updatewindow-2069691074413654165.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_50_3__scatterindices__32__updateshape__1_3__updatewindow-9204662166819519530.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_50_3__scatterindices__32__updateshape__1_3__updatewindow-9204662166819519530.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1__scatterindices__0__updateshape____updatewindowdims____i4654172382900524664.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1__scatterindices__0__updateshape____updatewindowdims____i4654172382900524664.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1__scatterindices__0__updateshape____updatewindowdims____i805910080804411976.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1__scatterindices__0__updateshape____updatewindowdims____i805910080804411976.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewind-1528822601276352271.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewind-1528822601276352271.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewind-3037328780648918720.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewind-3037328780648918720.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_4_2_3__scatterindices__3_2__updateshape__2___updatewindowd-6696604613778121788.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_4_2_3__scatterindices__3_2__updateshape__2___updatewindowd-6696604613778121788.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_4_2_3__scatterindices__3_2__updateshape__2___updatewindowd-7788287855338834369.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_4_2_3__scatterindices__3_2__updateshape__2___updatewindowd-7788287855338834369.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__upda6636636746706115426.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__upda6636636746706115426.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__upda7288769158933240945.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__upda7288769158933240945.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____update-5519337277775784500.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____update-5519337277775784500.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____update6802180533867290475.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____update6802180533867290475.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0___1_____2___3____updateshape__5-4899128541496460728.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0___1_____2___3____updateshape__5-4899128541496460728.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0___1_____2___3____updateshape__5-8281471711907089690.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0___1_____2___3____updateshape__5-8281471711907089690.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -586,8 +586,8 @@ func.func @select_and_scatter(
 
 // -----
 
-// CHECK-LABEL: func @scatter
-func.func @scatter(%input_tensor: tensor<200x100x300xf32>,
+// CHECK-LABEL: func @scatter_c16
+func.func @scatter_c16(%input_tensor: tensor<200x100x300xf32>,
     %scatter_indices: tensor<10x2xi32>, %updates: tensor<10x300xf32>) ->
       tensor<200x100x300xindex> {
   %0 = "stablehlo.scatter" (%input_tensor, %scatter_indices, %updates) ({

--- a/stablehlo/tests/interpret_scatter.mlir
+++ b/stablehlo/tests/interpret_scatter.mlir
@@ -25,3 +25,28 @@ func.func @scatter_op_test() {
                                         [[18, 19], [20, 21], [21, 22], [23, 24]]]> : tensor<3x4x2xi64>
   func.return
 }
+
+// -----
+
+func.func @scatter_op_test() {
+  %inputs = stablehlo.constant dense<[[1, 2, 3],
+                                      [4, 5, 6]]> : tensor<2x3xi64>
+  %scatter_indices = stablehlo.constant dense<[0, 10]> : tensor<2xi64>
+  %updates = stablehlo.constant dense<1> : tensor<2x3xi64>
+  %result = "stablehlo.scatter"(%inputs, %scatter_indices, %updates) ({
+    ^bb0(%arg0: tensor<i64>, %arg1: tensor<i64>):
+      %0 = stablehlo.add %arg0, %arg1 : tensor<i64>
+      stablehlo.return %0 : tensor<i64>
+  }) {
+    scatter_dimension_numbers = #stablehlo.scatter<
+      update_window_dims = [1],
+      inserted_window_dims = [0],
+      scatter_dims_to_operand_dims = [0],
+      index_vector_dim = 1>,
+    indices_are_sorted = false,
+    unique_indices = false
+  } : (tensor<2x3xi64>, tensor<2xi64>, tensor<2x3xi64>) -> tensor<2x3xi64>
+  check.expect_eq_const %result, dense<[[2, 3, 4],
+                                        [4, 5, 6]]> : tensor<2x3xi64>
+  func.return
+}

--- a/stablehlo/tests/interpret_scatter.mlir
+++ b/stablehlo/tests/interpret_scatter.mlir
@@ -1,0 +1,27 @@
+// RUN: stablehlo-translate --interpret -split-input-file %s
+
+func.func @scatter_op_test() {
+  %inputs = stablehlo.constant dense<[[[1, 2], [3, 4], [5, 6], [7, 8]],
+                                      [[9, 10], [11, 12], [13, 14], [15, 16]],
+                                      [[17, 18], [19, 20], [21, 22], [23, 24]]]> : tensor<3x4x2xi64>
+  %scatter_indices = stablehlo.constant dense<[[[0, 2], [1, 0], [2, 1]],
+                                               [[0, 1], [1, 0], [2, 0]]]> : tensor<2x3x2xi64>
+  %updates = stablehlo.constant dense<1> : tensor<2x3x2x2xi64>
+  %result = "stablehlo.scatter"(%inputs, %scatter_indices, %updates) ({
+    ^bb0(%arg0: tensor<i64>, %arg1: tensor<i64>):
+      %0 = stablehlo.add %arg0, %arg1 : tensor<i64>
+      stablehlo.return %0 : tensor<i64>
+  }) {
+    scatter_dimension_numbers = #stablehlo.scatter<
+      update_window_dims = [2, 3],
+      inserted_window_dims = [0],
+      scatter_dims_to_operand_dims = [1, 0],
+      index_vector_dim = 2>,
+    indices_are_sorted = false,
+    unique_indices = false
+  } : (tensor<3x4x2xi64>, tensor<2x3x2xi64>, tensor<2x3x2x2xi64>) -> tensor<3x4x2xi64>
+  check.expect_eq_const %result, dense<[[[1, 2], [5, 6], [8, 9], [8, 9]],
+                                        [[10, 11], [12, 13], [14, 15], [16, 17]],
+                                        [[18, 19], [20, 21], [21, 22], [23, 24]]]> : tensor<3x4x2xi64>
+  func.return
+}

--- a/stablehlo/tests/verify_scatter.mlir
+++ b/stablehlo/tests/verify_scatter.mlir
@@ -22,6 +22,8 @@ func.func @scatter(%input_tensor: tensor<200x100x300xf32>,
   func.return %0 : tensor<200x100x300xf32>
 }
 
+// -----
+
 // CHECK: func @scatter_with_unranked_inputs
 func.func @scatter_with_unranked_inputs(%input_tensor: tensor<*xf32>,
     %scatter_indices: tensor<*xi32>, %updates: tensor<*xf32>) ->
@@ -46,10 +48,10 @@ func.func @scatter_with_unranked_inputs(%input_tensor: tensor<*xf32>,
 
 // -----
 
-func.func @invalid_scatter(%input_tensor: tensor<200x100x300xf32>,
-    %scatter_indices: tensor<10x2xf32>, %updates: tensor<10x300xf32>) ->
-      tensor<200x100x300xf32> {
-  // expected-error @+1 {{operand #1 must be tensor of integer or index values, but got 'tensor<10x2xf32>'}}
+// CHECK: func @valid_scatter_dimensions_with_dynamic_index_vector_dim
+func.func @valid_scatter_dimensions_with_dynamic_index_vector_dim(
+    %input_tensor: tensor<*xf32>, %scatter_indices: tensor<10x?xi32>,
+    %updates: tensor<*xf32>) -> tensor<*xf32> {
   %0 = "stablehlo.scatter" (%input_tensor, %scatter_indices, %updates) ({
   ^bb0(%lhs: tensor<f32>, %rhs: tensor<f32>):
     %add = stablehlo.add %lhs, %rhs : tensor<f32>
@@ -58,46 +60,41 @@ func.func @invalid_scatter(%input_tensor: tensor<200x100x300xf32>,
     scatter_dimension_numbers = #stablehlo.scatter<
       update_window_dims = [1],
       inserted_window_dims = [0, 1],
-      scatter_dims_to_operand_dims = [0, 1],
+      scatter_dims_to_operand_dims = [0, 1, 2],
       index_vector_dim = 1
     >,
     indices_are_sorted = true,
     unique_indices = true
-  } : (tensor<200x100x300xf32>, tensor<10x2xf32>, tensor<10x300xf32>) ->
-      tensor<200x100x300xf32>
-  func.return %0 : tensor<200x100x300xf32>
-}
-
-// -----
-
-func.func @invalid_scatter(%input_tensor: tensor<*xf32>,
-    %scatter_indices: tensor<10x2xi32>, %updates: tensor<*xf32>) ->
-      tensor<*xf32> {
-  // expected-error @+1 {{expects scatter index leaf dimension to be within [0, rank(scatter_indices) + 1. rank(scatter_indices) is 2 and scatter index leaf dimension is 3.}}
-  %0 = "stablehlo.scatter" (%input_tensor, %scatter_indices, %updates) ({
-  ^bb0(%lhs: tensor<f32>, %rhs: tensor<f32>):
-    %add = stablehlo.add %lhs, %rhs : tensor<f32>
-    "stablehlo.return"(%add) : (tensor<f32>) -> ()
-  }) {
-    scatter_dimension_numbers = #stablehlo.scatter<
-      update_window_dims = [1],
-      inserted_window_dims = [0, 1],
-      scatter_dims_to_operand_dims = [0, 1],
-      index_vector_dim = 3
-    >,
-    indices_are_sorted = true,
-    unique_indices = true
-  } : (tensor<*xf32>, tensor<10x2xi32>, tensor<*xf32>) ->
-      tensor<*xf32>
+  } : (tensor<*xf32>, tensor<10x?xi32>, tensor<*xf32>) -> tensor<*xf32>
   func.return %0 : tensor<*xf32>
 }
 
 // -----
 
-func.func @invalid_scatter(%input_tensor: tensor<200x100x300xf32>,
-    %scatter_indices: tensor<10x2xi32>, %updates: tensor<10x300xf32>) ->
-      tensor<200x100x300xf32> {
-  // expected-error @+1 {{expects scatter index leaf dimension to be within [0, rank(scatter_indices) + 1. rank(scatter_indices) is 2 and scatter index leaf dimension is -1.}}
+func.func @scatter_c1(%arg0: tensor<3xi32>, %arg1: tensor<1x1xi32>,
+                            %arg2: tensor<1xi32>) -> tensor<3xi32> {
+  // expected-error @+1 {{Not all inputs have compatible shapes.}}
+  %0, %1 = "stablehlo.scatter"(%arg0, %arg2, %arg1, %arg2, %arg2) ({
+  ^bb0(%arg3: tensor<i32>, %arg4: tensor<i32>, %arg5: tensor<i32>, %arg6: tensor<i32>):
+    "stablehlo.return"(%arg3, %arg5) : (tensor<i32>, tensor<i32>) -> ()
+  }) {
+    indices_are_sorted = false,
+    scatter_dimension_numbers = #stablehlo.scatter<
+      update_window_dims = [],
+      inserted_window_dims = [0],
+      scatter_dims_to_operand_dims = [0],
+      index_vector_dim = 1,
+    >,
+    unique_indices = false
+  } : (tensor<3xi32>, tensor<1xi32>, tensor<1x1xi32>, tensor<1xi32>, tensor<1xi32>) -> (tensor<3xi32>, tensor<3xi32>)
+  func.return %0 : tensor<3xi32>
+}
+
+// -----
+
+func.func @scatter_c2(%input_tensor: tensor<200x100x300xf32>,
+    %scatter_indices: tensor<*xi32>, %updates: tensor<*xf32>) -> tensor<*xf32> {
+  // expected-error @+1 {{Expects rank-of operand to match size-of('update_window_dims')  + size-of('inserted_window_dims') i.e. 4 but got 3.}}
   %0 = "stablehlo.scatter" (%input_tensor, %scatter_indices, %updates) ({
   ^bb0(%lhs: tensor<f32>, %rhs: tensor<f32>):
     %add = stablehlo.add %lhs, %rhs : tensor<f32>
@@ -105,20 +102,40 @@ func.func @invalid_scatter(%input_tensor: tensor<200x100x300xf32>,
   }) {
     scatter_dimension_numbers = #stablehlo.scatter<
       update_window_dims = [1],
-      inserted_window_dims = [0, 1],
+      inserted_window_dims = [0, 1, 2],
       scatter_dims_to_operand_dims = [0, 1],
-      index_vector_dim = -1
+      index_vector_dim = 1
     >,
     indices_are_sorted = true,
     unique_indices = true
-  } : (tensor<200x100x300xf32>, tensor<10x2xi32>, tensor<10x300xf32>) ->
-      tensor<200x100x300xf32>
-  func.return %0 : tensor<200x100x300xf32>
+  } : (tensor<200x100x300xf32>, tensor<*xi32>, tensor<*xf32>) -> tensor<*xf32>
+  func.return %0 : tensor<*xf32>
 }
 
 // -----
 
-func.func @invalid_scatter(%input_tensor: tensor<*xf32>,
+func.func @scatter_c3(%input_tensor: tensor<3xi32>, %scatter_indices: tensor<1x1xi32>,
+                            %updates: tensor<1xi32>) -> tensor<3xi32> {
+  // expected-error @+1 {{Not all updates have compatible shapes.}}
+  %0, %1 = "stablehlo.scatter"(%input_tensor, %input_tensor, %scatter_indices, %input_tensor, %updates) ({
+  ^bb0(%arg3: tensor<i32>, %arg4: tensor<i32>, %arg5: tensor<i32>, %arg6: tensor<i32>):
+    "stablehlo.return"(%arg3, %arg5) : (tensor<i32>, tensor<i32>) -> ()
+  }) {
+    indices_are_sorted = false,
+    scatter_dimension_numbers = #stablehlo.scatter<
+      update_window_dims = [],
+      inserted_window_dims = [0],
+      scatter_dims_to_operand_dims = [0],
+      index_vector_dim = 1,
+    >,
+    unique_indices = false
+  } : (tensor<3xi32>, tensor<3xi32>, tensor<1x1xi32>, tensor<3xi32>, tensor<1xi32>) -> (tensor<3xi32>, tensor<3xi32>)
+  func.return %0 : tensor<3xi32>
+}
+
+// -----
+
+func.func @scatter_c4(%input_tensor: tensor<*xf32>,
     %scatter_indices: tensor<10x2xi32>, %updates: tensor<10x300xf32>) ->
       tensor<*xf32> {
   // expected-error @+1 {{expects updates tensor must be of rank 3 ( == rank-of('scatter_indices') - 1 + size-of('update_window_dims'), where 'scatter_indices' is expanded by a trailing 1 dimension if 'index_vector_dim' == rank-of('scatter_indices')), but got 2.}}
@@ -141,7 +158,7 @@ func.func @invalid_scatter(%input_tensor: tensor<*xf32>,
 
 // -----
 
-func.func @invalid_scatter(%input_tensor: tensor<200x100x300xf32>,
+func.func @scatter_c4(%input_tensor: tensor<200x100x300xf32>,
     %scatter_indices: tensor<10x2xi32>, %updates: tensor<10x300xf32>) ->
       tensor<200x100x300xf32> {
   // expected-error @+1 {{expects updates tensor must be of rank 3 ( == rank-of('scatter_indices') - 1 + size-of('update_window_dims'), where 'scatter_indices' is expanded by a trailing 1 dimension if 'index_vector_dim' == rank-of('scatter_indices')), but got 2.}}
@@ -165,11 +182,58 @@ func.func @invalid_scatter(%input_tensor: tensor<200x100x300xf32>,
 
 // -----
 
-func.func @invalid_scatter_dimensions() ->  tensor<512x1x6400x6400xf32> {
+func.func @scatter_c4(%input_tensor: tensor<200x100x300xf32>,
+    %scatter_indices: tensor<10x2xi32>, %updates: tensor<10x301xf32>) ->
+      tensor<200x100x300xf32> {
+  // expected-error @+1 {{expects bounds of the window dimensions of updates to not exceed the bounds of the corresponding dimensions of operand. For dimension 1, updates bound is 301, operand bound is 300.}}
+  %0 = "stablehlo.scatter" (%input_tensor, %scatter_indices, %updates) ({
+  ^bb0(%lhs: tensor<f32>, %rhs: tensor<f32>):
+    %add = stablehlo.add %lhs, %rhs : tensor<f32>
+    "stablehlo.return"(%add) : (tensor<f32>) -> ()
+  }) {
+    scatter_dimension_numbers = #stablehlo.scatter<
+      update_window_dims = [1],
+      inserted_window_dims = [0, 1],
+      scatter_dims_to_operand_dims = [0, 1],
+      index_vector_dim = 1
+    >,
+    indices_are_sorted = true,
+    unique_indices = true
+  } : (tensor<200x100x300xf32>, tensor<10x2xi32>, tensor<10x301xf32>) ->
+      tensor<200x100x300xf32>
+  func.return %0 : tensor<200x100x300xf32>
+}
+
+// -----
+
+func.func @scatter_c4(%input_tensor: tensor<200x100x300xf32>,
+    %scatter_indices: tensor<11x2xi32>, %updates: tensor<10x300xf32>) ->
+      tensor<200x100x300xf32> {
+  // expected-error @+1 {{expects bounds of the scatter dimensions of updates to be same as the bounds of the corresponding dimensions of scatter indices. For scatter dimension 0, updates bound is 10 , scatter_indices bound is 11.}}
+  %0 = "stablehlo.scatter" (%input_tensor, %scatter_indices, %updates) ({
+  ^bb0(%lhs: tensor<f32>, %rhs: tensor<f32>):
+    %add = stablehlo.add %lhs, %rhs : tensor<f32>
+    "stablehlo.return"(%add) : (tensor<f32>) -> ()
+  }) {
+    scatter_dimension_numbers = #stablehlo.scatter<
+      update_window_dims = [1],
+      inserted_window_dims = [0, 1],
+      scatter_dims_to_operand_dims = [0, 1],
+      index_vector_dim = 1
+    >,
+    indices_are_sorted = true,
+    unique_indices = true
+  } : (tensor<200x100x300xf32>, tensor<11x2xi32>, tensor<10x300xf32>) ->
+      tensor<200x100x300xf32>
+  func.return %0 : tensor<200x100x300xf32>
+}
+
+// -----
+
+func.func @scatter_c7() ->  tensor<512x1x6400x6400xf32> {
   %base = stablehlo.constant dense<0.000000e+00> : tensor<512x1x6400x6400xf32>
   %index = stablehlo.constant dense<0> : tensor<1xi32>
   %update = stablehlo.constant dense<1.000000e+00> : tensor<512x1x6400x6400xf32>
-
   // expected-error @+1 {{Expects update_window_dims to be sorted; got: [0, 1, 3, 2].}}
   %scatter = "stablehlo.scatter"(%base, %index, %update) ({
     ^bb0(%arg5: tensor<f32>, %arg6: tensor<f32>):
@@ -183,17 +247,15 @@ func.func @invalid_scatter_dimensions() ->  tensor<512x1x6400x6400xf32> {
       unique_indices = true} :
     (tensor<512x1x6400x6400xf32>, tensor<1xi32>, tensor<512x1x6400x6400xf32>) ->
       tensor<512x1x6400x6400xf32>
-
-  func.return %scatter :  tensor<512x1x6400x6400xf32>
+  func.return %scatter : tensor<512x1x6400x6400xf32>
 }
 
 // -----
 
-func.func @invalid_scatter_dimensions() ->  tensor<512x1x6400x6400xf32> {
+func.func @scatter_c7() ->  tensor<512x1x6400x6400xf32> {
   %base = stablehlo.constant dense<0.000000e+00> : tensor<512x1x6400x6400xf32>
   %index = stablehlo.constant dense<0> : tensor<1xi32>
   %update = stablehlo.constant dense<1.000000e+00> : tensor<512x1x6400x6400xf32>
-
   // expected-error @+1 {{Expects update_window_dims to not repeat; got: [0, 1, 2, 2].}}
   %scatter = "stablehlo.scatter"(%base, %index, %update) ({
     ^bb0(%arg5: tensor<f32>, %arg6: tensor<f32>):
@@ -207,17 +269,37 @@ func.func @invalid_scatter_dimensions() ->  tensor<512x1x6400x6400xf32> {
       unique_indices = true} :
     (tensor<512x1x6400x6400xf32>, tensor<1xi32>, tensor<512x1x6400x6400xf32>) ->
       tensor<512x1x6400x6400xf32>
-
-  func.return %scatter :  tensor<512x1x6400x6400xf32>
+  func.return %scatter : tensor<512x1x6400x6400xf32>
 }
 
 // -----
 
-func.func @invalid_scatter_dimensions() ->  tensor<512x1x6400x6400xf32> {
+func.func @scatter_c8() ->  tensor<512x1x6400x6400xf32> {
   %base = stablehlo.constant dense<0.000000e+00> : tensor<512x1x6400x6400xf32>
   %index = stablehlo.constant dense<0> : tensor<1xi32>
   %update = stablehlo.constant dense<1.000000e+00> : tensor<512x1x6400x6400xf32>
+  // expected-error @+1 {{Expects each element of update_window_dims to be in range [0, rank-of('updates') i.e. [0, 4). got: -1.}}
+  %scatter = "stablehlo.scatter"(%base, %index, %update) ({
+    ^bb0(%arg5: tensor<f32>, %arg6: tensor<f32>):
+      "stablehlo.return"(%arg6) : (tensor<f32>) -> ()
+  }) {
+    indices_are_sorted = true,
+    scatter_dimension_numbers = #stablehlo.scatter<
+      update_window_dims = [-1, 0, 1, 2],
+      scatter_dims_to_operand_dims = [3]>,
+      index_vector_dim = 0,
+      unique_indices = true} :
+    (tensor<512x1x6400x6400xf32>, tensor<1xi32>, tensor<512x1x6400x6400xf32>) ->
+      tensor<512x1x6400x6400xf32>
+  func.return %scatter : tensor<512x1x6400x6400xf32>
+}
 
+// -----
+
+func.func @scatter_c8() ->  tensor<512x1x6400x6400xf32> {
+  %base = stablehlo.constant dense<0.000000e+00> : tensor<512x1x6400x6400xf32>
+  %index = stablehlo.constant dense<0> : tensor<1xi32>
+  %update = stablehlo.constant dense<1.000000e+00> : tensor<512x1x6400x6400xf32>
   // expected-error @+1 {{Expects each element of update_window_dims to be in range [0, rank-of('updates') i.e. [0, 4). got: 4.}}
   %scatter = "stablehlo.scatter"(%base, %index, %update) ({
     ^bb0(%arg5: tensor<f32>, %arg6: tensor<f32>):
@@ -231,16 +313,14 @@ func.func @invalid_scatter_dimensions() ->  tensor<512x1x6400x6400xf32> {
       unique_indices = true} :
     (tensor<512x1x6400x6400xf32>, tensor<1xi32>, tensor<512x1x6400x6400xf32>) ->
       tensor<512x1x6400x6400xf32>
-
-  func.return %scatter :  tensor<512x1x6400x6400xf32>
+  func.return %scatter : tensor<512x1x6400x6400xf32>
 }
 
 // -----
 
-func.func @invalid_scatter_dimensions(%input_tensor: tensor<*xf32>,
+func.func @scatter_c9(%input_tensor: tensor<*xf32>,
     %scatter_indices: tensor<*xi32>, %updates: tensor<*xf32>) ->
       tensor<*xf32> {
-
   // expected-error @+1 {{Expects inserted_window_dims to be sorted; got: [1, 0].}}
   %0 = "stablehlo.scatter" (%input_tensor, %scatter_indices, %updates) ({
   ^bb0(%lhs: tensor<f32>, %rhs: tensor<f32>):
@@ -261,7 +341,7 @@ func.func @invalid_scatter_dimensions(%input_tensor: tensor<*xf32>,
 
 // -----
 
-func.func @invalid_scatter_dimensions(%input_tensor: tensor<200x100x300xf32>,
+func.func @scatter_c9(%input_tensor: tensor<200x100x300xf32>,
     %scatter_indices: tensor<10x2xi32>, %updates: tensor<10x300xf32>) ->
       tensor<200x100x300xf32> {
 // expected-error @+1 {{Expects inserted_window_dims to not repeat; got: [1, 1].}}
@@ -285,10 +365,33 @@ func.func @invalid_scatter_dimensions(%input_tensor: tensor<200x100x300xf32>,
 
 // -----
 
-func.func @invalid_scatter_dimensions(%input_tensor: tensor<200x100x300xf32>,
+func.func @scatter_c10(%input_tensor: tensor<200x100x300xf32>,
     %scatter_indices: tensor<10x2xi32>, %updates: tensor<10x300xf32>) ->
       tensor<200x100x300xf32> {
+  // expected-error @+1 {{Expects each element of inserted_window_dims to be in range [0, rank-of('operand') i.e. [0, 3). got: -1.}}
+  %0 = "stablehlo.scatter" (%input_tensor, %scatter_indices, %updates) ({
+  ^bb0(%lhs: tensor<f32>, %rhs: tensor<f32>):
+    %add = stablehlo.add %lhs, %rhs : tensor<f32>
+    "stablehlo.return"(%add) : (tensor<f32>) -> ()
+  }) {
+    scatter_dimension_numbers = #stablehlo.scatter<
+      update_window_dims = [1],
+      inserted_window_dims = [-1, 3],
+      scatter_dims_to_operand_dims = [0, 1],
+      index_vector_dim = 1
+    >,
+    indices_are_sorted = true,
+    unique_indices = true
+  } : (tensor<200x100x300xf32>, tensor<10x2xi32>, tensor<10x300xf32>) ->
+      tensor<200x100x300xf32>
+  func.return %0 : tensor<200x100x300xf32>
+}
 
+// -----
+
+func.func @scatter_c10(%input_tensor: tensor<200x100x300xf32>,
+    %scatter_indices: tensor<10x2xi32>, %updates: tensor<10x300xf32>) ->
+      tensor<200x100x300xf32> {
   // expected-error @+1 {{Expects each element of inserted_window_dims to be in range [0, rank-of('operand') i.e. [0, 3). got: 3.}}
   %0 = "stablehlo.scatter" (%input_tensor, %scatter_indices, %updates) ({
   ^bb0(%lhs: tensor<f32>, %rhs: tensor<f32>):
@@ -310,33 +413,9 @@ func.func @invalid_scatter_dimensions(%input_tensor: tensor<200x100x300xf32>,
 
 // -----
 
-func.func @invalid_scatter_dimensions(%input_tensor: tensor<200x100x300xf32>,
-    %scatter_indices: tensor<*xi32>, %updates: tensor<*xf32>) -> tensor<*xf32> {
-
-  // expected-error @+1 {{Expects rank-of operand to match size-of('update_window_dims')  + size-of('inserted_window_dims') i.e. 4 but got 3.}}
-  %0 = "stablehlo.scatter" (%input_tensor, %scatter_indices, %updates) ({
-  ^bb0(%lhs: tensor<f32>, %rhs: tensor<f32>):
-    %add = stablehlo.add %lhs, %rhs : tensor<f32>
-    "stablehlo.return"(%add) : (tensor<f32>) -> ()
-  }) {
-    scatter_dimension_numbers = #stablehlo.scatter<
-      update_window_dims = [1],
-      inserted_window_dims = [0, 1, 2],
-      scatter_dims_to_operand_dims = [0, 1],
-      index_vector_dim = 1
-    >,
-    indices_are_sorted = true,
-    unique_indices = true
-  } : (tensor<200x100x300xf32>, tensor<*xi32>, tensor<*xf32>) -> tensor<*xf32>
-  func.return %0 : tensor<*xf32>
-}
-
-// -----
-
-func.func @invalid_scatter_dimensions(%input_tensor: tensor<*xf32>,
+func.func @scatter_c11(%input_tensor: tensor<*xf32>,
     %scatter_indices: tensor<10x2xi32>, %updates: tensor<*xf32>) ->
       tensor<*xf32> {
-
   // expected-error @+1 {{Scatter op has 3 elements in scatter_dims_to_operand_dims and the bound of dimension index_vector_dim=1 of scatter_indices is 2. These two numbers must be equal.}}
   %0 = "stablehlo.scatter" (%input_tensor, %scatter_indices, %updates) ({
   ^bb0(%lhs: tensor<f32>, %rhs: tensor<f32>):
@@ -356,10 +435,12 @@ func.func @invalid_scatter_dimensions(%input_tensor: tensor<*xf32>,
   func.return %0 : tensor<*xf32>
 }
 
-func.func @valid_scatter_dimensions_with_dynamic_index_vector_dim(
-    %input_tensor: tensor<*xf32>, %scatter_indices: tensor<10x?xi32>,
-    %updates: tensor<*xf32>) -> tensor<*xf32> {
+// -----
 
+func.func @scatter_c11(%input_tensor: tensor<*xf32>,
+    %scatter_indices: tensor<10x2xi32>, %updates: tensor<*xf32>) ->
+      tensor<*xf32> {
+  // expected-error @+1 {{Scatter op has 3 elements in scatter_dims_to_operand_dims and the bound of dimension index_vector_dim=2 of scatter_indices is 1. These two numbers must be equal.}}
   %0 = "stablehlo.scatter" (%input_tensor, %scatter_indices, %updates) ({
   ^bb0(%lhs: tensor<f32>, %rhs: tensor<f32>):
     %add = stablehlo.add %lhs, %rhs : tensor<f32>
@@ -369,43 +450,20 @@ func.func @valid_scatter_dimensions_with_dynamic_index_vector_dim(
       update_window_dims = [1],
       inserted_window_dims = [0, 1],
       scatter_dims_to_operand_dims = [0, 1, 2],
-      index_vector_dim = 1
+      index_vector_dim = 2
     >,
     indices_are_sorted = true,
     unique_indices = true
-  } : (tensor<*xf32>, tensor<10x?xi32>, tensor<*xf32>) -> tensor<*xf32>
+  } : (tensor<*xf32>, tensor<10x2xi32>, tensor<*xf32>) ->
+      tensor<*xf32>
   func.return %0 : tensor<*xf32>
 }
 
 // -----
 
-func.func @invalid_scatter_dimensions(%input_tensor: tensor<200x100x300xf32>,
-    %scatter_indices: tensor<*xi32>, %updates: tensor<*xf32>) -> tensor<*xf32> {
-
-  // expected-error @+1 {{Invalid scatter_dims_to_operand_dims mapping; domain is [0, 3), got: 1->3.}}
-  %0 = "stablehlo.scatter" (%input_tensor, %scatter_indices, %updates) ({
-  ^bb0(%lhs: tensor<f32>, %rhs: tensor<f32>):
-    %add = stablehlo.add %lhs, %rhs : tensor<f32>
-    "stablehlo.return"(%add) : (tensor<f32>) -> ()
-  }) {
-    scatter_dimension_numbers = #stablehlo.scatter<
-      update_window_dims = [1],
-      inserted_window_dims = [0, 1],
-      scatter_dims_to_operand_dims = [0, 3],
-      index_vector_dim = 1
-    >,
-    indices_are_sorted = true,
-    unique_indices = true
-  } : (tensor<200x100x300xf32>, tensor<*xi32>, tensor<*xf32>) -> tensor<*xf32>
-  func.return %0 : tensor<*xf32>
-}
-
-// -----
-
-func.func @invalid_scatter_dimensions(%input_tensor: tensor<200x100x300xf32>,
+func.func @scatter_c12(%input_tensor: tensor<200x100x300xf32>,
     %scatter_indices: tensor<10x2xi32>, %updates: tensor<10x300xf32>) ->
       tensor<200x100x300xf32> {
-
   // expected-error @+1 {{Expects scatter_dims_to_operand_dims to not repeat; got: [0, 0].}}
   %0 = "stablehlo.scatter" (%input_tensor, %scatter_indices, %updates) ({
   ^bb0(%lhs: tensor<f32>, %rhs: tensor<f32>):
@@ -427,11 +485,54 @@ func.func @invalid_scatter_dimensions(%input_tensor: tensor<200x100x300xf32>,
 
 // -----
 
-func.func @invalid_scatter_update_window_dims(%input_tensor: tensor<200x100x300xf32>,
-    %scatter_indices: tensor<10x2xi32>, %updates: tensor<10x301xf32>) ->
-      tensor<200x100x300xf32> {
+func.func @scatter_c13(%input_tensor: tensor<200x100x300xf32>,
+    %scatter_indices: tensor<*xi32>, %updates: tensor<*xf32>) -> tensor<*xf32> {
+  // expected-error @+1 {{Invalid scatter_dims_to_operand_dims mapping; domain is [0, 3), got: 0->-1.}}
+  %0 = "stablehlo.scatter" (%input_tensor, %scatter_indices, %updates) ({
+  ^bb0(%lhs: tensor<f32>, %rhs: tensor<f32>):
+    %add = stablehlo.add %lhs, %rhs : tensor<f32>
+    "stablehlo.return"(%add) : (tensor<f32>) -> ()
+  }) {
+    scatter_dimension_numbers = #stablehlo.scatter<
+      update_window_dims = [1],
+      inserted_window_dims = [0, 1],
+      scatter_dims_to_operand_dims = [-1, 0],
+      index_vector_dim = 1
+    >,
+    indices_are_sorted = true,
+    unique_indices = true
+  } : (tensor<200x100x300xf32>, tensor<*xi32>, tensor<*xf32>) -> tensor<*xf32>
+  func.return %0 : tensor<*xf32>
+}
 
-  // expected-error @+1 {{expects bounds of the window dimensions of updates to not exceed the bounds of the corresponding dimensions of operand. For dimension 1, updates bound is 301, operand bound is 300.}}
+// -----
+
+func.func @scatter_c13(%input_tensor: tensor<200x100x300xf32>,
+    %scatter_indices: tensor<*xi32>, %updates: tensor<*xf32>) -> tensor<*xf32> {
+  // expected-error @+1 {{Invalid scatter_dims_to_operand_dims mapping; domain is [0, 3), got: 1->3.}}
+  %0 = "stablehlo.scatter" (%input_tensor, %scatter_indices, %updates) ({
+  ^bb0(%lhs: tensor<f32>, %rhs: tensor<f32>):
+    %add = stablehlo.add %lhs, %rhs : tensor<f32>
+    "stablehlo.return"(%add) : (tensor<f32>) -> ()
+  }) {
+    scatter_dimension_numbers = #stablehlo.scatter<
+      update_window_dims = [1],
+      inserted_window_dims = [0, 1],
+      scatter_dims_to_operand_dims = [0, 3],
+      index_vector_dim = 1
+    >,
+    indices_are_sorted = true,
+    unique_indices = true
+  } : (tensor<200x100x300xf32>, tensor<*xi32>, tensor<*xf32>) -> tensor<*xf32>
+  func.return %0 : tensor<*xf32>
+}
+
+// -----
+
+func.func @scatter_c14(%input_tensor: tensor<*xf32>,
+    %scatter_indices: tensor<10x2xi32>, %updates: tensor<*xf32>) ->
+      tensor<*xf32> {
+  // expected-error @+1 {{expects scatter index leaf dimension to be within [0, rank(scatter_indices) + 1. rank(scatter_indices) is 2 and scatter index leaf dimension is 3.}}
   %0 = "stablehlo.scatter" (%input_tensor, %scatter_indices, %updates) ({
   ^bb0(%lhs: tensor<f32>, %rhs: tensor<f32>):
     %add = stablehlo.add %lhs, %rhs : tensor<f32>
@@ -441,48 +542,21 @@ func.func @invalid_scatter_update_window_dims(%input_tensor: tensor<200x100x300x
       update_window_dims = [1],
       inserted_window_dims = [0, 1],
       scatter_dims_to_operand_dims = [0, 1],
-      index_vector_dim = 1
+      index_vector_dim = 3
     >,
     indices_are_sorted = true,
     unique_indices = true
-  } : (tensor<200x100x300xf32>, tensor<10x2xi32>, tensor<10x301xf32>) ->
-      tensor<200x100x300xf32>
-  func.return %0 : tensor<200x100x300xf32>
+  } : (tensor<*xf32>, tensor<10x2xi32>, tensor<*xf32>) ->
+      tensor<*xf32>
+  func.return %0 : tensor<*xf32>
 }
 
 // -----
 
-func.func @invalid_scatter_update_window_dims(%input_tensor: tensor<200x100x300xf32>,
-    %scatter_indices: tensor<11x2xi32>, %updates: tensor<10x300xf32>) ->
-      tensor<200x100x300xf32> {
-
-  // expected-error @+1 {{expects bounds of the scatter dimensions of updates to be same as the bounds of the corresponding dimensions of scatter indices. For scatter dimension 0, updates bound is 10 , scatter_indices bound is 11.}}
-  %0 = "stablehlo.scatter" (%input_tensor, %scatter_indices, %updates) ({
-  ^bb0(%lhs: tensor<f32>, %rhs: tensor<f32>):
-    %add = stablehlo.add %lhs, %rhs : tensor<f32>
-    "stablehlo.return"(%add) : (tensor<f32>) -> ()
-  }) {
-    scatter_dimension_numbers = #stablehlo.scatter<
-      update_window_dims = [1],
-      inserted_window_dims = [0, 1],
-      scatter_dims_to_operand_dims = [0, 1],
-      index_vector_dim = 1
-    >,
-    indices_are_sorted = true,
-    unique_indices = true
-  } : (tensor<200x100x300xf32>, tensor<11x2xi32>, tensor<10x300xf32>) ->
-      tensor<200x100x300xf32>
-  func.return %0 : tensor<200x100x300xf32>
-}
-
-// -----
-
-func.func @invalid_scatter_return_type(%input_tensor: tensor<200x100x300xf32>,
+func.func @scatter_c14(%input_tensor: tensor<200x100x300xf32>,
     %scatter_indices: tensor<10x2xi32>, %updates: tensor<10x300xf32>) ->
-      tensor<200x100xf32> {
-
-  // expected-error @+2 {{failed to infer returned types}}
-  // expected-error @+1 {{inferred type(s) 'tensor<200x100x300xf32>' are incompatible with return type(s) of operation 'tensor<200x100xf32>'}}
+      tensor<200x100x300xf32> {
+  // expected-error @+1 {{expects scatter index leaf dimension to be within [0, rank(scatter_indices) + 1. rank(scatter_indices) is 2 and scatter index leaf dimension is -1.}}
   %0 = "stablehlo.scatter" (%input_tensor, %scatter_indices, %updates) ({
   ^bb0(%lhs: tensor<f32>, %rhs: tensor<f32>):
     %add = stablehlo.add %lhs, %rhs : tensor<f32>
@@ -492,21 +566,20 @@ func.func @invalid_scatter_return_type(%input_tensor: tensor<200x100x300xf32>,
       update_window_dims = [1],
       inserted_window_dims = [0, 1],
       scatter_dims_to_operand_dims = [0, 1],
-      index_vector_dim = 1
+      index_vector_dim = -1
     >,
     indices_are_sorted = true,
     unique_indices = true
   } : (tensor<200x100x300xf32>, tensor<10x2xi32>, tensor<10x300xf32>) ->
-      tensor<200x100xf32>
-  func.return %0 : tensor<200x100xf32>
+      tensor<200x100x300xf32>
+  func.return %0 : tensor<200x100x300xf32>
 }
 
 // -----
 
-func.func @invalid_scatter_reducer(%input_tensor: tensor<200x100x300xf32>,
+func.func @scatter_c15(%input_tensor: tensor<200x100x300xf32>,
     %scatter_indices: tensor<10x2xi32>, %updates: tensor<10x300xf32>) ->
       tensor<200x100x300xf32> {
-
   // expected-error @+1 {{Reduction-region must take 2 parameters, but takes 1 parameter(s)}}
   %0 = "stablehlo.scatter" (%input_tensor, %scatter_indices, %updates) ({
   ^bb0(%lhs: tensor<f32>):
@@ -528,10 +601,9 @@ func.func @invalid_scatter_reducer(%input_tensor: tensor<200x100x300xf32>,
 
 // -----
 
-func.func @invalid_scatter_reducer(%input_tensor: tensor<200x100x300xf32>,
+func.func @scatter_c15(%input_tensor: tensor<200x100x300xf32>,
     %scatter_indices: tensor<10x2xi32>, %updates: tensor<10x300xf32>) ->
       tensor<200x100x300xf32> {
-
   // expected-error @+1 {{The reduction-region expected to return some value(s)}}
   %0 = "stablehlo.scatter" (%input_tensor, %scatter_indices, %updates) ({
   ^bb0(%lhs: tensor<f32>, %rhs: tensor<f32>):
@@ -553,10 +625,9 @@ func.func @invalid_scatter_reducer(%input_tensor: tensor<200x100x300xf32>,
 
 // -----
 
-func.func @invalid_scatter_reducer(%input_tensor: tensor<200x100x300xf32>,
+func.func @scatter_c15(%input_tensor: tensor<200x100x300xf32>,
     %scatter_indices: tensor<10x2xi32>, %updates: tensor<10x300xf32>) ->
       tensor<200x100x300xf32> {
-
   // expected-error @+1 {{Reduction-region here must produce 1 tensors, but produces 2 instead}}
   %0 = "stablehlo.scatter" (%input_tensor, %scatter_indices, %updates) ({
   ^bb0(%lhs: tensor<f32>, %rhs: tensor<f32>):
@@ -578,7 +649,7 @@ func.func @invalid_scatter_reducer(%input_tensor: tensor<200x100x300xf32>,
 
 // -----
 
-func.func @invalid_scatter_reducer(%input_tensor: tensor<200x100x300xf32>,
+func.func @scatter_c15(%input_tensor: tensor<200x100x300xf32>,
     %scatter_indices: tensor<10x2xi32>, %updates: tensor<10x300xf32>) ->
       tensor<200x100x300xf32> {
 
@@ -603,10 +674,9 @@ func.func @invalid_scatter_reducer(%input_tensor: tensor<200x100x300xf32>,
 
 // -----
 
-func.func @invalid_scatter_reducer(%input_tensor: tensor<200x100x300xf32>,
+func.func @scatter_c15(%input_tensor: tensor<200x100x300xf32>,
     %scatter_indices: tensor<10x2xi32>, %updates: tensor<10x300xf32>) ->
       tensor<200x100x300xf32> {
-
   // expected-error @+1 {{Reduction-region here must produce tensor-typed result(s), but produces 'tuple<tensor<f32>, tensor<f32>>' instead}}
   %0 = "stablehlo.scatter" (%input_tensor, %scatter_indices, %updates) ({
   ^bb0(%lhs: tensor<f32>, %rhs: tensor<f32>):
@@ -630,10 +700,9 @@ func.func @invalid_scatter_reducer(%input_tensor: tensor<200x100x300xf32>,
 
 // -----
 
-func.func @invalid_scatter_reducer(%input_tensor: tensor<200x100x300xf32>,
+func.func @scatter_c15(%input_tensor: tensor<200x100x300xf32>,
     %scatter_indices: tensor<10x2xi32>, %updates: tensor<10x300xf32>) ->
       tensor<200x100x300xf32> {
-
   // expected-error@+1 {{The type of reduction-region's parameter at index 0 is different than the corresponding result type: 'tensor<f32>' vs 'tensor<i32>'}}
   %0 = "stablehlo.scatter" (%input_tensor, %scatter_indices, %updates) ({
   ^bb0(%lhs: tensor<f32>, %rhs: tensor<f32>):
@@ -656,10 +725,9 @@ func.func @invalid_scatter_reducer(%input_tensor: tensor<200x100x300xf32>,
 
 // -----
 
-func.func @invalid_scatter_reducer(%input_tensor: tensor<200x100x300xf32>,
+func.func @scatter_c15(%input_tensor: tensor<200x100x300xf32>,
     %scatter_indices: tensor<10x2xi32>, %updates: tensor<10x300xf32>) ->
       tensor<200x100x300xf32> {
-
   // expected-error@+1 {{The type of reduction-region's parameter at index 1 is different than the corresponding result type: 'tensor<i32>' vs 'tensor<f32>'}}
   %0 = "stablehlo.scatter" (%input_tensor, %scatter_indices, %updates) ({
   ^bb0(%lhs: tensor<f32>, %rhs: tensor<i32>):
@@ -681,10 +749,9 @@ func.func @invalid_scatter_reducer(%input_tensor: tensor<200x100x300xf32>,
 
 // -----
 
-func.func @invalid_scatter_reducer(%input_tensor: tensor<200x100x300xf32>,
+func.func @scatter_c6_c15(%input_tensor: tensor<200x100x300xf32>,
     %scatter_indices: tensor<10x2xi32>, %updates: tensor<10x300xi32>) ->
       tensor<200x100x300xf32> {
-
   // expected-error@+1 {{The type of reduction-region's result type at index 0 differs from the op's corresponding init-value type: 'tensor<f32>' vs 'tensor<i32>'}}
   %0 = "stablehlo.scatter" (%input_tensor, %scatter_indices, %updates) ({
   ^bb0(%lhs: tensor<f32>, %rhs: tensor<f32>):
@@ -706,10 +773,9 @@ func.func @invalid_scatter_reducer(%input_tensor: tensor<200x100x300xf32>,
 
 // -----
 
-func.func @invalid_scatter_reducer(%input_tensor: tensor<200x100x300xi32>,
+func.func @scatter_c6_c15_c16(%input_tensor: tensor<200x100x300xi32>,
     %scatter_indices: tensor<10x2xi32>, %updates: tensor<10x300xf32>) ->
       tensor<200x100x300xf32> {
-
   // expected-error@+1 {{The element-type of reduction-region's argument at index 1 is expected to be 'i32', but got 'tensor<f32>' as its type.}}
   %0 = "stablehlo.scatter" (%input_tensor, %scatter_indices, %updates) ({
   ^bb0(%lhs: tensor<f32>, %rhs: tensor<f32>):

--- a/stablehlo/tests/verify_scatter.mlir
+++ b/stablehlo/tests/verify_scatter.mlir
@@ -230,6 +230,54 @@ func.func @scatter_c4(%input_tensor: tensor<200x100x300xf32>,
 
 // -----
 
+func.func @scatter_c6_c15(%input_tensor: tensor<200x100x300xf32>,
+    %scatter_indices: tensor<10x2xi32>, %updates: tensor<10x300xi32>) ->
+      tensor<200x100x300xf32> {
+  // expected-error@+1 {{The type of reduction-region's result type at index 0 differs from the op's corresponding init-value type: 'tensor<f32>' vs 'tensor<i32>'}}
+  %0 = "stablehlo.scatter" (%input_tensor, %scatter_indices, %updates) ({
+  ^bb0(%lhs: tensor<f32>, %rhs: tensor<f32>):
+    %add = stablehlo.add %lhs, %rhs :  tensor<f32>
+    "stablehlo.return"(%add) : (tensor<f32>) -> ()
+  }) {
+    scatter_dimension_numbers = #stablehlo.scatter<
+      update_window_dims = [1],
+      inserted_window_dims = [0, 1],
+      scatter_dims_to_operand_dims = [0, 1],
+      index_vector_dim = 1
+    >,
+    indices_are_sorted = true,
+    unique_indices = true
+  } : (tensor<200x100x300xf32>, tensor<10x2xi32>, tensor<10x300xi32>) ->
+      tensor<200x100x300xf32>
+  func.return %0 : tensor<200x100x300xf32>
+}
+
+// -----
+
+func.func @scatter_c6_c15_c16(%input_tensor: tensor<200x100x300xi32>,
+    %scatter_indices: tensor<10x2xi32>, %updates: tensor<10x300xf32>) ->
+      tensor<200x100x300xf32> {
+  // expected-error@+1 {{The element-type of reduction-region's argument at index 1 is expected to be 'i32', but got 'tensor<f32>' as its type.}}
+  %0 = "stablehlo.scatter" (%input_tensor, %scatter_indices, %updates) ({
+  ^bb0(%lhs: tensor<f32>, %rhs: tensor<f32>):
+    %add = stablehlo.add %lhs, %rhs :  tensor<f32>
+    "stablehlo.return"(%add) : (tensor<f32>) -> ()
+  }) {
+    scatter_dimension_numbers = #stablehlo.scatter<
+      update_window_dims = [1],
+      inserted_window_dims = [0, 1],
+      scatter_dims_to_operand_dims = [0, 1],
+      index_vector_dim = 1
+    >,
+    indices_are_sorted = true,
+    unique_indices = true
+  } : (tensor<200x100x300xi32>, tensor<10x2xi32>, tensor<10x300xf32>) ->
+      tensor<200x100x300xf32>
+  func.return %0 : tensor<200x100x300xf32>
+}
+
+// -----
+
 func.func @scatter_c7() ->  tensor<512x1x6400x6400xf32> {
   %base = stablehlo.constant dense<0.000000e+00> : tensor<512x1x6400x6400xf32>
   %index = stablehlo.constant dense<0> : tensor<1xi32>
@@ -743,54 +791,6 @@ func.func @scatter_c15(%input_tensor: tensor<200x100x300xf32>,
     indices_are_sorted = true,
     unique_indices = true
   } : (tensor<200x100x300xf32>, tensor<10x2xi32>, tensor<10x300xf32>) ->
-      tensor<200x100x300xf32>
-  func.return %0 : tensor<200x100x300xf32>
-}
-
-// -----
-
-func.func @scatter_c6_c15(%input_tensor: tensor<200x100x300xf32>,
-    %scatter_indices: tensor<10x2xi32>, %updates: tensor<10x300xi32>) ->
-      tensor<200x100x300xf32> {
-  // expected-error@+1 {{The type of reduction-region's result type at index 0 differs from the op's corresponding init-value type: 'tensor<f32>' vs 'tensor<i32>'}}
-  %0 = "stablehlo.scatter" (%input_tensor, %scatter_indices, %updates) ({
-  ^bb0(%lhs: tensor<f32>, %rhs: tensor<f32>):
-    %add = stablehlo.add %lhs, %rhs :  tensor<f32>
-    "stablehlo.return"(%add) : (tensor<f32>) -> ()
-  }) {
-    scatter_dimension_numbers = #stablehlo.scatter<
-      update_window_dims = [1],
-      inserted_window_dims = [0, 1],
-      scatter_dims_to_operand_dims = [0, 1],
-      index_vector_dim = 1
-    >,
-    indices_are_sorted = true,
-    unique_indices = true
-  } : (tensor<200x100x300xf32>, tensor<10x2xi32>, tensor<10x300xi32>) ->
-      tensor<200x100x300xf32>
-  func.return %0 : tensor<200x100x300xf32>
-}
-
-// -----
-
-func.func @scatter_c6_c15_c16(%input_tensor: tensor<200x100x300xi32>,
-    %scatter_indices: tensor<10x2xi32>, %updates: tensor<10x300xf32>) ->
-      tensor<200x100x300xf32> {
-  // expected-error@+1 {{The element-type of reduction-region's argument at index 1 is expected to be 'i32', but got 'tensor<f32>' as its type.}}
-  %0 = "stablehlo.scatter" (%input_tensor, %scatter_indices, %updates) ({
-  ^bb0(%lhs: tensor<f32>, %rhs: tensor<f32>):
-    %add = stablehlo.add %lhs, %rhs :  tensor<f32>
-    "stablehlo.return"(%add) : (tensor<f32>) -> ()
-  }) {
-    scatter_dimension_numbers = #stablehlo.scatter<
-      update_window_dims = [1],
-      inserted_window_dims = [0, 1],
-      scatter_dims_to_operand_dims = [0, 1],
-      index_vector_dim = 1
-    >,
-    indices_are_sorted = true,
-    unique_indices = true
-  } : (tensor<200x100x300xi32>, tensor<10x2xi32>, tensor<10x300xf32>) ->
       tensor<200x100x300xf32>
   func.return %0 : tensor<200x100x300xf32>
 }


### PR DESCRIPTION
We have the following constraints in the spec:

```
(I1) `inputs` variadic number of tensors.
(I2) `scatter_indices` tensor of integer type.
(I3) `updates` variadic number of tensors.
(I4) `update_window_dims` 1-dimensional tensor constant of type `si64`.
(I5) `inserted_window_dims` 1-dimensional tensor constant of type `si64`.
(I6) `scatter_dims_to_operand_dims` 1-dimensional tensor constant of type `si64`.
(I7) `index_vector_dim` constant of type `si64`.
(I8) `indices_are_sorted` constant of type `i1`.
(I9) `unique_indices` constant of type `i1`.
(I10) `update_computation` function.
(C1) All `inputs` have the same shape.
(C2) rank(`inputs`[0]) = size(`update_window_dims`) +
     size(`inserted_window_dims`).
(C3) All `updates` have the same shape.
(C4) `shape(updates[0])` =
      `combine(update_scatter_dim_sizes, update_window_dim_sizes)` where:
* `update_scatter_dim_sizes` = `shape(scatter_indices)` except that
  the dimension size of `scatter_indices` corresponding to
  `index_vector_dim` is not included.
* `update_window_dim_sizes` <= `shape(inputs[0])` except that
  the dimension sizes in `inputs[0]` corresponding to `inserted_window_dims`
  are not included.
* `combine` puts `update_scatter_dim_sizes` at axes corresponding to
 `update_scatter_dims` and `update_window_dim_sizes` at axes corresponding
 to `update_window_dims`.
(C5) N = size(`inputs`) = size(`updates`) and N >= 1.
(C6) `element_type(updates[k]) = element_type(inputs[k])` for all k $\in$
     [0, N).
(C7) All dimensions in `update_window_dims` are unique and sorted.
(C8) For all i in [0, size(`update_window_dims`)), 0 <=
`update_window_dims`[i] < rank(`updates`[0]).
(C9) All dimensions in `inserted_window_dims` are unique and sorted.
(C10) For all i in [0, size(`inserted_window_dims`)), 0 <=
`inserted_window_dims`[i] < rank(`inputs`[0]).
(C11) size(`scatter_dims_to_operand_dims`) =
     `index_vector_dim` < rank(`scatter_indices`) ?
     dim(`scatter_indices`, `index_vector_dim`) : 1.
(C12) All dimensions in `scatter_dims_to_operand_dims` are unique.
(C13) For all i in [0, size(`scatter_dims_to_operand_dims`)), 0 <=
    `scatter_dims_to_operand_dims`[i] < rank(`inputs`[0]).
(C14) 0 <= `index_vector_dim` <= rank(`scatter_indices`).
(C15) `update_computation` has type
      `(tensor<E0>, ..., tensor<EN-1>, tensor<E0>, ..., tensor<EN-1>) -> (tensor<E0>, ..., tensor<EN-1>)`
      where `Ek = element_type(inputs[k])` for all k in [0, N).
(C16) `inputs[k]` and `result[k]` have the same type for all k in [0, N).
```

These constraints will be comprehensively covered by the following tests:

```
I1: a) `inputs` variadic number of tensors. (Covered by ODS).
I2: a) `scatter_indices` tensor of integer type. (Covered by ODS).
I3: a) `updates` variadic number of tensors. (Covered by ODS).
I4: a) `update_window_dims` 1-dimensional tensor constant of type `si64`. (Covered by ODS).
I5: a) `inserted_window_dims` 1-dimensional tensor constant of type `si64`. (Covered by ODS).
I6: a) `scatter_dims_to_operand_dims` 1-dimensional tensor constant of type `si64`. (Covered by ODS).
I7: a) `index_vector_dim` constant of type `si64`. (Covered by ODS).
I8: a) `indices_are_sorted` constant of type `i1`. (Covered by ODS).
I9: a) `unique_indices` constant of type `i1`. (Covered by ODS).
I10: a) `update_computation` function. (Covered by ODS).
C1: a) Not all `inputs` have the same shape.
C2: a) rank(`inputs`[0]) != size(`update_window_dims`) +
       size(`inserted_window_dims`).
C3: a) Not all `updates` have the same shape.
C4: a) `shape(updates[0])` !=
      `combine(update_scatter_dim_sizes, update_window_dim_sizes)`.
    b) `update_scatter_dim_sizes` != `shape(scatter_indices)` except that the
       dimension size of `scatter_indices` corresponding to `index_vector_dim`
       is not included.
    c) `update_window_dim_sizes` <= `shape(inputs[0])` except that the dimension
       sizes in `inputs[0]` corresponding to `inserted_window_dims` are not
       included.
    where `combine` puts `update_scatter_dim_sizes` at axes corresponding to
    `update_scatter_dims` and `update_window_dim_sizes` at axes corresponding to
    `update_window_dims`.
C5: a) N != size(`inputs`). (Covered by ODS).
    b) N != size(`updates`). (Covered by ODS).
    c) N < 1. (Covered by ODS).
C6: a) `element_type(updates[k]) != element_type(inputs[k])` for any k in [0, N).
C7: a) Dimensions in `update_window_dims` are not unique.
    b) Dimensions in `update_window_dims` are not sorted.
C8: a) For any i in [0, size(`update_window_dims`)), `update_window_dims`[i] < 0.
    b) For any i in [0, size(`update_window_dims`)), `update_window_dims`[i] >= rank(`updates`[0]). 
C9: a) Dimensions in `inserted_window_dims` are not unique.
    b) Dimensions in `inserted_window_dims` are not sorted.
C10: a) For any i in [0, size(`inserted_window_dims`)), `inserted_window_dims`[i] < 0.
     b) For any i in [0, size(`inserted_window_dims`)), >= rank(`inputs`[0]).
C11: a) size(`scatter_dims_to_operand_dims`) !=
     `index_vector_dim` < rank(`scatter_indices`) ?
     dim(`scatter_indices`, `index_vector_dim`) : 1.
C12: a) Dimensions in `scatter_dims_to_operand_dims` are not unique.
C13: a) For any i in [0, size(`scatter_dims_to_operand_dims`)), `scatter_dims_to_operand_dims`[i] < 0.
     b) For any i in [0, size(`scatter_dims_to_operand_dims`)), `scatter_dims_to_operand_dims`[i] >= rank(`inputs`[0]).
C14: a) `index_vector_dim` < 0.
     b) `index_vector_dim` > rank(`scatter_indices`).
C15: a) `update_computation` does not have type
        `(tensor<E0>, ..., tensor<EN-1>, tensor<E0>, ..., tensor<EN-1>) -> (tensor<E0>, ..., tensor<EN-1>)`
        where `Ek = element_type(inputs[k])` for any k $\in$ [0, N).
C16: a) type(`inputs[k]`) != type(`result[k]`) for any k $\in$ [0, N).
```

If we drop the "Covered by ODS" pieces, this will leave us with the following test cases:

```
C1a: Not all `inputs` have the same shape.
C2a: rank(`inputs`[0]) != size(`update_window_dims`) + size(`inserted_window_dims`).
C3a: Not all `updates` have the same shape.
C4a: `shape(updates[0])` !=
     `combine(update_scatter_dim_sizes, update_window_dim_sizes)`.
C4b: `update_scatter_dim_sizes` != `shape(scatter_indices)` except that the
     dimension size of `scatter_indices` corresponding to `index_vector_dim`
     is not included.
C4c: `update_window_dim_sizes` <= `shape(inputs[0])` except that the dimension
     sizes in `inputs[0]` corresponding to `inserted_window_dims` are not
     included.
     where `combine` puts `update_scatter_dim_sizes` at axes corresponding to
     `update_scatter_dims` and `update_window_dim_sizes` at axes corresponding to
     `update_window_dims`.
C6a: `element_type(updates[k]) != element_type(inputs[k])` for any k in [0, N).
C7a: Dimensions in `update_window_dims` are not unique.
C7b: Dimensions in `update_window_dims` are not sorted.
C8a: For any i in [0, size(`update_window_dims`)), `update_window_dims`[i] < 0.
C8b: For any i in [0, size(`update_window_dims`)), `update_window_dims`[i] >= rank(`updates`[0]). 
C9a: Dimensions in `inserted_window_dims` are not unique.
C9b: Dimensions in `inserted_window_dims` are not sorted.
C10a: For any i in [0, size(`inserted_window_dims`)), `inserted_window_dims`[i] < 0.
C10b: For any i in [0, size(`inserted_window_dims`)), >= rank(`inputs`[0]).
C11a: size(`scatter_dims_to_operand_dims`) !=
      `index_vector_dim` < rank(`scatter_indices`) ?
      dim(`scatter_indices`, `index_vector_dim`) : 1.
C12a: Dimensions in `scatter_dims_to_operand_dims` are not unique.
C13a: For any i in [0, size(`scatter_dims_to_operand_dims`)), `scatter_dims_to_operand_dims`[i] < 0.
C13b: For any i in [0, size(`scatter_dims_to_operand_dims`)), `scatter_dims_to_operand_dims`[i] >= rank(`inputs`[0]).
C14a: `index_vector_dim` < 0.
C14b: `index_vector_dim` > rank(`scatter_indices`).
C15a: `update_computation` does not have type
      `(tensor<E0>, ..., tensor<EN-1>, tensor<E0>, ..., tensor<EN-1>) -> (tensor<E0>, ..., tensor<EN-1>)`
      where `Ek = element_type(inputs[k])` for any k $\in$ [0, N).
C16a: type(`inputs[k]`) != type(`result[k]`) for any k $\in$ [0, N).
```

Notes:
  * Some missing verifications were added.
  * Updates typo in spec wording (i.e. For any k -> For all k).
  * Updates notation `do` -> `di`, `ds` -> `dj`

closes #987