### PR TITLE
Use bytecodeVersion = 1 when serializing MLIR bytecode

### DIFF
--- a/stablehlo/api/PortableApi.cpp
+++ b/stablehlo/api/PortableApi.cpp
@@ -61,6 +61,15 @@ LogicalResult deserializePortableArtifact(StringRef artifactStr,
   loadSerializationDialects(&context);
   auto module = deserializePortableArtifact(artifactStr, &context);
   if (!module) return failure();
+
+  // TODO(gleasonk): I don't think we have formalized our compatibility policy
+  // for bytecode produced by deserializePortableArtifact, so I'm not sure how
+  // this config should look like.
+  // With that in mind, bytecodeVersion = 1 looks like the best option at the
+  // moment of writing. The forward compatibility provided by it might be
+  // ultimately unneeded, but until we've established that, let's play it safe.
+  BytecodeWriterConfig writerConfig;
+  writerConfig.setDesiredBytecodeVersion(1);
   return writeBytecodeToFile(*module, os);
 }
 

--- a/stablehlo/dialect/Serialization.cpp
+++ b/stablehlo/dialect/Serialization.cpp
@@ -52,10 +52,19 @@ LogicalResult serializePortableArtifact(ModuleOp module,
     }
   }
 
-  // TODO(#1282): Consider adding a header to identify StableHLO portable
+  // TODO(#1508): Consider adding a header to identify StableHLO portable
   // artifact versions.
-  (void)writeBytecodeToFile(module, os);
-  return success();
+  BytecodeWriterConfig writerConfig;
+  // bytecodeVersion = 1 is what has been predominantly used in practice to
+  // serialize portable StableHLO artifacts.
+  // Theoretically speaking, StableHLO v0.9.0 which introduced compatibility
+  // guarantees was released on 3/2/2023 and bytecodeVersion = 1 was released
+  // on 3/10/2023, so there was a time period when we guaranteed compatibility
+  // for StableHLO consumers which only supported bytecodeVersion = 0.
+  // However, this time period (1 month of forward compatibility) has expired,
+  // so it's fine to hardcode bytecodeVersion = 1 here.
+  writerConfig.setDesiredBytecodeVersion(1);
+  return writeBytecodeToFile(module, os);
 }
 
 OwningOpRef<ModuleOp> deserializePortableArtifact(StringRef sourceStr,


### PR DESCRIPTION
https://reviews.llvm.org/D149515 has just landed, so we must explicitly specify bytecodeVersion when using BytecodeWriter to avoid breaking forward compatibility guarantees.

More specifically, we want to avoid a situation where:
  1) A StableHLO producer using a post-D149515 version of LLVM
     serializes a StableHLO program to bytecode. (This will use
     bytecodeVersion = 2 by default).
  2) A StableHLO consumer using a pre-D149515 version of LLVM within
     the 1 month StableHLO forward compatibility window cannot
     deserialize the StableHLO program.

We don't have forward compatibility tests yet, so this PR doesn't have tests either. See #1498 for an RFC for forward compatibility testing.