### PR TITLE
Fix incorrect `window_end` calculation for ReduceWindowOp

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4223,7 +4223,7 @@ where:
 * (C15) `shape(results[0]) = num_windows` where:
   * `dilated_input_shape = shape(inputs[0]) = 0 ? 0 : (shape(inputs[0]) - 1) * base_dilations + 1`.
   * `padded_input_shape = padding[:, 0] + dilated_input_shape + padding[:, 1]`.
-  * `dilated_window_shape = window_dimensions = 0 ? 0 : (window_dimensions - 1) * window_dilations + 1`.
+  * `dilated_window_shape = (window_dimensions - 1) * window_dilations + 1`.
   * `is_empty_window = padded_input_shape = 0 || dilated_window_shape > padded_input_shape`.
   * `num_windows = is_empty_window ? 0 : floor((padded_input_shape - dilated_window_shape) / window_strides) + 1`.
 * (C16) `element_type(results...) = element_type(init_values...)`.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4179,7 +4179,7 @@ where:
 * `padded_inputs = pad(inputs..., init_values..., padding[:, 0], padding[:, 1],
   base_dilations - 1)`.
 * `window_start = result_index * window_strides`.
-* `window_end = window_start + window_dimensions + (window_dimensions - 1) * (window_dilations - 1)`.
+* `window_end = window_start + (window_dimensions - 1) * window_dilations + 1`.
 * `windows = slice(padded_inputs..., window_start, window_end,
   window_dilations)`.
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4179,7 +4179,7 @@ where:
 * `padded_inputs = pad(inputs..., init_values..., padding[:, 0], padding[:, 1],
   base_dilations - 1)`.
 * `window_start = result_index * window_strides`.
-* `window_end = window_start + window_dimensions + window_dilations - 1`.
+* `window_end = window_start + window_dimensions + (window_dimensions - 1) * (window_dilations - 1)`.
 * `windows = slice(padded_inputs..., window_start, window_end,
   window_dilations)`.
 

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -1215,8 +1215,7 @@ SmallVector<Tensor> evalReduceWindowOp(
        resultIt != results[0].index_end(); ++resultIt) {
     SmallVector<Tensor> windows;
     auto windowStart = (*resultIt) * windowStrides;
-    auto windowEnd = windowStart + windowDimensions +
-                     (windowDimensions - 1) * (windowDilations - 1);
+    auto windowEnd = windowStart + (windowDimensions - 1) * windowDilations + 1;
     for (const auto &paddedInput : paddedInputs)
       windows.push_back(
           evalSliceOp(paddedInput, windowStart, windowEnd, windowDilations));

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -1215,7 +1215,8 @@ SmallVector<Tensor> evalReduceWindowOp(
        resultIt != results[0].index_end(); ++resultIt) {
     SmallVector<Tensor> windows;
     auto windowStart = (*resultIt) * windowStrides;
-    auto windowEnd = windowStart + windowDimensions + windowDilations - 1;
+    auto windowEnd = windowStart + windowDimensions +
+                     (windowDimensions - 1) * (windowDilations - 1);
     for (const auto &paddedInput : paddedInputs)
       windows.push_back(
           evalSliceOp(paddedInput, windowStart, windowEnd, windowDilations));

--- a/stablehlo/tests/interpret_reduce_window.mlir
+++ b/stablehlo/tests/interpret_reduce_window.mlir
@@ -17,3 +17,23 @@ func.func @reduce_window() {
   check.expect_eq_const %result, dense<[[0, 0], [3, 4]]> : tensor<2x2xi64>
   func.return
 }
+
+// -----
+
+func.func @reduce_window_issue_1662() {
+  %input = stablehlo.constant dense<[[1, 2], [3, 4], [5, 6]]> : tensor<3x2xi64>
+  %init_value = stablehlo.constant dense<0> : tensor<i64>
+  %result = "stablehlo.reduce_window"(%input, %init_value) ({
+    ^bb0(%arg0: tensor<i64>, %arg1: tensor<i64>):
+      %0 = stablehlo.add %arg0, %arg1 : tensor<i64>
+      stablehlo.return %0 : tensor<i64>
+  }) {
+    base_dilations = dense<[2, 1]> : tensor<2xi64>,
+    padding = dense<[[2, 1], [0, 0]]> : tensor<2x2xi64>,
+    window_dilations = dense<[3, 1]> : tensor<2xi64>,
+    window_dimensions = dense<[3, 1]> : tensor<2xi64>,
+    window_strides = dense<[4, 1]> : tensor<2xi64>
+  } : (tensor<3x2xi64>, tensor<i64>) -> tensor<1x2xi64>
+  check.expect_eq_const %result, dense<[[5, 6]]> : tensor<1x2xi64>
+  func.return
+}


### PR DESCRIPTION
Turns out https://github.com/openxla/stablehlo/pull/1492 didn't actually fix the bug since `window_end` is still calculated incorrectly.

Shoutout to @pravnar for filing the bug :)

closes #1662 