### PR TITLE
Update compatibility.md

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -137,13 +137,6 @@ StableHLO programs that were serialized by the latest release of libStablehlo.
 
 ## Future work
 
-**5 years of compatibility guarantees.** In H2 2023, we are planning to release
-StableHLO v1.0 which will implement high-priority improvements, including
-cleaning up the frontend contract and providing a reference implementation.
-Having obtained these improvements and resolved key specification compliance
-issues, StableHLO will be ready for full compatibility guarantees - 5 years of
-forward and backward compatibility. See [roadmap.md](roadmap.md) for details.
-
 **Organize compatibility suite.** At the moment, the compatibility suite
 is one directory with many unstructured files. We are planning to triage and
 organize it, making sure that it's organized, comprehensive and deduplicated

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -27,11 +27,8 @@ planning to release StableHLO v0.9 in Q1 2023.
 **StableHLO v1.0** will implement high-priority improvements, including
 cleaning up the frontend contract (with the goal that StableHLO programs only
 include ops from the StableHLO dialect, rather than today's mixture of dialects
-and unregistered attributes) and providing a reference implementation. Having
-obtained these improvements and resolved key specification compliance issues,
-StableHLO will be ready for full compatibility guarantees - 5 years of forward
-and backward compatibility. We are planning to release StableHLO v1.0 in
-H2 2023.
+and unregistered attributes) and providing a reference implementation. We are
+planning to release StableHLO v1.0 in H2 2023.
 
 ## Workstreams
 

--- a/rfcs/20220912-compatibility.md
+++ b/rfcs/20220912-compatibility.md
@@ -2,7 +2,7 @@
 
 Status: Approved<br/>
 Initial version: 9/12/2022<br/>
-Last updated: 3/9/2022
+Last updated: 12/13/2022
 
 ## Version log
 
@@ -10,7 +10,6 @@ Last updated: 3/9/2022
 * 11/9/2022: Major updates based on a prototype implementation and conversations
              with OpenXLA and MLIR communities.
 * 12/13/2022: Approved.
-* 3/9/2023: Extend backward compatibility guarantees from 1 month to 6 months.
 
 ## Introduction
 
@@ -116,9 +115,8 @@ and we can have a discussion about supporting it.
 
 **(G4) Version 0.x.x:** There will be some stability guarantees while in major
 version 0. There is not stability guaranteed within the major version, but we
-will provide 6 months of backward and 1 month of forward compatibility
-guarantees between minor versions.
-This approach is chosen to allow dialect evolution and cleanup in
+will provide 1 month of forward and backward compatibility between minor
+versions. This approach is chosen to allow dialect evolution and cleanup in
 the early days, as well as refine compatibility procedures while meeting the
 requirements of early adopters. Stability within major version will begin
 with version `1.x.x` and will happen in 2023.


### PR DESCRIPTION
We have recently approved #1600 - an RFC about compatibility. This PR updates compatibility.md - the source of truth for StableHLO's compatibility guarantees - to the latest plan of record.

Also, this PR rolls back changes to the original compatibility RFC done in #1306. I now think that it was a mistake to retroactively update it, even if the plan of record changed - it is much easier to reason about RFCs if they are immutable.