### PR TITLE
Use func.func and func.return in the spec

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -29,7 +29,7 @@ Below is an example program with a function `@main` which has 3 inputs
 has 6 ops.
 
 ```mlir
-stablehlo.func @main(
+func.func @main(
   %image: tensor<28x28xf32>,
   %weights: tensor<784x10xf32>,
   %bias: tensor<1x10xf32>
@@ -39,14 +39,14 @@ stablehlo.func @main(
   %2 = "stablehlo.add"(%1, %bias) : (tensor<1x10xf32>, tensor<1x10xf32>) -> tensor<1x10xf32>
   %3 = "stablehlo.constant"() { value = dense<0.0> : tensor<1x10xf32> } : () -> tensor<1x10xf32>
   %4 = "stablehlo.maximum"(%2, %3) : (tensor<1x10xf32>, tensor<1x10xf32>) -> tensor<1x10xf32>
-  "stablehlo.return"(%4): (tensor<1x10xf32>) -> ()
+  "func.return"(%4): (tensor<1x10xf32>) -> ()
 }
 ```
 
 ### Functions
 
 ```ebnf
-Func        ::= 'stablehlo' '.' 'func' FuncId FuncInputs FuncOutputs '{' FuncBody '}'
+Func        ::= 'func' '.' 'func' FuncId FuncInputs FuncOutputs '{' FuncBody '}'
 FuncInputs  ::= '(' [FuncInput {',' FuncInput}] `)`
 FuncInput   ::= '%' ValueId ':' ValueType
 FuncOutputs ::= ['->' FuncOutput, {',' FuncOutput}]


### PR DESCRIPTION
The stablehlo.func and stablehlo.return syntax in the opening example of the spec was aspirational, and at the time we expected that we'll soon adopt it.

A lot of the time has passed, and we still haven't gotten around to doing this, while we've been getting regular questions about this. Let's reflect reality in the example for now - we can always change it back once we address #425.