### PR TITLE
 Specification for UniformQuantizeOp and UniformDequantizeOp

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -5538,7 +5538,7 @@ Performs element-wise conversion of quantized tensor `operand` to a
 floating-point tensor `result` according to the quantization parameters defined
 by the `operand` type.
 
-Formally, `result = dequantize(operand)`.
+More formally, `result = dequantize(operand)`.
 
 #### Inputs
 
@@ -5573,7 +5573,7 @@ Performs element-wise conversion of floating-point tensor or quantized tensor
 `operand` to a quantized tensor `result` according to the quantization
 parameters defined by the `result` type.
 
-Formally,
+More formally,
 
 * If `is_float(operand)`:
   * `result = quantize(operand, type(result))`.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -5560,9 +5560,13 @@ Formally, `result = (operand - zero_point(operand)) * scale(operand)`.
 #### Examples
 
 ```mlir
-// %operand: 20
+// %operand: 10
 %result = "stablehlo.uniform_dequantize"(%operand) : (tensor<!quant.uniform<i8<-128:127>:f32, 0.5:-20>>) -> tensor<f32>
-// %result: 20.0
+// %result: 15.0
+
+// %operand: [10, 10]
+%result = "stablehlo.uniform_dequantize"(%operand) : (tensor<3x!quant.uniform<i8<-128:127>:f32:0, {0.1:-30, 0.5:-20}>>) -> tensor<3xf32>
+// %result: [4.0, 15.0]
 ```
 
 ### uniform_quantize
@@ -5592,8 +5596,8 @@ Formally,
 
 #### Outputs
 
-| Name     | Type                     | Constraints      |
-|----------|--------------------------|------------------|
+| Name     | Type             | Constraints      |
+|----------|------------------|------------------|
 | `result` | quantized tensor | (C1), (C2), (C3) |
 
 #### Constraints
@@ -5601,16 +5605,19 @@ Formally,
 * (C1) If `element_type(operand)` is a floating-point type,
   * `element_type(operand) = expressed_type(result)`.
 * (C2) If `element_type(operand)` is a quantized type,
-  * `num_bits(storage_type(operand)) >= num_bits(storage_type(result))`.
   * `expressed_type(operand) = expressed_type(result)`.
 * (C3) `shape(operand) = shape(result)`.
 
 #### Examples
 
 ```mlir
-// %operand: 20.0
+// %operand: 15.0
 %result = "stablehlo.uniform_quantize"(%operand) : (tensor<f32>) -> tensor<!quant.uniform<i8<-128:127>:f32, 0.5:-20>>
-// %result: 20
+// %result: 10
+
+// %operand: [4.0, 15.0]
+%result = "stablehlo.uniform_quantize"(%operand) : (tensor<3xf32>) -> tensor<3x!quant.uniform<i8<-128:127>:f32:0, {0.1:-30, 0.5:-20}>>
+// %result: [10, 10]
 ```
 
 ### while

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -5560,12 +5560,8 @@ Formally, `result = (operand - zero_point(operand)) * scale(operand)`.
 #### Examples
 
 ```mlir
-// %operand: 10
-%result = "stablehlo.uniform_dequantize"(%operand) : (tensor<!quant.uniform<i8<-128:127>:f32, 0.5:-20>>) -> tensor<f32>
-// %result: 15.0
-
 // %operand: [10, 10]
-%result = "stablehlo.uniform_dequantize"(%operand) : (tensor<3x!quant.uniform<i8<-128:127>:f32:0, {0.1:-30, 0.5:-20}>>) -> tensor<3xf32>
+%result = "stablehlo.uniform_dequantize"(%operand) : (tensor<2x!quant.uniform<i8<-128:127>:f32:0, {0.1:-30, 0.5:-20}>>) -> tensor<2xf32>
 // %result: [4.0, 15.0]
 ```
 
