### PR TITLE
Belatedly bump patch version after integrate 0.11.4 -> 0.11.5

### DIFF
--- a/stablehlo/dialect/Version.h
+++ b/stablehlo/dialect/Version.h
@@ -38,7 +38,7 @@ class Version {
   static FailureOr<Version> fromString(llvm::StringRef versionRef);
 
   /// Return a Version representing the current VHLO dialect version.
-  static Version getCurrentVersion() { return Version(0, 11, 4); }
+  static Version getCurrentVersion() { return Version(0, 11, 5); }
 
   /// Return a Version representing the minimum supported VHLO dialect version.
   static Version getMinimumVersion() { return Version(0, 9, 0); }


### PR DESCRIPTION
Our integrate process involves bumping Version.h on GitHub after a successful landing of an downstream integrate. This is done to make sure that the subsequent downstream integrate is guaranteed to receive a different version, so that we can tell them apart down the line.

Unfortunately, I forgot to do that after the previous downstream integrate: https://github.com/tensorflow/mlir-hlo/commit/e46e2b655d70a9099acd47be940ca3c0973583a2 which had its Version.h say 0.11.4.

Now we have another downstream integrate that has just landed: https://github.com/tensorflow/mlir-hlo/commit/a1cd423b7ae9cf9f48cd21494756d85d04e97411, and it has the same version as its predecessor (its Version.h also says 0.11.4). This is exactly what the integrate process was trying to avoid.

To untangle this, I propose that we:
  1) Bump Version.h to 0.11.5 on GitHub (this PR).
  2) Bump Version.h to 0.11.5 downstream (there'll be a separate CL).
  3) After 1) and 2) are merged, we tag the GitHub HEAD as v0.11.5.
  4) And then proceed as usual.