### PR TITLE
Specification of quantized ops from `Control-flow`, `Distribution`, `Extensibility`, and `Miscellaneous` categories. 

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3126,11 +3126,9 @@ separate outputs to improve clarity
 Fills an `output` tensor with values in increasing order starting from zero
 along the `iota_dimension` dimension. More formally,
 
-* For non-quantized case: `output[result_index] = constant(
-        result_index[iota_dimension], element_type(output))`.
-* For quantized case: `output[result_index] = constant(
-        quantize(result_index[iota_dimension], element_type(output)),
-        element_type(output))`.
+`output[result_index] = constant(is_quantized(output) ?
+quantize(result_index[iota_dimension], element_type(output)) :
+result_index[iota_dimension], element_type(output))`.
 
 #### Inputs
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -517,7 +517,7 @@ have the following constraints:
 * (C2) `is_wellformed(imaginary_part, complex_element_type(complex_type))`.
 
 ```ebnf
-TensorConstant ::= TensorLiteral ':' TensorType
+TensorConstant ::= TensorLiteral ':' ( TensorType | QuantizedTensorType )
 TensorLiteral  ::= 'dense' '<' (DenseLiteral | ElementLiteral) '>'
 DenseLiteral   ::= DenseDimension | DenseElements
 DenseDimension ::= '[' [DenseLiteral {',' DenseLiteral}] ']'
@@ -533,8 +533,10 @@ represents a tensor value with the following mapping from indices to elements:
 implementation-defined. Tensor constants have the following constraints:
 
 * (C1) `has_syntax(tensor_literal, element_type(tensor_type))`, where:
-  * `has_syntax(element_literal: Syntax, element_type: Type) =
-    is_wellformed(element_literal, type)`.
+  * `has_syntax(element_literal: Syntax, tensor_element_type: Type) =
+    is_wellformed(element_literal, tensor_element_type)`.
+  * `has_syntax(element_literal: Syntax, quantized_tensor_element_type: Type) =
+    is_wellformed(element_literal, storage_type(quantized_tensor_element_type))`.
   * `has_syntax(tensor_literal: List, element_type: Type) =
     has_syntax(tensor_literal..., element_type)`.
 * (C2) `has_shape(tensor_literal, shape(tensor_type))`, where:
@@ -1875,7 +1877,8 @@ Produces an `output` tensor from a constant `value`.
 
 #### Constraints
 
-* (C1) `type(value) = type(output)`.
+* (C1) `type(value) = is_quantized(output) ? storage_type(output) :
+       type(output)`.
 
 #### Examples
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4437,29 +4437,25 @@ In conversations with many stakeholders, this op has come up as effectively
 deprecated, so in the future we are planning to explore removing it
 ([#597](https://github.com/openxla/stablehlo/issues/597)).
 
-For quantized types, performs
-`quantize(rng(dequantize(a), dequantize(b), shape, rng_distribution), type(result))`.
-
 #### Inputs
 
-| Label | Name               | Type                                                                                            | Constraints |
-|-------|--------------------|-------------------------------------------------------------------------------------------------|-------------|
-| (I1)  | `a`                | 0-dimensional tensor of integer, boolean, or floating-point type or per-tensor quantized tensor | (C1), (C2)  |
-| (I2)  | `b`                | 0-dimensional tensor of integer, boolean, or floating-point type or per-tensor quantized tensor | (C1), (C2)  |
-| (I3)  | `shape`            | 1-dimensional tensor constant of type `si64`                                                    | (C3)        |
-| (I4)  | `rng_distribution` | enum of `UNIFORM` and `NORMAL`                                                                  | (C2)        |
+| Label | Name               | Type                                                             | Constraints |
+|-------|--------------------|------------------------------------------------------------------|-------------|
+| (I1)  | `a`                | 0-dimensional tensor of integer, boolean, or floating-point type | (C1), (C2)  |
+| (I2)  | `b`                | 0-dimensional tensor of integer, boolean, or floating-point type | (C1), (C2)  |
+| (I3)  | `shape`            | 1-dimensional tensor constant of type `si64`                     | (C3)        |
+| (I4)  | `rng_distribution` | enum of `UNIFORM` and `NORMAL`                                   | (C2)        |
 
 #### Outputs
 
-| Name     | Type                                                                              | Constraints |
-|----------|-----------------------------------------------------------------------------------|-------------|
-| `result` | tensor of integer, boolean, or floating-point type or per-tensor quantized tensor | (C1-C3)     |
+| Name     | Type                                               | Constraints |
+|----------|----------------------------------------------------|-------------|
+| `result` | tensor of integer, boolean, or floating-point type | (C1-C3)     |
 
 #### Constraints
 
-* (C1) `baseline_element_type(a) = baseline_element_type(b) =
-       baseline_element_type(result)`.
-* (C2) If `rng_distribution = NORMAL`, then `is_float(a)` or `is_quantized(a)`.
+* (C1) `element_type(a) = element_type(b) = element_type(result)`.
+* (C2) If `rng_distribution = NORMAL`, then `is_float(a)`.
 * (C3) `shape(result) = shape`.
 
 #### Examples

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2712,8 +2712,11 @@ for `fft_type = RFFT`. For example, for `L = 3`:
 * `result2[i0, ..., :, iR-1] = ifft(result1[i0, ..., :, iR-1])`.
 * `result[i0, ..., :] = irfft(result2[i0, ..., :])`.
 
-For quantized types, performs
-`quantize(fft(dequantize(operand), fft_type, fft_length), type(result))`.
+For quantized types, performs:
+
+* `fft(dequantize(operand), fft_type, fft_length)` if `fft_type = RFFT`.
+* `quantize(fft((operand, fft_type, fft_length), type(result)))` if `fft_type
+   = IRFFT`.
 
 #### Inputs
 
@@ -2725,9 +2728,9 @@ For quantized types, performs
 
 #### Outputs
 
-| Name     | Type                                     | Constraints      |
-|----------|------------------------------------------|------------------|
-| `result` | tensor of floating-point or complex type | (C2), (C4), (C5) |
+| Name     | Type                                                                    | Constraints      |
+|----------|-------------------------------------------------------------------------|------------------|
+| `result` | tensor of floating-point or complex type or per-tensor quantized tensor | (C2), (C4), (C5) |
 
 #### Constraints
 
@@ -2737,12 +2740,12 @@ For quantized types, performs
     have the same complex type.
   * If `fft_type = IFFT`, `element_type(operand)` and `element_type(result)`
     have the same complex type.
-  * If `fft_type = RFFT`, `element_type(operand)` is a floating-point type or
-    `is_quantized(operand)` and `element_type(result)` is a complex type of the
-    same floating-point semantics.
-  * If `fft_type = IRFFT`, `element_type(operand)` is a complex type and
-    `element_type(result)` is a floating-point type of the same floating-point
-    semantics.
+  * If `fft_type = RFFT`, (`is_float(operand)` or `is_quantized(operand)`) and
+    `is_complex(result)` such that `complex_element_type(element_type(result))
+    = is_quantized(operand) ? expressed_type(operand) : element_type(operand)`.
+  * If `fft_type = IRFFT`, `is_complex(operand)`and (`is_float(result)` or
+    `is_quantized(result)`) such that `complex_element_type(element_type(operand))
+    = is_quantized(result) ? expressed_type(result) : element_type(result)`.
 * (C3) `1 <= size(fft_length) <= 3`.
 * (C4) If among `operand` and `result`, there is a tensor `real` of a
 floating-point type, then `shape(real)[-size(fft_length):] = fft_length`.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1177,7 +1177,7 @@ feature_index), operand, scale, offset, mean, variance, type(result))`.
 * (C1) `0 <= feature_index < rank(operand)`.
 * (C2) `baseline_element_type(operand) = baseline_element_type(scale) =
        baseline_element_type(offset) = baseline_element_type(mean) =
-       baseline_element_type(variance) = baseline_type(result)`.
+       baseline_element_type(variance) = baseline_element_type(result)`.
 * (C3) `size(scale) = dim(operand, feature_index)`.
 * (C4) `size(offset) = dim(operand, feature_index)`.
 * (C5) `size(mean) = dim(operand, feature_index)`.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -698,7 +698,7 @@ Afterwards, within each `process_group`:
 
 | Label | Name                    | Type                                         | Constraints |
 |-------|-------------------------|----------------------------------------------|-------------|
-| (I1)  | `operand`               | tensor                                       | (C1), (C6)  |
+| (I1)  | `operand`               | tensor or per-tensor quantized tensor        | (C1), (C6)  |
 | (I2)  | `all_gather_dim`        | constant of type `si64`                      | (C1), (C6)  |
 | (I3)  | `replica_groups`        | 2-dimensional tensor constant of type `si64` | (C2-C4)     |
 | (I4)  | `channel_id`            | constant of type `si64`                      | (C5)        |
@@ -706,9 +706,9 @@ Afterwards, within each `process_group`:
 
 #### Outputs
 
-| Name     | Type   | Constraints |
-|----------|--------|-------------|
-| `result` | tensor | (C6)        |
+| Name     | Type                                  | Constraints |
+|----------|---------------------------------------|-------------|
+| `result` | tensor or per-tensor quantized tensor | (C6)        |
 
 #### Constraints
 
@@ -849,7 +849,7 @@ Afterwards, within each `process_group`:
 
 | Label | Name               | Type                                         | Constraints      |
 |-------|--------------------|----------------------------------------------|------------------|
-| (I1)  | `operand`          | tensor                                       | (C1)             |
+| (I1)  | `operand`          | tensor or per-tensor quantized tensor        | (C1)             |
 | (I2)  | `split_dimension`  | constant of type `si64`                      | (C1), (C2), (C8) |
 | (I3)  | `concat_dimension` | constant of type `si64`                      | (C3), (C8)       |
 | (I4)  | `split_count`      | constant of type `si64`                      | (C2), (C4), (C8) |
@@ -858,9 +858,9 @@ Afterwards, within each `process_group`:
 
 #### Outputs
 
-| Name     | Type   | Constraints |
-|----------|--------|-------------|
-| `result` | tensor | (C8)        |
+| Name     | Type                                  | Constraints |
+|----------|---------------------------------------|-------------|
+| `result` | tensor or per-tensor quantized tensor | (C8)        |
 
 #### Constraints
 
@@ -1640,15 +1640,15 @@ Afterwards, `result@process` is given by:
 
 | Label | Name                  | Type                                         | Constraints |
 |-------|-----------------------|----------------------------------------------|-------------|
-| (I1)  | `operand`             | tensor                                       | (C5)        |
+| (I1)  | `operand`             | tensor or per-tensor quantized tensor        | (C5)        |
 | (I2)  | `source_target_pairs` | 2-dimensional tensor constant of type `si64` | (C1-C4)     |
 | (I3)  | `channel_id`          | constant of type `si64`                      |             |
 
 #### Outputs
 
-| Name     | Type   | Constraints |
-|----------|--------|-------------|
-| `result` | tensor | (C1)        |
+| Name     | Type                                  | Constraints |
+|----------|---------------------------------------|-------------|
+| `result` | tensor or per-tensor quantized tensor | (C1)        |
 
 #### Constraints
 
@@ -3079,9 +3079,9 @@ separate outputs to improve clarity
 
 #### Outputs
 
-| Name      | Type                                 | Constraints |
-|-----------|--------------------------------------|-------------|
-| `results` | variadic number of tensors or tokens | (C1), (C2)  |
+| Name      | Type                                                               | Constraints |
+|-----------|--------------------------------------------------------------------|-------------|
+| `results` | variadic number of tensors, per-tensor quantized tensors or tokens | (C1), (C2)  |
 
 #### Constraints
 
@@ -3656,7 +3656,8 @@ Semantics of `outfeed_config` is implementation-defined.
 
 | Label | Name             | Type                       |
 |-------|------------------|----------------------------|
-| (I1)  | `inputs`         | variadic number of tensors |
+| (I1)  | `inputs`         | variadic number of tensors or per-tensor quantized
+tensors|
 | (I2)  | `token`          | `token`                    |
 | (I3)  | `outfeed_config` | constant of type `string`  |
 
@@ -3904,9 +3905,9 @@ separate outputs to improve clarity
 
 #### Outputs
 
-| Name      | Type                                 | Constraints |
-|-----------|--------------------------------------|-------------|
-| `results` | variadic number of tensors or tokens | (C2), (C3)  |
+| Name      | Type                                                               | Constraints |
+|-----------|--------------------------------------------------------------------|-------------|
+| `results` | variadic number of tensors, per-tensor quantized tensors or tokens | (C2), (C3)  |
 
 #### Constraints
 
@@ -4937,13 +4938,13 @@ implementation-defined. This flag duplicates the information provided in
 
 #### Inputs
 
-| Label | Name               | Type                                            | Constraints |
-|-------|--------------------|-------------------------------------------------|-------------|
-| (I1)  | `inputs`           | variadic number of tensors                      |             |
-| (I2)  | `token`            | `token`                                         |             |
-| (I3)  | `channel_id`       | constant of type `si64`                         |             |
-| (I4)  | `channel_type`     | enum of `DEVICE_TO_DEVICE` and `DEVICE_TO_HOST` | (C1)        |
-| (I5)  | `is_host_transfer` | constant of type `i1`                           | (C1)        |
+| Label | Name               | Type                                                       | Constraints |
+|-------|--------------------|------------------------------------------------------------|-------------|
+| (I1)  | `inputs`           | variadic number of tensors or per-tensor quantized tensors |             |
+| (I2)  | `token`            | `token`                                                    |             |
+| (I3)  | `channel_id`       | constant of type `si64`                                    |             |
+| (I4)  | `channel_type`     | enum of `DEVICE_TO_DEVICE` and `DEVICE_TO_HOST`            | (C1)        |
+| (I5)  | `is_host_transfer` | constant of type `i1`                                      | (C1)        |
 
 #### Outputs
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1136,23 +1136,27 @@ def batch_norm_inference(operand, scale, offset, mean, variance, epsilon, featur
   return add(multiply(scale_bcast, normalized_operand), offset_bcast)
 ```
 
