### PR TITLE
Move chlo::TopKOp type inference into TypeInference.h

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -278,6 +278,7 @@ cc_library(
         ":chlo_attrs_inc_gen",
         ":chlo_enums_inc_gen",
         ":chlo_ops_inc_gen",
+        ":stablehlo_type_inference",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:BytecodeReader",
         "@llvm-project//mlir:BytecodeWriter",

--- a/stablehlo/dialect/CMakeLists.txt
+++ b/stablehlo/dialect/CMakeLists.txt
@@ -65,6 +65,7 @@ add_mlir_dialect_library(ChloOps
   LINK_LIBS PUBLIC
   StablehloBase
   StablehloBroadcastUtils
+  StablehloTypeInference
   MLIRArithDialect
   MLIRControlFlowInterfaces
   MLIRInferTypeOpInterface

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2856,6 +2856,42 @@ LogicalResult inferSortOp(
   return success();
 }
 
+LogicalResult inferTopKOp(
+    std::optional<Location> location, Value operand, int64_t k,
+    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
+  Builder builder(operand.getContext());
+  auto operandType = operand.getType().dyn_cast<RankedTensorType>();
+  if (!operandType) {
+    inferredReturnShapes.emplace_back(
+        operand.getType().cast<ShapedType>().getElementType());
+    inferredReturnShapes.emplace_back(builder.getI32Type());
+    return success();
+  }
+
+  if (operandType.getRank() < 1)
+    return emitOptionalError(location, "operand's rank must be at least 1");
+  auto operandLastDim = operandType.getRank() - 1;
+  if (!operandType.isDynamicDim(operandLastDim) &&
+      operandType.getDimSize(operandLastDim) < k)
+    return emitOptionalError(location,
+                             "operand's last dimension must be at least ", k);
+
+  SmallVector<int64_t> resultShape(operandType.getShape());
+  resultShape[operandLastDim] = k;
+  SmallVector<int64_t> resultBounds(
+      encodingToBounds(operandType.getEncoding()));
+  if (!resultBounds.empty())
+    resultBounds[operandLastDim] = ShapedType::kDynamic;
+
+  inferredReturnShapes.emplace_back(
+      resultShape, operandType.getElementType(),
+      hlo::boundsToEncoding(operandType.getEncoding(), resultBounds));
+  inferredReturnShapes.emplace_back(
+      resultShape, builder.getI32Type(),
+      hlo::boundsToEncoding(operandType.getEncoding(), resultBounds));
+  return success();
+}
+
 LogicalResult inferTransposeOp(std::optional<Location> loc, Value operand,
                                DenseIntElementsAttr permutation,
                                SmallVectorImpl<Type>& inferredReturnTypes) {

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -335,6 +335,10 @@ LogicalResult inferSortOp(
     std::optional<Location> location, ValueRange inputs,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
+LogicalResult inferTopKOp(
+    std::optional<Location> location, Value operand, int64_t k,
+    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
+
 LogicalResult inferTransposeOp(std::optional<Location> loc, Value operand,
                                DenseIntElementsAttr permutation,
                                SmallVectorImpl<Type>& inferredReturnTypes);

--- a/stablehlo/tests/ops_chlo.mlir
+++ b/stablehlo/tests/ops_chlo.mlir
@@ -90,28 +90,10 @@ func.func @rank_specialization_cluster(%arg0 : tensor<*xf32>, %arg1 : tensor<*xf
 
 // -----
 
-func.func @top_k(%arg0 : tensor<*xf32>) {
-  // expected-error @+2 {{failed to infer returned types}}
-  // @expected-error @+1{{operand must be ranked}}
-  %0:2 = chlo.top_k(%arg0, k=8) : tensor<*xf32> -> (tensor<8xf32>, tensor<8xi32>)
-  return
-}
-
-// -----
-
 func.func @top_k(%arg0 : tensor<f32>) {
   // expected-error @+2 {{failed to infer returned types}}
   // @expected-error @+1{{operand's rank must be at least 1}}
   %0:2 = chlo.top_k(%arg0, k=8) : tensor<f32> -> (tensor<8xf32>, tensor<8xi32>)
-  return
-}
-
-// -----
-
-func.func @top_k(%arg0 : tensor<?xf32>) {
-  // expected-error @+2 {{failed to infer returned types}}
-  // @expected-error @+1{{operand's last dimension must be static}}
-  %0:2 = chlo.top_k(%arg0, k=8) : tensor<?xf32> -> (tensor<8xf32>, tensor<8xi32>)
   return
 }
 
@@ -126,15 +108,36 @@ func.func @top_k(%arg0 : tensor<4xf32>) {
 
 // -----
 
-func.func @top_k(%arg0 : tensor<16xf32>) {
+func.func @top_k_1d(%arg0 : tensor<16xf32>) {
   %0:2 = chlo.top_k(%arg0, k=8) : tensor<16xf32> -> (tensor<8xf32>, tensor<8xi32>)
   return
 }
 
 // -----
 
-func.func @top_k(%arg0 : tensor<16x16xf32>) {
+func.func @top_k_nd(%arg0 : tensor<16x16xf32>) {
   %0:2 = chlo.top_k(%arg0, k=8) : tensor<16x16xf32> -> (tensor<16x8xf32>, tensor<16x8xi32>)
+  return
+}
+
+// -----
+
+func.func @top_k_unbounded(%arg0 : tensor<?x16x?xf32>) {
+  %0:2 = chlo.top_k(%arg0, k=8) : tensor<?x16x?xf32> -> (tensor<?x16x8xf32>, tensor<?x16x8xi32>)
+  return
+}
+
+// -----
+
+func.func @top_k_bounded(%arg0 : tensor<?x?x?xf32, #stablehlo.bounds<?, 16, 16>>) {
+  %0:2 = chlo.top_k(%arg0, k=8) : tensor<?x?x?xf32, #stablehlo.bounds<?, 16, 16>> -> (tensor<16x?x8xf32, #stablehlo.bounds<?, 16, ?>>, tensor<16x?x8xi32, #stablehlo.bounds<?, 16, ?>>)
+  return
+}
+
+// -----
+
+func.func @top_k_unranked(%arg0 : tensor<*xf32>) {
+  %0:2 = chlo.top_k(%arg0, k=8) : tensor<*xf32> -> (tensor<*xf32>, tensor<*xi32>)
   return
 }
 


### PR DESCRIPTION
This is needed to support the work on introducing mhlo::TopKOp. MLIR-HLO commit: https://github.com/tensorflow/mlir-hlo/commit/4651ac2e8375b706643fdab809e0bc30a7ecd666