### PR TITLE
Simplify evalWhileOp

### DIFF
--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -1568,14 +1568,9 @@ SmallVector<Tensor> evalWhileOp(ArrayRef<Tensor> operand, Region &cond,
   SmallVector<Tensor> results(operand);
 
   auto condResults = eval(cond, operand, &scope);
-  if (condResults.size() != 1)
-    llvm::report_fatal_error("Failed to evaluate cond");
-
   while (condResults[0].get({}).getBooleanValue()) {
     results = eval(body, results, &scope);
     condResults = eval(cond, results, &scope);
-    if (condResults.size() != 1)
-      llvm::report_fatal_error("Failed to evaluate cond");
   }
 
   return results;


### PR DESCRIPTION
This PR drops checking that evaluating WhileOp::cond produces exactly one result. This is guaranteed by the verifier, so this is not something that we should be checking in the interpreter.