### PR TITLE
[CMake] Make StableHLO build consistent with MLIR-HLO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,17 +37,25 @@ endif()
 #-------------------------------------------------------------------------------
 # Options and settings
 #-------------------------------------------------------------------------------
+option(STABLEHLO_BUILD_EMBEDDED "Build StableHLO as part of another project" OFF)
 option(STABLEHLO_ENABLE_BINDINGS_PYTHON "Enables StableHLO Python bindings" OFF)
 option(STABLEHLO_ENABLE_STRICT_BUILD "Build StableHLO with strict warnings and warnings as errors" OFF)
 
 #-------------------------------------------------------------------------------
 # Project setup and globals
 #-------------------------------------------------------------------------------
+set(STABLEHLO_STANDALONE_BUILD OFF)
+
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   set(STABLEHLO_STANDALONE_BUILD ON)
   project(stablehlo LANGUAGES CXX C)
   set(CMAKE_C_STANDARD 11)
   set(CMAKE_CXX_STANDARD 17)
+endif()
+
+if(NOT STABLEHLO_STANDALONE_BUILD AND NOT MLIR_BINARY_DIR)
+  # Building as part of LLVM via the external project mechanism.
+  set(STABLEHLO_EXTERNAL_PROJECT_BUILD ON)
 endif()
 
 #-------------------------------------------------------------------------------
@@ -59,8 +67,22 @@ if (STABLEHLO_ENABLE_STRICT_BUILD)
   set(LLVM_ENABLE_PEDANTIC ON)
 endif()
 
-if(STABLEHLO_STANDALONE_BUILD)
-  message(STATUS "Building StableHLO standalone")
+# Find MLIR to install if we are building standalone. If building as part of
+# another project, let it handle the MLIR dependency. The dependent project
+# might use a bundled version of MLIR instead of installing, for instance.
+if(STABLEHLO_EXTERNAL_PROJECT_BUILD)
+  message(STATUS "Building StableHLO as an external LLVM project")
+  set(MLIR_MAIN_SRC_DIR ${LLVM_MAIN_SRC_DIR}/../mlir ) # --src-root
+  set(MLIR_INCLUDE_DIR ${MLIR_MAIN_SRC_DIR}/include ) # --includedir
+  set(MLIR_GENERATED_INCLUDE_DIR ${LLVM_BINARY_DIR}/tools/mlir/include)
+  include_directories(SYSTEM ${MLIR_INCLUDE_DIR})
+  include_directories(SYSTEM ${MLIR_GENERATED_INCLUDE_DIR})
+  include_directories(SYSTEM ${MLIR_TABLEGEN_OUTPUT_DIR})
+
+  set(BACKEND_PACKAGE_STRING "${PACKAGE_STRING}")
+  list(APPEND CMAKE_MODULE_PATH "${MLIR_MAIN_SRC_DIR}/cmake/modules")
+elseif(NOT STABLEHLO_BUILD_EMBEDDED)
+  message(STATUS "Building StableHLO with an installed MLIR")
   find_package(MLIR REQUIRED CONFIG)
   message(STATUS "Using MLIRConfig.cmake in: ${MLIR_DIR}")
   message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
@@ -68,32 +90,20 @@ if(STABLEHLO_STANDALONE_BUILD)
   set(LLVM_LIBRARY_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/lib)
   list(APPEND CMAKE_MODULE_PATH "${MLIR_CMAKE_DIR}")
   list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
-
-  include(TableGen)
-  include(AddLLVM)
-  include(AddMLIR)
-  include(HandleLLVMOptions)
-  include_directories(${LLVM_INCLUDE_DIRS})
-  include_directories(${MLIR_INCLUDE_DIRS})
-  include_directories(${CMAKE_CURRENT_SOURCE_DIR})
-  include_directories(${CMAKE_CURRENT_BINARY_DIR})
-  link_directories(${LLVM_BUILD_LIBRARY_DIR})
-  add_definitions(${LLVM_DEFINITIONS})
 else()
-  message(STATUS "Building StableHLO as part of another project")
-  set(MLIR_MAIN_SRC_DIR ${LLVM_MAIN_SRC_DIR}/../mlir ) # --src-root
-  set(MLIR_INCLUDE_DIR ${MLIR_MAIN_SRC_DIR}/include ) # --includedir
-  set(MLIR_GENERATED_INCLUDE_DIR ${LLVM_BINARY_DIR}/tools/mlir/include)
-
-  include_directories(SYSTEM ${MLIR_INCLUDE_DIR})
-  include_directories(SYSTEM ${MLIR_GENERATED_INCLUDE_DIR})
-  include_directories(SYSTEM ${MLIR_TABLEGEN_OUTPUT_DIR})
-  include_directories(${CMAKE_CURRENT_SOURCE_DIR})
-  include_directories(${CMAKE_CURRENT_BINARY_DIR})
-
-  set(BACKEND_PACKAGE_STRING "${PACKAGE_STRING}")
-  list(APPEND CMAKE_MODULE_PATH "${MLIR_MAIN_SRC_DIR}/cmake/modules")
+  message(STATUS "Building StableHLO embedded in another project")
 endif()
+
+include(TableGen)
+include(AddLLVM)
+include(AddMLIR)
+include(HandleLLVMOptions)
+include_directories(${LLVM_INCLUDE_DIRS})
+include_directories(${MLIR_INCLUDE_DIRS})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+link_directories(${LLVM_BUILD_LIBRARY_DIR})
+add_definitions(${LLVM_DEFINITIONS})
 
 #-------------------------------------------------------------------------------
 # Python configuration


### PR DESCRIPTION
This applies when stablehlo is built by other projects enabled as an
external llvm project.

This change makes it match the mlir-hlo configuration more closely:
https://github.com/tensorflow/mlir-hlo/blob/51ce2fa22bc9acff37332ad02ef39412f21ffc98/CMakeLists.txt#L113-L130,
and ease the transition from mlir-hlo to stablehlo:                                                                      
https://discourse.llvm.org/t/sunsetting-the-mlir-hlo-repository/70536.

Tested by embedding stablehlo into IREE.

Issue: https://github.com/openxla/stablehlo/issues/1549
