### PR TITLE
Add interpreter for AllGatherOp

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -709,32 +709,31 @@ Afterwards, within each `process_group`:
 
 #### Inputs
 
-| Label | Name                    | Type                                         | Constraints      |
-|-------|-------------------------|----------------------------------------------|------------------|
-| (I1)  | `operand`               | tensor or per-tensor quantized tensor        | (C1), (C2), (C7) |
-| (I2)  | `all_gather_dim`        | constant of type `si64`                      | (C1), (C2), (C7) |
-| (I3)  | `replica_groups`        | 2-dimensional tensor constant of type `si64` | (C3-C5)          |
-| (I4)  | `channel_id`            | constant of type `si64`                      | (C6)             |
-| (I5)  | `use_global_device_ids` | constant of type `i1`                        | (C6)             |
+| Label | Name                    | Type                                         | Constraints |
+|-------|-------------------------|----------------------------------------------|-------------|
+| (I1)  | `operand`               | tensor or per-tensor quantized tensor        | (C1), (C6)  |
+| (I2)  | `all_gather_dim`        | constant of type `si64`                      | (C1), (C6)  |
+| (I3)  | `replica_groups`        | 2-dimensional tensor constant of type `si64` | (C2-C4)     |
+| (I4)  | `channel_id`            | constant of type `si64`                      | (C5)        |
+| (I5)  | `use_global_device_ids` | constant of type `i1`                        | (C5)        |
 
 #### Outputs
 
 | Name     | Type                                  | Constraints |
 |----------|---------------------------------------|-------------|
-| `result` | tensor or per-tensor quantized tensor | (C7)        |
+| `result` | tensor or per-tensor quantized tensor | (C6)        |
 
 #### Constraints
 
-* (C1) `dim(operand, all_gather_dim) > 0`.
-* (C2) `0 <= all_gather_dim < rank(operand)`.
-* (C3) `is_unique(replica_groups)`.
-* (C4) `size(replica_groups)` is defined as:
+* (C1) `0 <= all_gather_dim < rank(operand)`.
+* (C2) `is_unique(replica_groups)`.
+* (C3) `size(replica_groups)` is defined as:
   * `num_replicas` if `cross_replica` is used.
   * `num_replicas` if `cross_replica_and_partition` is used.
   * `num_processes` if `flattened_ids` is used.
-* (C5) `0 <= replica_groups < size(replica_groups)`.
-* (C6) If `use_global_device_ids = true`, then `channel_id > 0`.
-* (C7) `type(result) = type(operand)` except:
+* (C4) `0 <= replica_groups < size(replica_groups)`.
+* (C5) If `use_global_device_ids = true`, then `channel_id > 0`.
+* (C6) `type(result) = type(operand)` except:
   * `dim(result, all_gather_dim) =
     dim(operand, all_gather_dim) * dim(process_groups, 1)`.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -45,7 +45,7 @@ one of the following tracking labels.
 | abs                      | yes           | yes          | yes            | yes             | yes         |
 | add                      | yes           | yes          | yes            | yes             | yes         |
 | after_all                | yes           | yes          | yes            | yes             | yes         |
-| all_gather               | yes           | revisit      | no             | no              | no          |
+| all_gather               | yes           | revisit      | no             | no              | yes         |
 | all_reduce               | yes           | revisit      | yes            | no              | yes         |
 | all_to_all               | yes           | revisit      | yes            | no              | no          |
 | and                      | yes           | yes          | yes            | yes             | yes         |

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -877,9 +877,13 @@ void AllToAllOp::build(OpBuilder& odsBuilder, OperationState& odsState,
 //===----------------------------------------------------------------------===//
 
 LogicalResult AllGatherOp::verify() {
+  int64_t channelId = 0;
+  if (auto channelHandleAttr = getChannelHandleAttr())
+    channelId = channelHandleAttr.getHandle();
+
   return hlo::verifyAllGatherOp(getLoc(), getOperand(), getAllGatherDim(),
-                                getReplicaGroups(), getUseGlobalDeviceIds(),
-                                getResult());
+                                getReplicaGroups(), channelId,
+                                getUseGlobalDeviceIds(), getResult());
 }
 
 //===----------------------------------------------------------------------===//

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1298,7 +1298,7 @@ def StableHLO_WhileOp: StableHLO_Op<"while", [
 }
 
 def StableHLO_AllGatherOp : StableHLO_Op<"all_gather",
