### PR TITLE
Correction to Min Normal bitstring for Float8E5M2FNUZ

### DIFF
--- a/rfcs/20230321-fp8_fnuz.md
+++ b/rfcs/20230321-fp8_fnuz.md
@@ -78,7 +78,7 @@ to all 0s
 |                   |Float8E5M2                                                                  |Float8E5M2FNUZ                                                             |
 |-------------------|----------------------------------------------------------------------------|---------------------------------------------------------------------------|
 |Bias               |15                                                                          |16                                                                         |
-|Min Normal Value   |`0bS0000100` = -1<sup>S</sup> $\times$ 1.0 $\times$ 2<sup>-14</sup>         |`0bS0001000` = -1<sup>S</sup> $\times$ 1.0 $\times$ 2<sup>-15</sup>        |
+|Min Normal Value   |`0bS0000100` = -1<sup>S</sup> $\times$ 1.0 $\times$ 2<sup>-14</sup>         |`0bS0000100` = -1<sup>S</sup> $\times$ 1.0 $\times$ 2<sup>-15</sup>        |
 |Max Normal Value   |`0bS1111011` = -1<sup>S</sup> $\times$ 1.75 $\times$ 2<sup>15</sup> = 57344 |`0bS1111111` = -1<sup>S</sup> $\times$ 1.75 $\times$ 2<sup>15</sup> = 57344|
 |Min Subnormal Value|`0bS0000001` = -1<sup>S</sup> $\times$ 0.25 $\times$ 2<sup>-14</sup>        |`0bS0000001` = -1<sup>S</sup> $\times$ 0.25 $\times$ 2<sup>-15</sup>       |
 |Max Subnormal Value|`0bS0000011` = -1<sup>S</sup> $\times$ 0.75 $\times$ 2<sup>-14</sup>        |`0bS0000011` = -1<sup>S</sup> $\times$ 0.75 $\times$ 2<sup>-15</sup>       |


### PR DESCRIPTION
The set bit was in the same place as for the E4M3 type - it should be the same as for Float8E5M2.