### PR TITLE
Add interpreter for AllReduceOp

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -784,13 +784,13 @@ Afterwards, within each `process_group`:
 
 #### Inputs
 
-| Label | Name                    | Type                                         | Constraints |
-|-------|-------------------------|----------------------------------------------|-------------|
-| (I1)  | `operand`               | tensor                                       | (C5), (C6)  |
-| (I2)  | `replica_groups`        | 2-dimensional tensor constant of type `si64` | (C1-C3)     |
-| (I3)  | `channel_id`            | constant of type `si64`                      | (C4)        |
-| (I4)  | `use_global_device_ids` | constant of type `i1`                        | (C4)        |
-| (I5)  | `computation`           | function                                     | (C5)        |
+| Label | Name                    | Type                                                             | Constraints |
+|-------|-------------------------|------------------------------------------------------------------|-------------|
+| (I1)  | `operand`               | tensor                                                           | (C5), (C6)  |
+| (I2)  | `replica_groups`        | variadic number of 1-dimensional tensor constants of type `si64` | (C1-C3)     |
+| (I3)  | `channel_id`            | constant of type `si64`                                          | (C4)        |
+| (I4)  | `use_global_device_ids` | constant of type `i1`                                            | (C4)        |
+| (I5)  | `computation`           | function                                                         | (C5)        |
 
 #### Outputs
 
@@ -802,7 +802,7 @@ Afterwards, within each `process_group`:
 
 * (C1) `is_unique(replica_groups)`.
 * (C2) `rank(replica_groups) = 2`.
-* (C3) `1 < size(replica_groups)`.
+* (C3) `1 <= size(replica_groups)`.
 * (C4) `0 <= replica_groups < N` where `N` is defined as:
   * `num_replicas` if `cross_replica` is used.
   * `num_replicas` if `cross_replica_and_partition` is used.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -801,16 +801,15 @@ Afterwards, within each `process_group`:
 #### Constraints
 
 * (C1) `is_unique(replica_groups)`.
-* (C2) `rank(replica_groups) = 2`.
-* (C3) `1 <= size(replica_groups)`.
-* (C4) `0 <= replica_groups < N` where `N` is defined as:
+* (C2) `size(replica_groups)` is defined as:
   * `num_replicas` if `cross_replica` is used.
   * `num_replicas` if `cross_replica_and_partition` is used.
   * `num_processes` if `flattened_ids` is used.
-* (C5) If `use_global_device_ids = true`, then `channel_id > 0`.
-* (C6) `computation` has type `(tensor<E>, tensor<E>) -> (tensor<E>)` where
+* (C3) `0 <= replica_groups < size(replica_groups)`.
+* (C4) If `use_global_device_ids = true`, then `channel_id > 0`.
+* (C5) `computation` has type `(tensor<E>, tensor<E>) -> (tensor<E>)` where
        `E = element_type(operand)`.
-* (C7) `type(result) = type(operand)`.
+* (C6) `type(result) = type(operand)`.
 
 #### Examples
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -46,7 +46,7 @@ one of the following tracking labels.
 | add                      | yes           | yes          | yes            | yes             | yes         |
 | after_all                | yes           | yes          | yes            | yes             | yes         |
 | all_gather               | yes           | revisit      | no             | no              | no          |
-| all_reduce               | yes           | revisit      | yes            | no              | no          |
+| all_reduce               | yes           | revisit      | yes            | no              | yes         |
 | all_to_all               | yes           | revisit      | yes            | no              | no          |
 | and                      | yes           | yes          | yes            | yes             | yes         |
 | atan2                    | yes           | yes          | yes            | yes             | yes         |

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -887,8 +887,13 @@ LogicalResult AllGatherOp::verify() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult AllReduceOp::verify() {
+  int64_t channelId = 0;
+  if (auto channelHandleAttr = getChannelHandleAttr())
+    channelId = channelHandleAttr.getHandle();
+
   return hlo::verifyAllReduceOp(getLoc(), getOperand(), getReplicaGroups(),
-                                getUseGlobalDeviceIds(), getComputation());
+                                channelId, getUseGlobalDeviceIds(),
+                                getComputation());
 }
 
 //===----------------------------------------------------------------------===//

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1331,7 +1331,7 @@ def StableHLO_AllGatherOp : StableHLO_Op<"all_gather", [SameOperandsAndResultEle
 }
 
 def StableHLO_AllReduceOp : StableHLO_Op<"all_reduce",
