### PR TITLE
[chlo] Add HLO_CompatibleOperandsAndResultElementType to validate quantized types

### DIFF
--- a/stablehlo/dialect/Base.td
+++ b/stablehlo/dialect/Base.td
@@ -202,6 +202,9 @@ def HLO_CompatibleOperandsAndResultType : TraitList<
     HLO_NativeOpTrait<"CompatibleOperandsAndResultType">
   ]>;
 
+def HLO_CompatibleOperandsAndResultElementType :
+  HLO_NativeOpTrait<"CompatibleOperandsAndResultElementType">;
+
 def HLO_BoundedAttrInterface : AttrInterface<"BoundedAttrInterface"> {
   let cppNamespace = "::mlir::hlo";
 

--- a/stablehlo/dialect/ChloOps.cpp
+++ b/stablehlo/dialect/ChloOps.cpp
@@ -26,6 +26,7 @@ limitations under the License.
 #include "mlir/IR/Diagnostics.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Transforms/InliningUtils.h"
+#include "stablehlo/dialect/Base.h"
 #include "stablehlo/dialect/BroadcastUtils.h"
 #include "stablehlo/dialect/ChloBytecode.h"
 #include "stablehlo/dialect/TypeInference.h"
@@ -143,7 +144,8 @@ LogicalResult InferBroadcastBinaryOpReturnTypeComponents(
   ShapedType lhsType = operands[0].getType().cast<ShapedType>();
   ShapedType rhsType = operands[1].getType().cast<ShapedType>();
   if (!lhsType || !rhsType ||
-      lhsType.getElementType() != rhsType.getElementType())
+      !hlo::isCompatibleElementTypeForHloTypeInference(
+          lhsType.getElementType(), rhsType.getElementType()))
     return emitOptionalError(location, "mismatched operand types");
   if (!elementType) elementType = lhsType.getElementType();
   inferredReturnShapes.push_back(

--- a/stablehlo/dialect/ChloOps.td
+++ b/stablehlo/dialect/ChloOps.td
@@ -117,7 +117,7 @@ class CHLO_BroadcastBinaryElementwiseOp<
 }
 
 def CHLO_BroadcastAddOp : CHLO_BroadcastBinaryElementwiseOp<"broadcast_add",
-    [Commutative, Pure, SameOperandsAndResultElementType]> {
+    [Commutative, Pure, HLO_CompatibleOperandsAndResultElementType]> {
   string summary = "Addition operator (with optional broadcasting)";
 
   string description = [{

--- a/stablehlo/tests/ops_chlo.mlir
+++ b/stablehlo/tests/ops_chlo.mlir
@@ -1,5 +1,22 @@
 // RUN: stablehlo-opt %s -verify-diagnostics -split-input-file | FileCheck %s
 
+
+// CHECK-LABEL: func @broadcast_add_quantized
+func.func @broadcast_add_quantized(%arg0: tensor<2x2x!quant.uniform<i8:f32, 2.0:15>>, %arg1: tensor<2x2x!quant.uniform<i8:f32, 3.0:15>>) -> tensor<2x2x!quant.uniform<i8:f32, 2.0:15>> {
+  %0 = "chlo.broadcast_add"(%arg0, %arg1) : (tensor<2x2x!quant.uniform<i8:f32, 2.0:15>>, tensor<2x2x!quant.uniform<i8:f32, 3.0:15>>) -> tensor<2x2x!quant.uniform<i8:f32, 2.0:15>>
+  func.return %0: tensor<2x2x!quant.uniform<i8:f32, 2.0:15>>
+}
+
+// -----
+
+func.func @broadcast_add_quantized(%arg0: tensor<2x2x!quant.uniform<i8:f32, 2.0:15>>, %arg1: tensor<2x2x!quant.uniform<i8:f32, 3.0:15>>) -> tensor<2x2x!quant.uniform<i16:f32, 2.0:15>> {
+  // expected-error @+1{{'chlo.broadcast_add' op requires compatible element types for all operands and results}}
+  %0 = "chlo.broadcast_add"(%arg0, %arg1) : (tensor<2x2x!quant.uniform<i8:f32, 2.0:15>>, tensor<2x2x!quant.uniform<i8:f32, 3.0:15>>) -> tensor<2x2x!quant.uniform<i16:f32, 2.0:15>>
+  func.return %0: tensor<2x2x!quant.uniform<i16:f32, 2.0:15>>
+}
+
+// -----
+
 func.func @constant_like(%arg0: tensor<1x2xi64>) -> (tensor<1x2xi32>) {
   // expected-error @+1 {{'chlo.constant_like' op value's type doesn't match element return type}}
   %0 = "chlo.constant_like"(%arg0) { value = 3.2 : f32 } : (tensor<1x2xi64>) -> tensor<1x2xi32>


### PR DESCRIPTION
Backport of https://github.com/tensorflow/mlir-hlo/commit/bb7b1eb4565e02a822a754bb536577454ffc64b2

Allows `CHLO::BroadcastAddOp` to support quantized types with compatible differences in representation.