### PR TITLE
Simplify evalConvertOp

### DIFF
--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -621,6 +621,21 @@ Element complex(const Element &e1, const Element &e2) {
                                      debugString(complexType).c_str()));
 }
 
+Element convert(Type type, const Element &e) {
+  if (isSupportedBooleanType(e.getType()))
+    return convert(type, e.getBooleanValue());
+  if (isSupportedSignedIntegerType(e.getType()))
+    return convert(type, e.getIntegerValue().getSExtValue());
+  if (isSupportedUnsignedIntegerType(e.getType()))
+    return convert(type, e.getIntegerValue().getZExtValue());
+  if (isSupportedFloatType(e.getType()))
+    return convert(type, e.getFloatValue());
+  if (isSupportedComplexType(e.getType()))
+    return convert(type, e.getComplexValue());
+  report_fatal_error(invalidArgument("Unsupported element type: %s",
+                                     debugString(e.getType()).c_str()));
+}
+
 Element convert(Type type, bool value) {
   if (isSupportedBooleanType(type)) return Element(type, value);
   return convert(type,

--- a/stablehlo/reference/Element.h
+++ b/stablehlo/reference/Element.h
@@ -158,6 +158,9 @@ Element ceil(const Element &e);
 /// Returns a complex type Element object.
 Element complex(const Element &e1, const Element &e2);
 
+/// Returns converted Element object.
+Element convert(Type type, const Element &e);
+
 /// Returns converted Element object of type `type` from source boolean `value`.
 Element convert(Type type, bool value);
 

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -747,31 +747,8 @@ Tensor evalConstantOp(ElementsAttr value) {
 
 Tensor evalConvertOp(const Tensor &operand, ShapedType resultType) {
   Tensor result(resultType);
-  auto operandElementType = operand.getElementType();
-  auto resultElementType = result.getElementType();
-  for (auto it = result.index_begin(); it != result.index_end(); ++it) {
-    if (isSupportedBooleanType(operandElementType))
-      result.set(
-          *it, convert(resultElementType, operand.get(*it).getBooleanValue()));
-    else if (isSupportedSignedIntegerType(operandElementType))
-      result.set(*it,
-                 convert(resultElementType,
-                         operand.get(*it).getIntegerValue().getSExtValue()));
-    else if (isSupportedUnsignedIntegerType(operandElementType))
-      result.set(*it,
-                 convert(resultElementType,
-                         operand.get(*it).getIntegerValue().getZExtValue()));
-    else if (isSupportedFloatType(operandElementType))
-      result.set(*it,
-                 convert(resultElementType, operand.get(*it).getFloatValue()));
-    else if (isSupportedComplexType(operandElementType))
-      result.set(
-          *it, convert(resultElementType, operand.get(*it).getComplexValue()));
-    else
-      report_fatal_error(
-          invalidArgument("Unsupported element type: %s",
-                          debugString(operandElementType).c_str()));
-  }
+  for (auto it = result.index_begin(); it != result.index_end(); ++it)
+    result.set(*it, convert(result.getElementType(), operand.get(*it)));
   return result;
 }
 


### PR DESCRIPTION
This PR introduces `Element convert(Type type, const Element &e)` which considerably simplifies `evalConvertOp` by hiding type-based dispatch in Element.h, consistently with many other implementations of evalFooOp functions.