### PR TITLE
Add interpreter for AllToAllOp

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -888,7 +888,7 @@ Afterwards, within each `process_group`:
   * `num_replicas` if `cross_replica` is used.
   * `num_partitions` if `cross_partition` is used.
 * (C7) `0 <= replica_groups < size(replica_groups)`.
-* (C8) `num_elements(replica_groups) / shape(replica_groups)[0] = split_count`.
+* (C8) `dim(replica_groups, 1) = split_count`.
 * (C9) `type(result) = type(operand)` except:
   * `dim(result, split_dimension) =
     dim(operand, split_dimension) / split_count`.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -862,20 +862,20 @@ Afterwards, within each `process_group`:
 
 #### Inputs
 
-| Label | Name               | Type                                         | Constraints      |
-|-------|--------------------|----------------------------------------------|------------------|
-| (I1)  | `operand`          | tensor or per-tensor quantized tensor        | (C1)             |
-| (I2)  | `split_dimension`  | constant of type `si64`                      | (C1), (C2), (C8) |
-| (I3)  | `concat_dimension` | constant of type `si64`                      | (C3), (C8)       |
-| (I4)  | `split_count`      | constant of type `si64`                      | (C2), (C4), (C8) |
-| (I5)  | `replica_groups`   | 2-dimensional tensor constant of type `si64` | (C7)             |
-| (I6)  | `channel_id`       | constant of type `si64`                      |                  |
+| Label | Name               | Type                                         | Constraints            |
+|-------|--------------------|----------------------------------------------|------------------------|
+| (I1)  | `operand`          | tensor or per-tensor quantized tensor        | (C1-C3), (C9)          |
+| (I2)  | `split_dimension`  | constant of type `si64`                      | (C1), (C2), (C9)       |
+| (I3)  | `concat_dimension` | constant of type `si64`                      | (C3), (C9)             |
+| (I4)  | `split_count`      | constant of type `si64`                      | (C2), (C4), (C8), (C9) |
+| (I5)  | `replica_groups`   | 2-dimensional tensor constant of type `si64` | (C5-C8)                |
+| (I6)  | `channel_id`       | constant of type `si64`                      |                        |
 
 #### Outputs
 
 | Name     | Type                                  | Constraints |
 |----------|---------------------------------------|-------------|
-| `result` | tensor or per-tensor quantized tensor | (C8)        |
+| `result` | tensor or per-tensor quantized tensor | (C9)        |
 
 #### Constraints
 
@@ -888,7 +888,8 @@ Afterwards, within each `process_group`:
   * `num_replicas` if `cross_replica` is used.
   * `num_partitions` if `cross_partition` is used.
 * (C7) `0 <= replica_groups < size(replica_groups)`.
-* (C8) `type(result) = type(operand)` except:
+* (C8) `num_elements(replica_groups) / shape(replica_groups)[0] = split_count`.
+* (C9) `type(result) = type(operand)` except:
   * `dim(result, split_dimension) =
     dim(operand, split_dimension) / split_count`.
   * `dim(result, concat_dimension) =
@@ -899,33 +900,27 @@ Afterwards, within each `process_group`:
 ```mlir
 // num_replicas: 2
 // num_partitions: 1
