### PR TITLE
Add interpreter for ReduceScatterOp

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4142,17 +4142,17 @@ Afterwards, within each `process_group`:
 
 #### Constraints
 
-* (C1) `0 <= scatter_dimension < rank(operand)`.
-* (C2) `is_unique(replica_groups)`.
-* (C3) `size(replica_groups)` is defined as:
+* (C1) `dim(operand, scatter_dimension) % dim(process_groups, 1) = 0`.
+* (C2) `0 <= scatter_dimension < rank(operand)`.
+* (C3) `is_unique(replica_groups)`.
+* (C4) `size(replica_groups)` is defined as:
   * `num_replicas` if `cross_replica` is used.
   * `num_replicas` if `cross_replica_and_partition` is used.
   * `num_processes` if `flattened_ids` is used.
-* (C4) `0 <= replica_groups < size(replica_groups)`.
-* (C5) If `use_global_device_ids = true`, then `channel_id > 0`.
-* (C6) `computation` has type `(tensor<E>, tensor<E>) -> (tensor<E>)` where
+* (C5) `0 <= replica_groups < size(replica_groups)`.
+* (C6) If `use_global_device_ids = true`, then `channel_id > 0`.
+* (C7) `computation` has type `(tensor<E>, tensor<E>) -> (tensor<E>)` where
        `E = element_type(operand)`.
-* (C7) `0 < dim(result, scatter_dimension)`.
 * (C8) `type(result) = type(operand)` except:
   * `dim(result, scatter_dimension) = dim(operand, scatter_dimension) /
     dim(process_groups, 1)`.

--- a/docs/status.md
+++ b/docs/status.md
@@ -120,7 +120,7 @@ one of the following tracking labels.
 | recv                     | yes           | revisit      | infeasible     | no              | no          |
 | reduce                   | yes           | revisit      | yes            | revisit         | yes         |
 | reduce_precision         | yes           | yes          | yes            | yes             | yes         |
-| reduce_scatter           | yes           | revisit      | no             | no              | no          |
+| reduce_scatter           | yes           | revisit      | no             | no              | yes         |
 | reduce_window            | yes           | revisit      | yes            | no              | yes         |
 | remainder                | yes           | yes          | yes            | yes             | yes         |
 | replica_id               | yes           | yes          | yes            | yes             | yes         |

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -138,9 +138,13 @@ void CollectivePermuteOp::build(OpBuilder& odsBuilder, OperationState& odsState,
 //===----------------------------------------------------------------------===//
 
 LogicalResult ReduceScatterOp::verify() {
+  int64_t channelId = 0;
+  if (auto channelHandleAttr = getChannelHandleAttr())
+    channelId = channelHandleAttr.getHandle();
+
   return hlo::verifyReduceScatterOp(
       getLoc(), getOperand(), getScatterDimension(), getReplicaGroups(),
-      getUseGlobalDeviceIds(), getComputation(), getResult());
+      channelId, getUseGlobalDeviceIds(), getComputation(), getResult());
 }
 
 //===----------------------------------------------------------------------===//

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1366,7 +1366,7 @@ def StableHLO_AllReduceOp : StableHLO_Op<"all_reduce",
 }
 
 def StableHLO_ReduceScatterOp : StableHLO_Op<"reduce_scatter",
