### PR TITLE
[RFC] Add TopK op to StableHLO

### DIFF
--- a/rfcs/20230606-topk.md
+++ b/rfcs/20230606-topk.md
@@ -14,7 +14,7 @@ the IR lowering chain.
 
 ## Background and Motivation
 
-The TopK operation is ubiquitous in both ML frameworks (e.g.,
+The TopK operation is ubiquitous in many ML frameworks (e.g.,
 [JAX](https://jax.readthedocs.io/en/latest/_autosummary/jax.lax.top_k.html),
 [tensorflow](https://www.tensorflow.org/api_docs/python/tf/math/top_k),
 [PyTorch](https://pytorch.org/docs/stable/generated/torch.topk.html)) and
@@ -77,6 +77,10 @@ Sample IR:
   attribute, we can more faithfully model input models and differentiate from
   sorting, especially when `k` is dynamic. This also makes it much more explicit
   whether sorting is performed, reducing the need to consult the StableHLO spec.
+* Make ordering a function argument to dynamic selection between sorted and
+  unordered results. It is unclear that there is need for this kind of dynamism.
+  The alternative -- emitting a `stablehlo.select` of the  two variants of
+  `stablehlo.top` provides an easy to employ workaround.
 
 ## Acknowledgements
 

--- a/rfcs/20230606-topk.md
+++ b/rfcs/20230606-topk.md
@@ -1,0 +1,88 @@
+# RFC: Add TopK Op to StableHLO
+
+Status: Draft<br/>
+Initial version: 2023-06-06<br/>
+Last updated: 2023-06-06
+
+## Summary
+
+We propose to add a new op: `stablehlo.topk`, which returns the first `k`
+elements of a tensor and their indices, based on a user-provided comparator. The
+goal of the new op is to bridge a gap between existing and emerging uses of TopK
+in models (especially transformers and LLMs, e.g.: [^1], [^2]), as well as in
+the IR lowering chain.
+
+## Background and Motivation
+
+The TopK operation is ubiquitous in both ML frameworks (e.g.,
+[JAX](https://jax.readthedocs.io/en/latest/_autosummary/jax.lax.top_k.html),
+[tensorflow](https://www.tensorflow.org/api_docs/python/tf/math/top_k),
+[PyTorch](https://pytorch.org/docs/stable/generated/torch.topk.html)) and
+compiler IRs ([XLA](https://www.tensorflow.org/xla/operation_semantics#top-k),
+[CHLO](https://github.com/openxla/stablehlo/blob/6f0d25ef2e05f4549c5e4ffc506436a4a13af51f/stablehlo/dialect/ChloOps.td#L811-L842),
+[MHLO](https://github.com/openxla/xla/commit/11a4424760f8814faa6da29a0e6dd9d5c168d22a#diff-9573e4e3a2bf686edee3437726f9dbccaf1b296e634d44f4df504d94bf2576d1),
+[LinalgExt](https://github.com/openxla/iree/blob/b5e45cd08eecbd97b0568f9c5fdac28b0f5e8f11/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td#L436-L480)),
+which makes its absence from StableHLO a point of friction. For example, in IREE
+we have to pattern match stablehlo `iota` + `sort` + `slice` and raise it back
+to `chlo.top_k`, so that we can efficiently lower it to `linalg_ext.topk`. See
+the IREE issue for more details: <https://github.com/openxla/iree/issues/13905>.
+
+The definitions of TopK in frontend frameworks and IRs vary in two places:
+
+* Whether `k` is static or dynamic.
+* Whether the results are sorted, unordered, or whether ordering is decided based
+  on a function argument.
+
+Note that when the input TopK gets lowered to `sort` followed by a dynamic slice,
+we generally lose the information about both. If `k` is a runtime value, we no
+longer know whether we can expect it to be much smaller than the number of
+elements, which makes it difficult to tell whether to rewrite sort as TopK or
+whether we truly have to sort all elements. Second, we may be introducing
+unnecessary ordering when the input semantics do not require for the results to
+be sorted.
+
+Note that we want to avoid degrading to a general `sort`, as this can lead to
+significant bottlenecks in real-world models, e.g.:
+<https://github.com/openxla/iree/issues/13865>.
+
+This loss of high level semantic information and high friction along the
+lowering chain makes us argue for a dedicated TopK op in StableHLO.
+
+## Implementation
+
+We propose to add a `stablehlo.topk` op with dynamic argument `k` and an
+attribute `order` (either `SORTED` or `UNORDERED`). This version of TopK should
+be a faithful representation of TopK in input frameworks that does not introduce
+needless sorting.
+
+Sample IR:
+
+```mlir
+%values, %indices = stablehlo.topk %values, %k, UNORDERED {
+  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
+    %predicate = stablehlo.compare GT, %arg0, %arg1 : (tensor<f32>, tensor<f32>) -> tensor<i1>
+    stablehlo.return %predicate : tensor<i1>
+} : (tensor<100xf32>, tensor<i64>) -> (tensor<5xf32>, tensor<5xi32>)
+```
+
+### Additional Considerations
+
+* When `k` is static, we should be able to trivially recognize it is a constant
+  and use that constant in further lowering to a `lower` dialect. When it is a
+  truly dynamic runtime value, we may anticipate a reasonable upper bound
+  lowered for `lower.topk` with a fallback to `lower.sort`.
+* Make sorting mandatory or unsupported. This removes some complexity from the
+  stablehlo op itself, but makes the IR more verbose when we do need sorting,
+  and in turn complicates lowering. We argue that by making sorting an
+  attribute, we can more faithfully model input models and differentiate from
+  sorting, especially when `k` is dynamic. This also makes it much more explicit
+  whether sorting is performed, reducing the need to consult the StableHLO spec.
+
+## Acknowledgements
+
+This RFC is inspire by past proposals from George Karpenkov and Eugene Burmako.
+
+___
+
+[^1]: [Explicit Sparse Transformer: Concentrated Attention Through Explicit Selection](https://arxiv.org/abs/1912.11637)
+[^2]: [Memory-efficient Transformers via Top-k Attention](https://arxiv.org/abs/2106.06899)

--- a/rfcs/20230606-topk.md
+++ b/rfcs/20230606-topk.md
@@ -9,8 +9,8 @@ Last updated: 2023-06-06
 We propose to add a new op: `stablehlo.topk`, which returns the first `k`
 elements of a tensor and their indices, based on a user-provided comparator. The
 goal of the new op is to bridge a gap between existing and emerging uses of TopK
-in models (especially transformers and LLMs, e.g.: [^1], [^2]), as well as in
-the IR lowering chain.
+in models (especially transformers and LLMs, e.g., [^1], [^2], [^3]), as well as
+in the IR lowering chain.
 
 ## Background and Motivation
 
@@ -88,5 +88,6 @@ This RFC is inspire by past proposals from George Karpenkov and Eugene Burmako.
 
 ___
 
-[^1]: [Explicit Sparse Transformer: Concentrated Attention Through Explicit Selection](https://arxiv.org/abs/1912.11637)
-[^2]: [Memory-efficient Transformers via Top-k Attention](https://arxiv.org/abs/2106.06899)
+[^1]: [Hierarchical Neural Story Generation](https://arxiv.org/abs/1805.04833)
+[^2]: [Explicit Sparse Transformer: Concentrated Attention Through Explicit Selection](https://arxiv.org/abs/1912.11637)
+[^3]: [Memory-efficient Transformers via Top-k Attention](https://arxiv.org/abs/2106.06899)


### PR DESCRIPTION
TopK is a common operation in ML frameworks and dialects, but is currently missing from StableHLO. This RFC proposed to add a new op to the StableHLO dialect: `stablehlo.topk`, and argues why `sort` is insufficient.

Note that both CHLO and MHLO already support TopK:
-  PR that introduced TopK in HLO: openxla/xla#2539.
-  PR that introduces the same functionality in MHLO: openxla/xla#3127.

Issue: openxla/stablehlo#1514
openxla-discuss: https://groups.google.com/a/openxla.org/g/openxla-discuss/c/hhieJAN4Eis