+For quantized types, performs
+`quantize(batch_norm_inference(dequantize(operand), scale, offset, mean,
+            variance, epsilon, feature_index), type(result))`.
+
 #### Inputs
 
-| Label | Name            | Type                                        | Constraints   |
-|-------|-----------------|---------------------------------------------|---------------|
-| (I1)  | `operand`       | tensor of floating-point type               | (C1-C7)       |
-| (I2)  | `scale`         | 1-dimensional tensor of floating-point type | (C2), (C3)    |
-| (I3)  | `offset`        | 1-dimensional tensor of floating-point type | (C2), (C4)    |
-| (I4)  | `mean`          | 1-dimensional tensor of floating-point type | (C5)          |
-| (I5)  | `variance`      | 1-dimensional tensor of floating-point type | (C2), (C6)    |
-| (I6)  | `epsilon`       | constant of type `f32`                      |               |
-| (I7)  | `feature_index` | constant of type `si64`                     | (C1), (C3-C6) |
+| Label | Name            | Type                                                         | Constraints   |
+|-------|-----------------|--------------------------------------------------------------|---------------|
+| (I1)  | `operand`       | tensor of floating-point type or per-tensor quantized tensor | (C1-C7)       |
+| (I2)  | `scale`         | 1-dimensional tensor of floating-point type                  | (C2), (C3)    |
+| (I3)  | `offset`        | 1-dimensional tensor of floating-point type                  | (C2), (C4)    |
+| (I4)  | `mean`          | 1-dimensional tensor of floating-point type                  | (C5)          |
+| (I5)  | `variance`      | 1-dimensional tensor of floating-point type                  | (C2), (C6)    |
+| (I6)  | `epsilon`       | constant of type `f32`                                       |               |
+| (I7)  | `feature_index` | constant of type `si64`                                      | (C1), (C3-C6) |
 
 #### Outputs
 
