### PR TITLE
Fix issues identified during integrate

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "gentbl_filegroup", "td_library")
 
 package(
@@ -863,8 +862,8 @@ cc_library(
     strip_include_prefix = ".",
     deps = [
         ":stablehlo_ops",
-        ":tosa_pdll_inc_gen",
         ":tosa_pass_inc_gen",
+        ":tosa_pdll_inc_gen",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Parser",


### PR DESCRIPTION
  * BUILD.bazel: remove import of unused build_test.
  * BUILD.bazel: order dependencies alphabetically.