### PR TITLE
Actually use the BytecodeWriterConfig in writeBytecodeToFile

### DIFF
--- a/stablehlo/api/PortableApi.cpp
+++ b/stablehlo/api/PortableApi.cpp
@@ -70,7 +70,7 @@ LogicalResult deserializePortableArtifact(StringRef artifactStr,
   // ultimately unneeded, but until we've established that, let's play it safe.
   BytecodeWriterConfig writerConfig;
   writerConfig.setDesiredBytecodeVersion(1);
-  return writeBytecodeToFile(*module, os);
+  return writeBytecodeToFile(*module, os, writerConfig);
 }
 
 }  // namespace stablehlo

--- a/stablehlo/dialect/Serialization.cpp
+++ b/stablehlo/dialect/Serialization.cpp
@@ -64,7 +64,7 @@ LogicalResult serializePortableArtifact(ModuleOp module,
   // However, this time period (1 month of forward compatibility) has expired,
   // so it's fine to hardcode bytecodeVersion = 1 here.
   writerConfig.setDesiredBytecodeVersion(1);
-  return writeBytecodeToFile(module, os);
+  return writeBytecodeToFile(module, os, writerConfig);
 }
 
 OwningOpRef<ModuleOp> deserializePortableArtifact(StringRef sourceStr,


### PR DESCRIPTION
 #1511 introduced BytecodeWriterConfig to our serialization logic,
but I forgot to actually use it. This PR fixes this oversight.

This mistake on my part happened because we don't have forward compatibility tests yet. To make sure that I didn't mess up anything else this time, I have manually verified the following:
  * At HEAD, build/bin/stablehlo-translate --serialize produces different payloads when: 1) local clone of llvm-project is pristine, 2) local clone of llvm-project has kVersion manually changed to 2. The only difference is the bytecodeVersion field in the serialized payloads.
  * With this PR, build/bin/stablehlo-translate --serialize produces the same payloads when: 1) local clone of llvm-project is pristine, 2) local clone of llvm-project has kVersion manually changed to 2. As expected, using BytecodeWriterConfig overrides kVersion.