@@ -5611,12 +5607,12 @@ Formally,
 #### Examples
 
 ```mlir
-// %operand: 15.0
-%result = "stablehlo.uniform_quantize"(%operand) : (tensor<f32>) -> tensor<!quant.uniform<i8<-128:127>:f32, 0.5:-20>>
-// %result: 10
-
 // %operand: [4.0, 15.0]
-%result = "stablehlo.uniform_quantize"(%operand) : (tensor<3xf32>) -> tensor<3x!quant.uniform<i8<-128:127>:f32:0, {0.1:-30, 0.5:-20}>>
+%result = "stablehlo.uniform_quantize"(%operand) : (tensor<2xf32>) -> tensor<2x!quant.uniform<i8<-128:127>:f32:0, {0.1:-30, 0.5:-20}>>
+// %result: [10, 10]
+
+// %operand: [10, 10]
+%result = "stablehlo.uniform_quantize"(%operand) : (tensor<2x!quant.uniform<i8<-128:127>:f32:0, {0.1:-30, 0.5:-20}>>) -> tensor<2x!quant.uniform<i8<-128:127>:f32:0, {0.1:-30, 0.5:-20}>>
 // %result: [10, 10]
 ```
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -154,6 +154,6 @@ one of the following tracking labels.
 | tuple                    | yes           | yes          | yes            | yes             | no          |
 | unary_einsum             | no            | revisit      | no             | yes             | revisit     |
 | uniform_dequantize       | yes           | yes          | yes            | yes             | no          |
-| uniform_quantize         | yes           | no           | infeasible     | yes             | no          |
+| uniform_quantize         | yes           | revisit      | infeasible     | yes             | no          |
 | while                    | yes           | revisit      | yes            | revisit         | yes         |
 | xor                      | yes           | yes          | yes            | yes             | yes         |

--- a/docs/status.md
+++ b/docs/status.md
@@ -153,7 +153,7 @@ one of the following tracking labels.
 | triangular_solve         | yes           | revisit      | yes            | no              | revisit     |
 | tuple                    | yes           | yes          | yes            | yes             | no          |
 | unary_einsum             | no            | revisit      | no             | yes             | revisit     |
-| uniform_dequantize       | no            | yes\*        | yes\*          | yes             | no          |
-| uniform_quantize         | no            | yes\*        | infeasible     | yes             | no          |
+| uniform_dequantize       | yes           | yes          | yes            | yes             | no          |
+| uniform_quantize         | yes           | no           | infeasible     | yes             | no          |
 | while                    | yes           | revisit      | yes            | revisit         | yes         |
 | xor                      | yes           | yes          | yes            | yes             | yes         |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -3059,16 +3059,16 @@ def StableHLO_UniformQuantizeOp : StableHLO_UnaryElementwiseOp<"uniform_quantize
       HLO_QuantizedIntTensor> {
   let summary = "UniformQuantize operation";
   let description = [{
-    This operation is a work in progress, so it is not yet included in
-    the StableHLO specification: https://github.com/openxla/stablehlo/issues/588.
+    Performs element-wise conversion of floating-point tensor or uniform
+    quantized tensor `operand` to a uniform quantized tensor `result`
+    according to the quantization parameters defined by the `result` type.
 
-    Informally, this operation converts floating point tensors or uniform
-    quantized tensors to uniform quantized tensors according to the quantization
-    parameters defined by the result type.
+    See:
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#uniform_quantize
 
     Example:
     ```mlir
-    %result = stablehlo.uniform_quantize %operand : (tensor<16x16xf32>) -> tensor<16x16x!quant.uniform<ui8:f32, 34.0:16>>
+    %result = stablehlo.uniform_quantize %operand : (tensor<2xf32>) -> tensor<2x!quant.uniform<i8:f32:0, {0.1:-30,0.5:-20}>>
     ```
   }];
 }
@@ -3077,16 +3077,16 @@ def StableHLO_UniformDequantizeOp : StableHLO_UnaryElementwiseOp<"uniform_dequan
       [InferTensorType, Pure], HLO_QuantizedIntTensor, TensorOf<[F32, BF16]>> {
   let summary = "UniformDequantize operation";
   let description = [{
-    This operation is a work in progress, so it is not yet included in
-    the StableHLO specification: https://github.com/openxla/stablehlo/issues/588.
+    Performs element-wise conversion of uniform quantized tensor `operand` to a
+    floating-point tensor `result` according to the quantization parameters
+    defined by the `operand` type.
 
-    Informally, this operation converts uniform quantized tensors to floating
-    point tensors according to the quantization parameters defined by the
-    operand type.
+    See:
+    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#uniform_dequantize
 
     Example:
     ```mlir
-    %result = stablehlo.uniform_dequantize %operand : (tensor<16x16x!quant.uniform<i8:f32, 34.0:16>>) -> tensor<16x16xf32>
+    %result = stablehlo.uniform_dequantize %operand : (tensor<2x!quant.uniform<i8:f32:0, {0.1:-30,0.5:-20}>>) -> tensor<2xf32>
     ```
   }];
 }

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -3075,7 +3075,7 @@ def StableHLO_UniformQuantizeOp : StableHLO_UnaryElementwiseOp<"uniform_quantize
 
 def StableHLO_UniformDequantizeOp : StableHLO_UnaryElementwiseOp<"uniform_dequantize",
       [InferTensorType, Pure], HLO_QuantizedIntTensor /*uniform_dequantize_i1*/,