-| Name     | Type                          | Constraints |
-|----------|-------------------------------|-------------|
-| `result` | tensor of floating-point type | (C2), (C7)  |
+| Name     | Type                                                         | Constraints |
+|----------|--------------------------------------------------------------|-------------|
+| `result` | tensor of floating-point type or per-tensor quantized tensor | (C2), (C7)  |
 
 #### Constraints
 
@@ -1530,18 +1534,22 @@ strict lower triangle correspondingly, are implementation-defined.
 If there exists `i` where the input matrix is not an Hermitian positive-definite
 matrix, then the behavior is undefined.
 
+For quantized types, performs
+`quantize(cholesky(dequantize(a), lower), type(result))`.
+
 #### Inputs
 
 | Label | Name    | Type                                       | Constraints |
 |-------|---------|--------------------------------------------|-------------|
-| (I1)  | `a`     | tensor of floating-point or complex type   | (C1-C3)     |
+| (I1)  | `a`     | tensor of floating-point or complex type or per-tensor
+quantized tensor   | (C1-C3)     |
 | (I2)  | `lower` | 0-dimensional tensor constant of type `i1` |             |
 
 #### Outputs
 
-| Name     | Type                                     | Constraints |
-|----------|------------------------------------------|-------------|
-| `result` | tensor of floating-point or complex type | (C1)        |
+| Name     | Type                                                                    | Constraints |
+|----------|-------------------------------------------------------------------------|-------------|
+| `result` | tensor of floating-point or complex type or per-tensor quantized tensor | (C1)        |
 
 #### Constraints
 
