### PR TITLE
Update spec and interpreter for ReduceWindowOp to properly calculate window_end

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4131,8 +4131,8 @@ where:
 * `padded_inputs = pad(inputs..., init_values..., padding[:, 0], padding[:, 1],
   base_dilations - 1)`.
 * `window_start = result_index * window_strides`.
-* `window_end = clamp(0, window_start + window_dimensions * window_dilations,
-  shape(inputs[0]))`.
+* `window_end = clamp(0, window_start + window_dimensions + window_dilations -
+  1, shape(inputs[0]))`.
 * `windows = slice(padded_inputs..., window_start, window_end,
   window_dilations)`.
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4131,7 +4131,8 @@ where:
 * `padded_inputs = pad(inputs..., init_values..., padding[:, 0], padding[:, 1],
   base_dilations - 1)`.
 * `window_start = result_index * window_strides`.
-* `window_end = window_start + window_dimensions`.
+* `window_end = clamp(0, window_start + window_dimensions * window_dilations,
+  shape(inputs[0]))`.
 * `windows = slice(padded_inputs..., window_start, window_end,
   window_dilations)`.
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4131,8 +4131,8 @@ where:
 * `padded_inputs = pad(inputs..., init_values..., padding[:, 0], padding[:, 1],
   base_dilations - 1)`.
 * `window_start = result_index * window_strides`.
-* `window_end = clamp(0, window_start + window_dimensions + window_dilations -
-  1, shape(inputs[0]))`.
+* `window_end = clamp(window_start, window_start + window_dimensions +
+  window_dilations - 1, shape(padded_inputs[0]))`.
 * `windows = slice(padded_inputs..., window_start, window_end,
   window_dilations)`.
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4131,8 +4131,7 @@ where:
 * `padded_inputs = pad(inputs..., init_values..., padding[:, 0], padding[:, 1],
   base_dilations - 1)`.
 * `window_start = result_index * window_strides`.
-* `window_end = clamp(window_start, window_start + window_dimensions +
-  window_dilations - 1, shape(padded_inputs[0]))`.
+* `window_end = window_start + window_dimensions + window_dilations - 1`.
 * `windows = slice(padded_inputs..., window_start, window_end,
   window_dilations)`.
 

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -1286,7 +1286,7 @@ SmallVector<Tensor> evalReduceWindowOp(
     SmallVector<Tensor> windows;
     auto windowStart = (*resultIt) * windowStrides;
     auto windowEnd =
-        clamp(0, windowStart + windowDimensions + windowDilations - 1,
+        clamp(windowStart, windowStart + windowDimensions + windowDilations - 1,
               paddedInputs[0].getShape());
     for (const auto &paddedInput : paddedInputs)
       windows.push_back(

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -1285,8 +1285,9 @@ SmallVector<Tensor> evalReduceWindowOp(
        resultIt != results[0].index_end(); ++resultIt) {
     SmallVector<Tensor> windows;
     auto windowStart = (*resultIt) * windowStrides;
-    auto windowEnd = clamp(0, windowStart + windowDimensions * windowDilations,
-                           paddedInputs[0].getShape());
+    auto windowEnd =
+        clamp(0, windowStart + windowDimensions + windowDilations - 1,
+              paddedInputs[0].getShape());
     for (const auto &paddedInput : paddedInputs)
       windows.push_back(
           evalSliceOp(paddedInput, windowStart, windowEnd, windowDilations));

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -1285,10 +1285,11 @@ SmallVector<Tensor> evalReduceWindowOp(
        resultIt != results[0].index_end(); ++resultIt) {
     SmallVector<Tensor> windows;
     auto windowStart = (*resultIt) * windowStrides;
+    auto windowEnd = clamp(0, windowStart + windowDimensions * windowDilations,
+                           paddedInputs[0].getShape());
     for (const auto &paddedInput : paddedInputs)
-      windows.push_back(evalSliceOp(paddedInput, windowStart,
-                                    windowStart + windowDimensions,
-                                    windowDilations));
+      windows.push_back(
+          evalSliceOp(paddedInput, windowStart, windowEnd, windowDilations));
 
     auto reducedValues =
         evalReduceOp(windows, initValues, inputs[0].getAxes(), body, scope);

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -1280,14 +1280,11 @@ SmallVector<Tensor> evalReduceWindowOp(
   for (auto [input, initValue] : llvm::zip(inputs, initValues))
     paddedInputs.push_back(evalPadOp(input, initValue, paddingLow, paddingHigh,
                                      baseDilations - 1));
-
   for (auto resultIt = results[0].index_begin();
        resultIt != results[0].index_end(); ++resultIt) {
     SmallVector<Tensor> windows;
     auto windowStart = (*resultIt) * windowStrides;
-    auto windowEnd =
-        clamp(windowStart, windowStart + windowDimensions + windowDilations - 1,
-              paddedInputs[0].getShape());
+    auto windowEnd = windowStart + windowDimensions + windowDilations - 1;
     for (const auto &paddedInput : paddedInputs)
       windows.push_back(
           evalSliceOp(paddedInput, windowStart, windowEnd, windowDilations));

--- a/stablehlo/testdata/reduce_window_add_window_dilation_shape_float32_4_6__initvalue_0_windowdimensions__2_2__windowstride1490052185320441557.mlir
+++ b/stablehlo/testdata/reduce_window_add_window_dilation_shape_float32_4_6__initvalue_0_windowdimensions__2_2__windowstride1490052185320441557.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/select_and_gather_add_dilations_shape_float32_4_6__selectprim_le_windowdimensions__2__2__windowstrid-1234442230378059557.mlir
+++ b/stablehlo/testdata/select_and_gather_add_dilations_shape_float32_4_6__selectprim_le_windowdimensions__2__2__windowstrid-1234442230378059557.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/select_and_gather_add_dilations_shape_float32_4_6__selectprim_le_windowdimensions__2__2__windowstrid4494141771612406334.mlir
+++ b/stablehlo/testdata/select_and_gather_add_dilations_shape_float32_4_6__selectprim_le_windowdimensions__2__2__windowstrid4494141771612406334.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {


### PR DESCRIPTION
The current spec does not use `slice` with the same semantics as what `stablehlo.slice` does. `stablehlo.slice` version of `limit_indices` accounts for dilation and also complies with SliceOp's constraint: `(C3) 0 <= start_indices[d] <= limit_indices[d] <= dim(operand, d) for all dimension d.`

ReduceWindowOp's `limit_indices` calculation does not account for the dilation and (C3), so we need to add dilation (minus 1 since limit_indices is exclusive).

This was discussed previously in the interpreter PR https://github.com/openxla/stablehlo/pull/1336#discussion_r1142826672. We kept the formulation as-is to assume that the program provides correct values, but we may not assume this is the case when we are explicitly constructing the input values.