### PR TITLE
Per-axis quantization specification for reshape, transpose, and broadcast_in_dim.

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1387,8 +1387,9 @@ in the `operand` tensor and produces a `result` tensor. More formally,
 * (C6) `is_per_tensor_quantized(operand) = is_per_tensor_quantized(result)`.
 * (C7) If `is_per_axis_quantized(result)`:
   * `quantized_dimension(result) = broadcast_dimensions[quantized_dimension(operand)]`.
-  * `If dim(operand, quantized_dimension(operand)) = 1, then
-    scales(result)[i] = scales(operand)[0] for i in
+  * If `dim(operand, quantized_dimension(operand)) = 1`, then
+    `scales(result)[i] = scales(operand)[0] and zero_points(result)[i] =
+    zero_points(operand)[0] for i in
     range(dim(result, quantized_dimension(result)))`.
 
 #### Examples
@@ -4385,15 +4386,15 @@ ordering of `index_space(result)` and `index_space(operand)`.
 * (C4) If `is_per_axis_quantized(operand)`:
   * `reduce(dims(operand, [0, 1, ..., quantization_dimension(operand) - 1]),
     init_values=1, dimensions=[0], body=lambda x, y: x * y) =
-    reduce(dims(operand, [0, 1, ..., quantization_dimension(result) - 1]),
+    reduce(dims(result, [0, 1, ..., quantization_dimension(result) - 1]),
     init_values=1, dimensions=[0], body=lambda x, y: x * y)`.
   * `dim(operand, quantization_dimension(operand)) =
     dim(result, quantization_dimension(result))`.
   * `reduce(dims(operand,
     [quantization_dimension(operand) + 1, ..., rank(operand) - 1]),
     init_values=1, dimensions=[0], body=lambda x, y: x * y) =
-    reduce(dims(operand,
-    [quantization_dimension(operand) + 1, ..., rank(operand) - 1]),
+    reduce(dims(result,
+    [quantization_dimension(result) + 1, ..., rank(result) - 1]),
     init_values=1, dimensions=[0], body=lambda x, y: x * y)`.
 
 #### Examples
@@ -5508,8 +5509,8 @@ where `result_index[d] = operand_index[permutation[d]]`.
 * (C2) `permutation` is a permutation of `range(rank(operand))`.
 * (C3) `shape(result) = dim(operand, permutation...)`.
 * (C4 `is_per_tensor_quantized(operand) = is_per_tensor_quantized(result)`.
-* (C5) If `is_per_axis_quantized(result)`, then `quantized_dimension(result) =
-       permutation(quantized_dimension(operand))`.
+* (C5) If `is_per_axis_quantized(result)`, then `quantized_dimension(operand) =
+       permutation(quantized_dimension(result))`.
 
 #### Examples
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -198,11 +198,12 @@ have quantized element types, instead of regular element types.
 In quantized tensors, quantization can be **per-tensor**, meaning, having
 one `scale` and `zero_point` for the entire tensor or can be **per-axis**,
 meaning, having multiple `scales` and `zero_points`, one pair per slice of
-a particular dimension `quantized_dimension`. More formally, in a tensor `t` of
-with per-axis quantization, there are `dim(t, quantized_dimension)` slices
-of the `quantized_dimension`: `t[:, ..., 0, ..., :], t[:, ..., 1, ..., :]`, etc.
-All elements in the `i`th slice use `scales[i]` and `zero_points[i]` as their
-quantization parameters. Quantized tensor types have the following constraints:
+a particular dimension `quantization_dimension`. More formally, in a tensor `t`
+with per-axis quantization, there are `dim(t, quantization_dimension)` slices
+of the `quantization_dimension`: `t[:, ..., 0, ..., :], t[:, ..., 1, ..., :]`,
+etc. All elements in the `i`th slice use `scales[i]` and `zero_points[i]` as
+their quantization parameters. Quantized tensor types have the following
+constraints:
 
 * For per-tensor quantization:
   * No additional constraints.
@@ -1378,11 +1379,11 @@ in the `operand` tensor and produces a `result` tensor. More formally,
 #### Constraints
 
 * (C1) `element_type(result)` is given by:
-  * `element_type(operand)`, if `!is_quantized(operand)`.
+  * `element_type(operand)`, if `!is_per_axis_quantized(operand)`.
   * `element_type(operand)` except that `quantization_dimension(operand)`,
   `scales(operand)`, and `zero_points(operand)` may differ from
   `quantization_dimension(result)`, `scales(result)`, and `zero_points(result)`
-  resp., if `is_quantized(operand)`.
+  resp., otherwise.
 * (C2) `size(broadcast_dimensions) = rank(operand)`.
 * (C3) `0 <= broadcast_dimensions < rank(result)`.
 * (C4) `is_unique(broadcast_dimensions)`.
@@ -1390,11 +1391,11 @@ in the `operand` tensor and produces a `result` tensor. More formally,
   * `dim(operand, d) = 1` or
   * `dim(operand, d) = dim(result, broadcast_dimensions[d])`.
 * (C6) If `is_per_axis_quantized(result)`:
-  * `quantized_dimension(result) = broadcast_dimensions[quantized_dimension(operand)]`.
-  * If `dim(operand, quantized_dimension(operand)) = 1`, then
+  * `quantization_dimension(result) = broadcast_dimensions[quantization_dimension(operand)]`.
+  * If `dim(operand, quantization_dimension(operand)) = 1`, then
     `scales(result)[i] = scales(operand)[0] and zero_points(result)[i] =
     zero_points(operand)[0] for i in
-    range(dim(result, quantized_dimension(result)))`.
+    range(dim(result, quantization_dimension(result)))`.
 
 #### Examples
 
@@ -4385,9 +4386,9 @@ ordering of `index_space(result)` and `index_space(operand)`.
 #### Constraints
 
 * (C1) `element_type(result)` is given by:
-  * `element_type(operand)`, if `!is_quantized(operand)`.
+  * `element_type(operand)`, if `!is_per_axis_quantized(operand)`.
   * `element_type(operand)` except that `quantization_dimension(operand)` and
-    `quantization_dimension(result)` may differ, if `is_quantized(operand)`.
+    `quantization_dimension(result)` may differ, otherwise.
 * (C2) `size(operand) = size(result)`.
 * (C3) If `is_per_axis_quantized(operand)`:
   * `reduce(dims(operand, [0, 1, ..., quantization_dimension(operand) - 1]),
@@ -5512,13 +5513,14 @@ where `result_index[d] = operand_index[permutation[d]]`.
 #### Constraints
 
 * (C1) `element_type(result)` is given by:
-  * `element_type(operand)`, if `!is_quantized(operand)`.
+  * `element_type(operand)`, if `!is_per_axis_quantized(operand)`.
   * `element_type(operand)` except that `quantization_dimension(operand)` and
-    `quantization_dimension(result)` may differ, if `is_quantized(operand)`.
+    `quantization_dimension(result)` may differ, otherwise.
 * (C2) `permutation` is a permutation of `range(rank(operand))`.
 * (C3) `shape(result) = dim(operand, permutation...)`.
-* (C4) If `is_per_axis_quantized(result)`, then `quantized_dimension(operand) =
-       permutation(quantized_dimension(result))`.
+* (C4) If `is_per_axis_quantized(result)`, then
+  `quantization_dimension(operand) =
+  permutation(quantization_dimension(result))`.
 
 #### Examples
 
@@ -6227,10 +6229,10 @@ def element_type(x: Value | Placeholder | Type):
 ```
 
 * `is_per_axis_quantized(x: Value | Placeholder | Type) -> Value` is a shortcut
-for `is_quantized(x) and quantized_dimension(x) is not None`.
+for `is_quantized(x) and quantization_dimension(x) is not None`.
 
 * `is_per_tensor_quantized(x: Value | Placeholder | Type) -> Value` is a
-shortcut for `is_quantized(x) and quantized_dimension(x) is None`.
+shortcut for `is_quantized(x) and quantization_dimension(x) is None`.
 
 * `is_quantized(x: Value | Placeholder | Type) -> Value` is a shortcut for
 `is_quantized_tensor_element_type(x)`.
@@ -6365,7 +6367,7 @@ def compute_zero_points(quantized_type, result_type):
     return broadcast_in_dim(constant(zero_point(quantized_type), storage_type(quantized_type)), [], result_type)
   if is_per_axis_quantized(quantized_type):
     for i in index_space(result_type):
-      d = quantized_dimension(quantized_type)
+      d = quantization_dimension(quantized_type)
       zero_points[i] = zero_points(quantized_type)[i[d]]
     return zero_points
 
@@ -6375,7 +6377,7 @@ def compute_scales(quantized_type, result_type):
             type(result_type))
   if is_per_axis_quantized(quantized_type):
     for i in index_space(result_type):
-      d = quantized_dimension(quantized_type)
+      d = quantization_dimension(quantized_type)
       scales[i] = scales(quantized_type)[i[d]]
     return scales
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1377,7 +1377,12 @@ in the `operand` tensor and produces a `result` tensor. More formally,
 
 #### Constraints
 
-* (C1) `element_type(operand) = element_type(result)`.
+* (C1) `element_type(result)` is given by:
+  * `element_type(operand)`, if `!is_quantized(operand)`.
+  * `element_type(operand)` except that `quantization_dimension(operand)`,
+  `scales(operand)`, and `zero_points(operand)` may differ from
+  `quantization_dimension(result)`, `scales(result)`, and `zero_points(result)`
+  resp., if `is_quantized(operand)`.
 * (C2) `size(broadcast_dimensions) = rank(operand)`.
 * (C3) `0 <= broadcast_dimensions < rank(result)`.
 * (C4) `is_unique(broadcast_dimensions)`.
@@ -4379,7 +4384,10 @@ ordering of `index_space(result)` and `index_space(operand)`.
 
 #### Constraints
 
-* (C1) `element_type(operand) = element_type(result)`.
+* (C1) `element_type(result)` is given by:
+  * `element_type(operand)`, if `!is_quantized(operand)`.
+  * `element_type(operand)` except that `quantization_dimension(operand)` and
+    `quantization_dimension(result)` may differ, if `is_quantized(operand)`.
 * (C2) `size(operand) = size(result)`.
 * (C3) If `is_per_axis_quantized(operand)`:
   * `reduce(dims(operand, [0, 1, ..., quantization_dimension(operand) - 1]),
@@ -5493,7 +5501,7 @@ where `result_index[d] = operand_index[permutation[d]]`.
 | Label | Name          | Type                                         | Constraints |
 |-------|---------------|----------------------------------------------|-------------|
 | (I1)  | `operand`     | tensor or quantized tensor                   | (C1-C4)     |
-| (I2)  | `permutation` | 1-dimensional tensor constant of type `si74` | (C2-C4)     |
+| (I2)  | `permutation` | 1-dimensional tensor constant of type `si64` | (C2-C4)     |
 
 #### Outputs
 
@@ -5503,7 +5511,10 @@ where `result_index[d] = operand_index[permutation[d]]`.
 
 #### Constraints
 
-* (C1) `element_type(operand) = element_type(result)`.
+* (C1) `element_type(result)` is given by:
+  * `element_type(operand)`, if `!is_quantized(operand)`.
+  * `element_type(operand)` except that `quantization_dimension(operand)` and
+    `quantization_dimension(result)` may differ, if `is_quantized(operand)`.
 * (C2) `permutation` is a permutation of `range(rank(operand))`.
 * (C3) `shape(result) = dim(operand, permutation...)`.
 * (C4) If `is_per_axis_quantized(result)`, then `quantized_dimension(operand) =

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1366,14 +1366,14 @@ in the `operand` tensor and produces a `result` tensor. More formally,
 
 | Label | Name                   | Type                                         | Constraints      |
 |-------|------------------------|----------------------------------------------|------------------|
-| (I1)  | `operand`              | tensor or quantized tensor                   | (C1-C2), (C5-C7) |
-| (I2)  | `broadcast_dimensions` | 1-dimensional tensor constant of type `si64` | (C2-C5), (C7)    |
+| (I1)  | `operand`              | tensor or quantized tensor                   | (C1-C2), (C5-C6) |
+| (I2)  | `broadcast_dimensions` | 1-dimensional tensor constant of type `si64` | (C2-C6)          |
 
 #### Outputs
 
 | Name     | Type                       | Constraints         |
 |----------|----------------------------|---------------------|
-| `result` | tensor or quantized tensor | (C1), (C3), (C5-C7) |
+| `result` | tensor or quantized tensor | (C1), (C3), (C5-C6) |
 
 #### Constraints
 
@@ -1384,8 +1384,7 @@ in the `operand` tensor and produces a `result` tensor. More formally,
 * (C5) For all `d` in `axes(operand)`:
   * `dim(operand, d) = 1` or
   * `dim(operand, d) = dim(result, broadcast_dimensions[d])`.
-* (C6) `is_per_tensor_quantized(operand) = is_per_tensor_quantized(result)`.
-* (C7) If `is_per_axis_quantized(result)`:
+* (C6) If `is_per_axis_quantized(result)`:
   * `quantized_dimension(result) = broadcast_dimensions[quantized_dimension(operand)]`.
   * If `dim(operand, quantized_dimension(operand)) = 1`, then
     `scales(result)[i] = scales(operand)[0] and zero_points(result)[i] =
@@ -4370,20 +4369,19 @@ ordering of `index_space(result)` and `index_space(operand)`.
 
 | Label | Name      | Type                       | Constraints |
 |-------|-----------|----------------------------|-------------|
-| (I1)  | `operand` | tensor or quantized tensor | (C1-C4)     |
+| (I1)  | `operand` | tensor or quantized tensor | (C1-C3)     |
 
 #### Outputs
 
 | Name     | Type                       | Constraints |
 |----------|----------------------------|-------------|
-| `result` | tensor or quantized tensor | (C1-C4)     |
+| `result` | tensor or quantized tensor | (C1-C3)     |
 
 #### Constraints
 
 * (C1) `element_type(operand) = element_type(result)`.
 * (C2) `size(operand) = size(result)`.
-* (C3) `is_per_tensor_quantized(operand) = is_per_tensor_quantized(result)`.
-* (C4) If `is_per_axis_quantized(operand)`:
+* (C3) If `is_per_axis_quantized(operand)`:
   * `reduce(dims(operand, [0, 1, ..., quantization_dimension(operand) - 1]),
     init_values=1, dimensions=[0], body=lambda x, y: x * y) =
     reduce(dims(result, [0, 1, ..., quantization_dimension(result) - 1]),
@@ -5492,24 +5490,23 @@ where `result_index[d] = operand_index[permutation[d]]`.
 
 #### Inputs
 
-| Label | Name          | Type                                         | Constraints   |
-|-------|---------------|----------------------------------------------|---------------|
-| (I1)  | `operand`     | tensor or quantized tensor                   | (C1-C5)       |
-| (I2)  | `permutation` | 1-dimensional tensor constant of type `si64` | (C2-C3), (C5) |
+| Label | Name          | Type                                         | Constraints |
+|-------|---------------|----------------------------------------------|-------------|
+| (I1)  | `operand`     | tensor or quantized tensor                   | (C1-C4)     |
+| (I2)  | `permutation` | 1-dimensional tensor constant of type `si74` | (C2-C4)     |
 
 #### Outputs
 
-| Name     | Type                       | Constraints |
-|----------|----------------------------|-------------|
-| `result` | tensor or quantized tensor | (C1), (C3)  |
+| Name     | Type                       | Constraints   |
+|----------|----------------------------|---------------|
+| `result` | tensor or quantized tensor | (C1), (C3-C4) |
 
 #### Constraints
 
 * (C1) `element_type(operand) = element_type(result)`.
 * (C2) `permutation` is a permutation of `range(rank(operand))`.
 * (C3) `shape(result) = dim(operand, permutation...)`.
-* (C4 `is_per_tensor_quantized(operand) = is_per_tensor_quantized(result)`.
-* (C5) If `is_per_axis_quantized(result)`, then `quantized_dimension(operand) =
+* (C4) If `is_per_axis_quantized(result)`, then `quantized_dimension(operand) =
        permutation(quantized_dimension(result))`.
 
 #### Examples


### PR DESCRIPTION
Based on the discussion in https://github.com/openxla/stablehlo/issues/1574, I propose the quantization specification for the following data movement ops:
 -  **transpose**:  The `quantization_dimension` of `result` is also transposed based on the input `permutation` order.
 - **reshape**:  The `quantization_dimension` of the operand should not be merged or split.
 - **broadcast_in_dim**: For [degenerate dimension broadcasting](https://www.tensorflow.org/xla/broadcasting#broadcasting_similar-rank_arrays_with_degenerate_dimensions) of the operand's quantized dimension, the scales of the result are expanded.  