-    [SameOperandsAndResultElementType] /*all_gather_c7*/> {
+    [SameOperandsAndResultElementType] /*all_gather_c6*/> {
   string summary = "AllGather operation";
   string description = [{
     Within each process group in the process grid, concatenates the values of the

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1297,7 +1297,8 @@ def StableHLO_WhileOp: StableHLO_Op<"while", [
   let hasCustomAssemblyFormat = 1;
 }
 
-def StableHLO_AllGatherOp : StableHLO_Op<"all_gather", [SameOperandsAndResultElementType]> {
+def StableHLO_AllGatherOp : StableHLO_Op<"all_gather",
+    [SameOperandsAndResultElementType] /*all_gather_c7*/> {
   string summary = "AllGather operation";
   string description = [{
     Within each process group in the process grid, concatenates the values of the
@@ -1311,20 +1312,18 @@ def StableHLO_AllGatherOp : StableHLO_Op<"all_gather", [SameOperandsAndResultEle
     ```mlir
     %result = "stablehlo.all_gather"(%operand) {
       all_gather_dim = 1 : i64,
-      replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>
-      // channel_id = 0
-      channel_handle = #stablehlo.channel_handle<handle = 0, type = 0>,
-      // use_global_device_ids = false
-    } : (tensor<2x2xf32>) -> tensor<2x4xf32>
+      replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
+      channel_handle = #stablehlo.channel_handle<handle = 0, type = 0>
+    } : (tensor<2x2xi64>) -> tensor<2x4xi64>
     ```
   }];
 
   let arguments = (ins
-    HLO_Tensor:$operand,
-    I64Attr:$all_gather_dim,
-    I64ElementsAttr:$replica_groups,
-    OptionalAttr<StableHLO_ChannelHandle>:$channel_handle,
-    UnitAttr:$use_global_device_ids
+    HLO_Tensor:$operand, /*all_gather_i1*/
+    I64Attr:$all_gather_dim, /*all_gather_i2*/
+    I64ElementsAttr:$replica_groups, /*all_gather_i3*/
+    OptionalAttr<StableHLO_ChannelHandle>:$channel_handle, /*all_gather_i4*/
+    UnitAttr:$use_global_device_ids /*all_gather_i5*/
   );
   let results = (outs HLO_Tensor);
   let hasVerifier = 1;

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -436,19 +436,19 @@ LogicalResult verifyReplicaGroups(std::optional<Location> location,
   for (int64_t replicaId : replicaIds) {
     // Replica groups are stored in a 2D tensor. If the op supports non-uniform
     // groups, null replica IDs are stored as -1.
-    // all_gather_c5
+    // all_gather_c4
     if (replicaId == -1) {
       if (!allGroupsMustHaveSameSize) continue;
       return emitOptionalError(location, "Invalid replica id -1");
     }
 
-    // all_gather_c3, all_reduce_c1
+    // all_gather_c2, all_reduce_c1
     if (!replicaIdsSeen.insert(replicaId).second)
       return emitOptionalError(location, "replica id #", replicaId,
                                " seen more than once");
   }
 
-  // all_gather_c5, all_reduce_c3
+  // all_gather_c4, all_reduce_c3
   for (size_t id = 0; id < replicaIdsSeen.size(); id++)
     if (!replicaIdsSeen.contains(id))
       return emitOptionalError(location, "replica id #", id,
@@ -3047,37 +3047,37 @@ LogicalResult verifyAllGatherOp(std::optional<Location> location, Value operand,
   auto operandType = operand.getType().dyn_cast<RankedTensorType>();
   auto resultType = result.getType().dyn_cast<RankedTensorType>();
 
-  // all_gather_c2
+  // all_gather_c1
   if (allGatherDim < 0)
     return emitOptionalError(location, "all_gather_dim cannot be negative");
 
   if (operandType) {
-    // all_gather_c2
+    // all_gather_c1
     if (allGatherDim >= operandType.getRank())
       return emitOptionalError(
           location, "all_gather_dim must be a valid index of operand");
 
-    // all_gather_c1
+    // TODO()
     if (operandType.getDimSize(allGatherDim) == 0)
       return emitOptionalError(
           location,
           "dimension size of operand at 'all_gather_dim' cannot be zero");
   }
 
-  // all_gather_i3, all_gather_c3, all_gather_c5
+  // all_gather_i3, all_gather_c2, all_gather_c4
   if (failed(verifyReplicaGroups(location, replicaGroups,
                                  /*allGroupsMustHaveSameSize=*/true,
                                  useGlobalDeviceIds,
                                  /*expectedGroupSize=*/std::nullopt)))
     return failure();
 
-  // all_gather_c6
+  // all_gather_c5
   if (useGlobalDeviceIds && channelId < 0)
     return emitOptionalError(
         location,
         "channel_id cannot be negative when useGlobalDeviceIds is set");
 
-  // all_gather_c7
+  // all_gather_c6
   if (operandType && resultType) {
     if (resultType.getRank() != operandType.getRank())
       return emitOptionalError(location,
@@ -3085,7 +3085,7 @@ LogicalResult verifyAllGatherOp(std::optional<Location> location, Value operand,
 
     for (int64_t i = 0; i < operandType.getRank(); i++) {
       if (i == allGatherDim) continue;
-      // all_gather_c7
+      // all_gather_c6
       if (!verifyCompatibleDims(resultType.getDimSize(i),
                                 operandType.getDimSize(i)))
         return emitOptionalError(
@@ -3098,7 +3098,7 @@ LogicalResult verifyAllGatherOp(std::optional<Location> location, Value operand,
         resultType.isDynamicDim(allGatherDim))
       return success();
 
-    // all_gather_c7
+    // all_gather_c6
     if ((resultType.getDimSize(allGatherDim) %
          operandType.getDimSize(allGatherDim)) != 0)
       return emitOptionalError(

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -3057,7 +3057,7 @@ LogicalResult verifyAllGatherOp(std::optional<Location> location, Value operand,
       return emitOptionalError(
           location, "all_gather_dim must be a valid index of operand");
 
-    // TODO()
+    // TODO(#1745): Sync verification of AllGather with HLO.
     if (operandType.getDimSize(allGatherDim) == 0)
       return emitOptionalError(
           location,

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -370,7 +370,8 @@ LogicalResult inferWhileOp(std::optional<Location> location, ValueRange operand,
 LogicalResult verifyAllGatherOp(std::optional<Location> location, Value operand,
                                 int64_t allGatherDim,
                                 DenseIntElementsAttr replicaGroups,
-                                bool useGlobalDeviceIds, Value result);
+                                int64_t channelId, bool useGlobalDeviceIds,
+                                Value result);
 
 LogicalResult verifyAllReduceOp(std::optional<Location> location, Value operand,
                                 DenseIntElementsAttr replicaGroups,

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -33,6 +33,10 @@ namespace stablehlo {
 Tensor evalAbsOp(const Tensor &operand, ShapedType resultType);
 Tensor evalAddOp(const Tensor &lhs, const Tensor &rhs, ShapedType resultType);
 Token evalAfterAllOp(ArrayRef<Token> inputs, MLIRContext *context);
+Tensor evalAllGatherOp(const Tensor &operand, int64_t allGatherDim,
+                       SmallVector<SmallVector<uint32_t>> replicaGroups,
+                       ChannelId channelId, bool useGlobalDeviceIds,
+                       Process *process, ShapedType resultType);
 Tensor evalAllReduceOp(const Tensor &operand,
                        SmallVector<SmallVector<uint32_t>> replicaGroups,
                        ChannelId channelId, bool useGlobalDeviceIds,

--- a/stablehlo/tests/interpret_all_gather.mlir
+++ b/stablehlo/tests/interpret_all_gather.mlir
@@ -1,0 +1,74 @@
+// RUN: stablehlo-translate --interpret -split-input-file %s
+
+module @cross_replica {
+  func.func public @all_gather(%arg0 : tensor<2x2xi64>) -> tensor<2x4xi64> {
+    %result = "stablehlo.all_gather"(%arg0) {
+      all_gather_dim = 1 : i64,
+      replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>
+    } : (tensor<2x2xi64>) -> tensor<2x4xi64>
+    return %result : tensor<2x4xi64>
+  }
+  func.func public @main() {
+    %0 = stablehlo.constant dense<[[1, 2], [3, 4]]> : tensor<2x2xi64>
+    %1 = stablehlo.constant dense<[[5, 6], [7, 8]]> : tensor<2x2xi64>
+    %results:2 = "interpreter.run_parallel"(%0, %1) {
+      programs=[["all_gather"], ["all_gather"]]
+    } : (tensor<2x2xi64>, tensor<2x2xi64>) -> (tensor<2x4xi64>, tensor<2x4xi64>)
+    check.expect_eq_const %results#0, dense<[[1, 2, 5, 6],
+                                             [3, 4, 7, 8]]> : tensor<2x4xi64>
+    check.expect_eq_const %results#1, dense<[[1, 2, 5, 6],
+                                             [3, 4, 7, 8]]> : tensor<2x4xi64>
+    func.return
+  }
+}
+
+// -----
+
+module @cross_replica_and_partition {
+  func.func public @all_gather(%arg0 : tensor<2x2xi64>) -> tensor<2x4xi64> {
+    %result = "stablehlo.all_gather"(%arg0) {
+      all_gather_dim = 1 : i64,
+      replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
+      channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>
+    } : (tensor<2x2xi64>) -> tensor<2x4xi64>
+    return %result : tensor<2x4xi64>
+  }
+  func.func public @main() {
+    %0 = stablehlo.constant dense<[[1, 2], [3, 4]]> : tensor<2x2xi64>
+    %1 = stablehlo.constant dense<[[5, 6], [7, 8]]> : tensor<2x2xi64>
+    %results:2 = "interpreter.run_parallel"(%0, %1) {
+      programs=[["all_gather"], ["all_gather"]]
+    } : (tensor<2x2xi64>, tensor<2x2xi64>) -> (tensor<2x4xi64>, tensor<2x4xi64>)
+    check.expect_eq_const %results#0, dense<[[1, 2, 5, 6],
+                                             [3, 4, 7, 8]]> : tensor<2x4xi64>
+    check.expect_eq_const %results#1, dense<[[1, 2, 5, 6],
+                                             [3, 4, 7, 8]]> : tensor<2x4xi64>
+    func.return
+  }
+}
+
+// -----
+
+module @flattened_ids {
+  func.func public @all_gather(%arg0 : tensor<2x2xi64>) -> tensor<2x4xi64> {
+    %result = "stablehlo.all_gather"(%arg0) {
+      all_gather_dim = 1 : i64,
+      replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
+      channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
+      use_global_device_ids
+    } : (tensor<2x2xi64>) -> tensor<2x4xi64>
+    return %result : tensor<2x4xi64>
+  }
+  func.func public @main() {
+    %0 = stablehlo.constant dense<[[1, 2], [3, 4]]> : tensor<2x2xi64>
+    %1 = stablehlo.constant dense<[[5, 6], [7, 8]]> : tensor<2x2xi64>
+    %results:2 = "interpreter.run_parallel"(%0, %1) {
+      programs=[["all_gather"], ["all_gather"]]
+    } : (tensor<2x2xi64>, tensor<2x2xi64>) -> (tensor<2x4xi64>, tensor<2x4xi64>)
+    check.expect_eq_const %results#0, dense<[[1, 2, 5, 6],
+                                             [3, 4, 7, 8]]> : tensor<2x4xi64>
+    check.expect_eq_const %results#1, dense<[[1, 2, 5, 6],
+                                             [3, 4, 7, 8]]> : tensor<2x4xi64>
+    func.return
+  }
+}

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -606,7 +606,7 @@ func.func @alltoall_invalid_replica_group(%data: tensor<4x16xf32>) -> tensor<16x
 
 // -----
 
-func.func @all_gather_c1(%arg0: tensor<128x0xf32>) -> tensor<128x100xf32> {
+func.func @allgather_gather_along_zero_dimension(%arg0: tensor<128x0xf32>) -> tensor<128x100xf32> {
   // expected-error@+1 {{dimension size of operand at 'all_gather_dim' cannot be zero}}
   %0 = "stablehlo.all_gather"(%arg0) {
     all_gather_dim = 1 : i64,
@@ -618,7 +618,7 @@ func.func @all_gather_c1(%arg0: tensor<128x0xf32>) -> tensor<128x100xf32> {
 
 // -----
 
-func.func @all_gather_c2(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
+func.func @all_gather_c1(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
   // expected-error@+1 {{all_gather_dim cannot be negative}}
   %0 = "stablehlo.all_gather"(%arg0) {
     all_gather_dim = -1 : i64,
@@ -630,7 +630,7 @@ func.func @all_gather_c2(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
 
 // -----
 
-func.func @all_gather_c2(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
+func.func @all_gather_c1(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
   // expected-error@+1 {{all_gather_dim must be a valid index of operand}}
   %0 = "stablehlo.all_gather"(%arg0) {
     all_gather_dim = 2 : i64,
@@ -642,7 +642,7 @@ func.func @all_gather_c2(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
 
 // -----
 
-func.func @all_gather_c3(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
+func.func @all_gather_c2(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
   // expected-error@+1 {{replica id #2 seen more than once}}
   %0 = "stablehlo.all_gather"(%arg0) {
     all_gather_dim = 1 : i64,
@@ -654,7 +654,7 @@ func.func @all_gather_c3(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
 
 // -----
 
-func.func @all_gather_c5(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
+func.func @all_gather_c4(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
   // expected-error@+1 {{Invalid replica id -1}}
   %0 = "stablehlo.all_gather"(%arg0) {
     all_gather_dim = 1 : i64,
@@ -666,7 +666,7 @@ func.func @all_gather_c5(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
 
 // -----
 
-func.func @all_gather_c5(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
+func.func @all_gather_c4(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
   // expected-error@+1 {{replica id #4 not seen in replica groups}}
   %0 = "stablehlo.all_gather"(%arg0) {
     all_gather_dim = 1 : i64,
@@ -678,7 +678,7 @@ func.func @all_gather_c5(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
 
 // -----
 
-func.func @all_gather_c6(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
+func.func @all_gather_c5(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
   // expected-error@+1 {{channel_id cannot be negative when useGlobalDeviceIds is set}}
   %0 = "stablehlo.all_gather"(%arg0) {
     all_gather_dim = 1 : i64,
@@ -691,7 +691,7 @@ func.func @all_gather_c6(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
 
 // -----
 
-func.func @all_gather_c7(%arg0: tensor<8x2x32xf32>) -> tensor<8x8xf32> {
+func.func @all_gather_c6(%arg0: tensor<8x2x32xf32>) -> tensor<8x8xf32> {
   // expected-error@+1 {{operand and result must have the same rank}}
   %0 = "stablehlo.all_gather"(%arg0) {
     all_gather_dim = 1 : i64,
@@ -703,7 +703,7 @@ func.func @all_gather_c7(%arg0: tensor<8x2x32xf32>) -> tensor<8x8xf32> {
 
 // -----
 
-func.func @all_gather_c7(%arg0: tensor<8x2xf32>) -> tensor<4x8xf32> {
+func.func @all_gather_c6(%arg0: tensor<8x2xf32>) -> tensor<4x8xf32> {
   // expected-error@+1 {{operand and result should have the same shape except for the dimension size at 'all_gather_dim'}}
   %0 = "stablehlo.all_gather"(%arg0) {
     all_gather_dim = 1 : i64,
@@ -715,7 +715,7 @@ func.func @all_gather_c7(%arg0: tensor<8x2xf32>) -> tensor<4x8xf32> {
 
 // -----
 
-func.func @all_gather_c7(%arg0: tensor<128x32xf32>) -> tensor<128x100xf32> {
+func.func @all_gather_c6(%arg0: tensor<128x32xf32>) -> tensor<128x100xf32> {
   // expected-error@+1 {{result gather dimension has size 100, expected to be a multiple of operand gather dimension size 32}}
   %0 = "stablehlo.all_gather"(%arg0) {
     all_gather_dim = 1 : i64,

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -606,19 +606,7 @@ func.func @alltoall_invalid_replica_group(%data: tensor<4x16xf32>) -> tensor<16x
 
 // -----
 
-func.func @allgather_incompatible_types(%arg0: tensor<128x32xf32>) -> tensor<128x100xf32> {
-  // expected-error@+1 {{result gather dimension has size 100, expected to be a multiple of operand gather dimension size 32}}
-  %0 = "stablehlo.all_gather"(%arg0) {
-    all_gather_dim = 1 : i64,
-    channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
-    replica_groups = dense<[[0, 2, 4, 6], [1, 3, 5, 7]]> : tensor<2x4xi64>
-  } : (tensor<128x32xf32>) -> tensor<128x100xf32>
-  func.return %0 : tensor<128x100xf32>
-}
-
-// -----
-
-func.func @allgather_gather_along_zero_dimension(%arg0: tensor<128x0xf32>) -> tensor<128x100xf32> {
+func.func @all_gather_c1(%arg0: tensor<128x0xf32>) -> tensor<128x100xf32> {
   // expected-error@+1 {{dimension size of operand at 'all_gather_dim' cannot be zero}}
   %0 = "stablehlo.all_gather"(%arg0) {
     all_gather_dim = 1 : i64,
@@ -630,45 +618,7 @@ func.func @allgather_gather_along_zero_dimension(%arg0: tensor<128x0xf32>) -> te
 
 // -----
 
-// CHECK-LABEL: func @allgather_dynamic_gather_dim
-func.func @allgather_dynamic_gather_dim(%arg0: tensor<128x32xf32>) -> tensor<128x?xf32> {
-  %0 = "stablehlo.all_gather"(%arg0) {
-    all_gather_dim = 1 : i64,
-    channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
-    replica_groups = dense<[[0, 2, 4, 6], [1, 3, 5, 7]]> : tensor<2x4xi64>,
-    use_global_device_ids
-  } : (tensor<128x32xf32>) -> tensor<128x?xf32>
-  func.return %0 : tensor<128x?xf32>
-}
-
-// -----
-
-// CHECK-LABEL: func @allgather_dynamic_non_gather_dim
-func.func @allgather_dynamic_non_gather_dim(%arg0: tensor<128x32xf32>) -> tensor<?x64xf32> {
-  %0 = "stablehlo.all_gather"(%arg0) {
-    all_gather_dim = 1 : i64,
-    channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
-    replica_groups = dense<[[0, 2, 4, 6], [1, 3, 5, 7]]> : tensor<2x4xi64>,
-    use_global_device_ids
-  } : (tensor<128x32xf32>) -> tensor<?x64xf32>
-  func.return %0 : tensor<?x64xf32>
-}
-
-// -----
-
-func.func @all_gather_invalid_dim(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
-  // expected-error@+1 {{all_gather_dim must be a valid index of operand}}
-  %0 = "stablehlo.all_gather"(%arg0) {
-    all_gather_dim = 2 : i64,
-    channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
-    replica_groups = dense<[[0, 2, 4, 6], [1, 3, 5, 7]]> : tensor<2x4xi64>
-  } : (tensor<8x2xf32>) -> tensor<8x8xf32>
-  func.return %0 : tensor<8x8xf32>
-}
-
-// -----
-
-func.func @all_gather_invalid_dim(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
+func.func @all_gather_c2(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
   // expected-error@+1 {{all_gather_dim cannot be negative}}
   %0 = "stablehlo.all_gather"(%arg0) {
     all_gather_dim = -1 : i64,
@@ -680,68 +630,19 @@ func.func @all_gather_invalid_dim(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
 
 // -----
 
-func.func @all_gather_invalid_result_shape(%arg0: tensor<8x2x32xf32>) -> tensor<8x8xf32> {
-  // expected-error@+1 {{operand and return must have the same rank}}
+func.func @all_gather_c2(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
+  // expected-error@+1 {{all_gather_dim must be a valid index of operand}}
   %0 = "stablehlo.all_gather"(%arg0) {
-    all_gather_dim = 1 : i64,
+    all_gather_dim = 2 : i64,
     channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
     replica_groups = dense<[[0, 2, 4, 6], [1, 3, 5, 7]]> : tensor<2x4xi64>
-  } : (tensor<8x2x32xf32>) -> tensor<8x8xf32>
-  func.return %0 : tensor<8x8xf32>
-}
-
-// -----
-
-func.func @all_gather_invalid_result_shape(%arg0: tensor<8x2xf32>) -> tensor<4x8xf32> {
-  // expected-error@+1 {{operand and result should have the same shape except for the dimension size at 'all_gather_dim'}}
-  %0 = "stablehlo.all_gather"(%arg0) {
-    all_gather_dim = 1 : i64,
-    channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
-    replica_groups = dense<[[0, 2, 4, 6], [1, 3, 5, 7]]> : tensor<2x4xi64>
-  } : (tensor<8x2xf32>) -> tensor<4x8xf32>
-  func.return %0 : tensor<4x8xf32>
-}
-
-// -----
-
-func.func @all_gather_invalid_replica_group_shape(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
-  // expected-error@+1 {{replica groups should be a rank 2 tensor}}
-  %0 = "stablehlo.all_gather"(%arg0) {
-    all_gather_dim = 1 : i64,
-    channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
-    replica_groups = dense<[[[0], [1], [2], [3]]]> : tensor<1x4x1xi64>
   } : (tensor<8x2xf32>) -> tensor<8x8xf32>
   func.return %0 : tensor<8x8xf32>
 }
 
 // -----
 
-func.func @all_gather_invalid_replica_group_shape(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
-  // expected-error@+1 {{replica groups cannot be empty}}
-  %0 = "stablehlo.all_gather"(%arg0) {
-    all_gather_dim = 1 : i64,
-    channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
-    replica_groups = dense<0> : tensor<0x2xi64>,
-    use_global_device_ids
-  } : (tensor<8x2xf32>) -> tensor<8x8xf32>
-  func.return %0 : tensor<8x8xf32>
-}
-
-// -----
-
-func.func @all_gather_invalid_replica_group(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
-  // expected-error@+1 {{replica id #1 not seen in replica groups}}
-  %0 = "stablehlo.all_gather"(%arg0) {
-    all_gather_dim = 1 : i64,
-    channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
-    replica_groups = dense<[[-5, -4, -3, 0]]> : tensor<1x4xi64>
-  } : (tensor<8x2xf32>) -> tensor<8x8xf32>
-  func.return %0 : tensor<8x8xf32>
-}
-
-// -----
-
-func.func @all_gather_invalid_replica_group(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
+func.func @all_gather_c3(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
   // expected-error@+1 {{replica id #2 seen more than once}}
   %0 = "stablehlo.all_gather"(%arg0) {
     all_gather_dim = 1 : i64,
@@ -753,12 +654,85 @@ func.func @all_gather_invalid_replica_group(%arg0: tensor<8x2xf32>) -> tensor<8x
 
 // -----
 
-func.func @all_gather_invalid_replica_group(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
+func.func @all_gather_c5(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
+  // expected-error@+1 {{Invalid replica id -1}}
+  %0 = "stablehlo.all_gather"(%arg0) {
+    all_gather_dim = 1 : i64,
+    channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
+    replica_groups = dense<[[0, 2, 4, 6], [1, 3, 5, -1]]> : tensor<2x4xi64>
+  } : (tensor<8x2xf32>) -> tensor<8x8xf32>
+  func.return %0 : tensor<8x8xf32>
+}
+
+// -----
+
+func.func @all_gather_c5(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
   // expected-error@+1 {{replica id #4 not seen in replica groups}}
   %0 = "stablehlo.all_gather"(%arg0) {
     all_gather_dim = 1 : i64,
     channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
     replica_groups = dense<[[0, 2, 6, 8], [1, 3, 5, 7]]> : tensor<2x4xi64>
+  } : (tensor<8x2xf32>) -> tensor<8x8xf32>
+  func.return %0 : tensor<8x8xf32>
+}
+
+// -----
+
+func.func @all_gather_c6(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
+  // expected-error@+1 {{channel_id cannot be negative when useGlobalDeviceIds is set}}
+  %0 = "stablehlo.all_gather"(%arg0) {
+    all_gather_dim = 1 : i64,
+    replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>,
+    channel_handle = #stablehlo.channel_handle<handle = -1, type = 0>,
+    use_global_device_ids
+  } : (tensor<8x2xf32>) -> tensor<8x8xf32>
+  func.return %0 : tensor<8x8xf32>
+}
+
+// -----
+
+func.func @all_gather_c7(%arg0: tensor<8x2x32xf32>) -> tensor<8x8xf32> {
+  // expected-error@+1 {{operand and result must have the same rank}}
+  %0 = "stablehlo.all_gather"(%arg0) {
+    all_gather_dim = 1 : i64,
+    channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
+    replica_groups = dense<[[0, 2, 4, 6], [1, 3, 5, 7]]> : tensor<2x4xi64>
+  } : (tensor<8x2x32xf32>) -> tensor<8x8xf32>
+  func.return %0 : tensor<8x8xf32>
+}
+
+// -----
+
+func.func @all_gather_c7(%arg0: tensor<8x2xf32>) -> tensor<4x8xf32> {
+  // expected-error@+1 {{operand and result should have the same shape except for the dimension size at 'all_gather_dim'}}
+  %0 = "stablehlo.all_gather"(%arg0) {
+    all_gather_dim = 1 : i64,
+    channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
+    replica_groups = dense<[[0, 2, 4, 6], [1, 3, 5, 7]]> : tensor<2x4xi64>
+  } : (tensor<8x2xf32>) -> tensor<4x8xf32>
+  func.return %0 : tensor<4x8xf32>
+}
+
+// -----
+
+func.func @all_gather_c7(%arg0: tensor<128x32xf32>) -> tensor<128x100xf32> {
+  // expected-error@+1 {{result gather dimension has size 100, expected to be a multiple of operand gather dimension size 32}}
+  %0 = "stablehlo.all_gather"(%arg0) {
+    all_gather_dim = 1 : i64,
+    channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
+    replica_groups = dense<[[0, 2, 4, 6], [1, 3, 5, 7]]> : tensor<2x4xi64>
+  } : (tensor<128x32xf32>) -> tensor<128x100xf32>
+  func.return %0 : tensor<128x100xf32>
+}
+
+// -----
+
+func.func @all_gather_i3(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
+  // expected-error@+1 {{replica groups should be a rank 2 tensor}}
+  %0 = "stablehlo.all_gather"(%arg0) {
+    all_gather_dim = 1 : i64,
+    channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
+    replica_groups = dense<[[[0], [1], [2], [3]]]> : tensor<1x4x1xi64>
   } : (tensor<8x2xf32>) -> tensor<8x8xf32>
   func.return %0 : tensor<8x8xf32>
 }


### PR DESCRIPTION
We have the following constraints in the spec:

```
(I1) `operand`: tensor or per-tensor quantized tensor.
(I2) `all_gather_dim`: constant of type `si64`.
(I3) `replica_groups`: 2-dimensional tensor constant of type `si64`.
(I4) `channel_id`: constant of type `si64`.
(I5) `use_global_device_ids`: constant of type `i1`.
(C1) `0 <= all_gather_dim < rank(operand)`.
(C2) `is_unique(replica_groups)`.
(C3) `size(replica_groups)` is defined as:
* `num_replicas` if `cross_replica` is used.
* `num_replicas` if `cross_replica_and_partition` is used.
* `num_processes` if `flattened_ids` is used.
(C4) `0 <= replica_groups < size(replica_groups)`.
(C5) If `use_global_device_ids = true`, then `channel_id > 0`.
(C6) `type(result) = type(operand)` except:
* `dim(result, all_gather_dim) =
  dim(operand, all_gather_dim) * dim(process_groups, 1)`.
```

These constraints will be comprehensively covered by the following tests:

```
I1: a) `operand` is not a tensor. (Covered by ODS).
I2: a) `all_gather_dim` is not a constant of type `si64`. (Covered by ODS).
I3: a) `replica_groups` is not a 2-dimensional tensor constant.
I3: b) `element_type(replica_groups) != si64`. (Covered by ODS).
I4: a) `channel_id` is not a constant of type `si64`. (Covered by ODS).
I5: a) `use_global_device_ids` is not a constant of type `i1`. (Covered by ODS).
C1: a) `all_gather_dim < 0`.
C1: b) `all_gather_dim >= rank(operand)`.
C2: a) `is_unique(replica_groups) = false`.
C3: a) `size(replica_groups)` is defined as:
* `num_replicas` if `cross_replica` is used.
* `num_replicas` if `cross_replica_and_partition` is used.
* `num_processes` if `flattened_ids` is used. 
C4: a) `replica_groups < 0`.
C4: b) `replica_groups >= size(replica_groups)`.
C5: a) `use_global_device_ids = true` and `channel_id <= 0`.
C6: a) `type(result) != type(operand)` except:
* `dim(result, all_gather_dim) =
  dim(operand, all_gather_dim) * dim(process_groups, 1)`.
```

If we drop the "Covered by ODS" pieces, this will leave us with the following test cases:

```
I3: a) `replica_groups` is not a 2-dimensional tensor constant.
C1: a) `all_gather_dim < 0`.
C1: b) `all_gather_dim >= rank(operand)`.
C2: a) `is_unique(replica_groups) = false`.
C3: a) `size(replica_groups)` is defined as:
* `num_replicas` if `cross_replica` is used.
* `num_replicas` if `cross_replica_and_partition` is used.
* `num_processes` if `flattened_ids` is used. 
C4: a) `replica_groups < 0`.
C4: b) `replica_groups >= size(replica_groups)`.
C5: a) `use_global_device_ids = true` and `channel_id <= 0`.
C6: a) `type(result) != type(operand)` except:
* `dim(result, all_gather_dim) =
  dim(operand, all_gather_dim) * dim(process_groups, 1)`.
```

Notes:
  * C3a verification is infeasible since `num_replicas` and `num_partitions` are not known statically.
  * C4b verification is infeasible since `size(replica_groups)` is not known statically.

closes #1118