### PR TITLE
fix BUILD.bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -326,7 +326,7 @@ td_library(
     ],
     includes = ["."],
     deps = [
-        "//:base_td_files",
+        ":base_td_files",
     ],
 )
 


### PR DESCRIPTION
This will cause that llvm/torch-mlir failed to integrate mlir-hlo with bazel.