@@ -1861,9 +1869,9 @@ Produces an `output` tensor from a constant `value`.
 
 #### Outputs
 
-| Name     | Type   | Constraints |
-|----------|--------|-------------|
-| `output` | tensor | (C1)        |
+| Name     | Type                                  | Constraints |
+|----------|---------------------------------------|-------------|
+| `output` | tensor or per-tensor quantized tensor | (C1)        |
 
 #### Constraints
 
@@ -2701,13 +2709,16 @@ for `fft_type = RFFT`. For example, for `L = 3`:
 * `result2[i0, ..., :, iR-1] = ifft(result1[i0, ..., :, iR-1])`.
 * `result[i0, ..., :] = irfft(result2[i0, ..., :])`.
 
+For quantized types, performs
+`quantize(fft(dequantize(operand), fft_type, fft_length), type(result))`.
+
 #### Inputs
 
-| Label | Name         | Type                                         | Constraints            |
-|-------|--------------|----------------------------------------------|------------------------|
-| (I1)  | `operand`    | tensor of floating-point or complex type     | (C1), (C2), (C4), (C5) |
-| (I2)  | `fft_type`   | enum of `FFT`, `IFFT`, `RFFT`, and `IRFFT`   | (C2), (C5)             |
-| (I3)  | `fft_length` | 1-dimensional tensor constant of type `si64` | (C1), (C3), (C4)       |
+| Label | Name         | Type                                                                    | Constraints            |
+|-------|--------------|-------------------------------------------------------------------------|------------------------|
+| (I1)  | `operand`    | tensor of floating-point or complex type or per-tensor quantized tensor | (C1), (C2), (C4), (C5) |
+| (I2)  | `fft_type`   | enum of `FFT`, `IFFT`, `RFFT`, and `IRFFT`                              | (C2), (C5)             |
+| (I3)  | `fft_length` | 1-dimensional tensor constant of type `si64`                            | (C1), (C3), (C4)       |
 
 #### Outputs
 
