### PR TITLE
Add license header to StablehloLspServerMain.cpp

### DIFF
--- a/stablehlo/tools/StablehloLspServerMain.cpp
+++ b/stablehlo/tools/StablehloLspServerMain.cpp
@@ -1,3 +1,18 @@
+/* Copyright 2023 The StableHLO Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "mlir/InitAllDialects.h"
 #include "mlir/InitAllExtensions.h"
 #include "mlir/InitAllPasses.h"


### PR DESCRIPTION
Follows up on #1620 to consistently follow the convention that we're using in the codebase.