### PR TITLE
Sharpen wording in compatibility.md

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -10,12 +10,8 @@ that StableHLO provides, based on the process established in
 The current version of StableHLO can be found in
 [Version.h](https://github.com/openxla/stablehlo/blob/main/stablehlo/dialect/Version.h#:~:text=getCurrentVersion).
 
-In the 0.x.x series, StableHLO is providing limited compatibility guarantees
-as described in the Guarantees section. In H2 2023, we are planning to release
-StableHLO 1.0.0, which will provide full compatibility guarantees - see the
-[Future work](#future-work) section for more details.
-
-The minor version is bumped every time changes to the StableHLO opset or
+In the 0.x.x series, the minor version is bumped every time changes to
+the StableHLO opset or
 [the StableHLO serialization format](bytecode.md) are made, and the patch
 version is bumped every time we integrate StableHLO downstream, i.e. into the
 openxla/xla repository.


### PR DESCRIPTION
This follows up on #1606, further removing the traces of the compatibility policy that got updated in a recent compatibility RFC.