-// %operand@(0, 0): [
-//                   [1.0, 2.0, 3.0, 4.0],
-//                   [5.0, 6.0, 7.0, 8.0]
-//                  ]
-// %operand@(1, 0): [
-//                   [9.0, 10.0, 11.0, 12.0],
-//                   [13.0, 14.0, 15.0, 16.0]
-//                  ]
+// %operand@(0, 0): [[1, 2, 3, 4],
+//                   [5, 6, 7, 8]]
+// %operand@(1, 0): [[9, 10, 11, 12],
+//                   [13, 14, 15, 16]]
 %result = "stablehlo.all_to_all"(%operand) {
   split_dimension = 1 : i64,
   concat_dimension = 0 : i64,
   split_count = 2 : i64,
   replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>
-} : (tensor<2x4xf32>) -> tensor<4x2xf32>
-// %result@(0, 0): [
-//                  [1.0, 2.0],
-//                  [5.0, 6.0],
-//                  [9.0, 10.0],
-//                  [13.0, 14.0]
-//                 ]
-// %result@(1, 0): [
-//                  [3.0, 4.0],
-//                  [7.0, 8.0],
-//                  [11.0, 12.0],
-//                  [15.0, 16.0]
-//                 ]
+} : (tensor<2x4xi64>) -> tensor<4x2xi64>
+// %result@(0, 0): [[1, 2],
+//                  [5, 6],
+//                  [9, 10],
+//                  [13, 14]]
+// %result@(1, 0): [[3, 4],
+//                  [7, 8],
+//                  [11, 12],
+//                  [15, 16]]
 ```
+
+&nbsp;[More Examples](../stablehlo/tests/interpret_all_to_all.mlir)
 
 ### and
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -47,7 +47,7 @@ one of the following tracking labels.
 | after_all                | yes           | yes          | yes            | yes             | yes         |
 | all_gather               | yes           | revisit      | no             | no              | yes         |
 | all_reduce               | yes           | revisit      | yes            | no              | yes         |
-| all_to_all               | yes           | revisit      | yes            | no              | no          |
+| all_to_all               | yes           | revisit      | yes            | no              | yes         |
 | and                      | yes           | yes          | yes            | yes             | yes         |
 | atan2                    | yes           | yes          | yes            | yes             | yes         |
 | batch_norm_grad          | yes           | revisit      | yes            | no              | revisit     |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1406,7 +1406,8 @@ def StableHLO_ReduceScatterOp : StableHLO_Op<"reduce_scatter",
 }
 
 def StableHLO_AllToAllOp : StableHLO_Op<"all_to_all",
-    [SameOperandsAndResultElementType, InferTensorType]> {
+    [SameOperandsAndResultElementType /*all_to_all_c9*/,
+     InferTensorType /*all_to_all_c9*/]> {
   let summary = "AllToAll operation";
   let description = [{
     Within each process group in the process grid, splits the values of the
@@ -1424,17 +1425,17 @@ def StableHLO_AllToAllOp : StableHLO_Op<"all_to_all",
       concat_dimension = 0 : i64,
       split_count = 2 : i64,
       replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>
-    } : (tensor<2x4xf32>) -> tensor<4x2xf32>
+    } : (tensor<2x4xi64>) -> tensor<4x2xi64>
     ```
   }];
 
   let arguments = (ins
-    HLO_Tensor:$operand,
-    I64Attr:$split_dimension,
-    I64Attr:$concat_dimension,
-    I64Attr:$split_count,
-    I64ElementsAttr:$replica_groups,
-    OptionalAttr<StableHLO_ChannelHandle>:$channel_handle
+    HLO_Tensor:$operand, /*all_to_all_i1*/
+    I64Attr:$split_dimension, /*all_to_all_i2*/
+    I64Attr:$concat_dimension, /*all_to_all_i3*/
+    I64Attr:$split_count, /*all_to_all_i4*/
+    I64ElementsAttr:$replica_groups, /*all_to_all_i5*/
+    OptionalAttr<StableHLO_ChannelHandle>:$channel_handle /*all_to_all_i6*/
   );
   let results = (outs HLO_Tensor);
 

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -42,6 +42,11 @@ Tensor evalAllReduceOp(const Tensor &operand,
                        ChannelId channelId, bool useGlobalDeviceIds,
                        Region &computation, Process *process, Scope &scope,
                        ShapedType resultType);
