### PR TITLE
Add stop-gap static forward compatibility tests

### DIFF
--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_10_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_10_0.mlir
@@ -1,6 +1,7 @@
 // RUN: stablehlo-opt --mlir-print-op-generic %s.bc | FileCheck %s
 // RUN: stablehlo-translate --deserialize %s.bc | stablehlo-translate --serialize --target=0.10.0 | stablehlo-opt --mlir-print-op-generic | FileCheck %s
 // RUN: diff <(stablehlo-translate --deserialize %s.bc | stablehlo-opt) <(stablehlo-opt --strip-debuginfo %s)
+// RUN: diff %s.bc <(stablehlo-translate --serialize --target=0.10.0 --strip-debuginfo %s)
 
 // ============ ATTRIBUTES ============
 

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_11_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_11_0.mlir
@@ -1,6 +1,7 @@
 // RUN: stablehlo-opt --mlir-print-op-generic %s.bc | FileCheck %s
 // RUN: stablehlo-translate --deserialize %s.bc | stablehlo-translate --serialize --target=0.11.0 | stablehlo-opt --mlir-print-op-generic | FileCheck %s
 // RUN: diff <(stablehlo-translate --deserialize %s.bc | stablehlo-opt) <(stablehlo-opt --strip-debuginfo %s)
+// RUN: diff %s.bc <(stablehlo-translate --serialize --target=0.11.0 --strip-debuginfo %s)
 
 // ============ ATTRIBUTES ============
 

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_9_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_9_0.mlir
@@ -1,6 +1,7 @@
 // RUN: stablehlo-opt --mlir-print-op-generic %s.bc | FileCheck %s
 // RUN: stablehlo-translate --deserialize %s.bc | stablehlo-translate --serialize --target=0.9.0 | stablehlo-opt --mlir-print-op-generic | FileCheck %s
 // RUN: diff <(stablehlo-translate --deserialize %s.bc | stablehlo-opt) <(stablehlo-opt --strip-debuginfo %s)
+// RUN: diff %s.bc <(stablehlo-translate --serialize --target=0.9.0 --strip-debuginfo %s)
 
 // ============ ATTRIBUTES ============
 


### PR DESCRIPTION
Use https://github.com/openxla/stablehlo/pull/1524 as diffbase.

This is a stop-gap measure to improve the detection of forward incompatibilities in the StableHLO repo, and repos where StableHLO is exported like openxla/xla, while the Forward Compatibility Testing RFC (https://github.com/openxla/stablehlo/pull/1498) is reviewed. These tests will be reworked based on the outcome of the RFC review.

The forward compatibility test is a byte-wise comparison using:

```bash
# %s = stablehlo/tests/stablehlo_legalize_to_vhlo.0_10_0.mlir
diff %s.bc <(stablehlo-translate --serialize --target=0.10.0 --strip-debuginfo %s)
```
