### PR TITLE
Update CustomCallOp status to `yes` and update ODS

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2245,7 +2245,7 @@ the XLA compiler. In the future, we are planning to unify this metadata
   backend_config = "bar",
   api_version = 1 : i32,
   called_computations = [@foo]
-} : (tensor<f32>) -> tensor<f32>
+} : (tensor<f64>) -> tensor<f64>
 ```
 
 ### divide

--- a/docs/status.md
+++ b/docs/status.md
@@ -74,7 +74,7 @@ one of the following tracking labels.
 | create_token             | no            | yes\*        | yes\*          | yes             | no          |
 | cross-replica-sum        | no            | revisit      | yes\*          | no              | no          |
 | cstr_reshapable          | no            | revisit      | no             | yes             | no          |
-| custom_call              | yes           | yes          | infeasible     | yes             | no          |
+| custom_call              | yes           | yes          | infeasible     | yes             | yes         |
 | divide                   | yes           | yes          | yes            | yes             | yes         |
 | dot                      | no            | revisit      | infeasible     | yes             | no          |
 | dot_general              | yes           | revisit      | infeasible     | no              | no          |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2140,13 +2140,10 @@ def StableHLO_CustomCallOp: StableHLO_Op<"custom_call",
 
     Example:
     ```mlir
-    %results = "stablehlo.custom_call"(%input0) {
-      call_target_name = "foo",
-      has_side_effect = false,
+    %results = stablehlo.custom_call @foo(%input0) {
       backend_config = "bar",
-      api_version = 1 : i32,
       called_computations = [@foo]
-    } : (tensor<f32>) -> tensor<f32>
+    } : (tensor<f64>) -> tensor<f64>
     ```
   }];
 


### PR DESCRIPTION
We already have an implementation to handle custom_call ops by passing a fallback function to handle them. This PR updates the status to reflect that. Other minor change include updating the example in td file to use pretty-print format following the [guide](https://github.com/openxla/stablehlo/blob/main/docs/reference.md#testing-guidelines).