+Tensor evalAllToAllOp(const Tensor &operand, Axis splitDimension,
+                      Axis concatDimension, int64_t splitCount,
+                      SmallVector<SmallVector<uint32_t>> replicaGroups,
+                      ChannelId channelId, Process *process,
+                      ShapedType resultType);
 Tensor evalAndOp(const Tensor &lhs, const Tensor &rhs, ShapedType resultType);
 Tensor evalAtan2Op(const Tensor &lhs, const Tensor &rhs, ShapedType resultType);
 Tensor evalBitcastConvertOp(const Tensor &operand, ShapedType resultType);

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -102,8 +102,8 @@ func.func @cholesky(%arg0: tensor<1x2x2xf32>) -> tensor<1x2x2xindex> {
 
 // -----
 
-// CHECK-LABEL: func @alltoall
-func.func @alltoall(%data: tensor<4x16xf32>) -> tensor<16x4xindex> {
+// CHECK-LABEL: func @all_to_all_c9
+func.func @all_to_all_c9(%data: tensor<4x16xf32>) -> tensor<16x4xindex> {
   %0 = "stablehlo.all_to_all"(%data) {
     split_dimension = 1 : i64,
     concat_dimension = 0 : i64,
@@ -117,8 +117,8 @@ func.func @alltoall(%data: tensor<4x16xf32>) -> tensor<16x4xindex> {
 
 // -----
 
-// CHECK-LABEL: func @alltoall_bounds
-func.func @alltoall_bounds(%data: tensor<16x?xf32, #stablehlo.bounds<?, 5>>) -> tensor<*xindex> {
+// CHECK-LABEL: func @all_to_all_bounds
+func.func @all_to_all_bounds(%data: tensor<16x?xf32, #stablehlo.bounds<?, 5>>) -> tensor<*xindex> {
   %0 = "stablehlo.all_to_all"(%data) {
     split_dimension = 0 : i64,
     concat_dimension = 1 : i64,

--- a/stablehlo/tests/interpret_all_to_all.mlir
+++ b/stablehlo/tests/interpret_all_to_all.mlir
@@ -1,0 +1,64 @@
+// RUN: stablehlo-translate --interpret -split-input-file %s
+
+module @cross_replica {
+  func.func public @all_to_all(%operand : tensor<2x4xi64>) -> tensor<4x2xi64> {
+    %result = "stablehlo.all_to_all"(%operand) {
+      split_dimension = 1 : i64,
+      concat_dimension = 0 : i64,
+      split_count = 2 : i64,
+      replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>
+    } : (tensor<2x4xi64>) -> tensor<4x2xi64>
+    return %result : tensor<4x2xi64>
+  }
+  func.func public @main() {
+    %inputs0 = stablehlo.constant dense<[[1, 2, 3, 4],
+                                         [5, 6, 7, 8]]> : tensor<2x4xi64>
+    %inputs1 = stablehlo.constant dense<[[9, 10, 11, 12],
+                                         [13, 14, 15, 16]]> : tensor<2x4xi64>
+    %results:2 = "interpreter.run_parallel"(%inputs0, %inputs1) {
+      programs=[["all_to_all"], ["all_to_all"]]
+    } : (tensor<2x4xi64>, tensor<2x4xi64>) -> (tensor<4x2xi64>, tensor<4x2xi64>)
+    check.expect_eq_const %results#0, dense<[[1, 2],
+                                             [5, 6],
+                                             [9, 10],
+                                             [13, 14]]> : tensor<4x2xi64>
+    check.expect_eq_const %results#1, dense<[[3, 4],
+                                             [7, 8],
+                                             [11, 12],
+                                             [15, 16]]> : tensor<4x2xi64>
+    func.return
+  }
+}
+
+// -----
+
+module @cross_partition {
+  func.func public @all_to_all(%operand : tensor<2x4xi64>) -> tensor<4x2xi64> {
+    %result = "stablehlo.all_to_all"(%operand) {
+      split_dimension = 1 : i64,
+      concat_dimension = 0 : i64,
+      split_count = 2 : i64,
+      replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
+      channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>
+    } : (tensor<2x4xi64>) -> tensor<4x2xi64>
+    return %result : tensor<4x2xi64>
+  }
+  func.func public @main() {
+    %inputs0 = stablehlo.constant dense<[[1, 2, 3, 4],
+                                         [5, 6, 7, 8]]> : tensor<2x4xi64>
+    %inputs1 = stablehlo.constant dense<[[9, 10, 11, 12],
+                                         [13, 14, 15, 16]]> : tensor<2x4xi64>
+    %results:2 = "interpreter.run_parallel"(%inputs0, %inputs1) {
+      programs=[["all_to_all", "all_to_all"]]
+    } : (tensor<2x4xi64>, tensor<2x4xi64>) -> (tensor<4x2xi64>, tensor<4x2xi64>)
+    check.expect_eq_const %results#0, dense<[[1, 2],
+                                             [5, 6],
+                                             [9, 10],
+                                             [13, 14]]> : tensor<4x2xi64>
+    check.expect_eq_const %results#1, dense<[[3, 4],
+                                             [7, 8],
+                                             [11, 12],
+                                             [15, 16]]> : tensor<4x2xi64>
+    func.return
+  }
+}

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -399,8 +399,8 @@ func.func @reduce_scatter_dynamic(%data: tensor<?x?xf32>) -> tensor<?x?xf32> {
 
 // -----
 
-// CHECK-LABEL: func @alltoall
-func.func @alltoall(%data: tensor<4x16xf32>) -> tensor<16x4xf32> {
+// CHECK-LABEL: func @all_to_all
+func.func @all_to_all(%data: tensor<4x16xf32>) -> tensor<16x4xf32> {
   %0 = "stablehlo.all_to_all"(%data) {
     split_dimension = 1 : i64,
     concat_dimension = 0 : i64,
@@ -413,8 +413,8 @@ func.func @alltoall(%data: tensor<4x16xf32>) -> tensor<16x4xf32> {
 
 // -----
 
-// CHECK-LABEL: func @alltoall_unranked_input
-func.func @alltoall_unranked_input(%data: tensor<*xf32>) -> tensor<*xf32> {
+// CHECK-LABEL: func @all_to_all_unranked_input
+func.func @all_to_all_unranked_input(%data: tensor<*xf32>) -> tensor<*xf32> {
   %0 = "stablehlo.all_to_all"(%data) {
     split_dimension = 1 : i64,
     concat_dimension = 0 : i64,
@@ -426,8 +426,8 @@ func.func @alltoall_unranked_input(%data: tensor<*xf32>) -> tensor<*xf32> {
 
 // -----
 
-// CHECK-LABEL: func @alltoall_dynamic_split_dim
-func.func @alltoall_dynamic_split_dim(%data: tensor<4x?xf32>) -> tensor<20x?xf32> {
+// CHECK-LABEL: func @all_to_all_dynamic_split_dim
+func.func @all_to_all_dynamic_split_dim(%data: tensor<4x?xf32>) -> tensor<20x?xf32> {
   %0 = "stablehlo.all_to_all"(%data) {
     split_dimension = 1 : i64,
     concat_dimension = 0 : i64,
@@ -439,8 +439,8 @@ func.func @alltoall_dynamic_split_dim(%data: tensor<4x?xf32>) -> tensor<20x?xf32
 
 // -----
 
-// CHECK-LABEL: func @alltoall_dynamic_concat_dim
-func.func @alltoall_dynamic_concat_dim(%data: tensor<?x16xf32>) -> tensor<?x4xf32> {
+// CHECK-LABEL: func @all_to_all_dynamic_concat_dim
+func.func @all_to_all_dynamic_concat_dim(%data: tensor<?x16xf32>) -> tensor<?x4xf32> {
   %0 = "stablehlo.all_to_all"(%data) {
     split_dimension = 1 : i64,
     concat_dimension = 0 : i64,
@@ -452,7 +452,7 @@ func.func @alltoall_dynamic_concat_dim(%data: tensor<?x16xf32>) -> tensor<?x4xf3
 
 // -----
 
-func.func @alltoall_negative_split_dimension(%data: tensor<4x16xf32>) -> tensor<16x4xf32> {
+func.func @all_to_all_c1(%data: tensor<4x16xf32>) -> tensor<16x4xf32> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{AllToAll split_dimension cannot be negative}}
   %0 = "stablehlo.all_to_all"(%data) {
@@ -466,7 +466,7 @@ func.func @alltoall_negative_split_dimension(%data: tensor<4x16xf32>) -> tensor<
 
 // -----
 
-func.func @alltoall_out_bound_split_dimension(%data: tensor<4x16xf32>) -> tensor<16x4xf32> {
+func.func @all_to_all_c1(%data: tensor<4x16xf32>) -> tensor<16x4xf32> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{AllToAll split_dimension 2 is out-of-bounds for input rank 2}}
   %0 = "stablehlo.all_to_all"(%data) {
@@ -480,49 +480,7 @@ func.func @alltoall_out_bound_split_dimension(%data: tensor<4x16xf32>) -> tensor
 
 // -----
 
-func.func @alltoall_negative_concat_dimension(%data: tensor<4x16xf32>) -> tensor<16x4xf32> {
-  // expected-error@+2 {{failed to infer returned types}}
-  // expected-error@+1 {{AllToAll concat_dimension cannot be negative}}
-  %0 = "stablehlo.all_to_all"(%data) {
-    split_dimension = 1 : i64,
-    concat_dimension = -1 : i64,
-    split_count = 4 : i64,
-    replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>
-  } : (tensor<4x16xf32>) -> tensor<16x4xf32>
-  func.return %0 : tensor<16x4xf32>
-}
-
-// -----
-
-func.func @alltoall_out_bound_concat_dimension(%data: tensor<4x16xf32>) -> tensor<16x4xf32> {
-  // expected-error@+2 {{failed to infer returned types}}
-  // expected-error@+1 {{AllToAll concat_dimension 2 is out-of-bounds for input rank 2}}
-  %0 = "stablehlo.all_to_all"(%data) {
-    split_dimension = 1 : i64,
-    concat_dimension = 2 : i64,
-    split_count = 4 : i64,
-    replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>
-  } : (tensor<4x16xf32>) -> tensor<16x4xf32>
-  func.return %0 : tensor<16x4xf32>
-}
-
-// -----
-
-func.func @alltoall_invalid_split_count(%data: tensor<4x16xf32>) -> tensor<16x4xf32> {
-  // expected-error@+2 {{failed to infer returned types}}
-  // expected-error@+1 {{AllToAll split_count must be > 0}}
-  %0 = "stablehlo.all_to_all"(%data) {
-    split_dimension = 1 : i64,
-    concat_dimension = 0 : i64,
-    split_count = 0 : i64,
-    replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>
-  } : (tensor<4x16xf32>) -> tensor<16x4xf32>
-  func.return %0 : tensor<16x4xf32>
-}
-
-// -----
-
-func.func @alltoall_invalid_split_dim_size(%data: tensor<4x16xf32>) -> tensor<16x4xf32> {
+func.func @all_to_all_c2(%data: tensor<4x16xf32>) -> tensor<16x4xf32> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{split dimension has size 16, expected to be a multiple of split_count 5}}
   %0 = "stablehlo.all_to_all"(%data) {
@@ -536,35 +494,49 @@ func.func @alltoall_invalid_split_dim_size(%data: tensor<4x16xf32>) -> tensor<16
 
 // -----
 
-func.func @alltoall_invalid_replica_group(%data: tensor<4x16xf32>) -> tensor<16x4xf32> {
+func.func @all_to_all_c3(%data: tensor<4x16xf32>) -> tensor<16x4xf32> {
   // expected-error@+2 {{failed to infer returned types}}
-  // expected-error@+1 {{replica groups should be a rank 2 tensor}}
+  // expected-error@+1 {{AllToAll concat_dimension cannot be negative}}
   %0 = "stablehlo.all_to_all"(%data) {
     split_dimension = 1 : i64,
-    concat_dimension = 0 : i64,
+    concat_dimension = -1 : i64,
     split_count = 4 : i64,
-    replica_groups = dense<[[[0], [1], [2], [3]]]> : tensor<1x4x1xi64>
+    replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>
   } : (tensor<4x16xf32>) -> tensor<16x4xf32>
   func.return %0 : tensor<16x4xf32>
 }
 
 // -----
 
-func.func @alltoall_invalid_replica_group(%data: tensor<4x16xf32>) -> tensor<16x4xf32> {
+func.func @all_to_all_c3(%data: tensor<4x16xf32>) -> tensor<16x4xf32> {
   // expected-error@+2 {{failed to infer returned types}}
-  // expected-error@+1 {{replica id #1 not seen in replica groups}}
+  // expected-error@+1 {{AllToAll concat_dimension 2 is out-of-bounds for input rank 2}}
   %0 = "stablehlo.all_to_all"(%data) {
     split_dimension = 1 : i64,
-    concat_dimension = 0 : i64,
+    concat_dimension = 2 : i64,
     split_count = 4 : i64,
-    replica_groups = dense<[[-5, -4, -3, 0]]> : tensor<1x4xi64>
+    replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>
   } : (tensor<4x16xf32>) -> tensor<16x4xf32>
   func.return %0 : tensor<16x4xf32>
 }
 
 // -----
 
-func.func @alltoall_invalid_replica_group(%data: tensor<4x16xf32>) -> tensor<16x4xf32> {
+func.func @all_to_all_c4(%data: tensor<4x16xf32>) -> tensor<16x4xf32> {
+  // expected-error@+2 {{failed to infer returned types}}
+  // expected-error@+1 {{AllToAll split_count must be > 0}}
+  %0 = "stablehlo.all_to_all"(%data) {
+    split_dimension = 1 : i64,
+    concat_dimension = 0 : i64,
+    split_count = 0 : i64,
+    replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>
+  } : (tensor<4x16xf32>) -> tensor<16x4xf32>
+  func.return %0 : tensor<16x4xf32>
+}
+
+// -----
+
+func.func @all_to_all_c5(%data: tensor<4x16xf32>) -> tensor<16x4xf32> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{replica id #2 seen more than once}}
   %0 = "stablehlo.all_to_all"(%data) {
@@ -578,21 +550,21 @@ func.func @alltoall_invalid_replica_group(%data: tensor<4x16xf32>) -> tensor<16x
 
 // -----
 
-func.func @alltoall_invalid_replica_group(%data: tensor<4x16xf32>) -> tensor<16x4xf32> {
+func.func @all_to_all_c7(%data: tensor<4x16xf32>) -> tensor<16x4xf32> {
   // expected-error@+2 {{failed to infer returned types}}
-  // expected-error@+1 {{replica id #4 not seen in replica groups}}
+  // expected-error@+1 {{replica id #1 not seen in replica groups}}
   %0 = "stablehlo.all_to_all"(%data) {
     split_dimension = 1 : i64,
     concat_dimension = 0 : i64,
     split_count = 4 : i64,
-    replica_groups = dense<[[0, 2, 6, 8], [1, 3, 5, 7]]> : tensor<2x4xi64>
+    replica_groups = dense<[[-5, -4, -3, 0]]> : tensor<1x4xi64>
   } : (tensor<4x16xf32>) -> tensor<16x4xf32>
   func.return %0 : tensor<16x4xf32>
 }
 
 // -----
 
-func.func @alltoall_invalid_replica_group(%data: tensor<4x16xf32>) -> tensor<16x4xf32> {
+func.func @all_to_all_c8(%data: tensor<4x16xf32>) -> tensor<16x4xf32> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{group size of replica_groups must be 4}}
   %0 = "stablehlo.all_to_all"(%data) {
@@ -600,6 +572,20 @@ func.func @alltoall_invalid_replica_group(%data: tensor<4x16xf32>) -> tensor<16x
     concat_dimension = 0 : i64,
     split_count = 4 : i64,
     replica_groups = dense<[[0, 2, 4], [1, 3, 5]]> : tensor<2x3xi64>
+  } : (tensor<4x16xf32>) -> tensor<16x4xf32>
+  func.return %0 : tensor<16x4xf32>
+}
+
+// -----
+
+func.func @all_to_all_i5(%data: tensor<4x16xf32>) -> tensor<16x4xf32> {
+  // expected-error@+2 {{failed to infer returned types}}
+  // expected-error@+1 {{replica groups should be a rank 2 tensor}}
+  %0 = "stablehlo.all_to_all"(%data) {
+    split_dimension = 1 : i64,
+    concat_dimension = 0 : i64,
+    split_count = 4 : i64,
+    replica_groups = dense<[[[0], [1], [2], [3]]]> : tensor<1x4x1xi64>
   } : (tensor<4x16xf32>) -> tensor<16x4xf32>
   func.return %0 : tensor<16x4xf32>
 }


### PR DESCRIPTION
We have the following constraints in the spec:

```
(I1) `operand` is a tensor.
(I2) `split_dimension` is a constant of type `si64`.
(I3) `concat_dimension` is a constant of type `si64`.
(I4) `split_count` is a constant of type `si64`.
(I5) `replica_groups` is a 2-dimensional tensor constant of type `si64`.
(I6) `channel_id` is a constant of type `si64`.
(C1) `0 <= split_dimension < rank(operand)`.
(C2) `dim(operand, split_dimension) % split_count = 0`.
(C3) `0 <= concat_dimension < rank(operand)`.
(C4) `0 < split_count`.
(C5) `is_unique(replica_groups)`.
(C6) `size(replica_groups)` is defined as:
* `num_replicas` if `cross_replica` is used.
* `num_partitions` if `cross_partition` is used.
(C7) `0 <= replica_groups < size(replica_groups)`.
(C8) `dim(replica_groups, 1) = split_count`.
(C9) `type(result) = type(operand)` except:
* `dim(result, split_dimension) =
  dim(operand, split_dimension) / split_count`.
* `dim(result, concat_dimension) =
  dim(operand, concat_dimension) * split_count`.
```

These constraints will be comprehensively covered by the following tests:

```
I1: a) `operand` is not a tensor. (Covered by ODS).
I2: a) `split_dimension` is not a constant of type `si64`. (Covered by ODS).
I3: a) `concat_dimension` is not a constant of type `si64`. (Covered by ODS).
I4: a) `split_count` is not a constant of type `si64`. (Covered by ODS).
I5: a) `replica_groups` is not a 2-dimensional tensor constant.
I5: b) `type(replica_groups) != si64`. (Covered by ODS).
I6: a) `channel_id` is not a constant of type `si64`. (Covered by ODS).
C1: a) `split_dimension < 0`.
C1: b) `split_dimension >= rank(operand)`.
C2: a) `dim(operand, split_dimension) % split_count != 0`.
C3: a) `concat_dimension < 0`.
C3: b) `concat_dimension >= rank(operand)`.
C4: a) `split_count <= 0`.
C5: a) `is_unique(replica_groups) = false`.
C6: a) `size(replica_groups)` is not defined as:
* `num_replicas` if `cross_replica` is used.
* `num_partitions` if `cross_partition` is used.
C7: a) `replica_groups < 0`.
C7: b) `replica_groups >= size(replica_groups)`.
C8: a) `dim(replica_groups, 1) != split_count`.
C9: a) `type(result) != type(operand)` except:
* `dim(result, split_dimension) =
  dim(operand, split_dimension) / split_count`.
* `dim(result, concat_dimension) =
  dim(operand, concat_dimension) * split_count`.
```

If we drop the "Covered by ODS" pieces, this will leave us with the following test cases:

```
I5: a) `replica_groups` is not a 2-dimensional tensor constant.
C1: a) `split_dimension < 0`.
C1: b) `split_dimension >= rank(operand)`.
C2: a) `dim(operand, split_dimension) % split_count != 0`.
C3: a) `concat_dimension < 0`.
C3: b) `concat_dimension >= rank(operand)`.
C4: a) `split_count <= 0`.
C5: a) `is_unique(replica_groups) = false`.
C6: a) `size(replica_groups)` is not defined as:
* `num_replicas` if `cross_replica` is used.
* `num_partitions` if `cross_partition` is used.
C7: a) `replica_groups < 0`.
C7: b) `replica_groups >= size(replica_groups)`.
C8: a) `dim(replica_groups, 1) != split_count`.
C9: a) `type(result) != type(operand)` except:
* `dim(result, split_dimension) =
  dim(operand, split_dimension) / split_count`.
* `dim(result, concat_dimension) =
  dim(operand, concat_dimension) * split_count`.
```

Notes:
  * C6a verification is infeasible since `num_replicas` and `num_partitions` are not known statically.
  * C7b verification is infeasible since `size(replica_groups)` is not known statically.