### PR TITLE
Bump patch version after integrate 0.11.5 -> 0.11.6

### DIFF
--- a/stablehlo/dialect/Version.h
+++ b/stablehlo/dialect/Version.h
@@ -38,7 +38,7 @@ class Version {
   static FailureOr<Version> fromString(llvm::StringRef versionRef);
 
   /// Return a Version representing the current VHLO dialect version.
-  static Version getCurrentVersion() { return Version(0, 11, 5); }
+  static Version getCurrentVersion() { return Version(0, 11, 6); }
 
   /// Return a Version representing the minimum supported VHLO dialect version.
   static Version getMinimumVersion() { return Version(0, 9, 0); }


### PR DESCRIPTION
This PR concludes this weeks integrates, which were a bit messed up because of my oversight. #1506 explains what happened and provides a fix, and this PR is the final step towards normalcy.