### PR TITLE
Unify references to discussion threads in RFCs

### DIFF
--- a/rfcs/20220912-compatibility.md
+++ b/rfcs/20220912-compatibility.md
@@ -2,7 +2,8 @@
 
 Status: Approved<br/>
 Initial version: 9/12/2022<br/>
-Last updated: 12/13/2022
+Last updated: 12/13/2022<br/>
+Discussion thread: [GitHub](https://github.com/openxla/stablehlo/pull/115)
 
 ## Version log
 

--- a/rfcs/20221031-fp8.md
+++ b/rfcs/20221031-fp8.md
@@ -3,5 +3,4 @@
 Status: Approved<br/>
 Initial version: 10/31/2022<br/>
 Last updated: 12/12/2022
-
-See [the OpenXLA RFC](https://github.com/openxla/xla/discussions/22).
+Discussion thread: [GitHub](https://github.com/openxla/xla/discussions/22)

--- a/rfcs/20230210-sparsity.md
+++ b/rfcs/20230210-sparsity.md
@@ -2,7 +2,8 @@
 
 Status: Reviewed<br/>
 Initial version: 2/10/2023<br/>
-Last updated: 4/12/2023
+Last updated: 4/12/2023<br/>
+Discussion thread: [GitHub](https://github.com/openxla/stablehlo/pull/1143)
 
 ## Motivation
 

--- a/rfcs/20230309-compatibility.md
+++ b/rfcs/20230309-compatibility.md
@@ -1,8 +1,9 @@
 # Increase backward compatibility guarantees to 6 months
 
 Status: Approved<br/>
-Initial version: 3/9/2022<br/>
-Last updated: 3/24/2022
+Initial version: 3/9/2023<br/>
+Last updated: 3/24/2023<br/>
+Discussion thread: [GitHub](https://github.com/openxla/stablehlo/pull/1306)
 
 ## Summary
 

--- a/rfcs/20230309-e4m3b11.md
+++ b/rfcs/20230309-e4m3b11.md
@@ -2,7 +2,8 @@
 
 Status: Approved<br/>
 Initial version: 3/9/2023<br/>
-Last updated: 3/24/2023
+Last updated: 3/24/2023<br/>
+Discussion thread: [GitHub](https://github.com/openxla/stablehlo/pull/1308)
 
 ## Summary
 

--- a/rfcs/20230321-fp8_fnuz.md
+++ b/rfcs/20230321-fp8_fnuz.md
@@ -2,7 +2,8 @@
 
 Status: Approved<br/>
 Initial version: 3/21/2023<br/>
-Last updated: 4/5/2023
+Last updated: 4/5/2023<br/>
+Discussion thread: [GitHub](https://github.com/openxla/stablehlo/pull/1342)
 
 ## Summary
 

--- a/rfcs/20230525-compatibility.md
+++ b/rfcs/20230525-compatibility.md
@@ -1,13 +1,11 @@
 # Reduce StableHLO v1.0 Compatibility Guarantees RFC
 
 Status: Approved<br/>
-Initial version: 5/25/2022<br/>
-Last updated: 6/8/2022
+Initial version: 5/25/2023<br/>
+Last updated: 6/8/2023<br/>
+Discussion thread: [openxla-discuss]((https://groups.google.com/a/openxla.org/g/openxla-discuss/c/yYjTDAsoygQ))
 
 ## Summary
-
-This RFC is cloned from OpenXLA Discuss:
-[[RFC] Reduce StableHLO v1.0 Compatibility Guarantees](https://groups.google.com/a/openxla.org/g/openxla-discuss/c/yYjTDAsoygQ)
 
 In the compatibility RFC from December 2022 we proposed 5 years of forward and
 backward compatibility for StableHLO v1.0. This was an aspirational goal, based


### PR DESCRIPTION
All RFCs now have a consistent "Discussion thread" header that points to the primary location where the discussion has been happening.

We went through quite a few approaches over the last year (GitHub discussions, GitHub PRs, mailing lists), so I think it's good to make this uniform.

Also, dates in some RFC documents were incorrectly referring to 2022 instead of 2023. I fixed that too.