### PR TITLE
fix bug in verification in ReduceOp

### DIFF
--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -502,8 +502,12 @@ LogicalResult verifyReduceOpInputsAndInferShape(
          dimension >= inputTypes[rankedInputIdx].getRank()) ||
         dimension < 0)
       return emitOptionalError(
-          location, "Out-of-bounds dimension ", dimension,
-          " for input-tensor rank: ", inputTypes[rankedInputIdx].getRank());
+          location, "Out-of-bounds dimension ", dimension, ", expected to be ",
+          allInputsUnranked
+              ? "> 0"
+              : "less than the input-tensor rank " +
+                    std::to_string(inputTypes[rankedInputIdx].getRank()));
+
     // reduce_c5
     if (!dimensionsToReduceSet.insert(dimension).second)
       return emitOptionalError(location,

--- a/stablehlo/tests/verify_reduce.mlir
+++ b/stablehlo/tests/verify_reduce.mlir
@@ -171,7 +171,7 @@ func.func @reduce_c2(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xi32>,
 func.func @reduce_c4(%arg0: tensor<?x?xf32>, %arg1 : tensor<f32>)
     -> (tensor<?xf32>) {
 
-  // expected-error@+1 {{Out-of-bounds dimension -1 for input-tensor rank: 2}}
+  // expected-error@+1 {{Out-of-bounds dimension -1, expected to be less than the input-tensor rank 2}}
   %0 = "stablehlo.reduce"(%arg0, %arg1) ({
 
   ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32> ):
@@ -187,7 +187,7 @@ func.func @reduce_c4(%arg0: tensor<?x?xf32>, %arg1 : tensor<f32>)
 func.func @reduce_c4(%arg0: tensor<?x?xf32>, %arg1 : tensor<f32>)
     -> (tensor<?xf32>) {
 
-  // expected-error@+1 {{Out-of-bounds dimension 2 for input-tensor rank: 2}}
+  // expected-error@+1 {{Out-of-bounds dimension 2, expected to be less than the input-tensor rank 2}}
   %0 = "stablehlo.reduce"(%arg0, %arg1) ({
 
   ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32> ):
@@ -196,6 +196,20 @@ func.func @reduce_c4(%arg0: tensor<?x?xf32>, %arg1 : tensor<f32>)
   }) {dimensions = dense<[2]> : tensor<1xi64>} : (tensor<?x?xf32>, tensor<f32>) -> tensor<?xf32>
 
   func.return %0: tensor<?xf32>
+}
+
+// -----
+
+func.func @reduce_c4(%arg0: tensor<*xf32>, %arg1 : tensor<*xf32>)
+    -> (tensor<*xf32>) {
+
+  // expected-error@+1 {{Out-of-bounds dimension -1, expected to be > 0}}
+  %0 = "stablehlo.reduce"(%arg0, %arg1) ({
+  ^bb0(%arg2: tensor<*xf32>, %arg3: tensor<*xf32> ):
+    %1 = "stablehlo.add"(%arg2, %arg3) : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
+    "stablehlo.return"(%1) : (tensor<*xf32>) -> ()
+  }) {dimensions = dense<[-1]> : tensor<1xi64>} : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
+  func.return %0: tensor<*xf32>
 }
 
 // -----


### PR DESCRIPTION
It seems that there is a bug in the verifier of `reduce` op when all the inputs are un-ranked. Specifically,

```
if ((!allInputsUnranked &&
         dimension >= inputTypes[rankedInputIdx].getRank()) ||
        dimension < 0)
      return emitOptionalError(
          location, "Out-of-bounds dimension ", dimension,
          " for input-tensor rank: ", inputTypes[rankedInputIdx].getRank());
```

If `allInputsUnranked` is true and `dimension < 0`, then while evaluating the error message ` inputTypes[rankedInputIdx].getRank()` we will incur an invalid memory access as  `rankedInputIdx = -1` when `allInputsUnranked = true`.

Added a test to reproduce that. 