### PR TITLE
Align the notation of spec and interpreter for Data Movement operations

### DIFF
--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -767,14 +767,15 @@ Tensor evalBroadcastInDimOp(const Tensor &operand,
                             const Axes &broadcastDimensions,
                             ShapedType resultType) {
   Tensor result(resultType);
-  auto operandShape = operand.getShape();
   for (auto resultIt = result.index_begin(); resultIt != result.index_end();
        ++resultIt) {
-    Index operandIndex(operandShape.size());
-    for (auto [operandDim, resultDim] : llvm::enumerate(broadcastDimensions))
-      operandIndex[operandDim] =
-          operandShape[operandDim] == 1 ? 0 : (*resultIt)[resultDim];
-    result.set(*resultIt, operand.get(operandIndex));
+    Index resultIndex = *resultIt;
+    Index operandIndex(operand.getRank(), 0);
+    for (auto d = 0; d < operand.getRank(); ++d) {
+      if (operand.getShape()[d] == 1) continue;
+      operandIndex[d] = resultIndex[broadcastDimensions[d]];
+    }
+    result.set(resultIndex, operand.get(operandIndex));
   }
   return result;
 }
@@ -999,11 +1000,14 @@ Tensor evalDynamicUpdateSliceOp(const Tensor &operand, const Tensor &update,
   auto adjustedStartIndices =
       clamp(0, evalIndex(startIndices), operand.getShape() - update.getShape());
   for (auto resultIt = result.index_begin(); resultIt != result.index_end();
-       ++resultIt)
-    result.set(*resultIt, operand.get(*resultIt));
-  for (auto updateIt = update.index_begin(); updateIt != update.index_end();
-       ++updateIt)
-    result.set(*updateIt + adjustedStartIndices, update.get(*updateIt));
+       ++resultIt) {
+    Index resultIndex = *resultIt;
+    Index updateIndex = resultIndex - adjustedStartIndices;
+    if (updateIndex.inBounds(update.getShape()))
+      result.set(resultIndex, update.get(updateIndex));
+    else
+      result.set(resultIndex, operand.get(resultIndex));
+  }
   return result;
 }
 
@@ -1194,17 +1198,15 @@ Tensor evalOrOp(const Tensor &lhs, const Tensor &rhs, ShapedType resultType) {
 Tensor evalPadOp(const Tensor &operand, const Tensor &paddingValue,
                  const Sizes &edgePaddingLow, const Sizes &interiorPadding,
                  ShapedType resultType) {
-  Tensor result(resultType);
-  for (auto resultIt = result.index_begin(); resultIt != result.index_end();
-       ++resultIt)
-    result.set(*resultIt, paddingValue.get({}));
+  Tensor result(resultType, paddingValue.get({}));
   for (auto operandIt = operand.index_begin(); operandIt != operand.index_end();
        ++operandIt) {
-    auto resultIndex = edgePaddingLow + *operandIt * (interiorPadding + 1);
+    auto operandIndex = *operandIt;
+    auto resultIndex = edgePaddingLow + operandIndex * (interiorPadding + 1);
     // Bound check is needed here because of negative padding which could
     // swallow some operand indices.
     if (resultIndex.inBounds(result.getShape()))
-      result.set(resultIndex, operand.get(*operandIt));
+      result.set(resultIndex, operand.get(operandIndex));
   }
   return result;
 }
@@ -1311,13 +1313,13 @@ Tensor evalReshapeOp(const Tensor &operand, ShapedType resultType) {
 Tensor evalReverseOp(const Tensor &operand, const Axes &dimensions,
                      ShapedType resultType) {
   Tensor result(resultType);
-  auto resultShape = result.getShape();
   for (auto resultIt = result.index_begin(); resultIt != result.index_end();
        ++resultIt) {
-    Index operandIndex(*resultIt);
-    for (auto dim : dimensions)
-      operandIndex[dim] = (resultShape[dim] - 1) - operandIndex[dim];
-    result.set(*resultIt, operand.get(operandIndex));
+    Index resultIndex = *resultIt;
+    Index operandIndex(resultIndex);
+    for (auto d : dimensions)
+      operandIndex[d] = result.getShape()[d] - operandIndex[d] - 1;
+    result.set(resultIndex, operand.get(operandIndex));
   }
   return result;
 }
@@ -1402,8 +1404,8 @@ SmallVector<Tensor> evalScatterOp(
                  update.get(updateIndex)));
 
     auto updatedValues = eval(updateComputation, updateComputationArgs, &scope);
-    for (auto [result, value] : llvm::zip(results, updatedValues))
-      result.set(resultIndex, value.get({}));
+    for (auto [result, updatedValue] : llvm::zip(results, updatedValues))
+      result.set(resultIndex, updatedValue.get({}));
   }
 
   return results;