@@ -2723,9 +2734,9 @@ for `fft_type = RFFT`. For example, for `L = 3`:
     have the same complex type.
   * If `fft_type = IFFT`, `element_type(operand)` and `element_type(result)`
     have the same complex type.
-  * If `fft_type = RFFT`, `element_type(operand)` is a floating-point type and
-    `element_type(result)` is a complex type of the same floating-point
-    semantics.
+  * If `fft_type = RFFT`, `element_type(operand)` is a floating-point type or
+    `is_quantized(operand)` and `element_type(result)` is a complex type of the
+    same floating-point semantics.
   * If `fft_type = IRFFT`, `element_type(operand)` is a complex type and
     `element_type(result)` is a floating-point type of the same floating-point
     semantics.
@@ -3112,9 +3123,9 @@ constant(result_index[iota_dimension], element_type(output))`.
 
 #### Outputs
 
-| Name     | Type                                              | Constraints |
-|----------|---------------------------------------------------|-------------|
-| `output` | tensor of integer, floating-point or complex type | (C1)        |
+| Name     | Type                                                                             | Constraints |
+|----------|----------------------------------------------------------------------------------|-------------|
+| `output` | tensor of integer, floating-point or complex type or per-tensor quantized tensor | (C1)        |
 
 #### Constraints
 
@@ -3654,12 +3665,11 @@ Semantics of `outfeed_config` is implementation-defined.
 
 #### Inputs
 
-| Label | Name             | Type                       |
-|-------|------------------|----------------------------|
-| (I1)  | `inputs`         | variadic number of tensors or per-tensor quantized
-tensors|
-| (I2)  | `token`          | `token`                    |
-| (I3)  | `outfeed_config` | constant of type `string`  |
+| Label | Name             | Type                                                       |
+|-------|------------------|------------------------------------------------------------|
+| (I1)  | `inputs`         | variadic number of tensors or per-tensor quantized tensors |
+| (I2)  | `token`          | `token`                                                    |
+| (I3)  | `outfeed_config` | constant of type `string`                                  |
 
 #### Outputs
 
@@ -4424,25 +4434,29 @@ In conversations with many stakeholders, this op has come up as effectively
 deprecated, so in the future we are planning to explore removing it
 ([#597](https://github.com/openxla/stablehlo/issues/597)).
 
+For quantized types, performs
+`quantize(rng(dequantize(a), dequantize(b), shape, rng_distribution), type(result))`.
+
 #### Inputs
 
-| Label | Name               | Type                                                             | Constraints |
-|-------|--------------------|------------------------------------------------------------------|-------------|
-| (I1)  | `a`                | 0-dimensional tensor of integer, boolean, or floating-point type | (C1), (C2)  |
-| (I2)  | `b`                | 0-dimensional tensor of integer, boolean, or floating-point type | (C1), (C2)  |
-| (I3)  | `shape`            | 1-dimensional tensor constant of type `si64`                     | (C3)        |
-| (I4)  | `rng_distribution` | enum of `UNIFORM` and `NORMAL`                                   | (C2)        |
+| Label | Name               | Type                                                                                            | Constraints |
+|-------|--------------------|-------------------------------------------------------------------------------------------------|-------------|
+| (I1)  | `a`                | 0-dimensional tensor of integer, boolean, or floating-point type or per-tensor quantized tensor | (C1), (C2)  |
+| (I2)  | `b`                | 0-dimensional tensor of integer, boolean, or floating-point type or per-tensor quantized tensor | (C1), (C2)  |
+| (I3)  | `shape`            | 1-dimensional tensor constant of type `si64`                                                    | (C3)        |
+| (I4)  | `rng_distribution` | enum of `UNIFORM` and `NORMAL`                                                                  | (C2)        |
 
 #### Outputs
 
-| Name     | Type                                               | Constraints |
-|----------|----------------------------------------------------|-------------|
-| `result` | tensor of integer, boolean, or floating-point type | (C1-C3)     |
+| Name     | Type                                                                              | Constraints |
+|----------|-----------------------------------------------------------------------------------|-------------|
+| `result` | tensor of integer, boolean, or floating-point type or per-tensor quantized tensor | (C1-C3)     |
 
 #### Constraints
 
-* (C1) `element_type(a) = element_type(b) = element_type(result)`.
-* (C2) If `rng_distribution = NORMAL`, then `is_float(a)`.
+* (C1) `baseline_element_type(a) = baseline_element_type(b) =
+       baseline_element_type(result)`.
+* (C2) If `rng_distribution = NORMAL`, then `is_float(a)` or `is_quantized(a)`.
 * (C3) `shape(result) = shape`.
 
 #### Examples
@@ -5502,22 +5516,26 @@ the values in the other triangle are implementation-defined.
 If `unit_diagonal` is true, then the implementation can assume that the diagonal
 elements of `a` are equal to 1, otherwise the behavior is undefined.
 
+For quantized types, performs
+`quantize(triangular_solve(dequantize(a), dequantize(b), left_side, lower,
+            unit_diagonal, transpose_a), type(result))`.
+
 #### Inputs
 
-| Label | Name            | Type                                               | Constraints |
-|-------|-----------------|----------------------------------------------------|-------------|
-| (I1)  | `a`             | tensor of floating-point or complex type           | (C1-C3)     |
-| (I2)  | `b`             | tensor of floating-point or complex type           | (C1-C4)     |
-| (I3)  | `left_side`     | constant of type `i1`                              | (C3)        |
-| (I4)  | `lower`         | constant of type `i1`                              |             |
-| (I5)  | `unit_diagonal` | constant of type `i1`                              |             |
-| (I6)  | `transpose_a`   | enum of `NO_TRANSPOSE`, `TRANSPOSE`, and `ADJOINT` |             |
+| Label | Name            | Type                                                                    | Constraints |
+|-------|-----------------|-------------------------------------------------------------------------|-------------|
+| (I1)  | `a`             | tensor of floating-point or complex type or per-tensor quantized tensor | (C1-C3)     |
+| (I2)  | `b`             | tensor of floating-point or complex type or per-tensor quantized tensor | (C1-C4)     |
+| (I3)  | `left_side`     | constant of type `i1`                                                   | (C3)        |
+| (I4)  | `lower`         | constant of type `i1`                                                   |             |
+| (I5)  | `unit_diagonal` | constant of type `i1`                                                   |             |
+| (I6)  | `transpose_a`   | enum of `NO_TRANSPOSE`, `TRANSPOSE`, and `ADJOINT`                      |             |
 
 #### Outputs
 
-| Name     | Type                                     | Constraints |
-|----------|------------------------------------------|-------------|
-| `result` | tensor of floating-point or complex type | (C1)        |
+| Name     | Type                                                                    | Constraints |
+|----------|-------------------------------------------------------------------------|-------------|
+| `result` | tensor of floating-point or complex type or per-tensor quantized tensor | (C1)        |
 
 #### Constraints
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1655,9 +1655,8 @@ Afterwards, `result@process` is given by:
 
 * `operand@process_groups[i, 0]`, if there exists an `i` such that
   `process_groups[i, 1] = process`.
-* `broadcast_in_dim(is_quantized(result) ? constant(zero_point(result),
-  storage_type(result)) : constant(0, element_type(result)), [], type(result))`
-  otherwise.
+* `broadcast_in_dim(constant(0, element_type(result)), [], type(result))`
+   otherwise.
 
 #### Inputs
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1414,9 +1414,9 @@ where:
 
 #### Outputs
 
-| Name      | Type                                 | Constraints |
-|-----------|--------------------------------------|-------------|
-| `results` | variadic number of tensors or tokens | (C4)        |
+| Name      | Type                                                               | Constraints |
+|-----------|--------------------------------------------------------------------|-------------|
+| `results` | variadic number of tensors, per-tensor quantized tensors or tokens | (C4)        |
 
 #### Constraints
 
@@ -2993,9 +2993,9 @@ pred ? true_branch() : false_branch()`.
 
 #### Outputs
 
