### PR TITLE
Clarify what "unspecced features" means

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -159,8 +159,9 @@ dialect or even bytecode representation of the StableHLO dialect, do not have
 compatibility guarantees.
 
 **Unspecced features:** We may make incompatible changes to features which
-are not yet part of the StableHLO specification, e.g. we do not provide
-compatibility guarantees for unregistered attributes.
+are historically supported in StableHLO programs but are not yet part of the
+StableHLO specification, e.g. we do not provide compatibility guarantees for
+unregistered attributes.
 
 **Bug compatibility:** We may make incompatible changes if the implementation in
 libStablehlo contradicts the StableHLO specification, e.g. if a definition in


### PR DESCRIPTION
Based on a conversation with Kevin from earlier today. This is a nice catch and an important clarification.

We do want to provide compatibility guarantees around new features (e.g. make sure that they cannot be serialized to portable artifacts with older target versions) - unspecced features mean something different, which is explicitly elaborated in the document now.