### PR TITLE
Fix a constraint in `bitcast_convert` op

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1310,11 +1310,11 @@ implementation-defined as well.
   * If `num_bits(E') < num_bits(E)`:
     * `rank(result) = R + 1`.
     * `dim(result, i) = dim(operand, i)` for all `0 <= i < R`.
-    * `dim(result, R) = num_bits(E) / num_bits(E')`.
+    * `dim(result, R) * num_bits(E') = num_bits(E)`.
   * If `num_bits(E') > num_bits(E)`:
     * `rank(result) = R - 1`.
     * `dim(result, i) = dim(operand, i)` for all `0 <= i < R`.
-    * `dim(operand, R - 1) = num_bits(E') / num_bits(E)`.
+    * `dim(operand, R - 1) * num_bits(E) = num_bits(E')`.
 * (C2) If `is_complex(operand) or is_complex(result)`, then
   `is_complex(operand) and is_complex(result)`.
 


### PR DESCRIPTION
As recommended in https://github.com/openxla/stablehlo/pull/1566/files/13a2c8b6e518d611fb7bd0747096392478291eef#r1237644676, the constraint in `bitcast_convert` is revised to make sure that the `num_bits(E) % num_bits(E') == 0` when `num_bits(E') < num_bits(E)` and `num_bits(E') % num_bits(E) == 0` when  `num_bits(E) < num_bits(E')`. 

Note that this does not need a change in existing verification and testing as the the verifier for `bitcast_convert` is doing the exact [check](https://github.com/openxla/stablehlo/blob/d8f0c12e2a7541cfe6ba3a04c8a2fb350bdab43d/stablehlo/dialect/TypeInference.cpp#L3174) as proposed in the PR.