-| Name      | Type                                 | Constraints |
-|-----------|--------------------------------------|-------------|
-| `results` | variadic number of tensors or tokens | (C3)        |
+| Name      | Type                                                               | Constraints |
+|-----------|--------------------------------------------------------------------|-------------|
+| `results` | variadic number of tensors, per-tensor quantized tensors or tokens | (C3)        |
 
 #### Constraints
 
@@ -3575,15 +3575,15 @@ an identity, i.e. `result = operand`.
 
 #### Arguments
 
-| Name      | Type                                 | Constraints |
-|-----------|--------------------------------------|-------------|
-| `operand` | variadic number of tensors or tokens | (C1)        |
+| Name      | Type                                                               | Constraints |
+|-----------|--------------------------------------------------------------------|-------------|
+| `operand` | variadic number of tensors, per-tensor quantized tensors or tokens | (C1)        |
 
 #### Outputs
 
-| Name     | Type                                 | Constraints |
-|----------|--------------------------------------|-------------|
-| `result` | variadic number of tensors or tokens | (C1)        |
+| Name     | Type                                                               | Constraints |
+|----------|--------------------------------------------------------------------|-------------|
+| `result` | variadic number of tensors, per-tensor quantized tensors or tokens | (C1)        |
 
 #### Constraints
 