@@ -1463,7 +1465,9 @@ Tensor evalSliceOp(const Tensor &operand, const Sizes &startIndices,
   Tensor result(resultType);
   for (auto resultIt = result.index_begin(); resultIt != result.index_end();
        ++resultIt) {
-    result.set(*resultIt, operand.get(startIndices + *resultIt * strides));
+    Index resultIndex = *resultIt;
+    Index operandIndex = startIndices + resultIndex * strides;
+    result.set(resultIndex, operand.get(operandIndex));
   }
   return result;
 }
@@ -1482,13 +1486,16 @@ SmallVector<Tensor> evalSortOp(ArrayRef<Tensor> inputs, Axis dimension,
     // only needs to be done once per slice.
     if ((*resultIt)[adjustedDimension] != 0) continue;
 
-    // Instead of literally putting the slices together into a vector of tuples,
-    // we're representing these tuples with integer handles, with each handle
-    // being an index within the slice.
-    // Then, instead of sorting a vector of tuples, we're sorting a vector of
-    // handles, and the comparator knows how to use these handles to fetch
+    // SortOp sorts 1-dimensional slices of inputs together and produces
+    // 1-dimensional slices of results.
+    // In this implementation, we aren't going to materialize these slices as
+    // a tensor of tuples, but are going to represent these tuples with integer
+    // handles, with each handle being an index within the slice.
+    // Then, instead of sorting a tensor of tuples, we'll be sorting a tensor of
+    // handles, with the comparator knowing how to use these handles to fetch
     // the actual input elements being compared.
-    Index inputsTogether(inputs[0].getShape()[adjustedDimension]);
+    SmallVector<int64_t> inputsTogether(
+        inputs[0].getShape()[adjustedDimension]);
     std::iota(inputsTogether.begin(), inputsTogether.end(), 0);
     auto comparatorTogether = [&](int64_t lhsHandle, int64_t rhsHandle) {
       SmallVector<Tensor> args;
@@ -1498,15 +1505,11 @@ SmallVector<Tensor> evalSortOp(ArrayRef<Tensor> inputs, Axis dimension,
       rhsIndex[adjustedDimension] = rhsHandle;
       for (const auto &input : inputs) {
         auto argType = RankedTensorType::get({}, input.getElementType());
-        auto lhsEl = Tensor(argType);
-        auto rhsEl = Tensor(argType);
-        lhsEl.set({}, input.get(lhsIndex));
-        rhsEl.set({}, input.get(rhsIndex));
-        args.push_back(lhsEl);
-        args.push_back(rhsEl);
+        args.push_back(Tensor(argType, input.get(lhsIndex)));
+        args.push_back(Tensor(argType, input.get(rhsIndex)));
       }
-      auto cmpResult = eval(comparator, args, &scope);
-      return cmpResult[0].get({}).getBooleanValue();
+      auto comparatorResult = eval(comparator, args, &scope);
+      return comparatorResult[0].get({}).getBooleanValue();
     };
     if (isStable)
       std::stable_sort(inputsTogether.begin(), inputsTogether.end(),
@@ -1515,9 +1518,10 @@ SmallVector<Tensor> evalSortOp(ArrayRef<Tensor> inputs, Axis dimension,
       std::sort(inputsTogether.begin(), inputsTogether.end(),
                 comparatorTogether);
 
-    // After the vector of handles has been sorted, we apply the results of
+    // After the tensor of handles has been sorted, we apply the results of
     // this sort by reshuffling input elements into result elements.
-    for (auto [inputHandle, resultHandle] : llvm::enumerate(inputsTogether)) {
+    auto &resultsTogether = inputsTogether;
+    for (auto [inputHandle, resultHandle] : llvm::enumerate(resultsTogether)) {
       for (auto [input, result] : llvm::zip(inputs, results)) {
         auto inputIndex = *resultIt;
         auto resultIndex = *resultIt;
@@ -1557,8 +1561,9 @@ Tensor evalTransposeOp(const Tensor &operand, const Axes &permutation,
   Tensor result(resultType);
   for (auto operandIt = operand.index_begin(); operandIt != operand.index_end();
        ++operandIt) {
-    auto resultIndex = operandIt->permute(permutation);
-    result.set(resultIndex, operand.get(*operandIt));
+    Index operandIndex = *operandIt;
+    Index resultIndex = operandIndex.permute(permutation);
+    result.set(resultIndex, operand.get(operandIndex));
   }
   return result;
 }

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -934,9 +934,10 @@ Tensor evalConcatenateOp(ArrayRef<Tensor> inputs, Axis dimension,
   for (const auto &input : inputs) {
     for (auto inputIt = input.index_begin(); inputIt != input.index_end();
          ++inputIt) {
-      Index resultIndex(*inputIt);
+      Index inputIndex = *inputIt;
+      Index resultIndex(inputIndex);
       resultIndex[dimension] += dimensionOffset;
-      result.set(resultIndex, input.get(*inputIt));
+      result.set(resultIndex, input.get(inputIndex));
     }
     dimensionOffset += input.getShape()[dimension];
   }
@@ -1201,8 +1202,8 @@ Tensor evalPadOp(const Tensor &operand, const Tensor &paddingValue,
   Tensor result(resultType, paddingValue.get({}));
   for (auto operandIt = operand.index_begin(); operandIt != operand.index_end();
        ++operandIt) {
-    auto operandIndex = *operandIt;
-    auto resultIndex = edgePaddingLow + operandIndex * (interiorPadding + 1);
+    Index operandIndex = *operandIt;
+    Index resultIndex = edgePaddingLow + operandIndex * (interiorPadding + 1);
     // Bound check is needed here because of negative padding which could
     // swallow some operand indices.
     if (resultIndex.inBounds(result.getShape()))

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -1563,7 +1563,9 @@ Tensor evalTransposeOp(const Tensor &operand, const Axes &permutation,
   for (auto operandIt = operand.index_begin(); operandIt != operand.index_end();
        ++operandIt) {
     Index operandIndex = *operandIt;
-    Index resultIndex = operandIndex.permute(permutation);
+    Index resultIndex(result.getRank());
+    for (auto d = 0; d < result.getRank(); d++)
+      resultIndex[d] = operandIndex[permutation[d]];
     result.set(resultIndex, operand.get(operandIndex));
   }
   return result;

--- a/stablehlo/reference/Sizes.cpp
+++ b/stablehlo/reference/Sizes.cpp
@@ -27,13 +27,6 @@ raw_ostream &operator<<(raw_ostream &os, const Sizes &x) {
   return os;
 }
 
-Sizes Sizes::permute(ArrayRef<int64_t> permutation) const {
-  Sizes result(size());
-  for (size_t i = 0; i < permutation.size(); i++)
-    result[i] = (*this)[permutation[i]];
-  return result;
-}
-
 bool Sizes::inBounds(const Sizes &bounds) const {
   if (size() != bounds.size()) return false;
   for (auto [size, bound] : llvm::zip(*this, bounds))

--- a/stablehlo/reference/Sizes.h
+++ b/stablehlo/reference/Sizes.h
@@ -39,10 +39,6 @@ class Sizes : public SmallVector<int64_t> {
   explicit Sizes(DenseIntElementsAttr attr)
       : SmallVector(attr.getValues<int64_t>()) {}
 
-  // Returns `s` with the effect of applying `permutation`
-  // to `this` object, that is, `s[i] = (*this)[permutation[i]]`.
-  Sizes permute(ArrayRef<int64_t> permutation) const;
-
   /// Checks if an element `e` at kth axis of `this` object follows
   /// `0 <= e <= bounds[k]`.
   bool inBounds(const Sizes &bounds) const;


### PR DESCRIPTION
Data Movement operations were one of the first operations specced, so we were still working out the notation back then.

As mentioned in #484, inspired by our experience with the interpreter, it appears to be useful to express semantics of these operations in terms of result_index / operand_index rather than in terms of individual components of those indices.

I took a stab at tweaking the specification for these operations, and I think that going from scalars to tensors to represent indices results in more readable specification. Furthermore, descriptive names like result_index are more conducive to readability than i or j. Also, we can retire the somewhat weird "id" / "jd" notation for these ops.

Overall, I think that the specification and the implementation of data movement ops are well-aligned with each other. A few quirks:
  * ConcatenateOp, PadOp and TransposeOp are formulated in terms of operand's iteration space because they are much easier to implement this way. Everything else is formulated in terms of result's iteration space.
  * SortOp doesn't have a low-level 1:1 mapping, but there's a 1:1 mapping of high-level pieces and comments help with understanding.

Re: the rest of the opset (see the list of categories in https://docs.google.com/spreadsheets/d/1rvhxQMFUtCZ5DsY6X0_lJOCg9rVO2MdyeZlRorsc0UI/edit?resourcekey=0-5gMjnlkXDL6hCntv2yltaQ#gid=0):
  * Control Flow ops look good as well (modulo a minor simplification in #1553).
  * Data Movement ops are discussed in this PR.
  * Distribution ops are in the works and will be reviewed afterwards.
  * Dynamism ops are in the works as well, and we'll first need to spec them before worrying about the interpreter. Overall, I'm not worried because at runtime there's not going to be a difference between static ops and their dynamic counterparts.
  * Elementwise ops are straightforward as far as notation goes.
  * Extensibility ops are out of scope for now because we may decide to remove tuples altogether (#598).
  * Most of the Miscellaneous ops are going to be handled via passes in the long run, so I haven't reviewed those. The rest, i.e. constant and iota, are fine with a minor fix to iota.
  * Not in HLO ops are going to be out of the opset in the long run, so we haven't specced them and aren't planning to spec or implement them.
  * Quantization ops are elementwise, so they are straightforward too as far as notation goes.
  * Finally, Reduction ops are going to be tricky because their specs have been tricky, their implementations have been tricky, and their notations have been drifting apart. I opened #1551 to revisit this once we're done with the first round of implementations.