### PR TITLE
Add interpreter for InfeedOp

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3115,27 +3115,38 @@ separate outputs to improve clarity
 
 | Label | Name            | Type                      | Constraints |
 |-------|-----------------|---------------------------|-------------|
-| (I1)  | `token`         | `token`                   | (C2)        |
+| (I1)  | `token`         | `token`                   | (C3)        |
 | (I2)  | `infeed_config` | constant of type `string` |             |
 
 #### Outputs
 
 | Name      | Type                                                    | Constraints |
 |-----------|---------------------------------------------------------|-------------|
-| `results` | variadic number of tensors, quantized tensors or tokens | (C1), (C2)  |
+| `results` | variadic number of tensors, quantized tensors or tokens | (C1-C3)     |
 
 #### Constraints
 
 * (C1) `0 < size(results)`.
-* (C2) `is_token(type(results[-1]))`.
+* (C2) `is_tensor(type(results[:-1]))`.
+* (C3) `is_token(type(results[-1]))`.
 
 #### Examples
 
 ```mlir
-%results0, %results1 = "stablehlo.infeed"(%token) {
+// %token: !stablehlo.token
+// infeed_queue[0]: [[1, 2], [3, 4]]
+// infeed_queue[1]: [[5, 6], [7, 8]]
+%results0:2 = "stablehlo.infeed"(%token) {
   infeed_config = ""
-} : (!stablehlo.token) -> (tensor<3x3x3xi32>, !stablehlo.token)
+} : (!stablehlo.token) -> (tensor<2x2xi64>, !stablehlo.token)
+// results0#0: [[1, 2], [3, 4]]
+%results1:2 = "stablehlo.infeed"(%token) {
+  infeed_config = ""
+} : (!stablehlo.token) -> (tensor<2x2xi64>, !stablehlo.token)
+// results1#0: [[5, 6], [7, 8]]
 ```
+
+&nbsp;[More Examples](../stablehlo/tests/interpret_infeed.mlir)
 
 ### iota
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3113,10 +3113,10 @@ separate outputs to improve clarity
 
 #### Inputs
 
-| Label | Name            | Type                      | Constraints |
-|-------|-----------------|---------------------------|-------------|
-| (I1)  | `token`         | `token`                   | (C3)        |
-| (I2)  | `infeed_config` | constant of type `string` |             |
+| Label | Name            | Type                      |
+|-------|-----------------|---------------------------|
+| (I1)  | `token`         | `token`                   |
+| (I2)  | `infeed_config` | constant of type `string` |
 
 #### Outputs
 
@@ -3127,7 +3127,7 @@ separate outputs to improve clarity
 #### Constraints
 
 * (C1) `0 < size(results)`.
-* (C2) `is_tensor(type(results[:-1]))`.
+* (C2) `is_empty(result[:-1]) or is_tensor(type(results[:-1]))`.
 * (C3) `is_token(type(results[-1]))`.
 
 #### Examples

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3127,7 +3127,7 @@ separate outputs to improve clarity
 #### Constraints
 
 * (C1) `0 < size(results)`.
-* (C2) `is_empty(result[:-1]) or is_tensor(type(results[:-1]))`.
+* (C2) `is_empty(result[:-1])` or `is_tensor(type(results[:-1]))`.
 * (C3) `is_token(type(results[-1]))`.
 
 #### Examples

--- a/docs/status.md
+++ b/docs/status.md
@@ -96,7 +96,7 @@ one of the following tracking labels.
 | get_tuple_element        | yes           | yes          | yes            | yes             | yes         |
 | if                       | yes           | revisit      | yes            | no              | yes         |
 | imag                     | yes           | yes          | yes            | yes             | yes         |
-| infeed                   | yes           | revisit      | infeasible     | no              | yes         |
+| infeed                   | yes           | yes          | infeasible     | no              | yes         |
 | iota                     | yes           | yes          | infeasible     | yes             | yes         |
 | is_finite                | yes           | yes          | yes            | yes             | yes         |
 | log                      | yes           | yes          | yes            | yes             | yes         |

--- a/docs/status.md
+++ b/docs/status.md
@@ -96,7 +96,7 @@ one of the following tracking labels.
 | get_tuple_element        | yes           | yes          | yes            | yes             | yes         |
 | if                       | yes           | revisit      | yes            | no              | yes         |
 | imag                     | yes           | yes          | yes            | yes             | yes         |
-| infeed                   | yes           | revisit      | infeasible     | no              | no          |
+| infeed                   | yes           | revisit      | infeasible     | no              | yes         |
 | iota                     | yes           | yes          | infeasible     | yes             | yes         |
 | is_finite                | yes           | yes          | yes            | yes             | yes         |
 | log                      | yes           | yes          | yes            | yes             | yes         |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1003,15 +1003,14 @@ def StableHLO_InfeedOp : StableHLO_Op<"infeed", []> {
 
     Example:
     ```mlir
-    %results:2 = "stablehlo.infeed"(%token) {
-      infeed_config = ""
-    } : (!stablehlo.token) -> (tensor<3x3x3xi32>, !stablehlo.token)
+    %results0:2 = "stablehlo.infeed"(%token) :
+        (!stablehlo.token) -> (tensor<2x2xi64>, !stablehlo.token)
     ```
   }];
 
   let arguments = (ins
-    HLO_Token:$token,
-    DefaultValuedStrAttr<StrAttr, "">:$infeed_config,
+    HLO_Token:$token, /*infeed_i1*/
+    DefaultValuedStrAttr<StrAttr, "">:$infeed_config, /*infeed_i2*/
     OptionalAttr<ArrayAttr>:$layout
   );
   let results = (outs Variadic<HLO_StaticShapeTensorOrToken>);

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -3575,20 +3575,20 @@ LogicalResult verifyInfeedOp(HloDialectInterface* dialect,
         resultTypes.size());
 
   // infeed_c2
-  for (size_t i = 0; i < resultTypes.size() - 1; ++i)
-    if (!resultTypes[i].isa<TensorType>())
+  for (auto resultType : results.drop_back().getTypes())
+    if (!resultType.isa<TensorType>())
       return emitOptionalError(
           location,
           "all elements of result types, except the last element, are expected "
           "to be of tensor type, but got ",
-          resultTypes[i]);
+          resultType);
 
   // infeed_c3
-  if (!dialect->isTokenType(resultTypes[resultTypes.size() - 1]))
+  if (!dialect->isTokenType(results.back().getType()))
     return emitOptionalError(location,
                              "last element of result types is expected to "
                              "be of token type, but got ",
-                             resultTypes[resultTypes.size() - 1]);
+                             results.back().getType());
 
   if (!layout.has_value()) return success();
   if (!layout.value())

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -3563,18 +3563,27 @@ LogicalResult verifyDynamicReshapeOp(std::optional<Location> location,
   return success();
 }
 