@@ -5685,17 +5685,17 @@ The behavior of an infinite loop is TBD
 
 #### Inputs
 
-| Label | Name      | Type                                 | Constraints |
-|-------|-----------|--------------------------------------|-------------|
-| (I1)  | `operand` | variadic number of tensors or tokens | (C1-C3)     |
-| (I2)  | `cond`    | function                             | (C1)        |
-| (I3)  | `body`    | function                             | (C2)        |
+| Label | Name      | Type                                                               | Constraints |
+|-------|-----------|--------------------------------------------------------------------|-------------|
+| (I1)  | `operand` | variadic number of tensors, per-tensor quantized tensors or tokens | (C1-C3)     |
+| (I2)  | `cond`    | function                                                           | (C1)        |
+| (I3)  | `body`    | function                                                           | (C2)        |
 
 #### Outputs
 
-| Name      | Type                                 | Constraints |
-|-----------|--------------------------------------|-------------|
-| `results` | variadic number of tensors or tokens | (C3)        |
+| Name      | Type                                                               | Constraints |
+|-----------|--------------------------------------------------------------------|-------------|
+| `results` | variadic number of tensors, per-tensor quantized tensors or tokens | (C3)        |
 
 #### Constraints
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1655,8 +1655,9 @@ Afterwards, `result@process` is given by:
 
 * `operand@process_groups[i, 0]`, if there exists an `i` such that
   `process_groups[i, 1] = process`.
-* `broadcast_in_dim(constant(0, element_type(result)), [], type(result))`
-   otherwise.
+* `broadcast_in_dim(constant(is_quantized(result) ? quantize(0,
+  element_type(result)) : 0, element_type(result)), [], type(result))`
+  otherwise.
 
 #### Inputs
 
@@ -1998,8 +1999,7 @@ If `feature_group_count = 1` and `batch_group_count = 1`, then for all
 `output_spatial_index` in `index_space(dim(result, output_spatial_dimensions...))`,
 `result[result_shape(:, output_spatial_index, :)] = dot_product` where:
 
-* `padding_value = is_quantized_tensor(lhs) ? constant(zero_point(lhs),
-        storage_type(lhs)) : constant(0, element_type(lhs))`.
+* `padding_value = constant(is_quantized(lhs) ? quantize(0, element_type(lhs)) : 0, element_type(lhs))`.
 * `padded_lhs = pad(lhs, padding_value, lhs_padding[:, 0], lhs_padding[:, 1], lhs_base_dilations - 1)`.
 * `lhs_window_start = lhs_shape(0, output_spatial_index, 0) * lhs_window_strides`.
 * `lhs_window = slice(padded_lhs, lhs_window_start, lhs_window_start + lhs_window_dimensions, lhs_window_dilations)`.
@@ -3124,9 +3124,13 @@ separate outputs to improve clarity
 #### Semantics
 
 Fills an `output` tensor with values in increasing order starting from zero
