### PR TITLE
Make sure that getBytecodeVersion is compatible with upstream

### DIFF
--- a/stablehlo/dialect/Serialization.cpp
+++ b/stablehlo/dialect/Serialization.cpp
@@ -72,7 +72,8 @@ LogicalResult serializePortableArtifact(ModuleOp module,
       vhlo::Version::fromString(targetVersion)->getBytecodeVersion();
   if (failed(bytecodeVersion)) return failure();
   if (!(bytecode::kMinSupportedVersion <= bytecodeVersion &&
-        bytecodeVersion <= bytecode::kVersion)) return failure();
+        bytecodeVersion <= bytecode::kVersion))
+    return failure();
   writerConfig.setDesiredBytecodeVersion(bytecodeVersion.value());
 
   return writeBytecodeToFile(module, os, writerConfig);


### PR DESCRIPTION
Before calling writeBytecodeToFile, we also need to ensure that the bytecode version that we're requesting falls within the range of supported bytecode versions of the MLIR version that we're using.

Surprisingly, this isn't done by MLIR (e.g. the current behavior for setDesiredBytecodeVersion is to clamp the provided bytecode version to the range of supported versions, which may result in payloads whose StableHLO version doesn't match the expected bytecode version).