### PR TITLE
Bump patch version after integrate 0.13.0 -> 0.13.1

### DIFF
--- a/stablehlo/dialect/Version.h
+++ b/stablehlo/dialect/Version.h
@@ -38,7 +38,7 @@ class Version {
   static FailureOr<Version> fromString(llvm::StringRef versionRef);
 
   /// Return a Version representing the current VHLO dialect version.
-  static Version getCurrentVersion() { return Version(0, 13, 0); }
+  static Version getCurrentVersion() { return Version(0, 13, 1); }
 
   /// Return a Version representing the minimum supported VHLO dialect version.
   static Version getMinimumVersion() { return Version(0, 9, 0); }


### PR DESCRIPTION
Integrated commit: https://github.com/openxla/xla/commit/767423c2c190ce25ece07a7ea4367263f2d6d6e9