-along the `iota_dimension` dimension. More formally, `output[result_index] =
-constant(result_index[iota_dimension], is_quantized(output) ?
-        storage_type(output) : element_type(output))`.
+along the `iota_dimension` dimension. More formally,
+
+* For non-quantized case: `output[result_index] = constant(
+        result_index[iota_dimension], element_type(output))`.
+* For quantized case: `output[result_index] = constant(
+        quantize(result_index[iota_dimension], element_type(output)),
+        element_type(output))`.
 
 #### Inputs
 


### PR DESCRIPTION
### Summary 

This PRs provides the specification of the ops from the following categories:

* **Control-flow ops**: `after_all, case, if, optimization_barrier, while`
  - `afer_all`: Not applicable for quantization as the ops deals with setting data-flow ordering using tokens. 
  - `case, if`: These ops  implicitly captures operands from the parent scope. The result of these operations and the corresponding blocks  can be quantized types. 
  - `optimization_barrier`: The `operand` and `result` can both be quantized tensors.
  - `while`: The `operand` and `result` can both be quantized tensors and of same type. Per the semantics of `while` op, the output of the associated block is used for the next iteration with the `operand` used for the very first iteration. With that,  I do not think we can use the `operand` and `result` with different quantization types. 
 
* **Distribution**: `all_gather, all_reduce, all_to_all, collective_permute, infeed, outfeed, partition_id, recv, reduce_scatter, replica_id, send`
All the ops in this category except for the following ones will support quantized types:
  - `all_reduce, reduce_scatter`:  These involve quantization of reduction operation https://github.com/openxla/stablehlo/pull/1538. I would propose to address these two after the quantization of reduction ops are addressed. 
  - `partition_id, replica_id`: Not applicable 

* **Extensibility**: `custom_call, get_tuple_element, tuple`
All the ops in this category supports all the `ValueType`s including `QuantizedTensorType`. No change is needed in the existing spec. 

* **Miscellaneous**: `batch_norm_grad, batch_norm_inference, batch_norm_training, cholesky, constant, fft, iota, rng, rng_bit_generator, triangular_solve`
  - The specification of `batch_norm_inference`, `cholesky`, `triangular_solve` ops follow the same `dequantize-op-quantize` strategy as we followed for the elementwise ops. 
  - `batch_norm_grad, batch_norm_training`:  These involve quantization of reduction operation https://github.com/openxla/stablehlo/pull/1538. I would propose to address these two after the quantization of reduction ops are addressed. 
  - `constant, iota`: The output type of these ops can be a quantized type of user-defined quantization parameters.
  -  `fft`: This op supports `element_type(operand) = element_type(result) = complex type`, when the `fft_type` is `FFT`  or `IFFT`. For `fft_type = RFFT`, the op supports  floating-point `operand` and complex type `result` and for `fft_type = IRFFT`, it supports complex type `operand` and floating-point `result`. IMO, only for `fft_type = RFFT`, the operand can support quantized type and the semantics could be to quantize the operand to floating-point before doing the computation. 
  - `rng`: The `operand` and `result` can be of quantized type only when the `rng_distribution` is `NORMAL` in which case  the semantics follows the `dequantize_op_quantize` strategy. The motivation for this choice comes from the fact the  op supports floating point type only when `rng_distribution` is `NORMAL` and we propose to treat this op, on floating-point tensors, as an op on quantized tensor, along the lines of dequantize -> float computation -> quantize. 
  - `rng_bit_generator`: To be discussed in "open questions" section  below. 

### Open questions
 -  `rng_bit_generator`: This op generates a randomized output tensor based on a `rng_algorithm` algorithm (`DEFAULT`, `THREE_FRY`, and `PHILOX`). It is not clear how there algorithm should handle generating quantized output. My proposal here is to skip quantization of this op unless we have a use case for it. Please let me know your opinion on this. 

Please review and let me know your feedback. 



**update 06/26/2023**
Scoping `rng` out from quantization based on https://github.com/openxla/stablehlo/pull/1647#issuecomment-1607857449

**update 07/13/2023**
Per https://github.com/openxla/stablehlo/pull/1647#discussion_r1251233481, I proposed not to fuse de-quantization of operand and quantization of result for `fft_type = RFFT` and `fft_type = IRFFT` respectively for fft op. With that a user can explicit de-quantize of operand or quantize of result as needed.

In the current proposal, the `batch_norm_inference` op, do not consider the constant operand `epsilon` to be of quantized type. IMO, considering that operand with quantized type unnecessary complicate the expressiveness of the op.  