### PR TITLE
Add scheduled CI for StableHLO builds against LLVM@HEAD

### DIFF
--- a/.github/workflows/buildAndTestCMake.yml
+++ b/.github/workflows/buildAndTestCMake.yml
@@ -34,6 +34,7 @@ concurrency:
 
 jobs:
   cmake-build:
+    name: "cmake-build (${{ github.event_name == 'schedule' && 'llvm-project@HEAD' || 'llvm_version.txt' }})"
     env:
       LLVM_PROJECT_DIR: "llvm-project"
       LLVM_BUILD_DIR: "llvm-build"
@@ -42,7 +43,6 @@ jobs:
     strategy:
       fail-fast: false
     runs-on: ${{ github.repository == 'openxla/stablehlo' && 'ubuntu-22.04-64core' ||  'ubuntu-22.04'  }}
-    name: "cmake-build (${{ github.event_name == 'schedule' && 'llvm-project@HEAD' || 'llvm_version.txt' }})"
 
     steps:
     - name: Checkout StableHLO

--- a/.github/workflows/buildAndTestCMake.yml
+++ b/.github/workflows/buildAndTestCMake.yml
@@ -20,8 +20,8 @@ on:
   push:
     branches: [ main ]
   schedule:
-    # Run once a day
-    - cron:  '0 12 * * *'
+    # Run once every 6hr building against llvm-project@HEAD
+    - cron:  '0 */6 * * *'
   workflow_dispatch:
 
 # Ensure that only a single job or workflow using the same
@@ -43,6 +43,8 @@ jobs:
       fail-fast: false
     runs-on: ${{ github.repository == 'openxla/stablehlo' && 'ubuntu-22.04-64core' ||  'ubuntu-22.04'  }}
 
+    name: "cmake-build (${{ github.event_name == 'schedule' && 'llvm-project@HEAD' || 'llvm_version.txt' }})"
+
     steps:
     - name: Checkout StableHLO
       uses: actions/checkout@v2
@@ -51,7 +53,12 @@ jobs:
       id: llvm-version
       shell: bash
       run: |
-        echo "version=$(cat ${{ github.workspace }}/build_tools/llvm_version.txt)" >> $GITHUB_OUTPUT
+        USE_LLVM_HEAD=${{ github.event_name == 'schedule' }}
+        if [[ $USE_LLVM_HEAD = true ]]; then 
+          echo "version=main" >> $GITHUB_OUTPUT
+        else
+          echo "version=$(cat ${{ github.workspace }}/build_tools/llvm_version.txt)" >> $GITHUB_OUTPUT
+        fi;
 
     - name: Setup workspace
       uses: ./.github/actions/setup-build

--- a/.github/workflows/buildAndTestCMake.yml
+++ b/.github/workflows/buildAndTestCMake.yml
@@ -42,7 +42,6 @@ jobs:
     strategy:
       fail-fast: false
     runs-on: ${{ github.repository == 'openxla/stablehlo' && 'ubuntu-22.04-64core' ||  'ubuntu-22.04'  }}
-
     name: "cmake-build (${{ github.event_name == 'schedule' && 'llvm-project@HEAD' || 'llvm_version.txt' }})"
 
     steps:

--- a/.github/workflows/buildAndTestCMake.yml
+++ b/.github/workflows/buildAndTestCMake.yml
@@ -34,7 +34,7 @@ concurrency:
 
 jobs:
   cmake-build:
-    name: "cmake-build (${{ github.event_name == 'schedule' && 'llvm-project@HEAD' || 'llvm_version.txt' }})"
+    name: "cmake-build ${{ github.event_name == 'schedule' && '(llvm-project@HEAD)' || ''}}"
     env:
       LLVM_PROJECT_DIR: "llvm-project"
       LLVM_BUILD_DIR: "llvm-build"
@@ -53,7 +53,7 @@ jobs:
       shell: bash
       run: |
         USE_LLVM_HEAD=${{ github.event_name == 'schedule' }}
-        if [[ $USE_LLVM_HEAD = true ]]; then 
+        if [[ $USE_LLVM_HEAD = true ]]; then
           echo "version=main" >> $GITHUB_OUTPUT
         else
           echo "version=$(cat ${{ github.workspace }}/build_tools/llvm_version.txt)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Felt inspired after seeing a presentation on JAX CI in [openxla/openxla-pjrt-plugin](https://github.com/openxla/openxla-pjrt-plugin) (like [run_jaxtests_cpu.yml](https://github.com/openxla/openxla-pjrt-plugin/blob/main/.github/workflows/run_jaxtests_cpu.yml)), decided to add some frequent (every 6hr) builds against the latest LLVM revision to detect compatibility / other issues as soon as possible.

This is built on top of existing CI. The name of the buildAndTestCmake job now includes what StableHLO is being built against. Examples from my fork:
- [cmake-build (llvm-project@HEAD)](https://github.com/GleasonK/stablehlo/actions/runs/5136120754/jobs/9242454311)
- [cmake-build (llvm_version.txt)](https://github.com/GleasonK/stablehlo/actions/runs/5136234330/jobs/9242713655)

_Note: This only builds scheduled CI against HEAD, meaning it should have no impact on CI for pull requests._

Other things to consider:
- If LLVM build fails (not StableHLO build) should we exit with success, indicating a likely upstream breakage?
- How should these be monitored? Is subscribing to email notification enough?

Closes #1489