### PR TITLE
Offer StableHLO portable artifact deserialization as a pass pipeline

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -687,6 +687,7 @@ gentbl_cc_library(
 cc_library(
     name = "stablehlo_passes",
     srcs = [
+        "stablehlo/transforms/PassPipelines.cpp",
         "stablehlo/transforms/StablehloCanonicalizeDynamism.cpp",
         "stablehlo/transforms/StablehloLegalizeToVhlo.cpp",
         "stablehlo/transforms/StablehloRefineShapes.cpp",

--- a/stablehlo/dialect/Serialization.cpp
+++ b/stablehlo/dialect/Serialization.cpp
@@ -76,7 +76,7 @@ OwningOpRef<ModuleOp> deserializePortableArtifact(StringRef sourceStr,
 
   // Convert VHLO --> VHLO(current) --> StableHLO
   PassManager pm(context);
-  createDeserializePortableArtifactPipeline(pm);
+  createStablehloDeserializePipeline(pm);
   if (!succeeded(pm.run(*module))) {
     return nullptr;
   }

--- a/stablehlo/dialect/Serialization.cpp
+++ b/stablehlo/dialect/Serialization.cpp
@@ -76,9 +76,7 @@ OwningOpRef<ModuleOp> deserializePortableArtifact(StringRef sourceStr,
 
   // Convert VHLO --> VHLO(current) --> StableHLO
   PassManager pm(context);
-  pm.addPass(stablehlo::createVhloToVersionPass(
-      {vhlo::Version::getCurrentVersion().toString()}));
-  pm.addPass(stablehlo::createVhloLegalizeToStablehloPass());
+  createDeserializePortableArtifactPipeline(pm);
   if (!succeeded(pm.run(*module))) {
     return nullptr;
   }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.mlir
@@ -1,5 +1,6 @@
 // RUN: stablehlo-opt --stablehlo-legalize-to-vhlo --mlir-print-op-generic --split-input-file %s | FileCheck %s
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-opt --pass-pipeline='builtin.module(stablehlo-deserialize)') <(stablehlo-opt %s)
 // RUN: stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | (! grep 'Not Implemented')
 // RUN: stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | (! grep 'Not Implemented')
 

--- a/stablehlo/tools/StablehloOptMain.cpp
+++ b/stablehlo/tools/StablehloOptMain.cpp
@@ -27,6 +27,7 @@ limitations under the License.
 int main(int argc, char **argv) {
   mlir::registerAllPasses();
   mlir::hlo::registerAllTestPasses();
+  mlir::stablehlo::registerPassPipelines();
   mlir::stablehlo::registerPasses();
   mlir::tosa::registerStablehloLegalizeToTosaPassPass();
   mlir::tosa::registerStablehloPrepareForTosaPassPass();

--- a/stablehlo/transforms/CMakeLists.txt
+++ b/stablehlo/transforms/CMakeLists.txt
@@ -18,6 +18,7 @@ add_public_tablegen_target(PassesIncGen)
 
 add_mlir_dialect_library(StablehloPasses
   PARTIAL_SOURCES_INTENDED
+  PassPipelines.cpp
   StablehloCanonicalizeDynamism.cpp
   StablehloLegalizeToVhlo.cpp
   StablehloRefineShapes.cpp

--- a/stablehlo/transforms/PassPipelines.cpp
+++ b/stablehlo/transforms/PassPipelines.cpp
@@ -19,7 +19,7 @@ limitations under the License.
 namespace mlir {
 namespace stablehlo {
 
-void createDeserializePortableArtifactPipeline(OpPassManager &pm) {
+void createStablehloDeserializePipeline(OpPassManager &pm) {
   // Convert VHLO(version x.y.z) --> VHLO(current).
   pm.addPass(stablehlo::createVhloToVersionPass(
       {vhlo::Version::getCurrentVersion().toString()}));
@@ -31,7 +31,7 @@ void createDeserializePortableArtifactPipeline(OpPassManager &pm) {
 void registerPassPipelines() {
   PassPipelineRegistration<>("stablehlo-deserialize",
                              "Run an example pipeline.",
-                             createDeserializePortableArtifactPipeline);
+                             createStablehloDeserializePipeline);
 }
 
 }  // namespace stablehlo

--- a/stablehlo/transforms/PassPipelines.cpp
+++ b/stablehlo/transforms/PassPipelines.cpp
@@ -1,0 +1,39 @@
+/* Copyright 2022 The StableHLO Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "stablehlo/transforms/Passes.h"
+
+#include "mlir/Pass/PassManager.h"
+#include "stablehlo/dialect/Version.h"
+
+namespace mlir {
+namespace stablehlo {
+
+void createDeserializePortableArtifactPipeline(OpPassManager &pm) {
+  // Convert VHLO(version x.y.z) --> VHLO(current).
+  pm.addPass(stablehlo::createVhloToVersionPass(
+      {vhlo::Version::getCurrentVersion().toString()}));
+
+  // Convert VHLO --> StableHLO. Will not fail within compatibility window.
+  pm.addPass(stablehlo::createVhloLegalizeToStablehloPass());
+}
+
+void registerPassPipelines() {
+  PassPipelineRegistration<>("stablehlo-deserialize",
+                             "Run an example pipeline.",
+                             createDeserializePortableArtifactPipeline);
+}
+
+}  // namespace stablehlo
+}  // namespace mlir

--- a/stablehlo/transforms/PassPipelines.cpp
+++ b/stablehlo/transforms/PassPipelines.cpp
@@ -12,10 +12,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include "stablehlo/transforms/Passes.h"
-
 #include "mlir/Pass/PassManager.h"
 #include "stablehlo/dialect/Version.h"
+#include "stablehlo/transforms/Passes.h"
 
 namespace mlir {
 namespace stablehlo {

--- a/stablehlo/transforms/Passes.h
+++ b/stablehlo/transforms/Passes.h
@@ -50,9 +50,13 @@ void populateVhloToVersionPatterns(RewritePatternSet *patterns,
 
 //// Pass pipelines ////
 
-// StableHLO consumers can add this pipeline to convert portable
-// artifacts to StableHLO programs. This pipeline will silently pass
-// if programs are not portable artifacts.
+// StableHLO consumers can add this pipeline to convert portable artifacts to
+// StableHLO programs. This pipeline will silently pass if programs are not
+// portable artifacts.
+//
+// Uses vhlo-to-version and vhlo-legalize-to-stablehlo passes. Does not require
+// an option to specify VHLO target version since it always converts VHLO to
+// the current version in order to legalize to StableHLO.
 void createStablehloDeserializePipeline(OpPassManager &pm);
 
 // Adds `stablehlo-deserialize` pipeline as a registered pass pipeline

--- a/stablehlo/transforms/Passes.h
+++ b/stablehlo/transforms/Passes.h
@@ -51,9 +51,12 @@ void populateVhloToVersionPatterns(RewritePatternSet *patterns,
 //// Pass pipelines ////
 
 // StableHLO consumers can add this pipeline to convert portable
-// artifacts to StableHLO programs.
+// artifacts to StableHLO programs. This pipeline will silently pass
+// if programs are not portable artifacts.
 void createDeserializePortableArtifactPipeline(OpPassManager &pm);
 
+// Adds `stablehlo-deserialize` pipeline as a registered pass pipeline
+// for opt tools.
 void registerPassPipelines();
 
 }  // namespace stablehlo

--- a/stablehlo/transforms/Passes.h
+++ b/stablehlo/transforms/Passes.h
@@ -47,6 +47,15 @@ void populateVhloToStablehloPatterns(RewritePatternSet *patterns,
 void populateVhloToVersionPatterns(RewritePatternSet *patterns,
                                    TypeConverter *converter,
                                    MLIRContext *contexts);
+
+//// Pass pipelines ////
+
+// StableHLO consumers can add this pipeline to convert portable
+// artifacts to StableHLO programs.
+void createDeserializePortableArtifactPipeline(OpPassManager &pm);
+
+void registerPassPipelines();
+
 }  // namespace stablehlo
 }  // namespace mlir
 

--- a/stablehlo/transforms/Passes.h
+++ b/stablehlo/transforms/Passes.h
@@ -53,7 +53,7 @@ void populateVhloToVersionPatterns(RewritePatternSet *patterns,
 // StableHLO consumers can add this pipeline to convert portable
 // artifacts to StableHLO programs. This pipeline will silently pass
 // if programs are not portable artifacts.
-void createDeserializePortableArtifactPipeline(OpPassManager &pm);
+void createStablehloDeserializePipeline(OpPassManager &pm);
 
 // Adds `stablehlo-deserialize` pipeline as a registered pass pipeline
 // for opt tools.

--- a/stablehlo/transforms/VhloToVersion.cpp
+++ b/stablehlo/transforms/VhloToVersion.cpp
@@ -237,7 +237,6 @@ struct VhloToVersionPass : public VhloToVersionPassBase<VhloToVersionPass> {
         [&targetVersion](Operation* op) {
           return isLegalOperation(op, targetVersion);
         });
-    target.addIllegalDialect<stablehlo::StablehloDialect, func::FuncDialect>();
 
     vhlo::VhloToVersionConverter converter;
     RewritePatternSet patterns(&getContext());


### PR DESCRIPTION
Some users want to write APIs that accept portable artifacts _and_ other programs. Currently adding support for portable artifacts requires additional logic to test if input is a portable artifact, then deserialize it before running any other passes. This is not ergonomic, as the more MLIR way of doing this is to offer a pass that will deserialize _if_ the input is a portable artifact - for example, support for StableHLO was added to some TF APIs using a `createHloLegalizeToStablehlo` pass.

To get to a point to permit this, we need two changes:

1. Don't error on non-VHLO dialects when deserializing, currently only happens in `--vhlo-to-version`.
This isn't a big issue, as `--stablehlo-legalize-to-vhlo` already validates that programs are stable. The current way VHLO to version is written is already more lenient than StableHLO->VHLO, as it only errors on Func and StableHLO ops, meaning, for example, that arith ops are permitted even without this change (would be caught by StableHLO->VHLO though).

2. Add deserialization pipeline. This allows users of StableHLO to add these passes to their input pipeline to quickly support StableHLO portable artifacts.

Part of https://github.com/openxla/stablehlo/issues/1530.