-// Checks that the result type is of the form `zero_or_more_type(s),
-// stablehlo::token`
 LogicalResult verifyInfeedOp(HloDialectInterface* dialect,
                              std::optional<Location> location,
                              std::optional<ArrayAttr> layout,
                              ValueRange results) {
   auto resultTypes = results.getType();
+  // infeed_c1
   if (resultTypes.empty())
     return emitOptionalError(
         location, "result is expected to be at least of size 1, but got ",
         resultTypes.size());
 
+  // infeed_c2
+  for (size_t i = 0; i < resultTypes.size() - 1; ++i)
+    if (!resultTypes[i].isa<TensorType>())
+      return emitOptionalError(
+          location,
+          "everything but the last element of result types is expected to "
+          "be of tensor type, but got ",
+          resultTypes[i]);
+
+  // infeed_c3
   if (!dialect->isTokenType(resultTypes[resultTypes.size() - 1]))
     return emitOptionalError(location,
                              "last element of result types is expected to "

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -3579,7 +3579,7 @@ LogicalResult verifyInfeedOp(HloDialectInterface* dialect,
     if (!resultTypes[i].isa<TensorType>())
       return emitOptionalError(
           location,
-          "everything but the last element of result types is expected to "
+          "all elements of result types except the last element is expected to "
           "be of tensor type, but got ",
           resultTypes[i]);
 

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -3579,8 +3579,8 @@ LogicalResult verifyInfeedOp(HloDialectInterface* dialect,
     if (!resultTypes[i].isa<TensorType>())
       return emitOptionalError(
           location,
-          "all elements of result types except the last element is expected to "
-          "be of tensor type, but got ",
+          "all elements of result types, except the last element, are expected "
+          "to be of tensor type, but got ",
           resultTypes[i]);
 
   // infeed_c3

--- a/stablehlo/reference/InterpreterOps.h
+++ b/stablehlo/reference/InterpreterOps.h
@@ -34,7 +34,7 @@ class InterpreterDialect : public Dialect {
 };
 
 SmallVector<InterpreterValue> evalRunParallelOp(
-    ArrayRef<InterpreterValue> inputs, std::queue<StringAttr> *infeed,
+    ArrayRef<InterpreterValue> inputs, std::queue<StringAttr> &infeed,
     SmallVector<SmallVector<StringAttr>> programs, SymbolTable &symbolTable);
 
 }  // namespace interpreter

--- a/stablehlo/reference/InterpreterOps.h
+++ b/stablehlo/reference/InterpreterOps.h
@@ -16,6 +16,8 @@ limitations under the License.
 #ifndef STABLEHLO_REFERENCE_INTERPRETEROPS_H
 #define STABLEHLO_REFERENCE_INTERPRETEROPS_H
 
+#include <queue>
+
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/Support/LLVM.h"
@@ -32,7 +34,7 @@ class InterpreterDialect : public Dialect {
 };
 
 SmallVector<InterpreterValue> evalRunParallelOp(
-    ArrayRef<InterpreterValue> inputs,
+    ArrayRef<InterpreterValue> inputs, std::queue<StringAttr> *infeed,
     SmallVector<SmallVector<StringAttr>> programs, SymbolTable &symbolTable);
 
 }  // namespace interpreter

--- a/stablehlo/reference/InterpreterOps.td
+++ b/stablehlo/reference/InterpreterOps.td
@@ -70,6 +70,7 @@ def Interpreter_RunParallelOp : Op<Interpreter_Dialect, "run_parallel", []> {
   }];
   let arguments = (ins
     Variadic<HLO_TensorOrToken>:$inputs,
+    OptionalAttr<StrArrayAttr>:$infeed,
     Interpreter_ArrayOfStrArrayAttr:$programs
   );
   let results = (outs Variadic<HLO_TensorOrToken>:$results);

--- a/stablehlo/reference/InterpreterOps.td
+++ b/stablehlo/reference/InterpreterOps.td
@@ -66,7 +66,7 @@ def Interpreter_RunParallelOp : Op<Interpreter_Dialect, "run_parallel", []> {
     Example:
     ```mlir
     %results:2 = "interpreter.run_parallel"() {
-      infeed=[%infeed_queue0, @infeed_queue1]
+      infeed=[@infeed_queue0, @infeed_queue1]
       programs=[[@foo], [@bar]]
     } : () -> (tensor<ui32>, tensor<ui32>)
     ```

--- a/stablehlo/reference/InterpreterOps.td
+++ b/stablehlo/reference/InterpreterOps.td
@@ -16,6 +16,7 @@ limitations under the License.
 #ifndef STABLEHLO_REFERENCE_INTERPRETER_OPS
 #define STABLEHLO_REFERENCE_INTERPRETER_OPS
 
+include "mlir/IR/OpBase.td"
 include "stablehlo/dialect/Base.td"
 
 //===----------------------------------------------------------------------===//
@@ -34,8 +35,9 @@ def Interpreter_Dialect : Dialect {
   let usePropertiesForAttributes = 0;
 }
 
-def Interpreter_ArrayOfStrArrayAttr : TypedArrayAttrBase<StrArrayAttr,
-    "Array of StrArrayAttr">;
+def Interpreter_ArrayOfFlatSymbolRefArrayAttr :
+    TypedArrayAttrBase<FlatSymbolRefArrayAttr,
+    "Array of FlatSymbolRefArrayAttr">;
 
 //===----------------------------------------------------------------------===//
 // Interpreter op definitions.
@@ -64,14 +66,15 @@ def Interpreter_RunParallelOp : Op<Interpreter_Dialect, "run_parallel", []> {
     Example:
     ```mlir
     %results:2 = "interpreter.run_parallel"() {
-      programs=[["foo"], ["bar"]]
+      infeed=[%infeed_queue0, @infeed_queue1]
+      programs=[[@foo], [@bar]]
     } : () -> (tensor<ui32>, tensor<ui32>)
     ```
   }];
   let arguments = (ins
     Variadic<HLO_TensorOrToken>:$inputs,
-    OptionalAttr<StrArrayAttr>:$infeed,
-    Interpreter_ArrayOfStrArrayAttr:$programs
+    OptionalAttr<FlatSymbolRefArrayAttr>:$infeed,
+    Interpreter_ArrayOfFlatSymbolRefArrayAttr:$programs
   );
   let results = (outs Variadic<HLO_TensorOrToken>:$results);
   let hasVerifier = 1;

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -102,6 +102,8 @@ SmallVector<InterpreterValue> evalIfOp(const Tensor &pred, Region &trueBranch,
                                        Region &falseBranch, Process *process,
                                        Scope &scope);
 Tensor evalImagOp(const Tensor &operand, ShapedType resultType);
+SmallVector<InterpreterValue> evalInfeedOp(Token token, Process *process,
+                                           Region &region, Scope &scope);
 Tensor evalIotaOp(Axis iotaDimension, ShapedType resultType);
 Tensor evalIsFiniteOp(const Tensor &operand, ShapedType resultType);
 Tensor evalLog1pOp(const Tensor &operand, ShapedType resultType);

--- a/stablehlo/reference/Process.cpp
+++ b/stablehlo/reference/Process.cpp
@@ -40,6 +40,8 @@ ProcessGroups Process::flattenedIds(
   return grid_->flattenedIds(flattenedIdGroups);
 }
 
+StringAttr Process::infeed() { return grid_->infeed(); }
+
 ProcessId Process::getId() { return id_; }
 
 void Process::outfeed(ArrayRef<Tensor> inputs) { grid_->outfeed(inputs); }

--- a/stablehlo/reference/Process.h
+++ b/stablehlo/reference/Process.h
@@ -47,6 +47,9 @@ class Process {
   ProcessGroups flattenedIds(
       SmallVector<SmallVector<uint32_t>> flattenedIdGroups);
 
+  /// See "ProcessGrid::infeed".
+  StringAttr infeed();
+
   /// Getter for the underlying StableHLO `process_id`.
   ProcessId getId();
 

--- a/stablehlo/reference/ProcessGrid.cpp
+++ b/stablehlo/reference/ProcessGrid.cpp
@@ -114,11 +114,11 @@ void ProcessGrid::ThreadSafeQueue<T>::push(T input) {
 //===----------------------------------------------------------------------===//
 
 ProcessGrid::ProcessGrid(uint32_t numReplicas, uint32_t numPartitions,
-                         std::queue<StringAttr> *infeed)
+                         std::queue<StringAttr> &infeed)
     : numReplicas_(numReplicas), numPartitions_(numPartitions) {
-  while (!infeed->empty()) {
-    auto head = infeed->front();
-    infeed->pop();
+  while (!infeed.empty()) {
+    auto head = infeed.front();
+    infeed.pop();
     infeed_.push(head);
   }
 }

--- a/stablehlo/reference/ProcessGrid.cpp
+++ b/stablehlo/reference/ProcessGrid.cpp
@@ -96,15 +96,11 @@ detail::ThreadSafeQueue<T>::ThreadSafeQueue(const std::queue<T> &queue)
     : queue_(queue) {}
 
 template <typename T>
-T detail::ThreadSafeQueue<T>::front() {
+T detail::ThreadSafeQueue<T>::pop() {
   std::lock_guard<std::mutex> lock(lock_);
-  return queue_.front();
-}
-
-template <typename T>
-void detail::ThreadSafeQueue<T>::pop() {
-  std::lock_guard<std::mutex> lock(lock_);
+  auto result = queue_.front();
   queue_.pop();
+  return result;
 }
 
 template <typename T>
@@ -180,11 +176,7 @@ ProcessGroups ProcessGrid::flattenedIds(
   return processGroups;
 }
 
-StringAttr ProcessGrid::infeed() {
-  auto result = infeed_.front();
-  infeed_.pop();
-  return result;
-}
+StringAttr ProcessGrid::infeed() { return infeed_.pop(); }
 
 void ProcessGrid::outfeed(ArrayRef<Tensor> inputs) {
   outfeed_.push(llvm::to_vector(inputs));

--- a/stablehlo/reference/ProcessGrid.cpp
+++ b/stablehlo/reference/ProcessGrid.cpp
@@ -82,7 +82,7 @@ SmallVector<Tensor> RendezvousResult::getSortedTensors() const {
 //===----------------------------------------------------------------------===//
 
 template <typename K, typename V>
-V &ThreadSafeMap<K, V>::operator[](const K &key) {
+V &detail::ThreadSafeMap<K, V>::operator[](const K &key) {
   std::lock_guard<std::mutex> lock(lock_);
   return map_[key];
 }
@@ -92,23 +92,23 @@ V &ThreadSafeMap<K, V>::operator[](const K &key) {
 //===----------------------------------------------------------------------===//
 
 template <typename T>
-ThreadSafeQueue<T>::ThreadSafeQueue(const std::queue<T> &queue)
+detail::ThreadSafeQueue<T>::ThreadSafeQueue(const std::queue<T> &queue)
     : queue_(queue) {}
 
 template <typename T>
-T ThreadSafeQueue<T>::front() {
+T detail::ThreadSafeQueue<T>::front() {
   std::lock_guard<std::mutex> lock(lock_);
   return queue_.front();
 }
 
 template <typename T>
-void ThreadSafeQueue<T>::pop() {
+void detail::ThreadSafeQueue<T>::pop() {
   std::lock_guard<std::mutex> lock(lock_);
   queue_.pop();
 }
 
 template <typename T>
-void ThreadSafeQueue<T>::push(T input) {
+void detail::ThreadSafeQueue<T>::push(T input) {
   std::lock_guard<std::mutex> lock(lock_);
   queue_.emplace(input);
 }

--- a/stablehlo/reference/ProcessGrid.h
+++ b/stablehlo/reference/ProcessGrid.h
@@ -82,11 +82,8 @@ class ThreadSafeQueue {
   ThreadSafeQueue(const std::queue<T> &queue);
   /// @}
 
-  /// Returns a copy of the data at the first element of the queue.
-  T front();
-
-  /// Remove the first element of the queue.
-  void pop();
+  /// Remove the first element of the queue and return it.
+  T pop();
 
   /// Add `inputs` to the end of the queue.
   void push(T inputs);

--- a/stablehlo/reference/ProcessGrid.h
+++ b/stablehlo/reference/ProcessGrid.h
@@ -34,7 +34,7 @@ namespace stablehlo {
 struct ProcessId;
 class RendezvousResult;
 
-namespace {
+namespace detail {
 
 /// Internal storate used in `rendezvous` to manage concurrent access to the
 /// shared resource. Processes contribute their data to `values` concurrently.
@@ -99,7 +99,7 @@ class ThreadSafeQueue {
   std::queue<T> queue_;
 };
 
-}  // namespace
+}  // namespace detail
 
 using ChannelId = int64_t;
 
@@ -225,16 +225,19 @@ class ProcessGrid {
   /// Interal queue of strings which represents `func::FuncOp` mnemonic that
   /// returns a vector of Tensor. The function name is stored instead of the
   /// vector of tensors to save memory. See `ThreadSafeQueue`.
-  ThreadSafeQueue<StringAttr> infeed_;
+  detail::ThreadSafeQueue<StringAttr> infeed_;
 
   /// See `ThreadSafeQueue`.
-  ThreadSafeQueue<SmallVector<Tensor>> outfeed_;
+  detail::ThreadSafeQueue<SmallVector<Tensor>> outfeed_;
 
   /// See `ThreadSafeMap`.
-  ThreadSafeMap<std::pair<ProcessGroup, ChannelId>, RendezvousState> channels_;
+  detail::ThreadSafeMap<std::pair<ProcessGroup, ChannelId>,
+                        detail::RendezvousState>
+      channels_;
 
   /// Synchronization primitive used to manage concurrent access to `channels_`.
-  ThreadSafeMap<std::pair<ProcessGroup, ChannelId>, std::condition_variable>
+  detail::ThreadSafeMap<std::pair<ProcessGroup, ChannelId>,
+                        std::condition_variable>
       channelConditions_;
 };
 

--- a/stablehlo/reference/ProcessGrid.h
+++ b/stablehlo/reference/ProcessGrid.h
@@ -95,7 +95,7 @@ class ProcessGrid {
   /// \name Constructors
   /// @{
   ProcessGrid(uint32_t numReplicas, uint32_t numPartitions,
-              std::queue<StringAttr> *infeed);
+              std::queue<StringAttr> &infeed);
   /// @}
 
   /// StableHLO `cross_partition` communication strategy.

--- a/stablehlo/tests/interpret_all_gather.mlir
+++ b/stablehlo/tests/interpret_all_gather.mlir
@@ -12,7 +12,7 @@ module @cross_replica {
     %0 = stablehlo.constant dense<[[1, 2], [3, 4]]> : tensor<2x2xi64>
     %1 = stablehlo.constant dense<[[5, 6], [7, 8]]> : tensor<2x2xi64>
     %results:2 = "interpreter.run_parallel"(%0, %1) {
-      programs=[["all_gather"], ["all_gather"]]
+      programs=[[@all_gather], [@all_gather]]
     } : (tensor<2x2xi64>, tensor<2x2xi64>) -> (tensor<2x4xi64>, tensor<2x4xi64>)
     check.expect_eq_const %results#0, dense<[[1, 2, 5, 6],
                                              [3, 4, 7, 8]]> : tensor<2x4xi64>
@@ -37,7 +37,7 @@ module @cross_replica_and_partition {
     %0 = stablehlo.constant dense<[[1, 2], [3, 4]]> : tensor<2x2xi64>
     %1 = stablehlo.constant dense<[[5, 6], [7, 8]]> : tensor<2x2xi64>
     %results:2 = "interpreter.run_parallel"(%0, %1) {
-      programs=[["all_gather"], ["all_gather"]]
+      programs=[[@all_gather], [@all_gather]]
     } : (tensor<2x2xi64>, tensor<2x2xi64>) -> (tensor<2x4xi64>, tensor<2x4xi64>)
     check.expect_eq_const %results#0, dense<[[1, 2, 5, 6],
                                              [3, 4, 7, 8]]> : tensor<2x4xi64>
@@ -63,7 +63,7 @@ module @flattened_ids {
     %0 = stablehlo.constant dense<[[1, 2], [3, 4]]> : tensor<2x2xi64>
     %1 = stablehlo.constant dense<[[5, 6], [7, 8]]> : tensor<2x2xi64>
     %results:2 = "interpreter.run_parallel"(%0, %1) {
-      programs=[["all_gather"], ["all_gather"]]
+      programs=[[@all_gather], [@all_gather]]
     } : (tensor<2x2xi64>, tensor<2x2xi64>) -> (tensor<2x4xi64>, tensor<2x4xi64>)
     check.expect_eq_const %results#0, dense<[[1, 2, 5, 6],
                                              [3, 4, 7, 8]]> : tensor<2x4xi64>

--- a/stablehlo/tests/interpret_all_reduce.mlir
+++ b/stablehlo/tests/interpret_all_reduce.mlir
@@ -16,7 +16,7 @@ module @cross_replica {
     %inputs0 = stablehlo.constant dense<[1, 2, 3, 4]> : tensor<4xi64>
     %inputs1 = stablehlo.constant dense<[5, 6, 7, 8]> : tensor<4xi64>
     %results:2 = "interpreter.run_parallel"(%inputs0, %inputs1) {
-      programs=[["all_reduce"], ["all_reduce"]]
+      programs=[[@all_reduce], [@all_reduce]]
     } : (tensor<4xi64>, tensor<4xi64>) -> (tensor<4xi64>, tensor<4xi64>)
     check.expect_eq_const %results#0, dense<[6, 8, 10, 12]> : tensor<4xi64>
     check.expect_eq_const %results#1, dense<[6, 8, 10, 12]> : tensor<4xi64>
@@ -42,7 +42,7 @@ module @cross_replica_and_partition {
     %inputs0 = stablehlo.constant dense<[1, 2, 3, 4]> : tensor<4xi64>
     %inputs1 = stablehlo.constant dense<[5, 6, 7, 8]> : tensor<4xi64>
     %results:2 = "interpreter.run_parallel"(%inputs0, %inputs1) {
-      programs=[["all_reduce"], ["all_reduce"]]
+      programs=[[@all_reduce], [@all_reduce]]
     } : (tensor<4xi64>, tensor<4xi64>) -> (tensor<4xi64>, tensor<4xi64>)
     check.expect_eq_const %results#0, dense<[6, 8, 10, 12]> : tensor<4xi64>
     check.expect_eq_const %results#1, dense<[6, 8, 10, 12]> : tensor<4xi64>
@@ -69,7 +69,7 @@ module @flattened_ids {
     %inputs0 = stablehlo.constant dense<[1, 2, 3, 4]> : tensor<4xi64>
     %inputs1 = stablehlo.constant dense<[5, 6, 7, 8]> : tensor<4xi64>
     %results:2 = "interpreter.run_parallel"(%inputs0, %inputs1) {
-      programs=[["all_reduce"], ["all_reduce"]]
+      programs=[[@all_reduce], [@all_reduce]]
     } : (tensor<4xi64>, tensor<4xi64>) -> (tensor<4xi64>, tensor<4xi64>)
     check.expect_eq_const %results#0, dense<[6, 8, 10, 12]> : tensor<4xi64>
     check.expect_eq_const %results#1, dense<[6, 8, 10, 12]> : tensor<4xi64>
@@ -96,7 +96,7 @@ module @ragged_replica_groups {
     %inputs1 = stablehlo.constant dense<[5, 6, 7, 8]> : tensor<4xi64>
     %inputs2 = stablehlo.constant dense<[6, 8, 10, 12]> : tensor<4xi64>
     %results:3 = "interpreter.run_parallel"(%inputs0, %inputs1, %inputs2) {
-      programs=[["all_reduce"], ["all_reduce"], ["all_reduce"]]
+      programs=[[@all_reduce], [@all_reduce], [@all_reduce]]
     } : (tensor<4xi64>, tensor<4xi64>, tensor<4xi64>) ->
         (tensor<4xi64>, tensor<4xi64>, tensor<4xi64>)
     check.expect_eq_const %results#0, dense<[6, 8, 10, 12]> : tensor<4xi64>

--- a/stablehlo/tests/interpret_all_to_all.mlir
+++ b/stablehlo/tests/interpret_all_to_all.mlir
@@ -16,7 +16,7 @@ module @cross_replica {
     %inputs1 = stablehlo.constant dense<[[9, 10, 11, 12],
                                          [13, 14, 15, 16]]> : tensor<2x4xi64>
     %results:2 = "interpreter.run_parallel"(%inputs0, %inputs1) {
-      programs=[["all_to_all"], ["all_to_all"]]
+      programs=[[@all_to_all], [@all_to_all]]
     } : (tensor<2x4xi64>, tensor<2x4xi64>) -> (tensor<4x2xi64>, tensor<4x2xi64>)
     check.expect_eq_const %results#0, dense<[[1, 2],
                                              [5, 6],
@@ -49,7 +49,7 @@ module @cross_partition {
     %inputs1 = stablehlo.constant dense<[[9, 10, 11, 12],
                                          [13, 14, 15, 16]]> : tensor<2x4xi64>
     %results:2 = "interpreter.run_parallel"(%inputs0, %inputs1) {
-      programs=[["all_to_all", "all_to_all"]]
+      programs=[[@all_to_all, @all_to_all]]
     } : (tensor<2x4xi64>, tensor<2x4xi64>) -> (tensor<4x2xi64>, tensor<4x2xi64>)
     check.expect_eq_const %results#0, dense<[[1, 2],
                                              [5, 6],

--- a/stablehlo/tests/interpret_collective_permute.mlir
+++ b/stablehlo/tests/interpret_collective_permute.mlir
@@ -13,7 +13,7 @@ module @cross_replica {
     %inputs1 = stablehlo.constant dense<[[5, 6], [7, 8]]> : tensor<2x2xi64>
     %inputs2 = stablehlo.constant dense<[[9, 10], [11, 12]]> : tensor<2x2xi64>
     %results:3 = "interpreter.run_parallel"(%inputs0, %inputs1, %inputs2) {
-      programs=[["collective_permute"], ["collective_permute"], ["collective_permute"]]
+      programs=[[@collective_permute], [@collective_permute], [@collective_permute]]
     } : (tensor<2x2xi64>, tensor<2x2xi64>, tensor<2x2xi64>) ->
         (tensor<2x2xi64>, tensor<2x2xi64>, tensor<2x2xi64>)
     check.expect_eq_const %results#0, dense<[[0, 0], [0, 0]]> : tensor<2x2xi64>
@@ -38,7 +38,7 @@ module @cross_partition {
     %inputs1 = stablehlo.constant dense<[[5, 6], [7, 8]]> : tensor<2x2xi64>
     %inputs2 = stablehlo.constant dense<[[9, 10], [11, 12]]> : tensor<2x2xi64>
     %results:3 = "interpreter.run_parallel"(%inputs0, %inputs1, %inputs2) {
-      programs=[["collective_permute", "collective_permute", "collective_permute"]]
+      programs=[[@collective_permute, @collective_permute, @collective_permute]]
     } : (tensor<2x2xi64>, tensor<2x2xi64>, tensor<2x2xi64>) ->
         (tensor<2x2xi64>, tensor<2x2xi64>, tensor<2x2xi64>)
     check.expect_eq_const %results#0, dense<[[0, 0], [0, 0]]> : tensor<2x2xi64>

--- a/stablehlo/tests/interpret_infeed.mlir
+++ b/stablehlo/tests/interpret_infeed.mlir
@@ -31,33 +31,3 @@ module @distribution_ops {
     func.return
   }
 }
-
-// -----
-
-module @distribution_ops {
-  func.func public @infeed(%token : !stablehlo.token) ->
-                          (tensor<2x2xi64>, !stablehlo.token) {
-    %results0:2 = "stablehlo.infeed"(%token) :
-        (!stablehlo.token) -> (tensor<2x2xi64>, !stablehlo.token)
-    func.return %results0#0, %results0#1: tensor<2x2xi64>, !stablehlo.token
-  }
-  func.func public @infeed_queue0() -> (tensor<2x2xi64>) {
-    %queue0 = stablehlo.constant dense<[[1, 2], [3, 4]]> : tensor<2x2xi64>
-    func.return %queue0 : tensor<2x2xi64>
-  }
-  func.func public @infeed_queue1() -> (tensor<2x2xi64>) {
-    %queue0 = stablehlo.constant dense<[[5, 6], [7, 8]]> : tensor<2x2xi64>
-    func.return %queue0 : tensor<2x2xi64>
-  }
-  func.func public @main() {
-    %token = stablehlo.after_all : !stablehlo.token
-    %results:4 = "interpreter.run_parallel"(%token, %token) {
-      infeed=[@infeed_queue0, @infeed_queue1],
-      programs=[[@infeed], [@infeed]]
-    } : (!stablehlo.token, !stablehlo.token) ->
-        (tensor<2x2xi64>, !stablehlo.token, tensor<2x2xi64>, !stablehlo.token)
-    check.expect_eq_const %results#0, dense<[[1, 2], [3, 4]]> : tensor<2x2xi64>
-    check.expect_eq_const %results#2, dense<[[5, 6], [7, 8]]> : tensor<2x2xi64>
-    func.return
-  }
-}

--- a/stablehlo/tests/interpret_infeed.mlir
+++ b/stablehlo/tests/interpret_infeed.mlir
@@ -1,0 +1,35 @@
+// RUN: stablehlo-translate --interpret -split-input-file %s
+
+module @distribution_ops {
+  func.func public @infeed(%token : !stablehlo.token) ->
+                          (tensor<2x2xi64>, !stablehlo.token,
+                           tensor<2x2xi64>, !stablehlo.token) {
+    %results0:2 = "stablehlo.infeed"(%token) :
+        (!stablehlo.token) -> (tensor<2x2xi64>, !stablehlo.token)
+    %results1:2 = "stablehlo.infeed"(%token) :
+        (!stablehlo.token) -> (tensor<2x2xi64>, !stablehlo.token)
+    return %results0#0, %results0#1, %results1#0, %results1#1 :
+        tensor<2x2xi64>, !stablehlo.token, tensor<2x2xi64>, !stablehlo.token
+  }
+  func.func public @infeed_queue0() -> (tensor<2x2xi64>) {
+    %queue0 = stablehlo.constant dense<[[1, 2], [3, 4]]> : tensor<2x2xi64>
+    return %queue0 : tensor<2x2xi64>
+  }
+  func.func public @infeed_queue1() -> (tensor<2x2xi64>) {
+    %queue0 = stablehlo.constant dense<[[5, 6], [7, 8]]> : tensor<2x2xi64>
+    return %queue0 : tensor<2x2xi64>
+  }
+  func.func public @main() {
+    %token = stablehlo.after_all : !stablehlo.token
+    %results:4 = "interpreter.run_parallel"(%token) {
+      programs=[["infeed"]],
+      infeed=["infeed_queue0", "infeed_queue1"],
+      num_replicas=1,
+      num_partitions=1
+    } : (!stablehlo.token) ->
+        (tensor<2x2xi64>, !stablehlo.token, tensor<2x2xi64>, !stablehlo.token)
+    check.expect_eq_const %results#0, dense<[[1, 2], [3, 4]]> : tensor<2x2xi64>
+    check.expect_eq_const %results#2, dense<[[5, 6], [7, 8]]> : tensor<2x2xi64>
+    func.return
+  }
+}

--- a/stablehlo/tests/interpret_outfeed.mlir
+++ b/stablehlo/tests/interpret_outfeed.mlir
@@ -11,7 +11,7 @@ module @distribution_ops {
                                          [[5, 6], [7, 8]]]> : tensor<2x2x2xi64>
     %token = stablehlo.after_all : !stablehlo.token
     %results0 = "interpreter.run_parallel"(%inputs0, %token) {
-      programs=[["outfeed"]]
+      programs=[[@outfeed]]
     } : (tensor<2x2x2xi64>, !stablehlo.token) -> !stablehlo.token
     func.return
   }

--- a/stablehlo/tests/interpret_partition_id.mlir
+++ b/stablehlo/tests/interpret_partition_id.mlir
@@ -7,7 +7,7 @@ module @distribution_ops {
   }
   func.func public @main() {
     %results:2 = "interpreter.run_parallel"() {
-      programs=[["partition_id", "partition_id"]]
+      programs=[[@partition_id, @partition_id]]
     } : () -> (tensor<ui32>, tensor<ui32>)
     check.expect_eq_const %results#0, dense<0> : tensor<ui32>
     check.expect_eq_const %results#1, dense<1> : tensor<ui32>

--- a/stablehlo/tests/interpret_reduce_scatter.mlir
+++ b/stablehlo/tests/interpret_reduce_scatter.mlir
@@ -18,7 +18,7 @@ module @cross_replica {
     %inputs1 = stablehlo.constant dense<[[9, 10, 11, 12],
                                          [13, 14, 15, 16]]> : tensor<2x4xi64>
     %results:2 = "interpreter.run_parallel"(%inputs0, %inputs1) {
-      programs=[["reduce_scatter"], ["reduce_scatter"]]
+      programs=[[@reduce_scatter], [@reduce_scatter]]
     } : (tensor<2x4xi64>, tensor<2x4xi64>) -> (tensor<2x2xi64>, tensor<2x2xi64>)
     check.expect_eq_const %results#0, dense<[[10, 12],
                                              [18, 20]]> : tensor<2x2xi64>
@@ -49,7 +49,7 @@ module @cross_replica_and_partition {
     %inputs1 = stablehlo.constant dense<[[9, 10, 11, 12],
                                          [13, 14, 15, 16]]> : tensor<2x4xi64>
     %results:2 = "interpreter.run_parallel"(%inputs0, %inputs1) {
-      programs=[["reduce_scatter"], ["reduce_scatter"]]
+      programs=[[@reduce_scatter], [@reduce_scatter]]
     } : (tensor<2x4xi64>, tensor<2x4xi64>) -> (tensor<2x2xi64>, tensor<2x2xi64>)
     check.expect_eq_const %results#0, dense<[[10, 12],
                                              [18, 20]]> : tensor<2x2xi64>
@@ -81,7 +81,7 @@ module @flattened_ids {
     %inputs1 = stablehlo.constant dense<[[9, 10, 11, 12],
                                          [13, 14, 15, 16]]> : tensor<2x4xi64>
     %results:2 = "interpreter.run_parallel"(%inputs0, %inputs1) {
-      programs=[["reduce_scatter"], ["reduce_scatter"]]
+      programs=[[@reduce_scatter], [@reduce_scatter]]
     } : (tensor<2x4xi64>, tensor<2x4xi64>) -> (tensor<2x2xi64>, tensor<2x2xi64>)
     check.expect_eq_const %results#0, dense<[[10, 12],
                                              [18, 20]]> : tensor<2x2xi64>

--- a/stablehlo/tests/interpret_replica_id.mlir
+++ b/stablehlo/tests/interpret_replica_id.mlir
@@ -7,7 +7,7 @@ module @distribution_ops {
   }
   func.func public @main() {
     %results:2 = "interpreter.run_parallel"() {
-      programs=[["replica_id"], ["replica_id"]]
+      programs=[[@replica_id], [@replica_id]]
     } : () -> (tensor<ui32>, tensor<ui32>)
     check.expect_eq_const %results#0, dense<0> : tensor<ui32>
     check.expect_eq_const %results#1, dense<1> : tensor<ui32>

--- a/stablehlo/tests/ops_interpreter.mlir
+++ b/stablehlo/tests/ops_interpreter.mlir
@@ -7,7 +7,7 @@ module @run_parallel_success {
   }
   func.func @main() {
     "interpreter.run_parallel"() {
-      programs=[["foo"]]
+      programs=[[@foo]]
     } : () -> ()
     func.return
   }
@@ -37,7 +37,7 @@ module @run_parallel_invalid_programs_shape {
   func.func @main() {
     // expected-error@+1 {{Sizes of second dimension of `programs` should all match 1 but got 2}}
     "interpreter.run_parallel"() {
-      programs=[["foo"], ["bar", "baz"]]
+      programs=[[@foo], [@bar, @baz]]
     } : () -> ()
     func.return
   }
@@ -52,7 +52,7 @@ module @run_parallel_invalid_function {
   func.func @main() {
     // expected-error@+1 {{Function "bar" not found}}
     "interpreter.run_parallel"() {
-      programs=[["bar"], ["bar"]]
+      programs=[[@bar], [@bar]]
     } : () -> ()
     func.return
   }
@@ -68,7 +68,7 @@ module @run_parallel_invalid_arg_size {
     %inputs = stablehlo.constant dense<0> : tensor<i64>
     // expected-error@+1 {{Number of inputs (2) should match the sum of the number of inputs of all programs (1)}}
     "interpreter.run_parallel"(%inputs, %inputs) {
-      programs=[["foo"]]
+      programs=[[@foo]]
     } : (tensor<i64>, tensor<i64>) -> ()
     func.return
   }
@@ -84,8 +84,86 @@ module @run_parallel_invalid_results_size {
     %inputs = stablehlo.constant dense<0> : tensor<i64>
     // expected-error@+1 {{Number of results (0) should match the sum of the number of results of all programs (1)}}
     "interpreter.run_parallel"(%inputs) {
-      programs=[["foo"]]
+      programs=[[@foo]]
     } : (tensor<i64>) -> ()
+    func.return
+  }
+}
+
+// -----
+
+module @run_parallel_empty_infeed {
+  func.func @foo() {
+    func.return
+  }
+  func.func @main() {
+    // expected-error@+1 {{infeed attribute is optional or should not be empty}}
+    "interpreter.run_parallel"() {
+      infeed=[],
+      programs=[[@foo]]
+    } : () -> ()
+    func.return
+  }
+}
+
+// -----
+
+module @run_parallel_invalid_infeed {
+  func.func @foo() {
+    func.return
+  }
+  func.func @main() {
+    // expected-error@+1 {{Function "bar" not found}}
+    "interpreter.run_parallel"() {
+      infeed=[@bar],
+      programs=[[@foo]]
+    } : () -> ()
+    func.return
+  }
+}
+
+// -----
+
+module @run_parallel_invalid_infeed_return_count {
+  func.func @infeed(%token : !stablehlo.token) -> (tensor<i64>, !stablehlo.token) {
+    %results0:2 = "stablehlo.infeed"(%token) :
+        (!stablehlo.token) -> (tensor<i64>, !stablehlo.token)
+    func.return %results0#0, %results0#1 : tensor<i64>, !stablehlo.token
+  }
+  func.func @infeed_queue() -> (tensor<i64>, tensor<i64>) {
+    %result = stablehlo.constant dense<1> : tensor<i64>
+    func.return %result, %result : tensor<i64>, tensor<i64>
+  }
+  func.func @main() {
+    %token = stablehlo.after_all : !stablehlo.token
+    // expected-error@+1 {{Function "infeed_queue" should return 1 tensor but returns 2}}
+    "interpreter.run_parallel"(%token) {
+      infeed=[@infeed_queue],
+      programs=[[@infeed]]
+    } : (!stablehlo.token) -> (tensor<i64>, !stablehlo.token)
+    func.return
+  }
+}
+
+// -----
+
+module @run_parallel_invalid_infeed_return_type {
+  func.func @infeed(%token : !stablehlo.token) -> (tensor<i64>, !stablehlo.token) {
+    %results0:2 = "stablehlo.infeed"(%token) :
+        (!stablehlo.token) -> (tensor<i64>, !stablehlo.token)
+    func.return %results0#0, %results0#1 : tensor<i64>, !stablehlo.token
+  }
+  func.func @infeed_queue() -> !stablehlo.token {
+    %token = stablehlo.after_all : !stablehlo.token
+    func.return %token : !stablehlo.token
+  }
+  func.func @main() {
+    %token = stablehlo.after_all : !stablehlo.token
+    // expected-error@+1 {{Function "infeed_queue" should return a tensor type, but instead returns '!stablehlo.token'}}
+    "interpreter.run_parallel"(%token) {
+      infeed=[@infeed_queue],
+      programs=[[@infeed]]
+    } : (!stablehlo.token) -> (tensor<i64>, !stablehlo.token)
     func.return
   }
 }

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -1673,7 +1673,7 @@ func.func @infeed_c1(%token: !stablehlo.token) -> tensor<3x3xi32> {
 // -----
 
 func.func @infeed_c2(%token: !stablehlo.token) -> tuple<!stablehlo.token, !stablehlo.token> {
-  // expected-error@+1 {{everything but the last element of result types is expected to be of tensor type, but got '!stablehlo.token'}}
+  // expected-error@+1 {{all elements of result types except the last element is expected to be of tensor type, but got '!stablehlo.token'}}
   %0:2 = "stablehlo.infeed"(%token) {infeed_config = "foobar", layout = [[[0]], [0]]} : (!stablehlo.token) -> (!stablehlo.token, !stablehlo.token)
   %1 = "stablehlo.tuple"(%0#0, %0#1) : (!stablehlo.token, !stablehlo.token) -> tuple<!stablehlo.token, !stablehlo.token>
   func.return %1 : tuple<!stablehlo.token, !stablehlo.token>

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -1632,16 +1632,7 @@ func.func @imag_unranked(%arg0: tensor<*xf32>) -> tensor<*xf32> {
 
 // -----
 
-func.func @infeed_non_token_second_result(%token: !stablehlo.token) -> tuple<tensor<i32>, tensor<i32>> {
-  // expected-error@+1 {{last element of result types is expected to be of token type, but got 'tensor<i32>'}}
-  %0:2 = "stablehlo.infeed"(%token) {infeed_config = "foobar", layout = [[[0]], [0]]} : (!stablehlo.token) -> (tensor<i32>, tensor<i32>)
-  %1 = "stablehlo.tuple"(%0#0, %0#1) : (tensor<i32>, tensor<i32>) -> tuple<tensor<i32>, tensor<i32>>
-  func.return %1 : tuple<tensor<i32>, tensor<i32>>
-}
-
-// -----
-
-func.func @main(%arg0: !stablehlo.token) -> tensor<3x3xi32> {
+func.func @infeed(%arg0: !stablehlo.token) -> tensor<3x3xi32> {
   // expected-error@+1 {{layout-attribute size must be 2 (which is the number of op-results - 1 (for token result)), but got 1}}
   %0:3 = "stablehlo.infeed"(%arg0) {infeed_config = "foobar", layout=[[0, 1]]} : (!stablehlo.token) -> (tensor<3x3xi32>, tensor<i1>, !stablehlo.token)
   func.return %0#0 : tensor<3x3xi32>
@@ -1649,7 +1640,7 @@ func.func @main(%arg0: !stablehlo.token) -> tensor<3x3xi32> {
 
 // -----
 
-func.func @main(%arg0: !stablehlo.token) -> !stablehlo.token {
+func.func @infeed(%arg0: !stablehlo.token) -> !stablehlo.token {
   // expected-error@+1 {{layout-attribute size must be 0 (which is the number of op-results - 1 (for token result)), but got 1}}
   %0:1 = "stablehlo.infeed"(%arg0) {infeed_config = "foobar", layout=[[]]} : (!stablehlo.token) -> (!stablehlo.token)
   func.return %0#0 : !stablehlo.token
@@ -1657,7 +1648,7 @@ func.func @main(%arg0: !stablehlo.token) -> !stablehlo.token {
 
 // -----
 
-func.func @main(%arg0: !stablehlo.token) -> tensor<3x3xi32> {
+func.func @infeed(%arg0: !stablehlo.token) -> tensor<3x3xi32> {
   // expected-error@+1 {{layout-attribute expected to have elements of type array, but got 0 : i64}}
   %0:2 = "stablehlo.infeed"(%arg0) {infeed_config = "foobar", layout=[0]} : (!stablehlo.token) -> (tensor<3x3xi32>, !stablehlo.token)
   func.return %0#0 : tensor<3x3xi32>
@@ -1665,10 +1656,36 @@ func.func @main(%arg0: !stablehlo.token) -> tensor<3x3xi32> {
 
 // -----
 
-func.func @main(%arg0: !stablehlo.token) -> tensor<3x3xi32> {
-  // expected-error@+1 {{ayout-attribute's leaf elements are expected to be of type integer, but got []}}
+func.func @infeed(%arg0: !stablehlo.token) -> tensor<3x3xi32> {
+  // expected-error@+1 {{layout-attribute's leaf elements are expected to be of type integer, but got []}}
   %0:2 = "stablehlo.infeed"(%arg0) {infeed_config = "foobar", layout=[[0,[]]]} : (!stablehlo.token) -> (tensor<3x3xi32>, !stablehlo.token)
   func.return %0#0 : tensor<3x3xi32>
+}
+
+// -----
+
+func.func @infeed_c1(%token: !stablehlo.token) -> tensor<3x3xi32> {
+  // expected-error@+1 {{result is expected to be at least of size 1, but got 0}}
+  "stablehlo.infeed"(%token) {infeed_config = "foobar", layout=[[[0]], [0]]} : (!stablehlo.token) -> ()
+  func.return
+}
+
+// -----
+
+func.func @infeed_c2(%token: !stablehlo.token) -> tuple<!stablehlo.token, !stablehlo.token> {
+  // expected-error@+1 {{everything but the last element of result types is expected to be of tensor type, but got '!stablehlo.token'}}
+  %0:2 = "stablehlo.infeed"(%token) {infeed_config = "foobar", layout = [[[0]], [0]]} : (!stablehlo.token) -> (!stablehlo.token, !stablehlo.token)
+  %1 = "stablehlo.tuple"(%0#0, %0#1) : (!stablehlo.token, !stablehlo.token) -> tuple<!stablehlo.token, !stablehlo.token>
+  func.return %1 : tuple<!stablehlo.token, !stablehlo.token>
+}
+
+// -----
+
+func.func @infeed_c3(%token: !stablehlo.token) -> tuple<tensor<i32>, tensor<i32>> {
+  // expected-error@+1 {{last element of result types is expected to be of token type, but got 'tensor<i32>'}}
+  %0:2 = "stablehlo.infeed"(%token) {infeed_config = "foobar", layout = [[[0]], [0]]} : (!stablehlo.token) -> (tensor<i32>, tensor<i32>)
+  %1 = "stablehlo.tuple"(%0#0, %0#1) : (tensor<i32>, tensor<i32>) -> tuple<tensor<i32>, tensor<i32>>
+  func.return %1 : tuple<tensor<i32>, tensor<i32>>
 }
 
 // -----

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -1673,7 +1673,7 @@ func.func @infeed_c1(%token: !stablehlo.token) -> tensor<3x3xi32> {
 // -----
 
 func.func @infeed_c2(%token: !stablehlo.token) -> tuple<!stablehlo.token, !stablehlo.token> {
-  // expected-error@+1 {{all elements of result types except the last element is expected to be of tensor type, but got '!stablehlo.token'}}
+  // expected-error@+1 {{all elements of result types, except the last element, are expected to be of tensor type, but got '!stablehlo.token'}}
   %0:2 = "stablehlo.infeed"(%token) {infeed_config = "foobar", layout = [[[0]], [0]]} : (!stablehlo.token) -> (!stablehlo.token, !stablehlo.token)
   %1 = "stablehlo.tuple"(%0#0, %0#1) : (!stablehlo.token, !stablehlo.token) -> tuple<!stablehlo.token, !stablehlo.token>
   func.return %1 : tuple<!stablehlo.token, !stablehlo.token>

--- a/stablehlo/tools/StablehloTranslateMain.cpp
+++ b/stablehlo/tools/StablehloTranslateMain.cpp
@@ -60,10 +60,10 @@ llvm::Error wrapStatus(llvm::Error status, llvm::StringRef funcName,
 
 llvm::Error evalCustomCallCheckEq(stablehlo::CustomCallOp op,
                                   stablehlo::Scope &scope) {
-  if (op->getNumOperands() != 2) {
+  if (op->getNumOperands() != 2)
     return stablehlo::invalidArgument("Unsupported op: %s",
                                       debugString(op).c_str());
-  }
+
   auto actualResult = scope.findTensors(op->getOperands())[0];
   auto expectedResult = scope.findTensors(op->getOperands())[1];
   bool isInt = expectedResult.getElementType().isa<IntegerType>();
@@ -130,6 +130,11 @@ llvm::Error interpreterFallback(Operation &op, stablehlo::Process *process,
   if (auto runParallelOp =
           dyn_cast<stablehlo::interpreter::RunParallelOp>(op)) {
     auto runtimeOperands = scope.find(runParallelOp.getInputs());
+    std::queue<StringAttr> infeed;
+    if (auto infeedAttr = runParallelOp.getInfeed())
+      for (auto &value : infeedAttr->getValue())
+        infeed.push(value.cast<StringAttr>());
+
     SmallVector<SmallVector<StringAttr>> programs(
         runParallelOp.getPrograms().size());
     for (auto [i, replica] : llvm::enumerate(runParallelOp.getPrograms()))
@@ -138,7 +143,7 @@ llvm::Error interpreterFallback(Operation &op, stablehlo::Process *process,
 
     SymbolTable symbolTable{op.getParentOfType<ModuleOp>()};
     auto results = stablehlo::interpreter::evalRunParallelOp(
-        runtimeOperands, programs, symbolTable);
+        runtimeOperands, &infeed, programs, symbolTable);
     scope.add(runParallelOp.getResults(), results);
     return wrapStatus(llvm::Error::success(), funcName,
                       "interpreter.run_parallel");

--- a/stablehlo/tools/StablehloTranslateMain.cpp
+++ b/stablehlo/tools/StablehloTranslateMain.cpp
@@ -133,17 +133,17 @@ llvm::Error interpreterFallback(Operation &op, stablehlo::Process *process,
     std::queue<StringAttr> infeed;
     if (auto infeedAttr = runParallelOp.getInfeed())
       for (auto &value : infeedAttr->getValue())
-        infeed.push(value.cast<StringAttr>());
+        infeed.push(value.cast<FlatSymbolRefAttr>().getAttr());
 
     SmallVector<SmallVector<StringAttr>> programs(
         runParallelOp.getPrograms().size());
     for (auto [i, replica] : llvm::enumerate(runParallelOp.getPrograms()))
       for (auto &program : replica.cast<ArrayAttr>())
-        programs[i].push_back(program.cast<StringAttr>());
+        programs[i].push_back(program.cast<FlatSymbolRefAttr>().getAttr());
 
     SymbolTable symbolTable{op.getParentOfType<ModuleOp>()};
     auto results = stablehlo::interpreter::evalRunParallelOp(
-        runtimeOperands, &infeed, programs, symbolTable);
+        runtimeOperands, infeed, programs, symbolTable);
     scope.add(runParallelOp.getResults(), results);
     return wrapStatus(llvm::Error::success(), funcName,
                       "interpreter.run_parallel");


### PR DESCRIPTION
We have the following constraints in the spec:

```
(I1) `token` is a `token`.
(I2) `infeed_config` is a constant of type `string`.
(C1) `0 < size(results)`.
(C2) `is_empty(result[:-1])` or `is_tensor(type(results[:-1]))`.
(C3) `is_token(type(results[-1]))`.
```

These constraints will be comprehensively covered by the following tests:

```
I1: a) `token` is not a `token`. (Covered by ODS).
I2: a) `infeed_config` is not a constant of type `string`. (Covered by ODS).
C1: a) `size(results) <= 0`.
C2: a) `is_empty(result[:-1]) = false` and `is_tensor(type(results[:-1])) = false`.
C3: a) `type(results[-1]) != token`.
```

If we drop the "Covered by ODS" pieces, this will leave us with the following test cases:

```
C1: a) `size(results) <= 0`.
C2: a) `is_empty(result[:-1]) = false` and `is_tensor(type(results[:-1])) = false`.
C3: a) `type(results[-1]) != token`.
```

closes #1128