### PR TITLE
Add `HLO_Commutative` trait to avoid inheriting folders

### DIFF
--- a/stablehlo/dialect/Base.h
+++ b/stablehlo/dialect/Base.h
@@ -251,6 +251,10 @@ class BroadcastingElementwise
     : public mlir::OpTrait::TraitBase<ConcreteType, BroadcastingElementwise> {};
 
 template <typename ConcreteType>
+class IsCommutative
+    : public mlir::OpTrait::TraitBase<ConcreteType, IsCommutative> {};
+
+template <typename ConcreteType>
 class PairwiseSameOperandAndResultType
     : public mlir::OpTrait::TraitBase<ConcreteType,
                                       PairwiseSameOperandAndResultType> {

--- a/stablehlo/dialect/Base.td
+++ b/stablehlo/dialect/Base.td
@@ -189,6 +189,11 @@ class HLO_NativeOpTrait<string name> : NativeOpTrait<name> {
 // semantics.
 def HLO_BroadcastingElementwise : HLO_NativeOpTrait<"BroadcastingElementwise">;
 
+// This class adds property that the operation is commutative.
+// Upstream IsCommutative has default folders, and StableHLO aims to have no
+// default folders or canonicalizations.
+def HLO_Commutative : HLO_NativeOpTrait<"IsCommutative">;
+
 // Op has pairwise operand and result type matching: the number of operands
 // must be equal to the number of results and the type of ith operand must
 // match the type of ith result.

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -1467,7 +1467,7 @@ static bool isEligibleForCompactPrint(ReduceOp op) {
   if (innerOp.getNumOperands() != 2 ||
       !innerOp.hasTrait<mlir::OpTrait::OneResult>() ||
       !hasSameOperandAndResultTypes(innerOp) ||
-      !innerOp.hasTrait<mlir::OpTrait::IsCommutative>() ||
+      !innerOp.hasTrait<mlir::hlo::OpTrait::IsCommutative>() ||
       !innerOp.hasTrait<mlir::OpTrait::ZeroRegions>())
     return false;
 
@@ -1664,7 +1664,7 @@ ParseResult ReduceOp::parse(OpAsmParser& parser, OperationState& result) {
   if (!innerOpDialect || !innerOpDialect->getNamespace().equals("stablehlo") ||
       !innerOpNameInfo->hasTrait<mlir::OpTrait::NOperands<2>::Impl>() ||
       !innerOpNameInfo->hasTrait<mlir::OpTrait::OneResult>() ||
-      !innerOpNameInfo->hasTrait<mlir::OpTrait::IsCommutative>() ||
+      !innerOpNameInfo->hasTrait<mlir::hlo::OpTrait::IsCommutative>() ||
       !innerOpNameInfo->hasTrait<mlir::OpTrait::ZeroRegions>()) {
     parser.emitError(loc,
                      "expected the inner-op to be a commutative binary-op from "

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -687,7 +687,7 @@ class StableHLO_BinaryElementwiseOp<string mnemonic, list<Trait> traits,
 }
 
 def StableHLO_AddOp : StableHLO_BinaryElementwiseOp<"add",
-      [Commutative, Pure, HLO_CompatibleOperandsAndResultType]> {
+      [HLO_Commutative, Pure, HLO_CompatibleOperandsAndResultType]> {
   let summary = "Add operation";
   let description = [{
     Performs element-wise addition of two tensors `lhs` and `rhs` and produces a
@@ -769,7 +769,7 @@ def StableHLO_DivOp : StableHLO_BinaryElementwiseOp<"divide", [Pure,
 }
 
 def StableHLO_MaxOp : StableHLO_BinaryElementwiseOp<"maximum",
-      [Commutative, Pure, HLO_CompatibleOperandsAndResultType]> {
+      [HLO_Commutative, Pure, HLO_CompatibleOperandsAndResultType]> {
   let summary = "Max operation";
   let description = [{
     Performs element-wise max operation on tensors `lhs` and `rhs` and produces
@@ -786,7 +786,7 @@ def StableHLO_MaxOp : StableHLO_BinaryElementwiseOp<"maximum",
 }
 
 def StableHLO_MinOp : StableHLO_BinaryElementwiseOp<"minimum",
-      [Commutative, Pure, HLO_CompatibleOperandsAndResultType]> {
+      [HLO_Commutative, Pure, HLO_CompatibleOperandsAndResultType]> {
   let summary = "Min operation";
   let description = [{
     Performs element-wise min operation on tensors `lhs` and `rhs` and produces a
@@ -803,7 +803,7 @@ def StableHLO_MinOp : StableHLO_BinaryElementwiseOp<"minimum",
 }
 
 def StableHLO_MulOp : StableHLO_BinaryElementwiseOp<"multiply",
-      [Commutative, Pure, HLO_CompatibleOperandsAndResultType]> {
+      [HLO_Commutative, Pure, HLO_CompatibleOperandsAndResultType]> {
   let summary = "Mul operation";
   let description = [{
     Performs element-wise product of two tensors `lhs` and `rhs` and produces a
@@ -933,7 +933,7 @@ def StableHLO_SubtractOp : StableHLO_BinaryElementwiseOp<"subtract",
 // See https://www.tensorflow.org/xla/operation_semantics#element-wise_binary_arithmetic_operations
 class StableHLO_BinaryBiwiseOrLogicalElementwiseOp<string mnemonic> :
         StableHLO_BinaryElementwiseOp<mnemonic,
-          [Commutative, Pure, HLO_CompatibleOperandsAndResultType]> {
+          [HLO_Commutative, Pure, HLO_CompatibleOperandsAndResultType]> {
   let arguments = (ins
     HLO_PredOrIntTensor:$lhs,
     HLO_PredOrIntTensor:$rhs


### PR DESCRIPTION
After https://reviews.llvm.org/D155687 the builtin Commutative trait has folders by default. StableHLO does not want to have any default folding or canonicalization. Adding a `hlo::OpTrait::IsCommutative` and `HLO_Commutative` trait to avoid these folders.