-      HLO_FpTensor> { /*uniform_dequantize_c1*/
+      HLO_FpTensor> { /*uniform_dequantize_c1, uniform_dequantize_c2*/
   let summary = "UniformDequantize operation";
   let description = [{
     Performs element-wise conversion of quantized tensor `operand` to a

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -3055,13 +3055,13 @@ def StableHLO_RngBitGeneratorOp : StableHLO_Op<"rng_bit_generator", [Pure]> {
 
 // TODO(b/230662142): Implement unknown scales/zero_point cases.
 def StableHLO_UniformQuantizeOp : StableHLO_UnaryElementwiseOp<"uniform_quantize",
-      [Pure], TensorOf<[F32, BF16, HLO_QuantizedInt]>,
+      [Pure], TensorOf<[HLO_Float, HLO_QuantizedInt]>,
       HLO_QuantizedIntTensor> {
   let summary = "UniformQuantize operation";
   let description = [{
-    Performs element-wise conversion of floating-point tensor or uniform
-    quantized tensor `operand` to a uniform quantized tensor `result`
-    according to the quantization parameters defined by the `result` type.
+    Performs element-wise conversion of floating-point tensor or quantized
+    tensor `operand` to a quantized tensor `result` according to the
+    quantization parameters defined by the `result` type.
 
     See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec.md#uniform_quantize
@@ -3074,10 +3074,10 @@ def StableHLO_UniformQuantizeOp : StableHLO_UnaryElementwiseOp<"uniform_quantize
 }
 
 def StableHLO_UniformDequantizeOp : StableHLO_UnaryElementwiseOp<"uniform_dequantize",
-      [InferTensorType, Pure], HLO_QuantizedIntTensor, TensorOf<[F32, BF16]>> {
+      [InferTensorType, Pure], HLO_QuantizedIntTensor, HLO_FpTensor> {
   let summary = "UniformDequantize operation";
   let description = [{
-    Performs element-wise conversion of uniform quantized tensor `operand` to a
+    Performs element-wise conversion of quantized tensor `operand` to a
     floating-point tensor `result` according to the quantization parameters
     defined by the `operand` type.
 

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -3055,8 +3055,8 @@ def StableHLO_RngBitGeneratorOp : StableHLO_Op<"rng_bit_generator", [Pure]> {
 
 // TODO(b/230662142): Implement unknown scales/zero_point cases.
 def StableHLO_UniformQuantizeOp : StableHLO_UnaryElementwiseOp<"uniform_quantize",
-      [Pure], TensorOf<[HLO_Float, HLO_QuantizedInt]>,
-      HLO_QuantizedIntTensor> {
+      [Pure], TensorOf<[HLO_Float, HLO_QuantizedInt]> /*uniform_quantize_i1*/,
+      HLO_QuantizedIntTensor> { /*uniform_quantize_c1*/
   let summary = "UniformQuantize operation";
   let description = [{
     Performs element-wise conversion of floating-point tensor or quantized
@@ -3074,7 +3074,8 @@ def StableHLO_UniformQuantizeOp : StableHLO_UnaryElementwiseOp<"uniform_quantize
 }
 
 def StableHLO_UniformDequantizeOp : StableHLO_UnaryElementwiseOp<"uniform_dequantize",
-      [InferTensorType, Pure], HLO_QuantizedIntTensor, HLO_FpTensor> {
+      [InferTensorType, Pure], HLO_QuantizedIntTensor /*uniform_dequantize_i1*/,
+      HLO_FpTensor> { /*uniform_dequantize_c1*/
   let summary = "UniformDequantize operation";
   let description = [{
     Performs element-wise conversion of quantized tensor `operand` to a

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -3009,6 +3009,7 @@ LogicalResult inferUniformDequantizeOp(
   // Trait HLO_QuantizedIntTensor in ODS guarantees QuantizedType;
   auto quantType = operandType.getElementType().cast<quant::QuantizedType>();
   auto shape = operandType.cast<ShapedType>().getShape();
+  // uniform_dequantize_c1, uniform_dequantize_c2
   inferredReturnShapes.emplace_back(shape, quantType.getExpressedType());
   return success();
 }
@@ -3017,6 +3018,7 @@ LogicalResult inferUniformQuantizeOp(
     std::optional<Location> location, Value operand,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   auto operandType = operand.getType().cast<ShapedType>();
+  // uniform_quantize_c1
   inferredReturnShapes.emplace_back(
       operandType.hasRank() ? operandType.getShape() : ArrayRef<int64_t>{});
   return success();

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -234,8 +234,8 @@ func.func @clamp(%arg0: tensor<1xi32>) -> tensor<1xindex> {
 
 // -----
 
-// CHECK: func @uniform_dequantize
-func.func @uniform_dequantize(%arg: tensor<16x16x!quant.uniform<i8:f32, 34.0:16>>) -> tensor<16x16xindex> {
+// CHECK: func @uniform_dequantize_c2
+func.func @uniform_dequantize_c2(%arg: tensor<16x16x!quant.uniform<i8:f32, 34.0:16>>) -> tensor<16x16xindex> {
   %0 = stablehlo.uniform_dequantize %arg : (tensor<16x16x!quant.uniform<i8:f32, 34.0:16>>) -> tensor<16x16xf32>
   // CHECK: types0 = tensor<16x16xf32>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<16x16xf32>) -> tensor<16x16xindex>

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -5114,14 +5114,6 @@ func.func @uniform_dequantize(%arg: tensor<16x16x!quant.uniform<i8:f32, 34.0:16>
 
 // -----
 
-func.func @uniform_dequantize_i1(%arg: tensor<16x16xf32>) -> tensor<16x16xf32> {
-  // expected-error@+1 {{operand #0 must be tensor of 4/8/16/32-bit uniform quantized signed integer or 4/8/16/32-bit uniform quantized unsigned integer values, but got 'tensor<16x16xf32>'}}
-  %0 = stablehlo.uniform_dequantize %arg : (tensor<16x16xf32>) -> tensor<16x16xf32>
-  func.return %0 : tensor<16x16xf32>
-}
-
-// -----
-
 func.func @uniform_dequantize_unranked(%arg: tensor<*x!quant.uniform<i8:f32, 34.0:16>>) -> tensor<*xf32> {
   %0 = stablehlo.uniform_dequantize %arg : (tensor<*x!quant.uniform<i8:f32, 34.0:16>>) -> tensor<*xf32>
   func.return %0 : tensor<*xf32>

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -5090,7 +5090,7 @@ func.func @quantized_dot_general(%arg0: tensor<2x16x32x!quant.uniform<i8:f32, 2.
 
 // -----
 
-// CHECK: func @uniform_quantize
+// CHECK-LABEL: func @uniform_quantize
 func.func @uniform_quantize(%arg: tensor<16x16xf32>) -> tensor<16x16x!quant.uniform<ui8:f32, 34.0:16>> {
   %0 = stablehlo.uniform_quantize %arg : (tensor<16x16xf32>) -> tensor<16x16x!quant.uniform<ui8:f32, 34.0:16>>
   func.return %0 : tensor<16x16x!quant.uniform<ui8:f32, 34.0:16>>
@@ -5106,7 +5106,7 @@ func.func @uniform_requantize(%arg: tensor<16x16x!quant.uniform<i8:f32, 5.0:20>>
 
 // -----
 
-// CHECK: func @uniform_dequantize
+// CHECK-LABEL: func @uniform_dequantize
 func.func @uniform_dequantize(%arg: tensor<16x16x!quant.uniform<i8:f32, 34.0:16>>) -> tensor<16x16xf32> {
   %0 = stablehlo.uniform_dequantize %arg : (tensor<16x16x!quant.uniform<i8:f32, 34.0:16>>) -> tensor<16x16xf32>
   func.return %0 : tensor<16x16xf32>
@@ -5114,18 +5114,17 @@ func.func @uniform_dequantize(%arg: tensor<16x16x!quant.uniform<i8:f32, 34.0:16>
 
 // -----
 
-// CHECK: func @uniform_dequantize_unranked
-func.func @uniform_dequantize_unranked(%arg: tensor<*x!quant.uniform<i8:f32, 34.0:16>>) -> tensor<*xf32> {
-  %0 = stablehlo.uniform_dequantize %arg : (tensor<*x!quant.uniform<i8:f32, 34.0:16>>) -> tensor<*xf32>
-  func.return %0 : tensor<*xf32>
+func.func @uniform_dequantize_i1(%arg: tensor<16x16xf32>) -> tensor<16x16xf32> {
+  // expected-error@+1 {{operand #0 must be tensor of 4/8/16/32-bit uniform quantized signed integer or 4/8/16/32-bit uniform quantized unsigned integer values, but got 'tensor<16x16xf32>'}}
+  %0 = stablehlo.uniform_dequantize %arg : (tensor<16x16xf32>) -> tensor<16x16xf32>
+  func.return %0 : tensor<16x16xf32>
 }
 
 // -----
 
-func.func @uniform_dequantize_not_quantize(%arg: tensor<16x16xf32>) -> tensor<16x16xf32> {
-  // expected-error@+1 {{operand #0 must be tensor of 4/8/16/32-bit uniform quantized signed integer or 4/8/16/32-bit uniform quantized unsigned integer values, but got 'tensor<16x16xf32>'}}
-  %0 = stablehlo.uniform_dequantize %arg : (tensor<16x16xf32>) -> tensor<16x16xf32>
-  func.return %0 : tensor<16x16xf32>
+func.func @uniform_dequantize_unranked(%arg: tensor<*x!quant.uniform<i8:f32, 34.0:16>>) -> tensor<*xf32> {
+  %0 = stablehlo.uniform_dequantize %arg : (tensor<*x!quant.uniform<i8:f32, 34.0:16>>) -> tensor<*xf32>
+  func.return %0 : tensor<*xf32>
 }
 
 // -----


### PR DESCRIPTION
fixes #531
fixes #530 

## Summary 
The PR proposes the specification for `uniform.quantize` and `uniform.dequantize` ops. 

The specification of `uniform.quantize` also captures the re-quantization conversions from quantized tensor to quantized tensors. 

Please let me know your feedback. 


### Working notes on following the `reference_checklist.md` and `spec_checkilist.md`

#### uniform_dequantize

We have the following constraints from the spec  

```
(I1)  `operand` is a  quantized tensor
(C1) `shape(operand) = shape(result)`.
(C2) `element_type(result) = expressed_type(operand)`.
```

These constraints will be comprehensively covered by the following tests:

```
I1: a) `operand: quantized tensors`. (Covered by ODS).
C1: a) `shape(operand) != shape(result)`. (Covered by ODS)
C2: a) `element_type(result) != expressed_type(operand)`.
```

If we drop the "Covered by ODS" pieces, this will leave us with the following test cases:

```
C2: a) `element_type(result) != expressed_type(operand)`.
```

We already has a type inference test to cover the above. 


#### uniform_quantize

We have the following constraints from the spec  

```
(I1)  `operand: tensor of floating-point or quantized type`.
(C1) `shape(operand) = shape(result)`.
(C2) `expressed_type(result) = is_float(operand) ? element_type(operand) :
  expressed_type(operand)`.
```

These constraints will be comprehensively covered by the following tests:

```
I1: a) `operand: quantized tensors`. (Covered by ODS).
C1: a) `shape(operand) != shape(result)`. (Covered by ODS)
C2: a) if_float(operand): `expressed_type(result) != element_type(operand)`.
      b) if_quantized(operand): `expressed_type(result) !=  expressed_type(operand)`.
```

If we drop the "Covered by ODS" pieces, this will leave us with the following test cases:

```
C2: a) if_float(operand): `expressed_type(result) != element_type(operand)`.
      b) if_quantized(operand): `expressed_type(result) !=  expressed_type(operand)`.
```

The above will be covered as part of https://github.com/openxla/stablehlo/issues/1603.