### PR TITLE
Cleanup after a downstream integrate

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -451,7 +451,7 @@ cc_library(
     deps = [
         ":reference_process_grid",
         ":reference_tensor",
-    ]
+    ],
 )
 
 cc_library(
@@ -467,7 +467,7 @@ cc_library(
         ":reference_tensor",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Support",
-    ]
+    ],
 )
 
 cc_library(

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -775,7 +775,7 @@ Tensor evalAllReduceOp(const Tensor &operand,
   for (auto resultIt = result.index_begin(); resultIt != result.index_end();
        ++resultIt) {
     Tensor resultElement;
-    for (auto groupOperand : groupOperands) {
+    for (const auto &groupOperand : groupOperands) {
       auto groupOperandElement = makeScalar(groupOperand.get(*resultIt));
       if (resultElement)
         resultElement = eval(computation, {resultElement, groupOperandElement},

--- a/stablehlo/reference/ProcessGrid.cpp
+++ b/stablehlo/reference/ProcessGrid.cpp
@@ -20,9 +20,6 @@ limitations under the License.
 #include <optional>
 #include <utility>
 
-#include "llvm/ADT/STLExtras.h"
-#include "llvm/ADT/SmallVector.h"
-#include "llvm/Support/ErrorHandling.h"
 #include "stablehlo/reference/Tensor.h"
 
 namespace mlir {
@@ -91,7 +88,7 @@ ProcessGrid::ProcessGrid(uint32_t numReplicas, uint32_t numPartitions)
 ProcessGroups ProcessGrid::crossPartition(
     SmallVector<SmallVector<uint32_t>> partitionGroups) {
   ProcessGroups processGroups;
-  for (auto partitionGroup : partitionGroups) {
+  for (const auto &partitionGroup : partitionGroups) {
     for (uint32_t replicaId = 0; replicaId < numReplicas_; ++replicaId) {
       ProcessGroup processGroup;
       for (uint32_t partitionId : partitionGroup)
@@ -105,7 +102,7 @@ ProcessGroups ProcessGrid::crossPartition(
 ProcessGroups ProcessGrid::crossReplica(
     SmallVector<SmallVector<uint32_t>> replicaGroups) {
   ProcessGroups processGroups;
-  for (auto replicaGroup : replicaGroups) {
+  for (const auto &replicaGroup : replicaGroups) {
     for (uint32_t partitionId = 0; partitionId < numPartitions_;
          ++partitionId) {
       ProcessGroup processGroup;
@@ -120,7 +117,7 @@ ProcessGroups ProcessGrid::crossReplica(
 ProcessGroups ProcessGrid::crossReplicaAndPartition(
     SmallVector<SmallVector<uint32_t>> replicaGroups) {
   ProcessGroups processGroups;
-  for (auto replicaGroup : replicaGroups) {
+  for (const auto &replicaGroup : replicaGroups) {
     ProcessGroup processGroup;
     for (uint32_t partitionId = 0; partitionId < numPartitions_; ++partitionId)
       for (uint32_t replicaId : replicaGroup)
@@ -133,7 +130,7 @@ ProcessGroups ProcessGrid::crossReplicaAndPartition(
 ProcessGroups ProcessGrid::flattenedIds(
     SmallVector<SmallVector<uint32_t>> flattenedIdGroups) {
   ProcessGroups processGroups;
-  for (auto flattenedIdGroup : flattenedIdGroups) {
+  for (const auto &flattenedIdGroup : flattenedIdGroups) {
     ProcessGroup processGroup;
     for (auto flattenedId : flattenedIdGroup) {
       uint32_t replicaId = flattenedId / numPartitions_;

--- a/stablehlo/reference/ProcessGrid.h
+++ b/stablehlo/reference/ProcessGrid.h
@@ -24,7 +24,6 @@ limitations under the License.
 #include <queue>
 #include <utility>
 
-#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Support/LLVM.h"
 #include "stablehlo/reference/Tensor.h"
 
@@ -110,11 +109,11 @@ class ProcessGrid {
 
   /// StableHLO `cross_replica_and_partition` communication strategy.
   ProcessGroups crossReplicaAndPartition(
-      SmallVector<SmallVector<uint32_t>> partitionGroups);
+      SmallVector<SmallVector<uint32_t>> replicaGroups);
 
   /// StableHLO `flattened_ids` communication strategy.
   ProcessGroups flattenedIds(
-      SmallVector<SmallVector<uint32_t>> partitionGroups);
+      SmallVector<SmallVector<uint32_t>> flattenedIdGroups);
 
   /// Inserts `inputs` to StableHLO `outfeed`.
   void outfeed(ArrayRef<Tensor> inputs);

--- a/stablehlo/tools/StablehloTranslateMain.cpp
+++ b/stablehlo/tools/StablehloTranslateMain.cpp
@@ -33,7 +33,6 @@ limitations under the License.
 #include "stablehlo/reference/InterpreterOps.h"
 #include "stablehlo/reference/InterpreterValue.h"
 #include "stablehlo/reference/Ops.h"
-#include "stablehlo/reference/ProcessGrid.h"
 #include "stablehlo/reference/Scope.h"
 #include "stablehlo/reference/Tensor.h"
 #include "stablehlo/tests/CheckOps.h"


### PR DESCRIPTION
This PR addresses clang-tidy issues found during the ongoing downstream integrate (we don't run clang-tidy on our PRs yet, so these issues have deferred detection).