### PR TITLE
Make getMinVersion() and getMaxVersion() parse version numbers at compile time

### DIFF
--- a/stablehlo/dialect/VhloAttrs.td
+++ b/stablehlo/dialect/VhloAttrs.td
@@ -39,15 +39,14 @@ class VHLO_AttrDef<string name, string minVersion, string maxVersion>
   let cppNamespace = "::mlir::vhlo";
   let extraClassDeclaration = [{
     mlir::vhlo::Version getMinVersion() {
-      auto version = mlir::vhlo::Version::fromString("}] #  minVersion # [{");
-      if (failed(version)) llvm::report_fatal_error("invalid version }] # minVersion # [{ in }] # name # [{");
-      return *version;
+      return mlir::vhlo::Version(}] # !subst(".", ", ", minVersion) # [{);
     }
     mlir::vhlo::Version getMaxVersion() {
-      if (!strcmp("}] # maxVersion # [{", "current")) return Version::getCurrentVersion();
-      auto version = mlir::vhlo::Version::fromString("}] #  maxVersion # [{");
-      if (failed(version)) llvm::report_fatal_error("invalid version }] # maxVersion # [{ in }] # name # [{");
-      return *version;
+      }] # !if(
+        !eq(maxVersion, "current"),
+        [{ return mlir::vhlo::Version::getCurrentVersion(); }],
+        [{ return mlir::vhlo::Version("}] # !subst(".", ", ", maxVersion) # [{"); }]
+      ) # [{
     }
   }];
 }

--- a/stablehlo/dialect/VhloEnums.td
+++ b/stablehlo/dialect/VhloEnums.td
@@ -32,15 +32,14 @@ class VHLO_EnumAttr<EnumAttrInfo enumInfo, string name, string minVersion, strin
   : EnumAttr<VHLO_Dialect, enumInfo, name, [VHLO_VersionedAttrInterface]> {
   let extraClassDeclaration = [{
     mlir::vhlo::Version getMinVersion() {
-      auto version = mlir::vhlo::Version::fromString("}] #  minVersion # [{");
-      if (failed(version)) llvm::report_fatal_error("invalid version }] # minVersion # [{ in }] # name # [{");
-      return *version;
+      return mlir::vhlo::Version(}] # !subst(".", ", ", minVersion) # [{);
     }
     mlir::vhlo::Version getMaxVersion() {
-      if (!strcmp("}] # maxVersion # [{", "current")) return Version::getCurrentVersion();
-      auto version = mlir::vhlo::Version::fromString("}] #  maxVersion # [{");
-      if (failed(version)) llvm::report_fatal_error("invalid version }] # maxVersion # [{ in }] # name # [{");
-      return *version;
+      }] # !if(
+        !eq(maxVersion, "current"),
+        [{ return mlir::vhlo::Version::getCurrentVersion(); }],
+        [{ return mlir::vhlo::Version("}] # !subst(".", ", ", maxVersion) # [{"); }]
+      ) # [{
     }
   }];
 }

--- a/stablehlo/dialect/VhloOps.td
+++ b/stablehlo/dialect/VhloOps.td
@@ -40,15 +40,14 @@ class VHLO_Op<string mnemonic, string minVersion, string maxVersion, list<Trait>
       [DeclareOpInterfaceMethods<VHLO_VersionedOpInterface>] # traits> {
   let extraClassDefinition = [{
     mlir::vhlo::Version $cppClass::getMinVersion() {
-      auto version = mlir::vhlo::Version::fromString("}] #  minVersion # [{");
-      if (failed(version)) llvm::report_fatal_error("invalid version }] # minVersion # [{ in }] # mnemonic # [{");
-      return *version;
+      return mlir::vhlo::Version(}] # !subst(".", ", ", minVersion) # [{);
     }
     mlir::vhlo::Version $cppClass::getMaxVersion() {
-      if (!strcmp("}] # maxVersion # [{", "current")) return Version::getCurrentVersion();
-      auto version = mlir::vhlo::Version::fromString("}] #  maxVersion # [{");
-      if (failed(version)) llvm::report_fatal_error("invalid version }] # maxVersion # [{ in }] # mnemonic # [{");
-      return *version;
+      }] # !if(
+        !eq(maxVersion, "current"),
+        [{ return mlir::vhlo::Version::getCurrentVersion(); }],
+        [{ return mlir::vhlo::Version("}] # !subst(".", ", ", maxVersion) # [{"); }]
+      ) # [{
     }
   }];
 }

--- a/stablehlo/dialect/VhloTypes.td
+++ b/stablehlo/dialect/VhloTypes.td
@@ -38,15 +38,14 @@ class VHLO_TypeDef<string cppName, string name, string minVersion, string maxVer
   let mnemonic = name;
   let extraClassDeclaration = [{
     mlir::vhlo::Version getMinVersion() {
-      auto version = mlir::vhlo::Version::fromString("}] #  minVersion # [{");
-      if (failed(version)) llvm::report_fatal_error("invalid version }] # minVersion # [{ in }] # name # [{");
-      return *version;
+      return mlir::vhlo::Version(}] # !subst(".", ", ", minVersion) # [{);
     }
     mlir::vhlo::Version getMaxVersion() {
-      if (!strcmp("}] # maxVersion # [{", "current")) return Version::getCurrentVersion();
-      auto version = mlir::vhlo::Version::fromString("}] #  maxVersion # [{");
-      if (failed(version)) llvm::report_fatal_error("invalid version }] # maxVersion # [{ in }] # name # [{");
-      return *version;
+      }] # !if(
+        !eq(maxVersion, "current"),
+        [{ return mlir::vhlo::Version::getCurrentVersion(); }],
+        [{ return mlir::vhlo::Version("}] # !subst(".", ", ", maxVersion) # [{"); }]
+      ) # [{
     }
   }];
 }


### PR DESCRIPTION
`mlir::ConversionTarget::isLegal` call these two functions during StableHLO<->VHLO legalization, causing string version numbers to be repeatedly parsed by `mlir::vhlo::Version::fromString` at runtime. Our performance analysis indicates that such version number parsing can dominate the execution time of legalization pass.

Since version numbers are available to TableGen, this CL uses TableGen functions to parse version numbers at compile time. With this change, `getMinVersion()` and `getMaxVersion()` use `mlir::vhlo::Version(x, y, z)` to avoid string parsing, which greatly improves the performance.

Backport of https://github.com/tensorflow/mlir-hlo/commit/51ce2fa22bc9acff37332ad02ef39412f21ffc98
