### PR TITLE
Patch BUILD.bazel files after integrate

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -297,6 +297,7 @@ cc_library(
 
 gentbl_cc_library(
     name = "interpreter_ops_inc_gen",
+    strip_include_prefix = ".",
     tbl_outs = [
         (
             ["-gen-op-decls"],
@@ -309,7 +310,6 @@ gentbl_cc_library(
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "stablehlo/reference/InterpreterOps.td",
-    strip_include_prefix = ".",
     deps = [
         ":interpreter_ops_td_files",
     ],
@@ -419,8 +419,8 @@ cc_library(
         ":reference_element",
         ":reference_errors",
         ":reference_index",
-        ":reference_scope",
         ":reference_interpretervalue",
+        ":reference_scope",
         ":reference_tensor",
         ":reference_token",
         ":reference_types",
@@ -850,8 +850,8 @@ cc_binary(
     ],
     deps = [
         ":register",
-        "@llvm-project//mlir:AllPassesAndDialects",
         "@llvm-project//mlir:AllExtensions",
+        "@llvm-project//mlir:AllPassesAndDialects",
         "@llvm-project//mlir:MlirLspServerLib",
     ],
 )
@@ -862,8 +862,8 @@ cc_binary(
         "stablehlo/tools/StablehloTranslateMain.cpp",
     ],
     deps = [
-        ":reference_errors",
         ":interpreter_ops",
+        ":reference_errors",
         ":reference_ops",
         ":reference_scope",
         ":reference_tensor",


### PR DESCRIPTION
These include some lint related changes on the `BUILD.bazel` file.