### PR TITLE
Incorporate tosa/ tests into our test infrastructure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,21 @@ set(STABLEHLO_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(STABLEHLO_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
 set(STABLEHLO_TOOLS_DIR ${CMAKE_BINARY_DIR}/bin)
 
-add_custom_target(check-stablehlo)
+# Target that provides comprehensive testing for the StableHLO repository.
+# It includes both quick and slow tests (see check-stablehlo-quick and
+# check-stablehlo-slow below).
+add_custom_target(check-stablehlo-ci)
+
+# Target that aggregates slow tests. Long-running test targets should go
+# into dependencies of this target, and we shouldn't expect humans to run them
+# regularly during development.
+add_custom_target(check-stablehlo-slow)
+add_dependencies(check-stablehlo-ci check-stablehlo-slow)
+
+# Target that aggregates fast tests. We shouldn't add long-running test targets
+# as a dependency of this target, since we'd want humans to routinely use this
+# target during development.
+add_custom_target(check-stablehlo-quick)
+add_dependencies(check-stablehlo-ci check-stablehlo-quick)
 
 add_subdirectory(stablehlo)
-

--- a/build_tools/github_actions/ci_build_cmake.sh
+++ b/build_tools/github_actions/ci_build_cmake.sh
@@ -43,4 +43,4 @@ cmake -GNinja \
 
 # Build and Test StableHLO
 cd "$STABLEHLO_BUILD_DIR"
-ninja check-stablehlo
+ninja check-stablehlo-ci

--- a/build_tools/github_actions/ci_build_cmake_code_coverage.sh
+++ b/build_tools/github_actions/ci_build_cmake_code_coverage.sh
@@ -62,7 +62,7 @@ cmake -GNinja \
   -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} -fprofile-instr-generate -fprofile-arcs -ftest-coverage -fcoverage-mapping"
 
 # Build and Check StableHLO
-(cd "$STABLEHLO_BUILD_DIR" && ninja check-stablehlo)
+(cd "$STABLEHLO_BUILD_DIR" && ninja check-stablehlo-ci)
 
 BUILD_TOOLS_DIR="$(dirname "$(readlink -f "$0")")"
 

--- a/stablehlo/conversions/tosa/tests/CMakeLists.txt
+++ b/stablehlo/conversions/tosa/tests/CMakeLists.txt
@@ -19,10 +19,10 @@ configure_lit_site_cfg(
         ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.py
 )
 
-add_lit_testsuite(check-stablehlo-tosa-lit "Running the stablehlo-tosa regression tests"
+add_lit_testsuite(check-stablehlo-tosa "Running the tosa/ suite"
         ${CMAKE_CURRENT_BINARY_DIR}
         DEPENDS
         FileCheck
         stablehlo-opt
         )
-# add_dependencies(check-stablehlo-tests check-stablehlo-tosa-lit)
+add_dependencies(check-stablehlo-quick check-stablehlo-tosa)

--- a/stablehlo/conversions/tosa/tests/binary.mlir
+++ b/stablehlo/conversions/tosa/tests/binary.mlir
@@ -38,7 +38,7 @@ func.func @compare_ne(%arg0 : tensor<10xi32>, %arg1 : tensor<10xi32>) -> tensor<
 
 // CHECK-LABEL: @concatenate
 func.func @concatenate(%arg0 : tensor<3x3xf32>, %arg1 : tensor<3x3xf32>) -> tensor<6x3xf32> {
-  // CHECK: "tosa.concat"(%arg0, %arg1) {axis = 0 : i64} : (tensor<3x3xf32>, tensor<3x3xf32>) -> tensor<6x3xf32>
+  // CHECK: "tosa.concat"(%arg0, %arg1) <{axis = 0 : i64}> : (tensor<3x3xf32>, tensor<3x3xf32>) -> tensor<6x3xf32>
   %0 = "stablehlo.concatenate"(%arg0, %arg1) {dimension = 0 : i64} : (tensor<3x3xf32>, tensor<3x3xf32>) -> tensor<6x3xf32>
   return %0 : tensor<6x3xf32>
 }
@@ -60,8 +60,8 @@ func.func @divide_f32(%arg0 : tensor<10xf32>, %arg1 : tensor<10xf32>) -> tensor<
 
 // CHECK-LABEL: @dot_vector_vector
 func.func @dot_vector_vector(%arg0 : tensor<3xf32>, %arg1 : tensor<3xf32>) -> tensor<f32> {
-  // CHECK-DAG: %[[VAR0:.*]] = "tosa.reshape"(%arg0) {new_shape = array<i64: 1, 1, 3>}
-  // CHECK-DAG: %[[VAR1:.*]] = "tosa.reshape"(%arg1) {new_shape = array<i64: 1, 3, 1>}
+  // CHECK-DAG: %[[VAR0:.*]] = "tosa.reshape"(%arg0) <{new_shape = array<i64: 1, 1, 3>}>
+  // CHECK-DAG: %[[VAR1:.*]] = "tosa.reshape"(%arg1) <{new_shape = array<i64: 1, 3, 1>}>
   // CHECK-DAG: %[[VAR2:.*]] = "tosa.matmul"(%[[VAR0]], %[[VAR1]])
   // CHECK-DAG: %[[VAR3:.*]] = "tosa.reshape"(%[[VAR2]])
   %0 = "stablehlo.dot"(%arg0, %arg1) : (tensor<3xf32>, tensor<3xf32>) -> tensor<f32>
@@ -70,8 +70,8 @@ func.func @dot_vector_vector(%arg0 : tensor<3xf32>, %arg1 : tensor<3xf32>) -> te
 
 // CHECK-LABEL: @dot_vector_matrix
 func.func @dot_vector_matrix(%arg0 : tensor<2xf32>, %arg1 : tensor<2x3xf32>) -> tensor<3xf32> {
-  // CHECK-DAG: %[[VAR0:.*]] = "tosa.reshape"(%arg0) {new_shape = array<i64: 1, 1, 2>}
-  // CHECK-DAG: %[[VAR1:.*]] = "tosa.reshape"(%arg1) {new_shape = array<i64: 1, 2, 3>}
+  // CHECK-DAG: %[[VAR0:.*]] = "tosa.reshape"(%arg0) <{new_shape = array<i64: 1, 1, 2>}>
+  // CHECK-DAG: %[[VAR1:.*]] = "tosa.reshape"(%arg1) <{new_shape = array<i64: 1, 2, 3>}>
   // CHECK-DAG: %[[VAR2:.*]] = "tosa.matmul"(%[[VAR0]], %[[VAR1]])
   // CHECK-DAG: %[[VAR3:.*]] = "tosa.reshape"(%[[VAR2]])
   %0 = "stablehlo.dot"(%arg0, %arg1) : (tensor<2xf32>, tensor<2x3xf32>) -> tensor<3xf32>
@@ -80,8 +80,8 @@ func.func @dot_vector_matrix(%arg0 : tensor<2xf32>, %arg1 : tensor<2x3xf32>) -> 
 
 // CHECK-LABEL: @dot_matrix_vector
 func.func @dot_matrix_vector(%arg0 : tensor<2x3xf32>, %arg1 : tensor<3xf32>) -> tensor<2xf32> {
-  // CHECK-DAG: %[[VAR0:.*]] = "tosa.reshape"(%arg0) {new_shape = array<i64: 1, 2, 3>}
-  // CHECK-DAG: %[[VAR1:.*]] = "tosa.reshape"(%arg1) {new_shape = array<i64: 1, 3, 1>}
+  // CHECK-DAG: %[[VAR0:.*]] = "tosa.reshape"(%arg0) <{new_shape = array<i64: 1, 2, 3>}>
+  // CHECK-DAG: %[[VAR1:.*]] = "tosa.reshape"(%arg1) <{new_shape = array<i64: 1, 3, 1>}>
   // CHECK-DAG: %[[VAR2:.*]] = "tosa.matmul"(%[[VAR0]], %[[VAR1]])
   // CHECK-DAG: %[[VAR3:.*]] = "tosa.reshape"(%[[VAR2]])
   %0 = "stablehlo.dot"(%arg0, %arg1) : (tensor<2x3xf32>, tensor<3xf32>) -> tensor<2xf32>
@@ -90,8 +90,8 @@ func.func @dot_matrix_vector(%arg0 : tensor<2x3xf32>, %arg1 : tensor<3xf32>) -> 
 
 // CHECK-LABEL: @dot_matrix_matrix
 func.func @dot_matrix_matrix(%arg0 : tensor<2x3xf32>, %arg1 : tensor<3x4xf32>) -> tensor<2x4xf32> {
-  // CHECK-DAG: %[[VAR0:.*]] = "tosa.reshape"(%arg0) {new_shape = array<i64: 1, 2, 3>}
-  // CHECK-DAG: %[[VAR1:.*]] = "tosa.reshape"(%arg1) {new_shape = array<i64: 1, 3, 4>}
+  // CHECK-DAG: %[[VAR0:.*]] = "tosa.reshape"(%arg0) <{new_shape = array<i64: 1, 2, 3>}>
+  // CHECK-DAG: %[[VAR1:.*]] = "tosa.reshape"(%arg1) <{new_shape = array<i64: 1, 3, 4>}>
   // CHECK-DAG: %[[VAR2:.*]] = "tosa.matmul"(%[[VAR0]], %[[VAR1]])
   // CHECK-DAG: %[[VAR3:.*]] = "tosa.reshape"(%[[VAR2]])
   %0 = "stablehlo.dot"(%arg0, %arg1) : (tensor<2x3xf32>, tensor<3x4xf32>) -> tensor<2x4xf32>

--- a/stablehlo/conversions/tosa/tests/lit.cfg.py
+++ b/stablehlo/conversions/tosa/tests/lit.cfg.py
@@ -21,7 +21,7 @@ from lit.llvm import llvm_config
 
 # Populate Lit configuration with the minimal required metadata.
 # Some metadata is populated in lit.site.cfg.py.in.
-config.name = 'STABLEHLO_TOSA_OPT'
+config.name = 'STABLEHLO_TOSA_SUITE'
 config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
 config.suffixes = ['.mlir']
 config.test_source_root = os.path.dirname(__file__)

--- a/stablehlo/conversions/tosa/tests/nullary.mlir
+++ b/stablehlo/conversions/tosa/tests/nullary.mlir
@@ -17,16 +17,16 @@ func.func @constant_f64() -> tensor<10xf64> {
 
 // CHECK-LABEL: @iota_dimension_0
 func.func @iota_dimension_0() -> tensor<4x8xf32> {
-  // CHECK-DAG: %[[VAR0:.*]] = "tosa.const"() {value = dense<[0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00]> : tensor<4xf32>}
-  // CHECK-DAG: %[[VAR1:.*]] = "tosa.tile"(%[[VAR0]]) {multiples = array<i64: 1, 8>}
+  // CHECK-DAG: %[[VAR0:.*]] = "tosa.const"() <{value = dense<[0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00]> : tensor<4xf32>}>
+  // CHECK-DAG: %[[VAR1:.*]] = "tosa.tile"(%[[VAR0]]) <{multiples = array<i64: 1, 8>}>
   %0 = "stablehlo.iota"() {iota_dimension = 0 : i64} : () -> (tensor<4x8xf32>)
   return %0 : tensor<4x8xf32>
 }
 
 // CHECK-LABEL: @iota_dimension_1
 func.func @iota_dimension_1() -> tensor<4x8xi32> {
-  // CHECK-DAG: %[[VAR0:.*]] = "tosa.const"() {value = dense<[0, 1, 2, 3, 4, 5, 6, 7]> : tensor<8xi32>}
-  // CHECK-DAG: %[[VAR1:.*]] = "tosa.tile"(%[[VAR0]]) {multiples = array<i64: 4, 1>}
+  // CHECK-DAG: %[[VAR0:.*]] = "tosa.const"() <{value = dense<[0, 1, 2, 3, 4, 5, 6, 7]> : tensor<8xi32>}>
+  // CHECK-DAG: %[[VAR1:.*]] = "tosa.tile"(%[[VAR0]]) <{multiples = array<i64: 4, 1>}>
   %0 = "stablehlo.iota"() {iota_dimension = 1 : i64} : () -> (tensor<4x8xi32>)
   return %0 : tensor<4x8xi32>
 }

--- a/stablehlo/conversions/tosa/tests/ternary.mlir
+++ b/stablehlo/conversions/tosa/tests/ternary.mlir
@@ -2,7 +2,7 @@
 
 // CHECK-LABEL: @concatenate
 func.func @concatenate(%arg0 : tensor<5x2xf32>, %arg1 : tensor<5x5xf32>, %arg2 : tensor<5x7xf32>) -> tensor<5x14xf32> {
-  // CHECK: "tosa.concat"(%arg0, %arg1, %arg2) {axis = 1 : i64} : (tensor<5x2xf32>, tensor<5x5xf32>, tensor<5x7xf32>) -> tensor<5x14xf32>
+  // CHECK: "tosa.concat"(%arg0, %arg1, %arg2) <{axis = 1 : i64}> : (tensor<5x2xf32>, tensor<5x5xf32>, tensor<5x7xf32>) -> tensor<5x14xf32>
   %0 = "stablehlo.concatenate"(%arg0, %arg1, %arg2) {dimension = 1 : i64} : (tensor<5x2xf32>, tensor<5x5xf32>, tensor<5x7xf32>) -> tensor<5x14xf32>
   return %0 : tensor<5x14xf32>
 }

--- a/stablehlo/conversions/tosa/tests/unary.mlir
+++ b/stablehlo/conversions/tosa/tests/unary.mlir
@@ -30,7 +30,7 @@ func.func @exponential(%arg : tensor<10xf32>) -> tensor<10xf32> {
 
 // CHECK-LABEL: @exponential_minus_one
 func.func @exponential_minus_one(%arg : tensor<10xf32>) -> tensor<10xf32> {
-  // CHECK-DAG: %[[VAR0:.*]] = "tosa.const"() {value = dense<1.000000e+00>
+  // CHECK-DAG: %[[VAR0:.*]] = "tosa.const"() <{value = dense<1.000000e+00>
   // CHECK-DAG: %[[VAR1:.*]] = "tosa.exp"(%arg0)
   // CHECK-DAG: %[[VAR2:.*]] = "tosa.sub"(%[[VAR1]], %[[VAR0]])
   %0 = "stablehlo.exponential_minus_one"(%arg) : (tensor<10xf32>) -> tensor<10xf32>
@@ -46,7 +46,7 @@ func.func @floor(%arg : tensor<10xf32>) -> tensor<10xf32> {
 
 // CHECK-LABEL: @is_finite
 func.func @is_finite(%arg : tensor<10xf32>) -> tensor<10xi1> {
-  // CHECK-DAG: %[[VAR0:.*]] = "tosa.const"() {value = dense<0x7F800000>
+  // CHECK-DAG: %[[VAR0:.*]] = "tosa.const"() <{value = dense<0x7F800000>
   // CHECK-DAG: %[[VAR1:.*]] = "tosa.abs"(%arg0)
   // CHECK-DAG: %[[VAR2:.*]] = "tosa.equal"(%[[VAR1]], %[[VAR0]])
   // CHECK-DAG: %[[VAR3:.*]] = "tosa.logical_not"(%[[VAR2]])
@@ -63,7 +63,7 @@ func.func @log(%arg : tensor<10xf32>) -> tensor<10xf32> {
 
 // CHECK-LABEL: @log_plus_one
 func.func @log_plus_one(%arg : tensor<10xf16>) -> tensor<10xf16> {
-  // CHECK-DAG: %[[VAR0:.*]] = "tosa.const"() {value = dense<1.000000e+00>
+  // CHECK-DAG: %[[VAR0:.*]] = "tosa.const"() <{value = dense<1.000000e+00>
   // CHECK-DAG: %[[VAR1:.*]] = "tosa.add"(%arg0, %[[VAR0]])
   // CHECK-DAG: %[[VAR2:.*]] = "tosa.log"(%[[VAR1]])
   %0 = "stablehlo.log_plus_one"(%arg) : (tensor<10xf16>) -> tensor<10xf16>
@@ -79,7 +79,7 @@ func.func @negate(%arg : tensor<10xf32>) -> tensor<10xf32> {
 
 // CHECK-LABEL: @slice
 func.func @slice(%arg : tensor<4x3xf32>) -> tensor<2x2xf32> {
-  // CHECK: "tosa.slice"(%arg0) {size = array<i64: 2, 2>, start = array<i64: 2, 1>}
+  // CHECK: "tosa.slice"(%arg0) <{size = array<i64: 2, 2>, start = array<i64: 2, 1>}>
   %0 = "stablehlo.slice"(%arg) {
     start_indices = dense<[2, 1]> : tensor<2xi64>,
     limit_indices = dense<[4, 3]> : tensor<2xi64>,
@@ -121,7 +121,7 @@ func.func @tanh(%arg : tensor<10xf32>) -> tensor<10xf32> {
 
 // CHECK-LABEL: @transpose
 func.func @transpose(%arg0: tensor<1x2x3xf32>) -> tensor<3x2x1xf32> {
-  // CHECK-DAG: %[[VAR0:.*]] = "tosa.const"() {value = dense<[2, 1, 0]> : tensor<3xi64>} : () -> tensor<3xi64>
+  // CHECK-DAG: %[[VAR0:.*]] = "tosa.const"() <{value = dense<[2, 1, 0]> : tensor<3xi64>}> : () -> tensor<3xi64>
   // CHECK-DAG: %[[VAR1:.*]] = "tosa.transpose"(%arg0, %[[VAR0]])
   %0 = "stablehlo.transpose"(%arg0) {permutation = dense<[2, 1, 0]> : tensor<3xi64>} : (tensor<1x2x3xf32>) -> tensor<3x2x1xf32>
   return %0 : tensor<3x2x1xf32>
@@ -129,8 +129,8 @@ func.func @transpose(%arg0: tensor<1x2x3xf32>) -> tensor<3x2x1xf32> {
 
 // CHECK-LABEL: @while
 func.func @while(%arg0: tensor<i32>) -> tensor<i32> {
-  // CHECK-DAG: %[[VAR0:.*]] = "tosa.const"() {value = dense<3> : tensor<i32>}
-  // CHECK-DAG: %[[VAR1:.*]] = "tosa.const"() {value = dense<1> : tensor<i32>}
+  // CHECK-DAG: %[[VAR0:.*]] = "tosa.const"() <{value = dense<3> : tensor<i32>}
+  // CHECK-DAG: %[[VAR1:.*]] = "tosa.const"() <{value = dense<1> : tensor<i32>}
   // CHECK:     %[[VAR2:.*]] = "tosa.while_loop"(%arg0) ({
   // CHECK:     ^bb0(%[[ARG0:.+]]: tensor<i32>):
   // CHECK:       %[[VAR3:.*]] = "tosa.equal"(%[[ARG0]], %[[VAR0]])

--- a/stablehlo/integrations/python/tests/CMakeLists.txt
+++ b/stablehlo/integrations/python/tests/CMakeLists.txt
@@ -29,4 +29,4 @@ add_stablehlo_python_test(stablehlo-python-smoketest smoketest.py)
 add_stablehlo_python_test(stablehlo-python-stablehlo stablehlo.py)
 add_stablehlo_python_test(stablehlo-python-vhlo vhlo.py)
 
-add_dependencies(check-stablehlo check-stablehlo-python)
+add_dependencies(check-stablehlo-quick check-stablehlo-python)

--- a/stablehlo/testdata/CMakeLists.txt
+++ b/stablehlo/testdata/CMakeLists.txt
@@ -25,5 +25,5 @@ add_lit_testsuite(check-stablehlo-testdata "Running the testdata/ suite"
   stablehlo-opt
   stablehlo-translate
 )
-add_dependencies(check-stablehlo check-stablehlo-testdata)
+add_dependencies(check-stablehlo-slow check-stablehlo-testdata)
 

--- a/stablehlo/tests/CMakeLists.txt
+++ b/stablehlo/tests/CMakeLists.txt
@@ -26,7 +26,7 @@ add_lit_testsuite(check-stablehlo-tests "Running the tests/ suite"
   stablehlo-opt
   stablehlo-translate
 )
-add_dependencies(check-stablehlo check-stablehlo-tests)
+add_dependencies(check-stablehlo-quick check-stablehlo-tests)
 
 set(LLVM_TARGET_DEFINITIONS TestUtils.td)
 mlir_tablegen(TestUtils.h.inc -gen-pass-decls -name HloTest)


### PR DESCRIPTION
In #1466, we ran into some issues when adding the newly introduced tosa/ suite to relevant test targets, so this PR revamps this system to properly integrate tosa/ as well as simplify similar work in the future.

Instead of the state of the art with one `check-stablehlo` custom target and a bunch of suites becoming its dependencies, we now have three custom targets:
  1) check-stablehlo-ci whose name makes it clear that this is what
     runs in CI.
  2) check-stablehlo-slow for slow-running tests like the testdata/
     suite that we'd like to separate from the other suites, so that
     humans don't have to run them every time.
  3) check-stablehlo-quick for everything else.

Each suite becomes a dependency of either -slow or -quick, making its nature explicit and clearly documented.

Also, it looks like the tosa/ suite got broken by one of the LLVM bumps that happened between when its PR got created and when it got merged. I fixed those breakages too.