### PR TITLE
Disable OOB gather tests

### DIFF
--- a/stablehlo/testdata/gather_from_take_indices_name__5_oob__axis_0_enable_xla_True_mode_fill.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__5_oob__axis_0_enable_xla_True_mode_fill.mlir
@@ -1,4 +1,4 @@
-// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/gather_from_take_indices_name__5_oob__axis_1_enable_xla_True_mode_fill.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__5_oob__axis_1_enable_xla_True_mode_fill.mlir
@@ -1,4 +1,4 @@
-// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/gather_from_take_indices_name__5_oob__axis_2_enable_xla_True_mode_fill.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__5_oob__axis_2_enable_xla_True_mode_fill.mlir
@@ -1,4 +1,4 @@
-// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/gather_from_take_indices_name__6_neg__axis_0_enable_xla_True_mode_clip.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__6_neg__axis_0_enable_xla_True_mode_clip.mlir
@@ -1,4 +1,4 @@
-// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/gather_from_take_indices_name__6_neg__axis_1_enable_xla_True_mode_clip.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__6_neg__axis_1_enable_xla_True_mode_clip.mlir
@@ -1,4 +1,4 @@
-// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/gather_from_take_indices_name__7_neg__axis_0_enable_xla_True_mode_clip.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__7_neg__axis_0_enable_xla_True_mode_clip.mlir
@@ -1,4 +1,4 @@
-// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/gather_from_take_indices_name__7_neg__axis_1_enable_xla_True_mode_clip.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__7_neg__axis_1_enable_xla_True_mode_clip.mlir
@@ -1,4 +1,4 @@
-// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/gather_from_take_indices_name__8_neg_oob__axis_0_enable_xla_True_mode_clip.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__8_neg_oob__axis_0_enable_xla_True_mode_clip.mlir
@@ -1,4 +1,4 @@
-// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/gather_from_take_indices_name__8_neg_oob__axis_0_enable_xla_True_mode_fill.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__8_neg_oob__axis_0_enable_xla_True_mode_fill.mlir
@@ -1,4 +1,4 @@
-// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/gather_from_take_indices_name__8_neg_oob__axis_1_enable_xla_True_mode_clip.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__8_neg_oob__axis_1_enable_xla_True_mode_clip.mlir
@@ -1,4 +1,4 @@
-// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/gather_from_take_indices_name__8_neg_oob__axis_1_enable_xla_True_mode_fill.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__8_neg_oob__axis_1_enable_xla_True_mode_fill.mlir
@@ -1,4 +1,4 @@
-// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/gather_from_take_indices_name__8_neg_oob__axis_2_enable_xla_True_mode_fill.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__8_neg_oob__axis_2_enable_xla_True_mode_fill.mlir
@@ -1,4 +1,4 @@
-// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {


### PR DESCRIPTION
This PR disables `gather` related tests enabled by a script prematurely as part of #1597 (these were conditionally passing at the time of merge). They would be reenabled by #1541 which correctly passes these tests.