### PR TITLE
Add interpreter for OptimizationBarrierOp

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3561,6 +3561,8 @@ an identity, i.e. `result = operand`.
 // %result1: 1.0
 ```
 
+&nbsp;[More Examples](../stablehlo/tests/interpret_optimization_barrier.mlir)
+
 ### or
 
 #### Semantics

--- a/docs/status.md
+++ b/docs/status.md
@@ -108,7 +108,7 @@ one of the following tracking labels.
 | multiply                 | yes           | yes          | yes            | yes             | yes         |
 | negate                   | yes           | yes          | yes            | yes             | yes         |
 | not                      | yes           | yes          | yes            | yes             | yes         |
-| optimization_barrier     | yes           | yes          | yes            | yes             | no          |
+| optimization_barrier     | yes           | yes          | yes            | yes             | yes         |
 | or                       | yes           | yes          | yes            | yes             | yes         |
 | outfeed                  | yes           | yes          | yes            | no              | no          |
 | pad                      | yes           | yes          | yes            | yes             | yes         |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2950,7 +2950,7 @@ def StableHLO_TorchIndexSelectOp : StableHLO_Op<"torch_index_select", [Pure]> {
 
 def StableHLO_OptimizationBarrierOp : StableHLO_Op<"optimization_barrier",
       [Pure, HLO_PairwiseSameOperandAndResultType,
-      DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
+      DeclareOpInterfaceMethods<InferTypeOpInterface> /*optimization_barrier_c1*/]> {
   let summary = "OptimizationBarrier operation";
   let description = [{
     Ensures that the operations that produce the `operand` are executed before any
@@ -2958,7 +2958,7 @@ def StableHLO_OptimizationBarrierOp : StableHLO_Op<"optimization_barrier",
     from moving operations across the barrier. Other than that, the operation is
     an identity, i.e. `result` = `operand`.
 
-    See
+    See:
     https://github.com/openxla/stablehlo/blob/main/docs/spec.md#optimization_barrier
 
     Example:

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2442,6 +2442,7 @@ LogicalResult inferMapOp(
 LogicalResult inferOptimizationBarrierOp(
     std::optional<Location> location, ValueRange operand,
     SmallVectorImpl<Type>& inferredReturnTypes) {
+  // optimization_barrier_c1
   for (auto inputArgType : operand.getTypes())
     inferredReturnTypes.emplace_back(inputArgType);
   return success();

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -378,6 +378,11 @@ SmallVector<InterpreterValue> eval(
       auto operand = scope.findTensor(notOp.getOperand());
       auto result = evalNotOp(operand, notOp.getType());
       scope.add(op.getResult(0), result);
+    } else if (auto optimizationBarrierOp =
+                   dyn_cast<OptimizationBarrierOp>(op)) {
+      auto operand = scope.find(optimizationBarrierOp.getOperand());
+      auto results = evalOptimizationBarrierOp(operand);
+      scope.add(op.getResults(), results);
     } else if (auto orOp = dyn_cast<OrOp>(op)) {
       auto lhs = scope.findTensor(orOp.getLhs());
       auto rhs = scope.findTensor(orOp.getRhs());
@@ -1093,6 +1098,11 @@ Tensor evalNotOp(const Tensor &operand, ShapedType resultType) {
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, ~operand.get(*it));
   return result;
+}
+
+SmallVector<InterpreterValue> evalOptimizationBarrierOp(
+    ArrayRef<InterpreterValue> operand) {
+  return SmallVector<InterpreterValue>(operand);
 }
 
 Tensor evalOrOp(const Tensor &lhs, const Tensor &rhs, ShapedType resultType) {

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -92,6 +92,8 @@ Tensor evalMultiplyOp(const Tensor &lhs, const Tensor &rhs,
                       ShapedType resultType);
 Tensor evalNegOp(const Tensor &operand, ShapedType resultType);
 Tensor evalNotOp(const Tensor &operand, ShapedType resultType);
+SmallVector<InterpreterValue> evalOptimizationBarrierOp(
+    ArrayRef<InterpreterValue> operand);
 Tensor evalOrOp(const Tensor &lhs, const Tensor &rhs, ShapedType resultType);
 Tensor evalPadOp(const Tensor &operand, const Tensor &paddingValue,
                  const Sizes &edgePaddingLow, const Sizes &interiorPadding,

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -496,6 +496,20 @@ func.func @sort(%input0: tensor<16x16xf32>, %input1: tensor<16x16xi32>) -> tenso
 
 // -----
 
+// CHECK-LABEL: func @optimization_barrier_c1
+// CHECK-SAME: (%[[ARG0:.*]]: tensor<f32>,
+// CHECK-SAME: %[[ARG1:.*]]: tensor<f32>)
+func.func @optimization_barrier_c1(%arg0: tensor<f32>, %arg1: tensor<f32>) -> (tensor<index>, tensor<index>) {
+  // CHECK: %[[RESULT:.*]]:2 = stablehlo.optimization_barrier %[[ARG0]], %[[ARG1]] : tensor<f32>, tensor<f32>
+  // CHECK: %[[INFER:.*]]:2 = "hlo_test_infer.get_return_types"(%[[RESULT]]#0, %[[RESULT]]#1) : (tensor<f32>, tensor<f32>) -> (tensor<index>, tensor<index>)
+  // CHECK: return %[[INFER]]#0, %[[INFER]]#1 : tensor<index>, tensor<index>
+  %0:2 = "stablehlo.optimization_barrier"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> (tensor<f32>, tensor<f32>)
+  %1:2 = "hlo_test_infer.get_return_types"(%0#0, %0#1) : (tensor<f32>, tensor<f32>) -> (tensor<index>, tensor<index>)
+  func.return %1#0, %1#1 : tensor<index>, tensor<index>
+}
+
+// -----
+
 // CHECK-LABEL: func @outfeed
 func.func @outfeed(%arg0: tensor<3x3x3xi32>, %arg1: !stablehlo.token) -> !stablehlo.token {
   %0 = "stablehlo.outfeed"(%arg0, %arg1) {

--- a/stablehlo/tests/interpret_optimization_barrier.mlir
+++ b/stablehlo/tests/interpret_optimization_barrier.mlir
@@ -1,0 +1,10 @@
+// RUN: stablehlo-translate --interpret -split-input-file %s
+
+func.func @optimization_barrier_op_test() {
+  %operand0 = stablehlo.constant dense<0.0> : tensor<f32>
+  %operand1 = stablehlo.constant dense<1.0> : tensor<f32>
+  %result0, %result1 = stablehlo.optimization_barrier %operand0, %operand1 : tensor<f32>, tensor<f32>
+  check.expect_almost_eq_const %result0, dense<0.0> : tensor<f32>
+  check.expect_almost_eq_const %result1, dense<1.0> : tensor<f32>
+  func.return
+}

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -1797,6 +1797,14 @@ func.func @map_unranked(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) -> tensor<*x
 
 // -----
 
+// CHECK-LABEL: func @optimization_barrier
+func.func @optimization_barrier(%arg0: tensor<f32>, %arg1: tensor<f32>) -> (tensor<f32>, tensor<f32>) {
+  %0, %1 = "stablehlo.optimization_barrier"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> (tensor<f32>, tensor<f32>)
+  func.return %0, %1 : tensor<f32>, tensor<f32>
+}
+
+// -----
+
 // CHECK-LABEL: func @outfeed
 func.func @outfeed(%arg0: tensor<3x3x3xi32>, %arg1: !stablehlo.token) -> !stablehlo.token {
   %0 = "stablehlo.outfeed"(%arg0, %arg1) {


### PR DESCRIPTION
There are no constraints for this op, so no additional tests were added besides renaming/moving tests.

closes #1129 