-    [HLO_CompatibleOperandsAndResultType /*all_reduce_c7*/]> {
+    [HLO_CompatibleOperandsAndResultType /*all_reduce_c6*/]> {
   let summary = "AllReduce operation";
   let description = [{
     Within each process group in the process grid, applies a reduction function

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1331,7 +1331,7 @@ def StableHLO_AllGatherOp : StableHLO_Op<"all_gather", [SameOperandsAndResultEle
 }
 
 def StableHLO_AllReduceOp : StableHLO_Op<"all_reduce",
-    [HLO_CompatibleOperandsAndResultType]> {
+    [HLO_CompatibleOperandsAndResultType /*all_reduce_c7*/]> {
   let summary = "AllReduce operation";
   let description = [{
     Within each process group in the process grid, applies a reduction function
@@ -1344,25 +1344,24 @@ def StableHLO_AllReduceOp : StableHLO_Op<"all_reduce",
     Example:
     ```mlir
     %result = "stablehlo.all_reduce"(%operand) ({
-      ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
-        %0 = stablehlo.add %arg1, %arg2 : tensor<f32>
-        stablehlo.return %0 : tensor<f32>
+      ^bb0(%arg0: tensor<i64>, %arg1: tensor<i64>):
+        %0 = stablehlo.add %arg1, %arg2 : tensor<i64>
+        stablehlo.return %0 : tensor<i64>
     }) {
       replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>
-      // channel_id = 0
       channel_handle = #stablehlo.channel_handle<handle = 0, type = 0>
       // use_global_device_ids = false
-    } : (tensor<4xf32>) -> tensor<4xf32>
+    } : (tensor<4xi64>) -> tensor<4xi64>
     ```
   }];
 
   let arguments = (ins
-    HLO_Tensor:$operand,
-    I64ElementsAttr:$replica_groups,
-    OptionalAttr<StableHLO_ChannelHandle>:$channel_handle,
-    UnitAttr:$use_global_device_ids
+    HLO_Tensor:$operand, /*all_reduce_i1*/
+    I64ElementsAttr:$replica_groups, /*all_reduce_i2*/
+    OptionalAttr<StableHLO_ChannelHandle>:$channel_handle, /*all_reduce_i3*/
+    UnitAttr:$use_global_device_ids /*all_reduce_i4*/
   );
-  let regions = (region SizedRegion<1>:$computation);
+  let regions = (region SizedRegion<1>:$computation /*all_reduce_i5*/);
   let results = (outs HLO_Tensor);
   let hasVerifier = 1;
 }

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -426,7 +426,7 @@ LogicalResult verifyReplicaGroups(std::optional<Location> location,
                                   std::optional<size_t> expectedGroupSize) {
   auto replicaGroupType = replicaGroups.getType().cast<RankedTensorType>();
 
-  // all_reduce_c2
+  // all_reduce_c2_i2
   if (replicaGroupType.getRank() != 2)
     return emitOptionalError(location,
                              "replica groups should be a rank 2 tensor");

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -374,7 +374,8 @@ LogicalResult verifyAllGatherOp(std::optional<Location> location, Value operand,
 
 LogicalResult verifyAllReduceOp(std::optional<Location> location, Value operand,
                                 DenseIntElementsAttr replicaGroups,
-                                bool useGlobalDeviceIds, Region& computation);
+                                int64_t channelId, bool useGlobalDeviceIds,
+                                Region& computation);
 
 LogicalResult verifyBitcastConvertOp(std::optional<Location> location,
                                      Value operand, Value result);

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -33,6 +33,11 @@ namespace stablehlo {
 Tensor evalAbsOp(const Tensor &operand, ShapedType resultType);
 Tensor evalAddOp(const Tensor &lhs, const Tensor &rhs, ShapedType resultType);
 Token evalAfterAllOp(ArrayRef<Token> inputs, MLIRContext *context);
+Tensor evalAllReduceOp(const Tensor &operand,
+                       SmallVector<SmallVector<uint32_t>> replicaGroups,
+                       int64_t channelId, bool useGlobalDeviceIds,
+                       Region &region, Process *process, Scope &scope,
+                       ShapedType resultType);
 Tensor evalAndOp(const Tensor &lhs, const Tensor &rhs, ShapedType resultType);
 Tensor evalAtan2Op(const Tensor &lhs, const Tensor &rhs, ShapedType resultType);
 Tensor evalBitcastConvertOp(const Tensor &operand, ShapedType resultType);

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -36,7 +36,7 @@ Token evalAfterAllOp(ArrayRef<Token> inputs, MLIRContext *context);
 Tensor evalAllReduceOp(const Tensor &operand,
                        SmallVector<SmallVector<uint32_t>> replicaGroups,
                        int64_t channelId, bool useGlobalDeviceIds,
-                       Region &region, Process *process, Scope &scope,
+                       Region &computation, Process *process, Scope &scope,
                        ShapedType resultType);
 Tensor evalAndOp(const Tensor &lhs, const Tensor &rhs, ShapedType resultType);
 Tensor evalAtan2Op(const Tensor &lhs, const Tensor &rhs, ShapedType resultType);

--- a/stablehlo/reference/Process.cpp
+++ b/stablehlo/reference/Process.cpp
@@ -30,6 +30,16 @@ ProcessGroups Process::crossReplica(
   return grid_->crossReplica(replicaGroups);
 }
 
+ProcessGroups Process::crossReplicaAndPartition(
+    SmallVector<SmallVector<uint32_t>> replicaGroups) {
+  return grid_->crossReplicaAndPartition(replicaGroups);
+}
+
+ProcessGroups Process::flattenedIds(
+    SmallVector<SmallVector<uint32_t>> flattenedIdGroups) {
+  return grid_->flattenedIds(flattenedIdGroups);
+}
+
 ProcessId Process::getId() { return id_; }
 
 void Process::outfeed(ArrayRef<Tensor> inputs) { grid_->outfeed(inputs); }

--- a/stablehlo/reference/Process.h
+++ b/stablehlo/reference/Process.h
@@ -39,6 +39,14 @@ class Process {
   /// See `ProcessGrid::crossReplica`.
   ProcessGroups crossReplica(SmallVector<SmallVector<uint32_t>> replicaGroups);
 
+  /// See `ProcessGrid::crossReplicaAndPartition`.
+  ProcessGroups crossReplicaAndPartition(
+      SmallVector<SmallVector<uint32_t>> replicaGroups);
+
+  /// See `ProcessGrid::flattenedIds`.
+  ProcessGroups flattenedIds(
+      SmallVector<SmallVector<uint32_t>> flattenedIdGroups);
+
   /// Getter for the underlying StableHLO `process_id`.
   ProcessId getId();
 

--- a/stablehlo/reference/ProcessGrid.cpp
+++ b/stablehlo/reference/ProcessGrid.cpp
@@ -19,6 +19,8 @@ limitations under the License.
 #include <mutex>
 #include <utility>
 
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "stablehlo/reference/Tensor.h"
 
@@ -44,6 +46,20 @@ bool ProcessId::operator==(const ProcessId &other) const {
 }
 
 //===----------------------------------------------------------------------===//
+// ProcessGroups.
+//===----------------------------------------------------------------------===//
+
+ProcessGroups ProcessGroups::findAll(ProcessId processId) {
+  ProcessGroups groupsFound{};
+
+  for (auto processGroup : *this)
+    for (auto id : processGroup)
+      if (id == processId) groupsFound.push_back(processGroup);
+
+  return groupsFound;
+}
+
+//===----------------------------------------------------------------------===//
 // RendezvousResult.
 //===----------------------------------------------------------------------===//
 
@@ -57,6 +73,11 @@ Tensor RendezvousResult::lookup(ProcessId processId) {
   auto it = result_.find(processId);
   if (it != result_.end()) return it->second;
   return {};
+}
+
+SmallVector<Tensor> RendezvousResult::getTensors() {
+  return llvm::to_vector(
+      llvm::map_range(result_, [](const auto &pair) { return pair.second; }));
 }
 
 size_t RendezvousResult::size() { return result_.size(); }
@@ -100,6 +121,34 @@ ProcessGroups ProcessGrid::crossReplica(
 void ProcessGrid::outfeed(ArrayRef<Tensor> inputs) {
   std::lock_guard<std::mutex> lock(outfeedLock_);
   outfeed_.emplace(inputs);
+}
+
+ProcessGroups ProcessGrid::crossReplicaAndPartition(
+    SmallVector<SmallVector<uint32_t>> replicaGroups) {
+  ProcessGroups processGroups;
+  for (auto replicaGroup : replicaGroups) {
+    ProcessGroup processGroup;
+    for (uint32_t partitionId = 0; partitionId < numPartitions_; ++partitionId)
+      for (uint32_t replicaId : replicaGroup)
+        processGroup.push_back({replicaId, partitionId});
+    processGroups.push_back(processGroup);
+  }
+  return processGroups;
+}
+
+ProcessGroups ProcessGrid::flattenedIds(
+    SmallVector<SmallVector<uint32_t>> flattenedIdGroups) {
+  ProcessGroups processGroups;
+  for (auto flattenedIdGroup : flattenedIdGroups) {
+    ProcessGroup processGroup;
+    for (auto flattenedId : flattenedIdGroup) {
+      uint32_t replicaId = flattenedId / numPartitions_;
+      uint32_t partitionId = flattenedId % numPartitions_;
+      processGroup.push_back({replicaId, partitionId});
+    }
+    processGroups.push_back(processGroup);
+  }
+  return processGroups;
 }
 
 RendezvousResult ProcessGrid::rendezvous(ProcessGroup processGroup,

--- a/stablehlo/reference/ProcessGrid.cpp
+++ b/stablehlo/reference/ProcessGrid.cpp
@@ -106,8 +106,6 @@ ProcessGroups ProcessGrid::crossReplica(
     SmallVector<SmallVector<uint32_t>> replicaGroups) {
   ProcessGroups processGroups;
   for (auto replicaGroup : replicaGroups) {
-    if (replicaGroup.empty())
-      llvm::report_fatal_error("empty replicaGroup found during crossReplica");
     for (uint32_t partitionId = 0; partitionId < numPartitions_;
          ++partitionId) {
       ProcessGroup processGroup;
@@ -123,9 +121,6 @@ ProcessGroups ProcessGrid::crossReplicaAndPartition(
     SmallVector<SmallVector<uint32_t>> replicaGroups) {
   ProcessGroups processGroups;
   for (auto replicaGroup : replicaGroups) {
-    if (replicaGroup.empty())
-      llvm::report_fatal_error(
-          "empty replicaGroup found during crossReplicaAndPartition");
     ProcessGroup processGroup;
     for (uint32_t partitionId = 0; partitionId < numPartitions_; ++partitionId)
       for (uint32_t replicaId : replicaGroup)
@@ -139,9 +134,6 @@ ProcessGroups ProcessGrid::flattenedIds(
     SmallVector<SmallVector<uint32_t>> flattenedIdGroups) {
   ProcessGroups processGroups;
   for (auto flattenedIdGroup : flattenedIdGroups) {
-    if (flattenedIdGroup.empty())
-      llvm::report_fatal_error(
-          "empty flattenedIdGroup found during flattenedIds");
     ProcessGroup processGroup;
     for (auto flattenedId : flattenedIdGroup) {
       uint32_t replicaId = flattenedId / numPartitions_;

--- a/stablehlo/reference/ProcessGrid.h
+++ b/stablehlo/reference/ProcessGrid.h
@@ -74,7 +74,8 @@ class RendezvousResult {
   void clear();
 
   /// Iterates through the (ProcessId, Tensor) map entires and returns a vector
-  /// of Tensors sorted by ProcessId.
+  /// of Tensors sorted by ProcessId--(replicaId, partitionId) pair--in
+  /// lexicographical order.
   SmallVector<Tensor> getSortedTensors();
 
   /// Inserts `tensor` into the map using the key `processId`.

--- a/stablehlo/reference/ProcessGrid.h
+++ b/stablehlo/reference/ProcessGrid.h
@@ -52,10 +52,12 @@ struct ProcessId {
 };
 
 // StableHLO `process_group`.
-class ProcessGroup : public SmallVector<ProcessId> {};
+struct ProcessGroup : public SmallVector<ProcessId> {};
 
 // StableHLO `process_groups`.
-class ProcessGroups : public SmallVector<ProcessGroup> {};
+struct ProcessGroups : public SmallVector<ProcessGroup> {
+  ProcessGroups findAll(ProcessId processId);
+};
 
 /// Represents a result of a `ProcessGrid::rendezvous` where multiple processes
 /// synchronize at a barrier and contribute a Tensor each.
@@ -65,6 +67,9 @@ class RendezvousResult {
  public:
   /// Erases all elements in the map.
   void clear();
+
+  /// Returns the tensor values of the map `result_`.
+  SmallVector<Tensor> getTensors();
 
   /// Inserts `tensor` into the map using the key `processId`.
   void insert(ProcessId processId, Tensor tensor);
@@ -95,6 +100,14 @@ class ProcessGrid {
 
   /// StableHLO `cross_replica` communication strategy.
   ProcessGroups crossReplica(SmallVector<SmallVector<uint32_t>> replicaGroups);
+
+  /// StableHLO `cross_replica_and_partition` communication strategy.
+  ProcessGroups crossReplicaAndPartition(
+      SmallVector<SmallVector<uint32_t>> partitionGroups);
+
+  /// StableHLO `flattened_ids` communication strategy.
+  ProcessGroups flattenedIds(
+      SmallVector<SmallVector<uint32_t>> partitionGroups);
 
   /// Inserts `inputs` to StableHLO `outfeed`.
   void outfeed(ArrayRef<Tensor> inputs);

--- a/stablehlo/reference/ProcessGrid.h
+++ b/stablehlo/reference/ProcessGrid.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include <cstdint>
 #include <map>
 #include <mutex>
+#include <optional>
 #include <queue>
 #include <utility>
 
@@ -52,11 +53,15 @@ struct ProcessId {
 };
 
 // StableHLO `process_group`.
-struct ProcessGroup : public SmallVector<ProcessId> {};
+class ProcessGroup : public SmallVector<ProcessId> {};
 
 // StableHLO `process_groups`.
-struct ProcessGroups : public SmallVector<ProcessGroup> {
-  ProcessGroups findAll(ProcessId processId);
+class ProcessGroups : public SmallVector<ProcessGroup> {
+ public:
+  /// Iterates through the ProcessGroups and finds the first ProcessGroup
+  /// containing the `processId`. If the group is not found, std::nullopt is
+  /// returned.
+  std::optional<ProcessGroup> findGroup(ProcessId processId);
 };
 
 /// Represents a result of a `ProcessGrid::rendezvous` where multiple processes
@@ -68,8 +73,9 @@ class RendezvousResult {
   /// Erases all elements in the map.
   void clear();
 
-  /// Returns the tensor values of the map `result_`.
-  SmallVector<Tensor> getTensors();
+  /// Iterates through the (ProcessId, Tensor) map entires and returns a vector
+  /// of Tensors sorted by ProcessId.
+  SmallVector<Tensor> getSortedTensors();
 
   /// Inserts `tensor` into the map using the key `processId`.
   void insert(ProcessId processId, Tensor tensor);

--- a/stablehlo/reference/Tensor.cpp
+++ b/stablehlo/reference/Tensor.cpp
@@ -20,7 +20,6 @@ limitations under the License.
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/Support/Error.h"
-#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Support/DebugStringHelper.h"
 #include "stablehlo/reference/Errors.h"
 #include "stablehlo/reference/Types.h"
@@ -88,24 +87,11 @@ Buffer::Buffer(ShapedType type, AsmResourceBlob blob)
 
 Tensor::Tensor() {}
 
-Tensor::Tensor(const Element &initValue)
-    : impl_(llvm::makeIntrusiveRefCnt<detail::Buffer>(
-          RankedTensorType::get({}, initValue.getType()))) {
-  this->set({}, initValue);
-}
-
 Tensor::Tensor(ShapedType type)
     : impl_(llvm::makeIntrusiveRefCnt<detail::Buffer>(type)) {}
 
 Tensor::Tensor(ShapedType type, AsmResourceBlob blob)
     : impl_(llvm::makeIntrusiveRefCnt<detail::Buffer>(type, std::move(blob))) {}
-
-Tensor::Tensor(ShapedType type, const Element &initValue)
-    : impl_(llvm::makeIntrusiveRefCnt<detail::Buffer>(type)) {
-  for (auto indexIt = this->index_begin(); indexIt != this->index_end();
-       ++indexIt)
-    this->set(*indexIt, initValue);
-}
 
 Element Tensor::get(const Index &index) const {
   Type elementType = getType().getElementType();

--- a/stablehlo/reference/Tensor.cpp
+++ b/stablehlo/reference/Tensor.cpp
@@ -20,6 +20,7 @@ limitations under the License.
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/Support/Error.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Support/DebugStringHelper.h"
 #include "stablehlo/reference/Errors.h"
 #include "stablehlo/reference/Types.h"
@@ -86,6 +87,12 @@ Buffer::Buffer(ShapedType type, AsmResourceBlob blob)
 }  // namespace detail
 
 Tensor::Tensor() {}
+
+Tensor::Tensor(const Element &initValue)
+    : impl_(llvm::makeIntrusiveRefCnt<detail::Buffer>(
+          RankedTensorType::get({}, initValue.getType()))) {
+  this->set({}, initValue);
+}
 
 Tensor::Tensor(ShapedType type)
     : impl_(llvm::makeIntrusiveRefCnt<detail::Buffer>(type)) {}

--- a/stablehlo/reference/Tensor.h
+++ b/stablehlo/reference/Tensor.h
@@ -71,6 +71,8 @@ class Tensor {
   /// \name Constructors
   /// @{
   Tensor();
+  /// This constructor initializes the tensor with a scalar value.
+  explicit Tensor(const Element &initValue);
   explicit Tensor(ShapedType type);
   explicit Tensor(ShapedType type, AsmResourceBlob blob);
   /// This constructor initializes the tensor populated with the provided

--- a/stablehlo/reference/Tensor.h
+++ b/stablehlo/reference/Tensor.h
@@ -71,13 +71,8 @@ class Tensor {
   /// \name Constructors
   /// @{
   Tensor();
-  /// This constructor initializes the tensor with a scalar value.
-  explicit Tensor(const Element &initValue);
   explicit Tensor(ShapedType type);
   explicit Tensor(ShapedType type, AsmResourceBlob blob);
-  /// This constructor initializes the tensor populated with the provided
-  /// initial value. This constructor is O(n) with respect to the tensor size.
-  explicit Tensor(ShapedType type, const Element &initValue);
   Tensor(const Tensor &other) = default;
   /// @}
 

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -102,24 +102,6 @@ func.func @cholesky(%arg0: tensor<1x2x2xf32>) -> tensor<1x2x2xindex> {
 
 // -----
 
-// CHECK-LABEL: func @all_reduce_c7
-func.func @all_reduce_c7(%arg0: tensor<10xf32>) -> tensor<10xf32> {
-  %0 = "stablehlo.all_reduce"(%arg0) ({
-  // Perform max reduction inside the region
-  ^bb0(%lhs: tensor<f32>, %rhs: tensor<f32>):
-    %max = stablehlo.maximum %lhs, %rhs : tensor<f32>
-    "stablehlo.return"(%max) : (tensor<f32>) -> ()
-  })
-  {
-    replica_groups = dense<[[0, 2, 4, 6], [1, 3, 5, 7]]> : tensor<2x4xi64>,
-    channel_handle = #stablehlo.channel_handle<handle = 5,type = 2>,
-    use_global_device_ids
-  } : (tensor<10xf32>) -> tensor<10xf32>
-  func.return %0 : tensor<10xf32>
-}
-
-// -----
-
 // CHECK-LABEL: func @alltoall
 func.func @alltoall(%data: tensor<4x16xf32>) -> tensor<16x4xindex> {
   %0 = "stablehlo.all_to_all"(%data) {

--- a/stablehlo/tests/interpret_all_reduce.mlir
+++ b/stablehlo/tests/interpret_all_reduce.mlir
@@ -1,0 +1,79 @@
+// RUN: stablehlo-translate --interpret -split-input-file %s
+
+module @cross_replica {
+  func.func public @all_reduce(%operand : tensor<4xi64>) -> tensor<4xi64> {
+    %result = "stablehlo.all_reduce"(%operand) ({
+      ^bb0(%arg0: tensor<i64>, %arg1: tensor<i64>):
+        %0 = stablehlo.add %arg0, %arg1 : tensor<i64>
+        stablehlo.return %0 : tensor<i64>
+    }) {
+      replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
+      channel_handle = #stablehlo.channel_handle<handle = 0, type = 0>
+    } : (tensor<4xi64>) -> tensor<4xi64>
+    return %result : tensor<4xi64>
+  }
+  func.func public @main() {
+    %inputs0 = stablehlo.constant dense<[1, 2, 3, 4]> : tensor<4xi64>
+    %inputs1 = stablehlo.constant dense<[5, 6, 7, 8]> : tensor<4xi64>
+    %results:2 = "interpreter.run_parallel"(%inputs0, %inputs1) {
+      programs=[["all_reduce"], ["all_reduce"]]
+    } : (tensor<4xi64>, tensor<4xi64>) -> (tensor<4xi64>, tensor<4xi64>)
+    check.expect_eq_const %results#0, dense<[6, 8, 10, 12]> : tensor<4xi64>
+    check.expect_eq_const %results#1, dense<[6, 8, 10, 12]> : tensor<4xi64>
+    func.return
+  }
+}
+
+// -----
+
+module @cross_replica_and_partition {
+  func.func public @all_reduce(%operand : tensor<4xi64>) -> tensor<4xi64> {
+    %result = "stablehlo.all_reduce"(%operand) ({
+      ^bb0(%arg0: tensor<i64>, %arg1: tensor<i64>):
+        %0 = stablehlo.add %arg0, %arg1 : tensor<i64>
+        stablehlo.return %0 : tensor<i64>
+    }) {
+      replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
+      channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>
+    } : (tensor<4xi64>) -> tensor<4xi64>
+    return %result : tensor<4xi64>
+  }
+  func.func public @main() {
+    %inputs0 = stablehlo.constant dense<[1, 2, 3, 4]> : tensor<4xi64>
+    %inputs1 = stablehlo.constant dense<[5, 6, 7, 8]> : tensor<4xi64>
+    %results:2 = "interpreter.run_parallel"(%inputs0, %inputs1) {
+      programs=[["all_reduce"], ["all_reduce"]]
+    } : (tensor<4xi64>, tensor<4xi64>) -> (tensor<4xi64>, tensor<4xi64>)
+    check.expect_eq_const %results#0, dense<[6, 8, 10, 12]> : tensor<4xi64>
+    check.expect_eq_const %results#1, dense<[6, 8, 10, 12]> : tensor<4xi64>
+    func.return
+  }
+}
+
+// -----
+
+module @flattened_ids {
+  func.func public @all_reduce(%operand : tensor<4xi64>) -> tensor<4xi64> {
+    %result = "stablehlo.all_reduce"(%operand) ({
+      ^bb0(%arg0: tensor<i64>, %arg1: tensor<i64>):
+        %0 = stablehlo.add %arg0, %arg1 : tensor<i64>
+        stablehlo.return %0 : tensor<i64>
+    }) {
+      replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
+      channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
+      use_global_device_ids
+    } : (tensor<4xi64>) -> tensor<4xi64>
+    return %result : tensor<4xi64>
+  }
+  func.func public @main() {
+    %inputs0 = stablehlo.constant dense<[1, 2, 3, 4]> : tensor<4xi64>
+    %inputs1 = stablehlo.constant dense<[5, 6, 7, 8]> : tensor<4xi64>
+    %results:2 = "interpreter.run_parallel"(%inputs0, %inputs1) {
+      programs=[["all_reduce"], ["all_reduce"]]
+    } : (tensor<4xi64>, tensor<4xi64>) -> (tensor<4xi64>, tensor<4xi64>)
+    check.expect_eq_const %results#0, dense<[6, 8, 10, 12]> : tensor<4xi64>
+    check.expect_eq_const %results#1, dense<[6, 8, 10, 12]> : tensor<4xi64>
+    func.return
+  }
+}
+

--- a/stablehlo/tests/interpret_all_reduce.mlir
+++ b/stablehlo/tests/interpret_all_reduce.mlir
@@ -77,3 +77,31 @@ module @flattened_ids {
   }
 }
 
+// -----
+
+module @ragged_replica_groups {
+  func.func public @all_reduce(%operand : tensor<4xi64>) -> tensor<4xi64> {
+    %result = "stablehlo.all_reduce"(%operand) ({
+      ^bb0(%arg0: tensor<i64>, %arg1: tensor<i64>):
+        %0 = stablehlo.add %arg0, %arg1 : tensor<i64>
+        stablehlo.return %0 : tensor<i64>
+    }) {
+      replica_groups = dense<[[0, 1], [2, -1]]> : tensor<2x2xi64>,
+      channel_handle = #stablehlo.channel_handle<handle = 0, type = 0>
+    } : (tensor<4xi64>) -> tensor<4xi64>
+    return %result : tensor<4xi64>
+  }
+  func.func public @main() {
+    %inputs0 = stablehlo.constant dense<[1, 2, 3, 4]> : tensor<4xi64>
+    %inputs1 = stablehlo.constant dense<[5, 6, 7, 8]> : tensor<4xi64>
+    %inputs2 = stablehlo.constant dense<[6, 8, 10, 12]> : tensor<4xi64>
+    %results:3 = "interpreter.run_parallel"(%inputs0, %inputs1, %inputs2) {
+      programs=[["all_reduce"], ["all_reduce"], ["all_reduce"]]
+    } : (tensor<4xi64>, tensor<4xi64>, tensor<4xi64>) ->
+        (tensor<4xi64>, tensor<4xi64>, tensor<4xi64>)
+    check.expect_eq_const %results#0, dense<[6, 8, 10, 12]> : tensor<4xi64>
+    check.expect_eq_const %results#1, dense<[6, 8, 10, 12]> : tensor<4xi64>
+    check.expect_eq_const %results#2, dense<[6, 8, 10, 12]> : tensor<4xi64>
+    func.return
+  }
+}

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -40,19 +40,45 @@ func.func @invalid_reduce_scatter(%data: tensor<4x16xf32>) -> tensor<4x5xf32> {
 
 // -----
 
-func.func @main(%arg0: tensor<10xf32>) -> tensor<10xf32> {
-  %0 = "stablehlo.all_reduce"(%arg0) ({
-  // Perform max reduction inside the region
-  ^bb0(%lhs: tensor<f32>, %rhs: tensor<f32>):
-    %max = stablehlo.maximum %lhs, %rhs : tensor<f32>
+func.func @all_reduce_c1(%operand: tensor<10xf32>) -> tensor<10xf32> {
+  // expected-error@+1 {{replica id #1 seen more than once}}
+  %0 = "stablehlo.all_reduce"(%operand) ({
+  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
+    %max = stablehlo.maximum %arg0, %arg1 : tensor<f32>
     "stablehlo.return"(%max) : (tensor<f32>) -> ()
   })
   {
-    replica_groups = dense<[[0, 2, 4, 6], [1, 3, 5, 7]]> : tensor<2x4xi64>,
-    channel_handle = #stablehlo.channel_handle<
-      handle = 5,
-      type = 2
-    >,
+    replica_groups = dense<[[0, 1, 1, 3]]> : tensor<1x4xi64>
+  } : (tensor<10xf32>) -> tensor<10xf32>
+  func.return %0 : tensor<10xf32>
+}
+
+// -----
+
+func.func @all_reduce_c2(%operand: tensor<10xf32>) -> tensor<10xf32> {
+  // expected-error@+1 {{replica groups should be a rank 2 tensor}}
+  %0 = "stablehlo.all_reduce"(%operand) ({
+  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
+    %max = stablehlo.maximum %arg0, %arg1 : tensor<f32>
+    "stablehlo.return"(%max) : (tensor<f32>) -> ()
+  })
+  {
+    replica_groups = dense<0> : tensor<1xi64>
+  } : (tensor<10xf32>) -> tensor<10xf32>
+  func.return %0 : tensor<10xf32>
+}
+
+// -----
+
+func.func @all_reduce_c3(%operand: tensor<10xf32>) -> tensor<10xf32> {
+  //  expected-error@+1 {{replica groups cannot be empty}}
+  %0 = "stablehlo.all_reduce"(%operand) ({
+  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
+    %max = stablehlo.maximum %arg0, %arg1 : tensor<f32>
+    "stablehlo.return"(%max) : (tensor<f32>) -> ()
+  })
+  {
+    replica_groups = dense<0> : tensor<0x2xi64>,
     use_global_device_ids
   } : (tensor<10xf32>) -> tensor<10xf32>
   func.return %0 : tensor<10xf32>
@@ -60,7 +86,39 @@ func.func @main(%arg0: tensor<10xf32>) -> tensor<10xf32> {
 
 // -----
 
-func.func @all_reduce_invalid_reducer(%operand: tensor<10xf32>) -> tensor<10xf32> {
+func.func @all_reduce_c4(%operand: tensor<10xf32>) -> tensor<10xf32> {
+  //  expected-error@+1 {{replica id #2 not seen in replica groups}}
+  %0 = "stablehlo.all_reduce"(%operand) ({
+  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
+    %max = stablehlo.maximum %arg0, %arg1 : tensor<f32>
+    "stablehlo.return"(%max) : (tensor<f32>) -> ()
+  })
+  {
+    replica_groups = dense<[[0, 1, 3]]> : tensor<1x3xi64>
+  } : (tensor<10xf32>) -> tensor<10xf32>
+  func.return %0 : tensor<10xf32>
+}
+
+// -----
+
+func.func @all_reduce_c5(%operand: tensor<10xf32>) -> tensor<10xf32> {
+  //  expected-error@+1 {{channel_id must be positive when useGlobalDeviceIds is set but got: -1}}
+  %0 = "stablehlo.all_reduce"(%operand) ({
+  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
+    %max = stablehlo.maximum %arg0, %arg1 : tensor<f32>
+    "stablehlo.return"(%max) : (tensor<f32>) -> ()
+  })
+  {
+    replica_groups = dense<[[0, 2, 4, 6], [1, 3, 5, 7]]> : tensor<2x4xi64>,
+    channel_handle = #stablehlo.channel_handle<handle = -1, type = 0>,
+    use_global_device_ids
+  } : (tensor<10xf32>) -> tensor<10xf32>
+  func.return %0 : tensor<10xf32>
+}
+
+// -----
+
+func.func @all_reduce_c6(%operand: tensor<10xf32>) -> tensor<10xf32> {
   // expected-error@+1 {{Reduction-region must take 2 parameters, but takes 3 parameter(s)}}
   %0 = "stablehlo.all_reduce"(%operand) ({
   ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>, %arg2: tensor<f32>):
@@ -75,7 +133,7 @@ func.func @all_reduce_invalid_reducer(%operand: tensor<10xf32>) -> tensor<10xf32
 
 // -----
 
-func.func @all_reduce_invalid_reducer(%operand: tensor<10xf32>) -> tensor<10xf32> {
+func.func @all_reduce_c6(%operand: tensor<10xf32>) -> tensor<10xf32> {
   // expected-error@+1 {{The reduction-region expected to return some value(s)}}
   %0 = "stablehlo.all_reduce"(%operand) ({
   ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
@@ -90,7 +148,7 @@ func.func @all_reduce_invalid_reducer(%operand: tensor<10xf32>) -> tensor<10xf32
 
 // -----
 
-func.func @all_reduce_invalid_reducer(%operand: tensor<10xf32>) -> tensor<10xf32> {
+func.func @all_reduce_c6(%operand: tensor<10xf32>) -> tensor<10xf32> {
   // expected-error@+1 {{Reduction-region here must produce 1 tensors, but produces 2 instead}}
   %0 = "stablehlo.all_reduce"(%operand) ({
   ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
@@ -105,7 +163,7 @@ func.func @all_reduce_invalid_reducer(%operand: tensor<10xf32>) -> tensor<10xf32
 
 // -----
 
-func.func @all_reduce_invalid_reducer(%operand: tensor<10xf32>) -> tensor<10xf32> {
+func.func @all_reduce_c6(%operand: tensor<10xf32>) -> tensor<10xf32> {
   // expected-error@+1 {{Reduction-region here must produce tensor-typed result(s), but produces 'tuple<tensor<f32>, tensor<f32>>' instead}}
   %0 = "stablehlo.all_reduce"(%operand) ({
   ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
@@ -121,7 +179,7 @@ func.func @all_reduce_invalid_reducer(%operand: tensor<10xf32>) -> tensor<10xf32
 
 // -----
 
-func.func @all_reduce_invalid_reducer(%operand: tensor<10xf32>) -> tensor<10xf32> {
+func.func @all_reduce_c6(%operand: tensor<10xf32>) -> tensor<10xf32> {
   // expected-error@+1 {{The type of reduction-region's parameter at index 1 is different than the corresponding result type: 'tensor<i32>' vs 'tensor<f32>'}}
   %0 = "stablehlo.all_reduce"(%operand) ({
   ^bb0(%arg0: tensor<f32>, %arg1: tensor<i32>):
@@ -136,7 +194,7 @@ func.func @all_reduce_invalid_reducer(%operand: tensor<10xf32>) -> tensor<10xf32
 
 // -----
 
-func.func @all_reduce_invalid_reducer(%operand: tensor<10xf32>) -> tensor<10xf32> {
+func.func @all_reduce_c6(%operand: tensor<10xf32>) -> tensor<10xf32> {
   // expected-error@+1 {{The type of reduction-region's parameter at index 0 is different than the corresponding result type: 'tensor<f32>' vs 'tensor<i32>'}}
   %0 = "stablehlo.all_reduce"(%operand) ({
   ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
@@ -152,7 +210,7 @@ func.func @all_reduce_invalid_reducer(%operand: tensor<10xf32>) -> tensor<10xf32
 
 // -----
 
-func.func @all_reduce_invalid_reducer(%operand: tensor<10xf32>) -> tensor<10xf32> {
+func.func @all_reduce_c6(%operand: tensor<10xf32>) -> tensor<10xf32> {
   // expected-error@+1 {{The type of reduction-region's result type at index 0 differs from the op's corresponding init-value type: 'tensor<i32>' vs 'tensor<f32>'}}
   %0 = "stablehlo.all_reduce"(%operand) ({
   ^bb0(%arg0: tensor<i32>, %arg1: tensor<i32>):
@@ -167,7 +225,7 @@ func.func @all_reduce_invalid_reducer(%operand: tensor<10xf32>) -> tensor<10xf32
 
 // -----
 
-func.func @all_reduce_invalid_reducer(%operand: tensor<10xf32>) -> tensor<10xf32> {
+func.func @all_reduce_c6(%operand: tensor<10xf32>) -> tensor<10xf32> {
   // expected-error@+1 {{The type of reduction-region's result type at index 0 differs from the op's corresponding init-value type: 'tensor<4xf32>' vs 'tensor<f32>'}}
   %0 = "stablehlo.all_reduce"(%operand) ({
   ^bb0(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>):
@@ -176,97 +234,6 @@ func.func @all_reduce_invalid_reducer(%operand: tensor<10xf32>) -> tensor<10xf32
   })
   {
     replica_groups = dense<[[0, 2, 4, 6], [1, 3, 5, 7]]> : tensor<2x4xi64>
-  } : (tensor<10xf32>) -> tensor<10xf32>
-  func.return %0 : tensor<10xf32>
-}
-
-// -----
-
-func.func @all_reduce_invalid_return_type(%operand: tensor<10xf32>) -> tensor<10x4xf32> {
-  // expected-error@+1 {{requires compatible types for all operands and results}}
-  %0 = "stablehlo.all_reduce"(%operand) ({
-  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
-    %max = stablehlo.maximum %arg0, %arg1 : tensor<f32>
-    "stablehlo.return"(%max) : (tensor<f32>) -> ()
-  })
-  {
-    replica_groups = dense<[[0, 2, 4, 6], [1, 3, 5, 7]]> : tensor<2x4xi64>
-  } : (tensor<10xf32>) -> tensor<10x4xf32>
-  func.return %0 : tensor<10x4xf32>
-}
-
-// -----
-
-func.func @all_reduce_invalid_return_type(%operand: tensor<10xf32>) -> tensor<10xi32> {
-  // expected-error@+1 {{requires compatible types for all operands and results}}
-  %0 = "stablehlo.all_reduce"(%operand) ({
-  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
-    %max = stablehlo.maximum %arg0, %arg1 : tensor<f32>
-    "stablehlo.return"(%max) : (tensor<f32>) -> ()
-  })
-  {
-    replica_groups = dense<[[0, 2, 4, 6], [1, 3, 5, 7]]> : tensor<2x4xi64>
-  } : (tensor<10xf32>) -> tensor<10xi32>
-  func.return %0 : tensor<10xi32>
-}
-
-// -----
-
-func.func @all_reduce_invalid_replica_group(%operand: tensor<10xf32>) -> tensor<10xf32> {
-  // expected-error@+1 {{replica groups should be a rank 2 tensor}}
-  %0 = "stablehlo.all_reduce"(%operand) ({
-  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
-    %max = stablehlo.maximum %arg0, %arg1 : tensor<f32>
-    "stablehlo.return"(%max) : (tensor<f32>) -> ()
-  })
-  {
-    replica_groups = dense<0> : tensor<1xi64>
-  } : (tensor<10xf32>) -> tensor<10xf32>
-  func.return %0 : tensor<10xf32>
-}
-
-// -----
-
-func.func @all_reduce_invalid_replica_group(%operand: tensor<10xf32>) -> tensor<10xf32> {
-  // expected-error@+1 {{replica id #1 seen more than once}}
-  %0 = "stablehlo.all_reduce"(%operand) ({
-  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
-    %max = stablehlo.maximum %arg0, %arg1 : tensor<f32>
-    "stablehlo.return"(%max) : (tensor<f32>) -> ()
-  })
-  {
-    replica_groups = dense<[[0, 1, 1, 3]]> : tensor<1x4xi64>
-  } : (tensor<10xf32>) -> tensor<10xf32>
-  func.return %0 : tensor<10xf32>
-}
-
-// -----
-
-func.func @all_reduce_invalid_replica_group(%operand: tensor<10xf32>) -> tensor<10xf32> {
-  //  expected-error@+1 {{replica id #2 not seen in replica groups}}
-  %0 = "stablehlo.all_reduce"(%operand) ({
-  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
-    %max = stablehlo.maximum %arg0, %arg1 : tensor<f32>
-    "stablehlo.return"(%max) : (tensor<f32>) -> ()
-  })
-  {
-    replica_groups = dense<[[0, 1, 3]]> : tensor<1x3xi64>
-  } : (tensor<10xf32>) -> tensor<10xf32>
-  func.return %0 : tensor<10xf32>
-}
-
-// -----
-
-func.func @all_reduce_invalid_replica_group(%operand: tensor<10xf32>) -> tensor<10xf32> {
-  //  expected-error@+1 {{replica groups cannot be empty}}
-  %0 = "stablehlo.all_reduce"(%operand) ({
-  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
-    %max = stablehlo.maximum %arg0, %arg1 : tensor<f32>
-    "stablehlo.return"(%max) : (tensor<f32>) -> ()
-  })
-  {
-    replica_groups = dense<0> : tensor<0x2xi64>,
-    use_global_device_ids
   } : (tensor<10xf32>) -> tensor<10xf32>
   func.return %0 : tensor<10xf32>
 }

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -40,6 +40,23 @@ func.func @invalid_reduce_scatter(%data: tensor<4x16xf32>) -> tensor<4x5xf32> {
 
 // -----
 
+// TODO(#498): AllReduceOp replica groups does not need to be rank 2.
+func.func @all_reduce(%operand: tensor<10xf32>) -> tensor<10xf32> {
+  // expected-error@+1 {{replica groups should be a rank 2 tensor}}
+  %0 = "stablehlo.all_reduce"(%operand) ({
+  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
+    %max = stablehlo.maximum %arg0, %arg1 : tensor<f32>
+    "stablehlo.return"(%max) : (tensor<f32>) -> ()
+  })
+  {
+    replica_groups = dense<0> : tensor<1xi64>
+  } : (tensor<10xf32>) -> tensor<10xf32>
+  func.return %0 : tensor<10xf32>
+}
+
+
+// -----
+
 func.func @all_reduce_c1(%operand: tensor<10xf32>) -> tensor<10xf32> {
   // expected-error@+1 {{replica id #1 seen more than once}}
   %0 = "stablehlo.all_reduce"(%operand) ({
@@ -49,21 +66,6 @@ func.func @all_reduce_c1(%operand: tensor<10xf32>) -> tensor<10xf32> {
   })
   {
     replica_groups = dense<[[0, 1, 1, 3]]> : tensor<1x4xi64>
-  } : (tensor<10xf32>) -> tensor<10xf32>
-  func.return %0 : tensor<10xf32>
-}
-
-// -----
-
-func.func @all_reduce_c2_i2(%operand: tensor<10xf32>) -> tensor<10xf32> {
-  // expected-error@+1 {{replica groups should be a rank 2 tensor}}
-  %0 = "stablehlo.all_reduce"(%operand) ({
-  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
-    %max = stablehlo.maximum %arg0, %arg1 : tensor<f32>
-    "stablehlo.return"(%max) : (tensor<f32>) -> ()
-  })
-  {
-    replica_groups = dense<0> : tensor<1xi64>
   } : (tensor<10xf32>) -> tensor<10xf32>
   func.return %0 : tensor<10xf32>
 }
@@ -86,7 +88,7 @@ func.func @all_reduce_c3(%operand: tensor<10xf32>) -> tensor<10xf32> {
 
 // -----
 
-func.func @all_reduce_c4(%operand: tensor<10xf32>) -> tensor<10xf32> {
+func.func @all_reduce_c3(%operand: tensor<10xf32>) -> tensor<10xf32> {
   //  expected-error@+1 {{replica id #2 not seen in replica groups}}
   %0 = "stablehlo.all_reduce"(%operand) ({
   ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
@@ -101,7 +103,7 @@ func.func @all_reduce_c4(%operand: tensor<10xf32>) -> tensor<10xf32> {
 
 // -----
 
-func.func @all_reduce_c5(%operand: tensor<10xf32>) -> tensor<10xf32> {
+func.func @all_reduce_c4(%operand: tensor<10xf32>) -> tensor<10xf32> {
   //  expected-error@+1 {{channel_id must be positive when useGlobalDeviceIds is set but got: -1}}
   %0 = "stablehlo.all_reduce"(%operand) ({
   ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
@@ -118,7 +120,7 @@ func.func @all_reduce_c5(%operand: tensor<10xf32>) -> tensor<10xf32> {
 
 // -----
 
-func.func @all_reduce_c6(%operand: tensor<10xf32>) -> tensor<10xf32> {
+func.func @all_reduce_c5(%operand: tensor<10xf32>) -> tensor<10xf32> {
   // expected-error@+1 {{Reduction-region must take 2 parameters, but takes 3 parameter(s)}}
   %0 = "stablehlo.all_reduce"(%operand) ({
   ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>, %arg2: tensor<f32>):
@@ -133,7 +135,7 @@ func.func @all_reduce_c6(%operand: tensor<10xf32>) -> tensor<10xf32> {
 
 // -----
 
-func.func @all_reduce_c6(%operand: tensor<10xf32>) -> tensor<10xf32> {
+func.func @all_reduce_c5(%operand: tensor<10xf32>) -> tensor<10xf32> {
   // expected-error@+1 {{The reduction-region expected to return some value(s)}}
   %0 = "stablehlo.all_reduce"(%operand) ({
   ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
@@ -148,7 +150,7 @@ func.func @all_reduce_c6(%operand: tensor<10xf32>) -> tensor<10xf32> {
 
 // -----
 
-func.func @all_reduce_c6(%operand: tensor<10xf32>) -> tensor<10xf32> {
+func.func @all_reduce_c5(%operand: tensor<10xf32>) -> tensor<10xf32> {
   // expected-error@+1 {{Reduction-region here must produce 1 tensors, but produces 2 instead}}
   %0 = "stablehlo.all_reduce"(%operand) ({
   ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
@@ -163,7 +165,7 @@ func.func @all_reduce_c6(%operand: tensor<10xf32>) -> tensor<10xf32> {
 
 // -----
 
-func.func @all_reduce_c6(%operand: tensor<10xf32>) -> tensor<10xf32> {
+func.func @all_reduce_c5(%operand: tensor<10xf32>) -> tensor<10xf32> {
   // expected-error@+1 {{Reduction-region here must produce tensor-typed result(s), but produces 'tuple<tensor<f32>, tensor<f32>>' instead}}
   %0 = "stablehlo.all_reduce"(%operand) ({
   ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
@@ -179,7 +181,7 @@ func.func @all_reduce_c6(%operand: tensor<10xf32>) -> tensor<10xf32> {
 
 // -----
 
-func.func @all_reduce_c6(%operand: tensor<10xf32>) -> tensor<10xf32> {
+func.func @all_reduce_c5(%operand: tensor<10xf32>) -> tensor<10xf32> {
   // expected-error@+1 {{The type of reduction-region's parameter at index 1 is different than the corresponding result type: 'tensor<i32>' vs 'tensor<f32>'}}
   %0 = "stablehlo.all_reduce"(%operand) ({
   ^bb0(%arg0: tensor<f32>, %arg1: tensor<i32>):
@@ -194,7 +196,7 @@ func.func @all_reduce_c6(%operand: tensor<10xf32>) -> tensor<10xf32> {
 
 // -----
 
-func.func @all_reduce_c6(%operand: tensor<10xf32>) -> tensor<10xf32> {
+func.func @all_reduce_c5(%operand: tensor<10xf32>) -> tensor<10xf32> {
   // expected-error@+1 {{The type of reduction-region's parameter at index 0 is different than the corresponding result type: 'tensor<f32>' vs 'tensor<i32>'}}
   %0 = "stablehlo.all_reduce"(%operand) ({
   ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
@@ -210,7 +212,7 @@ func.func @all_reduce_c6(%operand: tensor<10xf32>) -> tensor<10xf32> {
 
 // -----
 
-func.func @all_reduce_c6(%operand: tensor<10xf32>) -> tensor<10xf32> {
+func.func @all_reduce_c5(%operand: tensor<10xf32>) -> tensor<10xf32> {
   // expected-error@+1 {{The type of reduction-region's result type at index 0 differs from the op's corresponding init-value type: 'tensor<i32>' vs 'tensor<f32>'}}
   %0 = "stablehlo.all_reduce"(%operand) ({
   ^bb0(%arg0: tensor<i32>, %arg1: tensor<i32>):
@@ -225,7 +227,7 @@ func.func @all_reduce_c6(%operand: tensor<10xf32>) -> tensor<10xf32> {
 
 // -----
 
-func.func @all_reduce_c6(%operand: tensor<10xf32>) -> tensor<10xf32> {
+func.func @all_reduce_c5(%operand: tensor<10xf32>) -> tensor<10xf32> {
   // expected-error@+1 {{The type of reduction-region's result type at index 0 differs from the op's corresponding init-value type: 'tensor<4xf32>' vs 'tensor<f32>'}}
   %0 = "stablehlo.all_reduce"(%operand) ({
   ^bb0(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>):

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -55,7 +55,7 @@ func.func @all_reduce_c1(%operand: tensor<10xf32>) -> tensor<10xf32> {
 
 // -----
 
-func.func @all_reduce_c2(%operand: tensor<10xf32>) -> tensor<10xf32> {
+func.func @all_reduce_c2_i2(%operand: tensor<10xf32>) -> tensor<10xf32> {
   // expected-error@+1 {{replica groups should be a rank 2 tensor}}
   %0 = "stablehlo.all_reduce"(%operand) ({
   ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):


### PR DESCRIPTION
We have the following constraints in the spec:

```
(I1) `operand` tensor.
(I2) `replica_groups` variadic number of 1-dimensional tensor constant of type `si64`.
(I3) `channel_id` constant of type `si64`.
(I4) `use_global_device_ids` constant of type `i1`.
(I5) `computation` function.
(C1) `is_unique(replica_groups)`.
(C2) `size(replica_groups)` is defined as:
* `num_replicas` if `cross_replica` is used.
* `num_replicas` if `cross_replica_and_partition` is used.
* `num_processes` if `flattened_ids` is used.
(C3) `0 <= replica_groups < size(replica_groups)`.
(C4) If `use_global_device_ids = true`, then `channel_id > 0`.
(C5) `computation` has type `(tensor<E>, tensor<E>) -> (tensor<E>)` where
     `E = element_type(operand)`.
(C6) `type(result) = type(operand)`.
```

These constraints will be comprehensively covered by the following tests:

```
I1: a) `operand` is not a tensor. (Covered by ODS).
I2: a) `replica_groups` is not a variadic number of 1-dimensional tensor.
I2: b) `element_type(replica_groups) != si64`. (Covered by ODS).
I3: a) `channel_id` is not a constant of type `si64`. (Covered by ODS).
I4: a) `use_global_device_ids` is not a constant of type `i1`. (Covered by ODS).
I5: a) `computation` is not a function. (Covered by ODS).
C1: a) `is_unique(replica_groups)` = false.
C2: a) `size(replica_groups)` is not defined as:
* `num_replicas` if `cross_replica` is used.
* `num_replicas` if `cross_replica_and_partition` is used.
* `num_processes` if `flattened_ids` is used.
C3: a) `replica_groups < 0`.
C3: b) `replica_groups >= size(replica_groups)`.
C4: a) If `use_global_device_ids = true` and `channel_id <= 0`.
C5: a) `computation` does not have type `(tensor<E>, tensor<E>) -> (tensor<E>)`
       where `E = element_type(operand)`.
C6: a) `type(result) != type(operand)`. (Covered by ODS).
```

If we drop the "Covered by ODS" pieces, this will leave us with the following test cases:

```
I2: a) `replica_groups` is not a variadic number of 1-dimensional tensor.
C1: a) `is_unique(replica_groups)` = false.
C2: a) `size(replica_groups)` is not defined as:
* `num_replicas` if `cross_replica` is used.
* `num_replicas` if `cross_replica_and_partition` is used.
* `num_processes` if `flattened_ids` is used.
C3: a) `replica_groups < 0`.
C3: b) `replica_groups >= size(replica_groups)`.
C4: a) If `use_global_device_ids = true` and `channel_id <= 0`.
C5: a) `computation` does not have type `(tensor<E>, tensor<E>) -> (tensor<E>)`
       where `E = element_type(operand)`.
```

Notes:
  * I2 is not tested due to #498.
  * C2a verification is infeasible since `num_replicas` and `num_partitions` are not knwon statically.
  * C3b verification is infeasible since `size(replica_groups)` is not known statically.

closes #1119