### PR TITLE
Cleanup after a downstream integrate

### DIFF
--- a/stablehlo/dialect/AssemblyFormat.cpp
+++ b/stablehlo/dialect/AssemblyFormat.cpp
@@ -307,7 +307,6 @@ void printSliceRanges(OpAsmPrinter& p, Operation* op,
         }
       });
   p << "]";
-  return;
 }
 
 ParseResult parseSliceRanges(OpAsmParser& parser,

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -646,7 +646,7 @@ Element bitcastConvertManyToOne(Type type, ArrayRef<Element> elements) {
         debugString(elements[0].getType()).c_str(), debugString(type).c_str()));
 
   APInt resultBits(resultNumBits, 0);
-  for (auto element : llvm::reverse(elements)) {
+  for (const auto &element : llvm::reverse(elements)) {
     if (operandNumBits != numBits(element.getType()))
       llvm::report_fatal_error("All elements must have the same numBits");
     auto operandBits = element.toBits();

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -699,7 +699,7 @@ Tensor evalBitcastConvertOp(const Tensor &operand, ShapedType resultType) {
          operandIt != operand.index_end(); ++operandIt) {
       auto resultElements =
           bitcastConvertOneToMany(resultElementType, operand.get(*operandIt));
-      for (auto resultElement : resultElements)
+      for (const auto &resultElement : resultElements)
         result.set(*resultIt++, resultElement);
     }
     return result;

--- a/stablehlo/tests/stablehlo_canonicalize_dynamism.mlir
+++ b/stablehlo/tests/stablehlo_canonicalize_dynamism.mlir
@@ -459,7 +459,7 @@ func.func @dynamic_reshape_inapplicable_dynamic_result_type(%arg0: tensor<4xf32>
 // CHECK-LABEL: func @real_dynamic_slice_to_dynamic_slice_success_static_result_type
 func.func @real_dynamic_slice_to_dynamic_slice_success_static_result_type(%arg0: tensor<4xf32>, %arg1: tensor<1xi64>) -> tensor<1xf32> {
   //  CHECK-NOT: stablehlo.real_dynamic_slice
-  //      CHECK: [[SIZE0_1D:%.*]] = stablehlo.slice %arg1 [0:1]
+  //      CHECK: [[SIZE0_1D:%.*]] = stablehlo.slice %arg1 [0:1] : (tensor<1xi64>) -> tensor<1xi64>
   // CHECK-NEXT: [[SIZE0_0D:%.*]] = stablehlo.reshape [[SIZE0_1D]] : (tensor<1xi64>) -> tensor<i64>
   // CHECK-NEXT: stablehlo.dynamic_slice %arg0, [[SIZE0_0D]], sizes = [1] : (tensor<4xf32>, tensor<i64>) -> tensor<1xf32>
   %0 = stablehlo.constant dense<1> : tensor<1xi64>
@@ -474,7 +474,7 @@ func.func @real_dynamic_slice_to_dynamic_slice_success_static_result_type(%arg0:
 // CHECK-LABEL: func @real_dynamic_slice_to_dynamic_slice_success_dynamic_result_type
 func.func @real_dynamic_slice_to_dynamic_slice_success_dynamic_result_type(%arg0: tensor<4xf32>, %arg1: tensor<1xi64>) -> tensor<?xf32> {
   //  CHECK-NOT: stablehlo.real_dynamic_slice
-  //      CHECK: [[SIZE0_1D:%.*]] = stablehlo.slice %arg1 [0:1]
+  //      CHECK: [[SIZE0_1D:%.*]] = stablehlo.slice %arg1 [0:1] : (tensor<1xi64>) -> tensor<1xi64>
   // CHECK-NEXT: [[SIZE0_0D:%.*]] = stablehlo.reshape [[SIZE0_1D]] : (tensor<1xi64>) -> tensor<i64>
   // CHECK-NEXT: stablehlo.dynamic_slice %arg0, [[SIZE0_0D]], sizes = [1] : (tensor<4xf32>, tensor<i64>) -> tensor<?xf32>
   %0 = stablehlo.constant dense<1> : tensor<1xi64>
@@ -509,7 +509,7 @@ func.func @real_dynamic_slice_to_dynamic_slice_inapplicable_unsupported_limit(%a
 // CHECK-LABEL: func @real_dynamic_slice_to_slice_success_static_result_type
 func.func @real_dynamic_slice_to_slice_success_static_result_type(%arg0: tensor<4xf32>) -> tensor<1xf32> {
   //  CHECK-NOT: stablehlo.real_dynamic_slice
-  //      CHECK: stablehlo.slice %arg0 [0:1:2]
+  //      CHECK: stablehlo.slice %arg0 [0:1:2] : (tensor<4xf32>) -> tensor<1xf32>
   %0 = stablehlo.constant dense<0> : tensor<1xi64>
   %1 = stablehlo.constant dense<1> : tensor<1xi64>
   %2 = stablehlo.constant dense<2> : tensor<1xi64>
@@ -522,7 +522,7 @@ func.func @real_dynamic_slice_to_slice_success_static_result_type(%arg0: tensor<
 // CHECK-LABEL: func @real_dynamic_slice_to_slice_success_dynamic_result_type
 func.func @real_dynamic_slice_to_slice_success_dynamic_result_type(%arg0: tensor<4xf32>) -> tensor<?xf32> {
   //  CHECK-NOT: stablehlo.real_dynamic_slice
-  //      CHECK: stablehlo.slice %arg0 [0:1:2]
+  //      CHECK: stablehlo.slice %arg0 [0:1:2] : (tensor<4xf32>) -> tensor<?xf32>
   %0 = stablehlo.constant dense<0> : tensor<1xi64>
   %1 = stablehlo.constant dense<1> : tensor<1xi64>
   %2 = stablehlo.constant dense<2> : tensor<1xi64>


### PR DESCRIPTION
This PR addresses clang-tidy issues found during the ongoing downstream integrate (we don't run clang-tidy on our PRs yet, so these issues have deferred detection).

Also, I changed stablehlo_canonicalize_dynamism.mlir to explicitly specify operation types in CHECK directives. This pass is all about operation types, so let's check them explicitly.