-    [SameOperandsAndResultElementType]> {
+    [SameOperandsAndResultElementType /*reduce_scatter_c8*/]> {
   let summary = "ReduceScatter operation";
   let description = [{
      Within each process group in the process grid, performs reduction, using
@@ -1380,27 +1380,25 @@ def StableHLO_ReduceScatterOp : StableHLO_Op<"reduce_scatter",
     Example:
     ```mlir
     %result = "stablehlo.reduce_scatter"(%operand) ({
-      ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
-      %0 = stablehlo.add %arg0, %arg1 : tensor<f32>
-      stablehlo.return %0 : tensor<f32>
+      ^bb0(%arg0: tensor<i64>, %arg1: tensor<i64>):
+      %0 = stablehlo.add %arg0, %arg1 : tensor<i64>
+      stablehlo.return %0 : tensor<i64>
     }) {
       scatter_dimension = 1 : i64,
       replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
-      // channel_id = 0
       channel_handle = #stablehlo.channel_handle<handle = 0, type = 0>
-      // use_global_device_ids = false
-    } : (tensor<2x4xf32>) -> tensor<2x2xf32>
+    } : (tensor<2x4xi64>) -> tensor<2x2xi64>
     ```
   }];
 
   let arguments = (ins
-    HLO_Tensor:$operand,
-    I64Attr:$scatter_dimension,
-    I64ElementsAttr:$replica_groups,
-    OptionalAttr<StableHLO_ChannelHandle>:$channel_handle,
-    UnitAttr:$use_global_device_ids
+    HLO_Tensor:$operand, /*reduce_scatter_i1*/
+    I64Attr:$scatter_dimension, /*reduce_scatter_i2*/
+    I64ElementsAttr:$replica_groups, /*reduce_scatter_i3*/
+    OptionalAttr<StableHLO_ChannelHandle>:$channel_handle, /*reduce_scatter_i4*/
+    UnitAttr:$use_global_device_ids /*reduce_scatter_i5*/
   );
-  let regions = (region SizedRegion<1>:$computation);
+  let regions = (region SizedRegion<1>:$computation /*reduce_scatter_i6*/);
   let results = (outs HLO_Tensor);
   let hasVerifier = 1;
 }

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -536,20 +536,20 @@ LogicalResult verifyReducerShape(std::optional<Location> loc, Block& block,
                                  ArrayRef<int64_t> allowedDimensions) {
   int64_t numInputs = inputTypes.size();
 
-  // all_reduce_c6, reduce_c6, reduce_scatter_c6, reduce_window_c13,
+  // all_reduce_c6, reduce_c6, reduce_scatter_c7, reduce_window_c13,
   // scatter_c15, select_and_scatter_c10
   if (static_cast<int64_t>(block.getArguments().size()) != numInputs * 2)
     return emitOptionalError(loc, "Reduction-region must take ", numInputs * 2,
                              " parameters, but takes ",
                              block.getArguments().size(), " parameter(s)");
 
-  // all_reduce_c6, reduce_c6, reduce_scatter_c6, reduce_window_c13,
+  // all_reduce_c6, reduce_c6, reduce_scatter_c7, reduce_window_c13,
   // scatter_c15, select_and_scatter_c10
   if (block.getTerminator()->getOperands().empty())
     return emitOptionalError(
         loc, "The reduction-region expected to return some value(s)");
 
-  // all_reduce_c6, reduce_c6, reduce_scatter_c6, reduce_window_c13,
+  // all_reduce_c6, reduce_c6, reduce_scatter_c7, reduce_window_c13,
   // scatter_c15, select_and_scatter_c10
   if (static_cast<int64_t>(block.getTerminator()->getOperands().size()) !=
       numInputs)
@@ -558,7 +558,7 @@ LogicalResult verifyReducerShape(std::optional<Location> loc, Block& block,
                              block.getTerminator()->getOperands().size(),
                              " instead");
 
-  // all_reduce_c6, reduce_c6, reduce_scatter_c6, reduce_window_c13,
+  // all_reduce_c6, reduce_c6, reduce_scatter_c7, reduce_window_c13,
   // scatter_c15, select_and_scatter_c10
   SmallVector<ShapedType> accumulatorSubShapes;
   for (Value retOperand : block.getTerminator()->getOperands()) {
@@ -573,7 +573,7 @@ LogicalResult verifyReducerShape(std::optional<Location> loc, Block& block,
   }
 
   for (int64_t inputIdx = 0; inputIdx < numInputs; ++inputIdx) {
-    // all_reduce_c6, reduce_c2, reduce_scatter_c6, reduce_window_c13,
+    // all_reduce_c6, reduce_c2, reduce_scatter_c7, reduce_window_c13,
     // scatter_c15, select_and_scatter_c10
     if (!compatibleShapeAndElementType(accumulatorSubShapes[inputIdx],
                                        block.getArgument(inputIdx).getType()))
@@ -583,7 +583,7 @@ LogicalResult verifyReducerShape(std::optional<Location> loc, Block& block,
           block.getArgument(inputIdx).getType(), " vs ",
           accumulatorSubShapes[inputIdx]);
 
-    // all_reduce_c6, reduce_c2, reduce_scatter_c6, reduce_window_c13,
+    // all_reduce_c6, reduce_c2, reduce_scatter_c7, reduce_window_c13,
     // scatter_c15, select_and_scatter_c3, select_and_scatter_c10
     if (!compatibleShapeAndElementType(
             accumulatorSubShapes[inputIdx],
@@ -596,7 +596,7 @@ LogicalResult verifyReducerShape(std::optional<Location> loc, Block& block,
           block.getArgument(numInputs + inputIdx).getType(), " vs ",
           accumulatorSubShapes[inputIdx]);
 
-    // all_reduce_c6, reduce_c6, reduce_scatter_c6, reduce_window_c13,
+    // all_reduce_c6, reduce_c6, reduce_scatter_c7, reduce_window_c13,
     // reduce_window_i2, scatter_c6, scatter_c15, select_and_scatter_c10
     if (!compatibleShapeAndElementType(accumulatorSubShapes[inputIdx],
                                        initValueTypes[inputIdx],
@@ -3720,7 +3720,7 @@ LogicalResult verifyReduceScatterOp(std::optional<Location> location,
                                  /*expectedGroupSize=*/std::nullopt)))
     return failure();
   auto operandType = operand.getType().cast<ShapedType>();
-  // reduce_scatter_c6
+  // reduce_scatter_c7
   if (failed(verifyReducerShape(
           location, computation.front(), {operandType},
           {RankedTensorType::get({}, operandType.getElementType())},
@@ -3743,7 +3743,7 @@ LogicalResult verifyReduceScatterOp(std::optional<Location> location,
     return emitOptionalError(
         location, "scatter dim should be less than operand/result rank");
 
-  // reduce_scatter_c5
+  // reduce_scatter_c6
   if (useGlobalDeviceIds && channelId <= 0)
     return emitOptionalError(
         location,
@@ -3756,12 +3756,12 @@ LogicalResult verifyReduceScatterOp(std::optional<Location> location,
 
   auto operandScatterDimSize = operandType.getDimSize(scatterDimension);
   auto resultScatterDimSize = resultType.getDimSize(scatterDimension);
-  // reduce_scatter_c7
+  // TODO(#1746): Sync verification of ReduceScatter with HLO.
   if (resultScatterDimSize == 0)
     return emitOptionalError(
         location, "result dimension size at scatter_dimension cannot be zero");
 
-  // reduce_scatter_c8
+  // TODO(#1746): Sync verification of ReduceScatter with HLO.
   if (operandScatterDimSize == 0)
     return emitOptionalError(
         location, "operand dimension size at scatter_dimension cannot be zero");

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -463,7 +463,7 @@ LogicalResult verifyReducePrecisionOp(std::optional<Location> location,
 LogicalResult verifyReduceScatterOp(std::optional<Location> location,
                                     Value operand, int64_t scatterDimension,
                                     DenseIntElementsAttr replicaGroups,
-                                    bool useGlobalDeviceIds,
+                                    int64_t channelId, bool useGlobalDeviceIds,
                                     Region& computation, Value result);
 
 LogicalResult verifyReduceWindowOp(

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -132,6 +132,11 @@ SmallVector<Tensor> evalReduceOp(ArrayRef<Tensor> inputs,
                                  ArrayRef<ShapedType> resultTypes);
 Tensor evalReducePrecisionOp(const Tensor &operand, int32_t exponentBits,
                              int32_t mantissaBits, ShapedType resultType);
+Tensor evalReduceScatterOp(const Tensor &operand, int64_t scatterDimension,
+                           SmallVector<SmallVector<uint32_t>> replicaGroups,
+                           ChannelId channelId, bool useGlobalDeviceIds,
+                           Region &region, Process *process, Scope &scope,
+                           ShapedType returnType);
 SmallVector<Tensor> evalReduceWindowOp(
     ArrayRef<Tensor> inputs, ArrayRef<Tensor> initValues,
     const Sizes &windowDimensions, const Sizes &windowStrides,

--- a/stablehlo/tests/interpret_reduce_scatter.mlir
+++ b/stablehlo/tests/interpret_reduce_scatter.mlir
@@ -1,0 +1,92 @@
+// RUN: stablehlo-translate --interpret -split-input-file %s
+
+module @cross_replica {
+  func.func public @reduce_scatter(%operand : tensor<2x4xi64>) -> tensor<2x2xi64> {
+    %result = "stablehlo.reduce_scatter"(%operand) ({
+      ^bb0(%arg0: tensor<i64>, %arg1: tensor<i64>):
+        %0 = stablehlo.add %arg0, %arg1 : tensor<i64>
+        stablehlo.return %0 : tensor<i64>
+    }) {
+      scatter_dimension = 1 : i64,
+      replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>
+    } : (tensor<2x4xi64>) -> tensor<2x2xi64>
+    return %result : tensor<2x2xi64>
+  }
+  func.func public @main() {
+    %inputs0 = stablehlo.constant dense<[[1, 2, 3, 4],
+                                         [5, 6, 7, 8]]> : tensor<2x4xi64>
+    %inputs1 = stablehlo.constant dense<[[9, 10, 11, 12],
+                                         [13, 14, 15, 16]]> : tensor<2x4xi64>
+    %results:2 = "interpreter.run_parallel"(%inputs0, %inputs1) {
+      programs=[["reduce_scatter"], ["reduce_scatter"]]
+    } : (tensor<2x4xi64>, tensor<2x4xi64>) -> (tensor<2x2xi64>, tensor<2x2xi64>)
+    check.expect_eq_const %results#0, dense<[[10, 12],
+                                             [18, 20]]> : tensor<2x2xi64>
+    check.expect_eq_const %results#1, dense<[[14, 16],
+                                             [22, 24]]> : tensor<2x2xi64>
+    func.return
+  }
+}
+
+// -----
+
+module @cross_replica_and_partition {
+  func.func public @reduce_scatter(%operand : tensor<2x4xi64>) -> tensor<2x2xi64> {
+    %result = "stablehlo.reduce_scatter"(%operand) ({
+      ^bb0(%arg0: tensor<i64>, %arg1: tensor<i64>):
+        %0 = stablehlo.add %arg0, %arg1 : tensor<i64>
+        stablehlo.return %0 : tensor<i64>
+    }) {
+      scatter_dimension = 1 : i64,
+      replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
+      channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>
+    } : (tensor<2x4xi64>) -> tensor<2x2xi64>
+    return %result : tensor<2x2xi64>
+  }
+  func.func public @main() {
+    %inputs0 = stablehlo.constant dense<[[1, 2, 3, 4],
+                                         [5, 6, 7, 8]]> : tensor<2x4xi64>
+    %inputs1 = stablehlo.constant dense<[[9, 10, 11, 12],
+                                         [13, 14, 15, 16]]> : tensor<2x4xi64>
+    %results:2 = "interpreter.run_parallel"(%inputs0, %inputs1) {
+      programs=[["reduce_scatter"], ["reduce_scatter"]]
+    } : (tensor<2x4xi64>, tensor<2x4xi64>) -> (tensor<2x2xi64>, tensor<2x2xi64>)
+    check.expect_eq_const %results#0, dense<[[10, 12],
+                                             [18, 20]]> : tensor<2x2xi64>
+    check.expect_eq_const %results#1, dense<[[14, 16],
+                                             [22, 24]]> : tensor<2x2xi64>
+    func.return
+  }
+}
+
+// -----
+
+module @flattened_ids {
+  func.func public @reduce_scatter(%operand : tensor<2x4xi64>) -> tensor<2x2xi64> {
+    %result = "stablehlo.reduce_scatter"(%operand) ({
+      ^bb0(%arg0: tensor<i64>, %arg1: tensor<i64>):
+        %0 = stablehlo.add %arg0, %arg1 : tensor<i64>
+        stablehlo.return %0 : tensor<i64>
+    }) {
+      scatter_dimension = 1 : i64,
+      replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
+      channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
+      use_global_device_ids
+    } : (tensor<2x4xi64>) -> tensor<2x2xi64>
+    return %result : tensor<2x2xi64>
+  }
+  func.func public @main() {
+    %inputs0 = stablehlo.constant dense<[[1, 2, 3, 4],
+                                         [5, 6, 7, 8]]> : tensor<2x4xi64>
+    %inputs1 = stablehlo.constant dense<[[9, 10, 11, 12],
+                                         [13, 14, 15, 16]]> : tensor<2x4xi64>
+    %results:2 = "interpreter.run_parallel"(%inputs0, %inputs1) {
+      programs=[["reduce_scatter"], ["reduce_scatter"]]
+    } : (tensor<2x4xi64>, tensor<2x4xi64>) -> (tensor<2x2xi64>, tensor<2x2xi64>)
+    check.expect_eq_const %results#0, dense<[[10, 12],
+                                             [18, 20]]> : tensor<2x2xi64>
+    check.expect_eq_const %results#1, dense<[[14, 16],
+                                             [22, 24]]> : tensor<2x2xi64>
+    func.return
+  }
+}

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -245,7 +245,7 @@ func.func @reduce_scatter_dynamic(%data: tensor<?x?xf32>) -> tensor<?x?xf32> {
 
 // -----
 
-func.func @reduce_scatter_c1(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
+func.func @reduce_scatter_c2(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
   // expected-error@+1 {{expects scatter_dimension >= 0}}
   %0 = "stablehlo.reduce_scatter"(%data) ({
     ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
@@ -258,7 +258,7 @@ func.func @reduce_scatter_c1(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
 
 // -----
 
-func.func @reduce_scatter_c1(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
+func.func @reduce_scatter_c2(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
   // expected-error@+1 {{scatter dim should be less than operand/result rank}}
   %0 = "stablehlo.reduce_scatter"(%data) ({
     ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
@@ -271,7 +271,7 @@ func.func @reduce_scatter_c1(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
 
 // -----
 
-func.func @reduce_scatter_c2(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
+func.func @reduce_scatter_c3(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
   //  expected-error@+1 {{replica id #1 seen more than once}}
   %0 = "stablehlo.reduce_scatter"(%data) ({
     ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
@@ -284,7 +284,7 @@ func.func @reduce_scatter_c2(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
 
 // -----
 
-func.func @reduce_scatter_c4(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
+func.func @reduce_scatter_c5(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
   //  expected-error@+1 {{Invalid replica id -1}}
   %0 = "stablehlo.reduce_scatter"(%data) ({
     ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
@@ -297,7 +297,7 @@ func.func @reduce_scatter_c4(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
 
 // -----
 
-func.func @reduce_scatter_c4(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
+func.func @reduce_scatter_c5(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
   //  expected-error@+1 {{replica id #2 not seen in replica groups}}
   %0 = "stablehlo.reduce_scatter"(%data) ({
     ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
@@ -310,7 +310,7 @@ func.func @reduce_scatter_c4(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
 
 // -----
 
-func.func @reduce_scatter_c5(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
+func.func @reduce_scatter_c6(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
   //  expected-error@+1 {{channel_id must be positive when useGlobalDeviceIds is set but got: 0}}
   %0 = "stablehlo.reduce_scatter"(%data) ({
     ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
@@ -324,7 +324,7 @@ func.func @reduce_scatter_c5(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
 
 // -----
 
-func.func @reduce_scatter_c6(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
+func.func @reduce_scatter_c7(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
   // expected-error@+1 {{Reduction-region must take 2 parameters, but takes 3 parameter(s)}}
   %0 = "stablehlo.reduce_scatter"(%data) ({
     ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>, %arg4: tensor<f32>):
@@ -337,7 +337,7 @@ func.func @reduce_scatter_c6(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
 
 // -----
 
-func.func @reduce_scatter_c6(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
+func.func @reduce_scatter_c7(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
   // expected-error@+1 {{The reduction-region expected to return some value(s)}}
   %0 = "stablehlo.reduce_scatter"(%data) ({
     ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
@@ -350,7 +350,7 @@ func.func @reduce_scatter_c6(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
 
 // -----
 
-func.func @reduce_scatter_c6(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
+func.func @reduce_scatter_c7(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
   // expected-error@+1 {{Reduction-region here must produce 1 tensors, but produces 2 instead}}
   %0 = "stablehlo.reduce_scatter"(%data) ({
     ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
@@ -363,7 +363,7 @@ func.func @reduce_scatter_c6(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
 
 // -----
 
-func.func @reduce_scatter_c6(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
+func.func @reduce_scatter_c7(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
   // expected-error@+1 {{Reduction-region here must produce tensor-typed result(s), but produces 'tuple<tensor<f32>, tensor<f32>>' instead}}
   %0 = "stablehlo.reduce_scatter"(%data) ({
     ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
@@ -376,7 +376,7 @@ func.func @reduce_scatter_c6(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
 
 // -----
 
-func.func @reduce_scatter_c6(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
+func.func @reduce_scatter_c7(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
   // expected-error@+1 {{The type of reduction-region's parameter at index 1 is different than the corresponding result type: 'tensor<i32>' vs 'tensor<f32>'}}
   %0 = "stablehlo.reduce_scatter"(%data) ({
     ^bb0(%arg2: tensor<f32>, %arg3: tensor<i32>):
@@ -389,7 +389,7 @@ func.func @reduce_scatter_c6(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
 
 // -----
 
-func.func @reduce_scatter_c6(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
+func.func @reduce_scatter_c7(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
   // expected-error@+1 {{The type of reduction-region's parameter at index 0 is different than the corresponding result type: 'tensor<f32>' vs 'tensor<i32>'}}
   %0 = "stablehlo.reduce_scatter"(%data) ({
     ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
@@ -403,7 +403,7 @@ func.func @reduce_scatter_c6(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
 
 // -----
 
-func.func @reduce_scatter_c6(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
+func.func @reduce_scatter_c7(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
   // expected-error@+1 {{The type of reduction-region's result type at index 0 differs from the op's corresponding init-value type: 'tensor<i32>' vs 'tensor<f32>'}}
   %0 = "stablehlo.reduce_scatter"(%data) ({
     ^bb0(%arg2: tensor<i32>, %arg3: tensor<i32>):
@@ -412,19 +412,6 @@ func.func @reduce_scatter_c6(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
   }) {replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>,
       scatter_dimension = 1 : i64} : (tensor<4x16xf32>) -> tensor<4x4xf32>
   func.return %0 : tensor<4x4xf32>
-}
-
-// -----
-
-func.func @reduce_scatter_c7(%data: tensor<4x16xf32>) -> tensor<4x0xf32> {
-  // expected-error@+1 {{result dimension size at scatter_dimension cannot be zero}}
-  %0 = "stablehlo.reduce_scatter"(%data) ({
-    ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
-    %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
-    "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>,
-      scatter_dimension = 1 : i64} : (tensor<4x16xf32>) -> tensor<4x0xf32>
-  func.return %0 : tensor<4x0xf32>
 }
 
 // -----
@@ -438,19 +425,6 @@ func.func @reduce_scatter_c8(%data: tensor<4x16xf32>) -> tensor<4xf32> {
   }) {replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>,
       scatter_dimension = 1 : i64} : (tensor<4x16xf32>) -> tensor<4xf32>
   func.return %0 : tensor<4xf32>
-}
-
-// -----
-
-func.func @reduce_scatter_c8(%data: tensor<4x0xf32>) -> tensor<4x4xf32> {
-  // expected-error@+1 {{operand dimension size at scatter_dimension cannot be zero}}
-  %0 = "stablehlo.reduce_scatter"(%data) ({
-    ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
-    %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
-    "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>,
-      scatter_dimension = 1 : i64} : (tensor<4x0xf32>) -> tensor<4x4xf32>
-  func.return %0 : tensor<4x4xf32>
 }
 
 // -----
@@ -489,6 +463,34 @@ func.func @reduce_scatter_i3(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
     "stablehlo.return"(%1) : (tensor<f32>) -> ()
   }) {replica_groups = dense<0> : tensor<1xi64>,
       scatter_dimension = 1 : i64} : (tensor<4x16xf32>) -> tensor<4x4xf32>
+  func.return %0 : tensor<4x4xf32>
+}
+
+// -----
+
+// TODO(#1746): Sync verification of ReduceScatter with HLO.
+func.func @reduce_scatter_invalid(%data: tensor<4x16xf32>) -> tensor<4x0xf32> {
+  // expected-error@+1 {{result dimension size at scatter_dimension cannot be zero}}
+  %0 = "stablehlo.reduce_scatter"(%data) ({
+    ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
+    %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
+    "stablehlo.return"(%1) : (tensor<f32>) -> ()
+  }) {replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>,
+      scatter_dimension = 1 : i64} : (tensor<4x16xf32>) -> tensor<4x0xf32>
+  func.return %0 : tensor<4x0xf32>
+}
+
+// -----
+
+// TODO(#1746): Sync verification of ReduceScatter with HLO.
+func.func @reduce_scatter_invalid(%data: tensor<4x0xf32>) -> tensor<4x4xf32> {
+  // expected-error@+1 {{operand dimension size at scatter_dimension cannot be zero}}
+  %0 = "stablehlo.reduce_scatter"(%data) ({
+    ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
+    %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
+    "stablehlo.return"(%1) : (tensor<f32>) -> ()
+  }) {replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>,
+      scatter_dimension = 1 : i64} : (tensor<4x0xf32>) -> tensor<4x4xf32>
   func.return %0 : tensor<4x4xf32>
 }
 

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -13,33 +13,6 @@ func.func private @invalid_type() -> !stablehlo.foobar
 
 // -----
 
-// CHECK-LABEL: func @reduce_scatter
-func.func @reduce_scatter(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
-  %0 = "stablehlo.reduce_scatter"(%data) ({
-    ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
-    %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
-    "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>,
-      scatter_dimension = 1 : i64,
-      use_global_device_ids} : (tensor<4x16xf32>) -> tensor<4x4xf32>
-  func.return %0 : tensor<4x4xf32>
-}
-
-// -----
-
-func.func @invalid_reduce_scatter(%data: tensor<4x16xf32>) -> tensor<4x5xf32> {
-  // expected-error@+1 {{operand scatter dimension has size 16, expected to be a multiple of result scatter dimension size 5}}
-  %0 = "stablehlo.reduce_scatter"(%data) ({
-    ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
-    %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
-    "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>,
-      scatter_dimension = 1 : i64} : (tensor<4x16xf32>) -> tensor<4x5xf32>
-  func.return %0 : tensor<4x5xf32>
-}
-
-// -----
-
 // TODO(#498): AllReduceOp replica groups does not need to be rank 2.
 func.func @all_reduce(%operand: tensor<10xf32>) -> tensor<10xf32> {
   // expected-error@+1 {{replica groups should be a rank 2 tensor}}
@@ -242,144 +215,16 @@ func.func @all_reduce_c5(%operand: tensor<10xf32>) -> tensor<10xf32> {
 
 // -----
 
-func.func @invalid_reduce_scatter(%data: tensor<4x0xf32>) -> tensor<4x4xf32> {
-  // expected-error@+1 {{operand scatter dimension cannot be zero}}
-  %0 = "stablehlo.reduce_scatter"(%data) ({
-    ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
-    %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
-    "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>,
-      scatter_dimension = 1 : i64} : (tensor<4x0xf32>) -> tensor<4x4xf32>
-  func.return %0 : tensor<4x4xf32>
-}
-
-// -----
-
-func.func @invalid_reduce_scatter(%data: tensor<4x16xf32>) -> tensor<4x0xf32> {
-  // expected-error@+1 {{result scatter dimension cannot be zero}}
-  %0 = "stablehlo.reduce_scatter"(%data) ({
-    ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
-    %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
-    "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>,
-      scatter_dimension = 1 : i64} : (tensor<4x16xf32>) -> tensor<4x0xf32>
-  func.return %0 : tensor<4x0xf32>
-}
-
-// -----
-
-func.func @invalid_reduce_scatter(%data: tensor<4x16xf32>) -> tensor<4xf32> {
-  // expected-error@+1 {{operand and result should have same rank}}
-  %0 = "stablehlo.reduce_scatter"(%data) ({
-    ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
-    %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
-    "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>,
-      scatter_dimension = 1 : i64} : (tensor<4x16xf32>) -> tensor<4xf32>
-  func.return %0 : tensor<4xf32>
-}
-
-// -----
-
-func.func @invalid_reduce_scatter(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
-  // expected-error@+1 {{scatter dim should be less than operand/result rank}}
-  %0 = "stablehlo.reduce_scatter"(%data) ({
-    ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
-    %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
-    "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>,
-      scatter_dimension = 4 : i64} : (tensor<4x16xf32>) -> tensor<4x4xf32>
-  func.return %0 : tensor<4x4xf32>
-}
-
-// -----
-
-func.func @invalid_reduce_scatter(%data: tensor<4x16xf32>) -> tensor<3x4xf32> {
-  // expected-error@+1 {{non scatter dimensions should be same for operand (4) and result (3)}}
-  %0 = "stablehlo.reduce_scatter"(%data) ({
-    ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
-    %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
-    "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>,
-      scatter_dimension = 1 : i64} : (tensor<4x16xf32>) -> tensor<3x4xf32>
-  func.return %0 : tensor<3x4xf32>
-}
-
-// -----
-
+// CHECK-LABEL: func @reduce_scatter
 func.func @reduce_scatter(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
-  // expected-error@+1 {{replica groups should be a rank 2 tensor}}
-  %0 = "stablehlo.reduce_scatter"(%data) ({
-    ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
-    %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
-    "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {replica_groups = dense<0> : tensor<1xi64>,
-      scatter_dimension = 1 : i64} : (tensor<4x16xf32>) -> tensor<4x4xf32>
-  func.return %0 : tensor<4x4xf32>
-}
-
-// -----
-
-func.func @reduce_scatter(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
-  //  expected-error@+1 {{Invalid replica id -1}}
-  %0 = "stablehlo.reduce_scatter"(%data) ({
-    ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
-    %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
-    "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {replica_groups = dense<[[0, -1, 2, 3]]> : tensor<1x4xi64>,
-      scatter_dimension = 1 : i64} : (tensor<4x16xf32>) -> tensor<4x4xf32>
-  func.return %0 : tensor<4x4xf32>
-}
-
-// -----
-
-func.func @reduce_scatter(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
-  //  expected-error@+1 {{replica id #1 seen more than once}}
-  %0 = "stablehlo.reduce_scatter"(%data) ({
-    ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
-    %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
-    "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {replica_groups = dense<[[0, 1, 1, 3]]> : tensor<1x4xi64>,
-      scatter_dimension = 1 : i64} : (tensor<4x16xf32>) -> tensor<4x4xf32>
-  func.return %0 : tensor<4x4xf32>
-}
-
-// -----
-
-func.func @reduce_scatter(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
-  //  expected-error@+1 {{replica id #2 not seen in replica groups}}
-  %0 = "stablehlo.reduce_scatter"(%data) ({
-    ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
-    %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
-    "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {replica_groups = dense<[[0, 1, 3]]> : tensor<1x3xi64>,
-      scatter_dimension = 1 : i64} : (tensor<4x16xf32>) -> tensor<4x4xf32>
-  func.return %0 : tensor<4x4xf32>
-}
-
-// -----
-
-func.func @invalid_reduce_scatter(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
-  // expected-error@+1 {{The reduction-region expected to return some value(s)}}
-  %0 = "stablehlo.reduce_scatter"(%data) ({
-    ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
-    %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
-    "stablehlo.return"() : () -> ()
-  }) {replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>,
-      scatter_dimension = 1 : i64} : (tensor<4x16xf32>) -> tensor<4x4xf32>
-  func.return %0 : tensor<4x4xf32>
-}
-
-// -----
-
-func.func @reduce_scatter(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
-  // expected-error@+1 {{expects scatter_dimension >= 0}}
   %0 = "stablehlo.reduce_scatter"(%data) ({
     ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
     %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
     "stablehlo.return"(%1) : (tensor<f32>) -> ()
   }) {replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>,
-      scatter_dimension = -1 : i64} : (tensor<4x16xf32>) -> tensor<4x4xf32>
+      scatter_dimension = 1 : i64,
+      channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
+      use_global_device_ids} : (tensor<4x16xf32>) -> tensor<4x4xf32>
   func.return %0 : tensor<4x4xf32>
 }
 
@@ -393,8 +238,258 @@ func.func @reduce_scatter_dynamic(%data: tensor<?x?xf32>) -> tensor<?x?xf32> {
     "stablehlo.return"(%1) : (tensor<f32>) -> ()
   }) {replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>,
       scatter_dimension = 1 : i64,
+      channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
       use_global_device_ids} : (tensor<?x?xf32>) -> tensor<?x?xf32>
   func.return %0 : tensor<?x?xf32>
+}
+
+// -----
+
+func.func @reduce_scatter_c1(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
+  // expected-error@+1 {{expects scatter_dimension >= 0}}
+  %0 = "stablehlo.reduce_scatter"(%data) ({
+    ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
+    %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
+    "stablehlo.return"(%1) : (tensor<f32>) -> ()
+  }) {replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>,
+      scatter_dimension = -1 : i64} : (tensor<4x16xf32>) -> tensor<4x4xf32>
+  func.return %0 : tensor<4x4xf32>
+}
+
+// -----
+
+func.func @reduce_scatter_c1(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
+  // expected-error@+1 {{scatter dim should be less than operand/result rank}}
+  %0 = "stablehlo.reduce_scatter"(%data) ({
+    ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
+    %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
+    "stablehlo.return"(%1) : (tensor<f32>) -> ()
+  }) {replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>,
+      scatter_dimension = 4 : i64} : (tensor<4x16xf32>) -> tensor<4x4xf32>
+  func.return %0 : tensor<4x4xf32>
+}
+
+// -----
+
+func.func @reduce_scatter_c2(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
+  //  expected-error@+1 {{replica id #1 seen more than once}}
+  %0 = "stablehlo.reduce_scatter"(%data) ({
+    ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
+    %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
+    "stablehlo.return"(%1) : (tensor<f32>) -> ()
+  }) {replica_groups = dense<[[0, 1, 1, 3]]> : tensor<1x4xi64>,
+      scatter_dimension = 1 : i64} : (tensor<4x16xf32>) -> tensor<4x4xf32>
+  func.return %0 : tensor<4x4xf32>
+}
+
+// -----
+
+func.func @reduce_scatter_c4(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
+  //  expected-error@+1 {{Invalid replica id -1}}
+  %0 = "stablehlo.reduce_scatter"(%data) ({
+    ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
+    %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
+    "stablehlo.return"(%1) : (tensor<f32>) -> ()
+  }) {replica_groups = dense<[[0, -1, 2, 3]]> : tensor<1x4xi64>,
+      scatter_dimension = 1 : i64} : (tensor<4x16xf32>) -> tensor<4x4xf32>
+  func.return %0 : tensor<4x4xf32>
+}
+
+// -----
+
+func.func @reduce_scatter_c4(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
+  //  expected-error@+1 {{replica id #2 not seen in replica groups}}
+  %0 = "stablehlo.reduce_scatter"(%data) ({
+    ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
+    %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
+    "stablehlo.return"(%1) : (tensor<f32>) -> ()
+  }) {replica_groups = dense<[[0, 1, 3]]> : tensor<1x3xi64>,
+      scatter_dimension = 1 : i64} : (tensor<4x16xf32>) -> tensor<4x4xf32>
+  func.return %0 : tensor<4x4xf32>
+}
+
+// -----
+
+func.func @reduce_scatter_c5(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
+  //  expected-error@+1 {{channel_id must be positive when useGlobalDeviceIds is set but got: 0}}
+  %0 = "stablehlo.reduce_scatter"(%data) ({
+    ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
+    %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
+    "stablehlo.return"(%1) : (tensor<f32>) -> ()
+  }) {replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>,
+      scatter_dimension = 1 : i64,
+      use_global_device_ids} : (tensor<4x16xf32>) -> tensor<4x4xf32>
+  func.return %0 : tensor<4x4xf32>
+}
+
+// -----
+
+func.func @reduce_scatter_c6(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
+  // expected-error@+1 {{Reduction-region must take 2 parameters, but takes 3 parameter(s)}}
+  %0 = "stablehlo.reduce_scatter"(%data) ({
+    ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>, %arg4: tensor<f32>):
+    %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
+    "stablehlo.return"() : () -> ()
+  }) {replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>,
+      scatter_dimension = 1 : i64} : (tensor<4x16xf32>) -> tensor<4x4xf32>
+  func.return %0 : tensor<4x4xf32>
+}
+
+// -----
+
+func.func @reduce_scatter_c6(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
+  // expected-error@+1 {{The reduction-region expected to return some value(s)}}
+  %0 = "stablehlo.reduce_scatter"(%data) ({
+    ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
+    %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
+    "stablehlo.return"() : () -> ()
+  }) {replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>,
+      scatter_dimension = 1 : i64} : (tensor<4x16xf32>) -> tensor<4x4xf32>
+  func.return %0 : tensor<4x4xf32>
+}
+
+// -----
+
+func.func @reduce_scatter_c6(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
+  // expected-error@+1 {{Reduction-region here must produce 1 tensors, but produces 2 instead}}
+  %0 = "stablehlo.reduce_scatter"(%data) ({
+    ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
+    %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
+    "stablehlo.return"(%1, %1) : (tensor<f32>, tensor<f32>) -> ()
+  }) {replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>,
+      scatter_dimension = 1 : i64} : (tensor<4x16xf32>) -> tensor<4x4xf32>
+  func.return %0 : tensor<4x4xf32>
+}
+
+// -----
+
+func.func @reduce_scatter_c6(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
+  // expected-error@+1 {{Reduction-region here must produce tensor-typed result(s), but produces 'tuple<tensor<f32>, tensor<f32>>' instead}}
+  %0 = "stablehlo.reduce_scatter"(%data) ({
+    ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
+    %1 = "stablehlo.tuple"(%arg2, %arg2) : (tensor<f32>, tensor<f32>) -> tuple<tensor<f32>, tensor<f32>>
+    "stablehlo.return"(%1) : (tuple<tensor<f32>, tensor<f32>>) -> ()
+  }) {replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>,
+      scatter_dimension = 1 : i64} : (tensor<4x16xf32>) -> tensor<4x4xf32>
+  func.return %0 : tensor<4x4xf32>
+}
+
+// -----
+
+func.func @reduce_scatter_c6(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
+  // expected-error@+1 {{The type of reduction-region's parameter at index 1 is different than the corresponding result type: 'tensor<i32>' vs 'tensor<f32>'}}
+  %0 = "stablehlo.reduce_scatter"(%data) ({
+    ^bb0(%arg2: tensor<f32>, %arg3: tensor<i32>):
+    %1 = stablehlo.add %arg2, %arg2 : tensor<f32>
+    "stablehlo.return"(%1) : (tensor<f32>) -> ()
+  }) {replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>,
+      scatter_dimension = 1 : i64} : (tensor<4x16xf32>) -> tensor<4x4xf32>
+  func.return %0 : tensor<4x4xf32>
+}
+
+// -----
+
+func.func @reduce_scatter_c6(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
+  // expected-error@+1 {{The type of reduction-region's parameter at index 0 is different than the corresponding result type: 'tensor<f32>' vs 'tensor<i32>'}}
+  %0 = "stablehlo.reduce_scatter"(%data) ({
+    ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
+    %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
+    %2 = "stablehlo.convert"(%1) : (tensor<f32>) -> tensor<i32>
+    "stablehlo.return"(%2) : (tensor<i32>) -> ()
+  }) {replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>,
+      scatter_dimension = 1 : i64} : (tensor<4x16xf32>) -> tensor<4x4xf32>
+  func.return %0 : tensor<4x4xf32>
+}
+
+// -----
+
+func.func @reduce_scatter_c6(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
+  // expected-error@+1 {{The type of reduction-region's result type at index 0 differs from the op's corresponding init-value type: 'tensor<i32>' vs 'tensor<f32>'}}
+  %0 = "stablehlo.reduce_scatter"(%data) ({
+    ^bb0(%arg2: tensor<i32>, %arg3: tensor<i32>):
+    %1 = stablehlo.add %arg2, %arg3 : tensor<i32>
+    "stablehlo.return"(%1) : (tensor<i32>) -> ()
+  }) {replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>,
+      scatter_dimension = 1 : i64} : (tensor<4x16xf32>) -> tensor<4x4xf32>
+  func.return %0 : tensor<4x4xf32>
+}
+
+// -----
+
+func.func @reduce_scatter_c7(%data: tensor<4x16xf32>) -> tensor<4x0xf32> {
+  // expected-error@+1 {{result dimension size at scatter_dimension cannot be zero}}
+  %0 = "stablehlo.reduce_scatter"(%data) ({
+    ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
+    %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
+    "stablehlo.return"(%1) : (tensor<f32>) -> ()
+  }) {replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>,
+      scatter_dimension = 1 : i64} : (tensor<4x16xf32>) -> tensor<4x0xf32>
+  func.return %0 : tensor<4x0xf32>
+}
+
+// -----
+
+func.func @reduce_scatter_c8(%data: tensor<4x16xf32>) -> tensor<4xf32> {
+  // expected-error@+1 {{operand and result should have same rank}}
+  %0 = "stablehlo.reduce_scatter"(%data) ({
+    ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
+    %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
+    "stablehlo.return"(%1) : (tensor<f32>) -> ()
+  }) {replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>,
+      scatter_dimension = 1 : i64} : (tensor<4x16xf32>) -> tensor<4xf32>
+  func.return %0 : tensor<4xf32>
+}
+
+// -----
+
+func.func @reduce_scatter_c8(%data: tensor<4x0xf32>) -> tensor<4x4xf32> {
+  // expected-error@+1 {{operand dimension size at scatter_dimension cannot be zero}}
+  %0 = "stablehlo.reduce_scatter"(%data) ({
+    ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
+    %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
+    "stablehlo.return"(%1) : (tensor<f32>) -> ()
+  }) {replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>,
+      scatter_dimension = 1 : i64} : (tensor<4x0xf32>) -> tensor<4x4xf32>
+  func.return %0 : tensor<4x4xf32>
+}
+
+// -----
+
+func.func @reduce_scatter_c8(%data: tensor<4x16xf32>) -> tensor<4x5xf32> {
+  // expected-error@+1 {{operand scatter dimension has size 16, expected to be a multiple of result scatter dimension size 5}}
+  %0 = "stablehlo.reduce_scatter"(%data) ({
+    ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
+    %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
+    "stablehlo.return"(%1) : (tensor<f32>) -> ()
+  }) {replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>,
+      scatter_dimension = 1 : i64} : (tensor<4x16xf32>) -> tensor<4x5xf32>
+  func.return %0 : tensor<4x5xf32>
+}
+
+// -----
+
+func.func @reduce_scatter_c8(%data: tensor<4x16xf32>) -> tensor<3x4xf32> {
+  // expected-error@+1 {{non scatter dimensions should be same for operand (4) and result (3)}}
+  %0 = "stablehlo.reduce_scatter"(%data) ({
+    ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
+    %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
+    "stablehlo.return"(%1) : (tensor<f32>) -> ()
+  }) {replica_groups = dense<[[0, 1, 2, 3]]> : tensor<1x4xi64>,
+      scatter_dimension = 1 : i64} : (tensor<4x16xf32>) -> tensor<3x4xf32>
+  func.return %0 : tensor<3x4xf32>
+}
+
+// -----
+
+func.func @reduce_scatter_i3(%data: tensor<4x16xf32>) -> tensor<4x4xf32> {
+  // expected-error@+1 {{replica groups should be a rank 2 tensor}}
+  %0 = "stablehlo.reduce_scatter"(%data) ({
+    ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
+    %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
+    "stablehlo.return"(%1) : (tensor<f32>) -> ()
+  }) {replica_groups = dense<0> : tensor<1xi64>,
+      scatter_dimension = 1 : i64} : (tensor<4x16xf32>) -> tensor<4x4xf32>
+  func.return %0 : tensor<4x4xf32>
 }
 
 // -----


### PR DESCRIPTION
We have the following constraints in the spec:

```
(I1) `operand` is a tensor.
(I2) `scatter_dimension` is a constant of type `si64`.
(I3) `replica_groups` is a 2-dimensional tensor constant of type `si64`.
(I4) `channel_id` is a constant of type `si64`.
(I5) `use_global_device_ids` is a constant of type `i1`.
(I6) `computation` is a function.
(C1) `dim(operand, scatter_dimension) % dim(process_groups, 1) = 0`.
(C2) `0 <= scatter_dimension < rank(operand)`.
(C3) `is_unique(replica_groups)`.
(C4) `size(replica_groups)` is defined as:
* `num_replicas` if `cross_replica` is used.
* `num_replicas` if `cross_replica_and_partition` is used.
* `num_processes` if `flattened_ids` is used.
(C5) `0 <= replica_groups < size(replica_groups)`.
(C6) If `use_global_device_ids = true`, then `channel_id > 0`.
(C7) `computation` has type `(tensor<E>, tensor<E>) -> (tensor<E>)` where
     `E = element_type(operand)`.
(C8) `type(result) = type(operand)` except:
* `dim(result, scatter_dimension) = dim(operand, scatter_dimension) /
  dim(process_groups, 1)`.
```

These constraints will be comprehensively covered by the following tests:

```
I1: a) `operand` is not a tensor. (Covered by ODS).
I2: a) `scatter_dimension` is not a constant of type `si64`. (Covered by ODS).
I3: a) `replica_groups` is not a 2-dimensional tensor constant.
I3: b) `element_type(replica_groups) != si64`. (Covered by ODS).
I4: a) `channel_id` is not a constant of type `si64`. (Covered by ODS).
I5: a) `use_global_device_ids` is not a constant of type `i1`. (Covered by ODS).
I6: a) `computation` is not a function. (Covered by ODS).
C1: a) `dim(operand, scatter_dimension) % dim(process_groups, 1) != 0`.
C2: a) `scatter_dimension < 0`.
C2: b) `scatter_dimension >= rank(operand)`.
C3: a) `is_unique(replica_groups) = false`.
C4: a) `size(replica_groups)` is not defined as:
* `num_replicas` if `cross_replica` is used.
* `num_replicas` if `cross_replica_and_partition` is used.
* `num_processes` if `flattened_ids` is used.
C5: a) `replica_groups < 0`.
C5: b) `replica_groups >= size(replica_groups)`.
C6: a) If `use_global_device_ids = true`, then `channel_id <= 0`.
C7: a) `computation` does not have type `(tensor<E>, tensor<E>) -> (tensor<E>)` where
     `E = element_type(operand)`.
C8: a) `type(result) != type(operand)` except:
* `dim(result, scatter_dimension) = dim(operand, scatter_dimension) /
  dim(process_groups, 1)`.
```

If we drop the "Covered by ODS" pieces, this will leave us with the following test cases:

```
I3: a) `replica_groups` is not a 2-dimensional tensor constant.
C1: a) `dim(operand, scatter_dimension) % dim(process_groups, 1) != 0`.
C2: a) `scatter_dimension < 0`.
C2: b) `scatter_dimension >= rank(operand)`.
C3: a) `is_unique(replica_groups) = false`.
C4: a) `size(replica_groups)` is not defined as:
* `num_replicas` if `cross_replica` is used.
* `num_replicas` if `cross_replica_and_partition` is used.
* `num_processes` if `flattened_ids` is used.
C5: a) `replica_groups < 0`.
C5: b) `replica_groups >= size(replica_groups)`.
C6: a) If `use_global_device_ids = true`, then `channel_id <= 0`.
C7: a) `computation` does not have type `(tensor<E>, tensor<E>) -> (tensor<E>)` where
     `E = element_type(operand)`.
C8: a) `type(result) != type(operand)` except:
* `dim(result, scatter_dimension) = dim(operand, scatter_dimension) /
  dim(process_groups, 1)`.
```

Notes:
  * C1a verification is infeasible since process_groups is not known statically.
  * C4a verification is infeasible since `num_replicas` and `num_partitions` are not known statically.
  * C5b verification is infeasible since `size(replica_groups)` is not known statically.

closes #1133