### PR TITLE
Fix race condition in `ProcessGrid::rendezvous`

### DIFF
--- a/stablehlo/reference/ProcessGrid.h
+++ b/stablehlo/reference/ProcessGrid.h
@@ -115,6 +115,9 @@ class ProcessGrid {
   ProcessGroups flattenedIds(
       SmallVector<SmallVector<uint32_t>> flattenedIdGroups);
 
+  /// Synchronizes access to StableHLO `channels`.
+  std::mutex &getChannelLock(std::pair<ProcessGroup, ChannelId> channelKey);
+
   /// Inserts `inputs` to StableHLO `outfeed`.
   void outfeed(ArrayRef<Tensor> inputs);
 
@@ -158,6 +161,11 @@ class ProcessGrid {
   /// this key is gradually populated with tensors arriving from different
   /// processes in the process group.
   std::map<std::pair<ProcessGroup, ChannelId>, RendezvousResult> channels_;
+
+  /// Synchronization primitive used to manage concurrent access to
+  /// `channelLocks_` to prevent multiple processes from creating multiple
+  /// mutexes when the map entry is empty.
+  std::mutex channelLock_;
 
   /// Synchronization primitive used to manage concurrent access to `channels_`.
   std::map<std::pair<ProcessGroup, ChannelId>, std::mutex> channelLocks_;


### PR DESCRIPTION
There is a race condition when two processes try to access `channelLocks_[channelKey]` at the same time when that key doesn't exist. The two processes will both create a mutex at the same time, acquiring different mutex instead of sharing the same one. It is also unsafe to read from `channels_[channelKey]` without a lock since this value can also be modified by another caller to `rendezvous` with a duplicate `processGroup` and `channelId` by another distribution op.