### PR TITLE
Add interpreters for TupleOp and GetTupleElementOp

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3001,6 +3001,8 @@ Extracts element at `index` position of the `operand` tuple and produces a
 // %result: [1.0, 2.0]
 ```
 
+&nbsp;[More Examples](../stablehlo/tests/interpret_tuple_and_get_tuple_element.mlir)
+
 ### if
 
 #### Semantics
@@ -5614,6 +5616,8 @@ Produces a `result` tuple from values `val`.
 %result = "stablehlo.tuple"(%val0, %val1) : (tensor<2xf32>, tuple<tensor<i32>>) -> tuple<tensor<2xf32>, tuple<tensor<i32>>>
 // %result: ([1.0, 2.0], (3))
 ```
+
+&nbsp;[More Examples](../stablehlo/tests/interpret_tuple_and_get_tuple_element.mlir)
 
 ### uniform_dequantize
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -93,7 +93,7 @@ one of the following tracking labels.
 | floor                    | yes           | yes          | yes            | yes             | yes         |
 | gather                   | yes           | yes          | yes            | no              | yes         |
 | get_dimension_size       | yes           | yes          | yes            | yes             | yes         |
-| get_tuple_element        | yes           | yes          | yes            | yes             | no          |
+| get_tuple_element        | yes           | yes          | yes            | yes             | yes         |
 | if                       | yes           | revisit      | yes            | no              | yes         |
 | imag                     | yes           | yes          | yes            | yes             | yes         |
 | infeed                   | yes           | revisit      | infeasible     | no              | no          |
@@ -151,7 +151,7 @@ one of the following tracking labels.
 | trace                    | no            | revisit      | no             | yes             | revisit     |
 | transpose                | yes           | yes          | yes            | yes             | yes         |
 | triangular_solve         | yes           | revisit      | yes            | no              | revisit     |
-| tuple                    | yes           | yes          | yes            | yes             | no          |
+| tuple                    | yes           | yes          | yes            | yes             | yes         |
 | unary_einsum             | no            | revisit      | no             | yes             | revisit     |
 | uniform_dequantize       | yes           | yes          | yes            | yes             | no          |
 | uniform_quantize         | yes           | revisit      | infeasible     | yes             | no          |

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1494,7 +1494,7 @@ def StableHLO_ReduceOp: StableHLO_ShapedInterfaceOp<"reduce", [
 // StableHLO tuple op definitions.
 //===----------------------------------------------------------------------===//
 def StableHLO_GetTupleElementOp: StableHLO_Op<"get_tuple_element", [Pure,
-     DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
+     DeclareOpInterfaceMethods<InferTypeOpInterface> /*get_tuple_element_c2*/]> {
   let summary = "GetTupleElement operation";
   let description = [{
     Extracts element at `index` position of the `operand` tuple and produces a
@@ -1505,12 +1505,12 @@ def StableHLO_GetTupleElementOp: StableHLO_Op<"get_tuple_element", [Pure,
 
     Example:
     ```mlir
-    %result = stablehlo.get_tuple_element %operand[0] : (tuple<tensor<2xf32>, tuple<tensor<i32>>>) -> tensor<2xf32>
+    %result = stablehlo.get_tuple_element %operand[0] : (tuple<tensor<2xf64>, tuple<tensor<i64>>>) -> tensor<2xf64>
     ```
   }];
   let arguments = (ins
-    HLO_Tuple:$operand,
-    I32Attr:$index
+    HLO_Tuple:$operand, /*get_tuple_element_i1*/
+    I32Attr:$index /*get_tuple_element_i2*/
   );
 
   let results = (outs HLO_TensorOrTokenOrTuple);
@@ -1521,7 +1521,7 @@ def StableHLO_GetTupleElementOp: StableHLO_Op<"get_tuple_element", [Pure,
 }
 
 def StableHLO_TupleOp : StableHLO_Op<"tuple", [Pure,
-     DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
+     DeclareOpInterfaceMethods<InferTypeOpInterface> /*tuple_c1*/]> {
   let summary = "Tuple operation";
   let description = [{
     Produces a `result` tuple from values `val`.
@@ -1531,11 +1531,11 @@ def StableHLO_TupleOp : StableHLO_Op<"tuple", [Pure,
 
     Example:
     ```mlir
-    %result = stablehlo.tuple %val0, %val1 : tuple<tensor<2xf32>, tuple<tensor<i32>>>
+    %result = stablehlo.tuple %val0, %val1 : tuple<tensor<2xf64>, tuple<tensor<i64>>>
     ```
    }];
 
-  let arguments = (ins Variadic<HLO_TensorOrTokenOrTuple>:$val);
+  let arguments = (ins Variadic<HLO_TensorOrTokenOrTuple>:$val /*tuple_i1*/);
   let results = (outs HLO_Tuple:$result);
 
   let assemblyFormat = [{

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2320,11 +2320,13 @@ LogicalResult inferGetTupleElementOp(
     SmallVectorImpl<Type>& inferredReturnTypes) {
   auto operandType = operand.getType().dyn_cast<TupleType>();
   if (!operandType) return failure();
+  // get_tuple_element_c1
   if (index < 0 || index >= static_cast<int64_t>(operandType.size()))
     return emitOptionalError(location, "index ", index,
                              " is out of bounds of operand with size ",
                              operandType.size());
 
+  // get_tuple_element_c2
   inferredReturnTypes.push_back(operandType.getType(index));
   return success();
 }
@@ -3006,6 +3008,7 @@ LogicalResult inferTriangularSolveOp(
 LogicalResult inferTupleOp(MLIRContext* context, std::optional<Location>,
                            ValueRange val,
                            SmallVectorImpl<Type>& inferredReturnTypes) {
+  // tuple_c1
   inferredReturnTypes.push_back(TupleType::get(context, val.getTypes()));
   return success();
 }

--- a/stablehlo/reference/InterpreterValue.cpp
+++ b/stablehlo/reference/InterpreterValue.cpp
@@ -24,8 +24,39 @@ limitations under the License.
 namespace mlir {
 namespace stablehlo {
 
+//===----------------------------------------------------------------------===//
+// Tuple.
+//===----------------------------------------------------------------------===//
+
+Tuple::Tuple(ArrayRef<InterpreterValue> val, TupleType type) : type_(type) {
+  for (auto value : val)
+    values_.push_back(std::make_shared<InterpreterValue>(std::move(value)));
+}
+
+InterpreterValue Tuple::get(int32_t index) const { return *values_[index]; }
+
+TupleType Tuple::getType() const { return type_; }
+
+void Tuple::print(raw_ostream &os) const {
+  getType().print(os);
+  os << " (\n";
+  for (size_t i = 0; i < values_.size(); ++i) {
+    values_[i]->dump();
+    if (i != values_.size() - 1) os << ",";
+    os << "\n";
+  }
+  os << ")";
+}
+
+void Tuple::dump() const { print(llvm::errs()); }
+
+//===----------------------------------------------------------------------===//
+// InterpreterValue.
+//===----------------------------------------------------------------------===//
+
 InterpreterValue::InterpreterValue(const Tensor &tensor) : value_(tensor) {}
 InterpreterValue::InterpreterValue(const Token &token) : value_(token) {}
+InterpreterValue::InterpreterValue(const Tuple &tuple) : value_(tuple) {}
 
 Tensor InterpreterValue::getTensor() const {
   if (!isTensor())
@@ -40,9 +71,16 @@ Token InterpreterValue::getToken() const {
   return std::get<Token>(value_);
 }
 
+Tuple InterpreterValue::getTuple() const {
+  if (!isTuple()) llvm::report_fatal_error("InterpreterValue is not a Tuple.");
+
+  return std::get<Tuple>(value_);
+}
+
 Type InterpreterValue::getType() const {
   if (isTensor()) return getTensor().getType();
   if (isToken()) return getToken().getType();
+  if (isTuple()) return getTuple().getType();
 
   report_fatal_error(invalidArgument("Unsupported interpreter value."));
 }
@@ -55,11 +93,17 @@ bool InterpreterValue::isToken() const {
   return std::holds_alternative<Token>(value_);
 }
 
+bool InterpreterValue::isTuple() const {
+  return std::holds_alternative<Tuple>(value_);
+}
+
 void InterpreterValue::print(raw_ostream &os) const {
   if (isTensor())
     getTensor().print(os);
   else if (isToken())
     getToken().print(os);
+  else if (isTuple())
+    getTuple().print(os);
   else
     report_fatal_error(invalidArgument("Unsupported interpreter value."));
 }

--- a/stablehlo/reference/InterpreterValue.cpp
+++ b/stablehlo/reference/InterpreterValue.cpp
@@ -60,19 +60,21 @@ InterpreterValue::InterpreterValue(const Tuple &tuple) : value_(tuple) {}
 
 Tensor InterpreterValue::getTensor() const {
   if (!isTensor())
-    llvm::report_fatal_error("InterpreterValue is not a Tensor.");
+    report_fatal_error(invalidArgument("InterpreterValue is not a Tensor."));
 
   return std::get<Tensor>(value_);
 }
 
 Token InterpreterValue::getToken() const {
-  if (!isToken()) llvm::report_fatal_error("InterpreterValue is not a Token.");
+  if (!isToken())
+    report_fatal_error(invalidArgument("InterpreterValue is not a Token."));
 
   return std::get<Token>(value_);
 }
 
 Tuple InterpreterValue::getTuple() const {
-  if (!isTuple()) llvm::report_fatal_error("InterpreterValue is not a Tuple.");
+  if (!isTuple())
+    report_fatal_error(invalidArgument("InterpreterValue is not a Tuple."));
 
   return std::get<Tuple>(value_);
 }

--- a/stablehlo/reference/InterpreterValue.h
+++ b/stablehlo/reference/InterpreterValue.h
@@ -25,6 +25,28 @@ limitations under the License.
 namespace mlir {
 namespace stablehlo {
 
+class InterpreterValue;
+
+class Tuple {
+ public:
+  /// \name Constructors
+  /// @{
+  Tuple(ArrayRef<InterpreterValue> val, TupleType type);
+  /// @}
+
+  InterpreterValue get(int32_t index) const;
+
+  TupleType getType() const;
+
+  /// Prints Tuple objects.
+  void print(raw_ostream &os) const;
+  void dump() const;
+
+ private:
+  TupleType type_;
+  SmallVector<std::shared_ptr<InterpreterValue>> values_;
+};
+
 class InterpreterValue {
  public:
   /// \name Constructors
@@ -32,6 +54,7 @@ class InterpreterValue {
   InterpreterValue() = default;
   InterpreterValue(const Tensor &tensor);
   InterpreterValue(const Token &token);
+  InterpreterValue(const Tuple &tuple);
   /// @}
 
   /// Getter method for Tensor object.
@@ -39,6 +62,9 @@ class InterpreterValue {
 
   /// Getter method for Token object.
   Token getToken() const;
+
+  /// Getter method for Tuple object.
+  Tuple getTuple() const;
 
   /// Getter method for type_;
   Type getType() const;
@@ -49,6 +75,9 @@ class InterpreterValue {
   /// Returns whether value_ is a Token object.
   bool isToken() const;
 
+  /// Returns whether value_ is a Tuple object.
+  bool isTuple() const;
+
   /// Print utilities for InterpreterValue objects.
   void print(raw_ostream &os) const;
 
@@ -56,7 +85,7 @@ class InterpreterValue {
   void dump() const;
 
  private:
-  std::variant<Tensor, Token> value_;
+  std::variant<Tensor, Token, Tuple> value_;
 };
 
 }  // namespace stablehlo

--- a/stablehlo/reference/InterpreterValue.h
+++ b/stablehlo/reference/InterpreterValue.h
@@ -34,12 +34,16 @@ class Tuple {
   Tuple(ArrayRef<InterpreterValue> val, TupleType type);
   /// @}
 
+  /// Getter method to access individual elements within the tuple.
   InterpreterValue get(int32_t index) const;
 
+  /// Getter method for type.
   TupleType getType() const;
 
   /// Prints Tuple objects.
   void print(raw_ostream &os) const;
+
+  /// Print utilities for Tuple objects.
   void dump() const;
 
  private:

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -453,6 +453,11 @@ SmallVector<InterpreterValue> eval(
       auto result = evalGetDimensionSizeOp(operand, dimension,
                                            getDimensionSizeOp.getType());
       scope.add(getDimensionSizeOp.getResult(), result);
+    } else if (auto getTupleElementOp = dyn_cast<GetTupleElementOp>(op)) {
+      auto operand = scope.findTuple(getTupleElementOp.getOperand());
+      auto result =
+          evalGetTupleElementOp(operand, getTupleElementOp.getIndex());
+      scope.add(getTupleElementOp.getResult(), result);
     } else if (auto ifOp = dyn_cast<IfOp>(op)) {
       auto pred = scope.findTensor(ifOp.getPred());
       auto &trueBranch = ifOp.getTrueBranch();
@@ -785,6 +790,10 @@ SmallVector<InterpreterValue> eval(
       scope.add(transposeOp.getResult(), result);
     } else if (isa<TriangularSolveOp>(op)) {
       failOnDecomposableOp(op);
+    } else if (auto tupleOp = dyn_cast<TupleOp>(op)) {
+      auto val = scope.find(tupleOp.getVal());
+      auto result = evalTupleOp(val, tupleOp.getType().cast<TupleType>());
+      scope.add(tupleOp.getResult(), result);
     } else if (isa<UnaryEinsumOp>(op)) {
       failOnDecomposableOp(op);
     } else if (auto whileOp = dyn_cast<WhileOp>(op)) {
@@ -1342,6 +1351,10 @@ Tensor evalGetDimensionSizeOp(const Tensor &operand, Axis dimension,
   result.set(
       {}, convert(resultType.getElementType(), operand.getShape()[dimension]));
   return result;
+}
+
+InterpreterValue evalGetTupleElementOp(const Tuple &operand, int32_t index) {
+  return operand.get(index);
 }
 
 SmallVector<InterpreterValue> evalIfOp(const Tensor &pred, Region &trueBranch,
@@ -1965,6 +1978,10 @@ Tensor evalTransposeOp(const Tensor &operand, const Axes &permutation,
     result.set(resultIndex, operand.get(operandIndex));
   }
   return result;
+}
+
+Tuple evalTupleOp(ArrayRef<InterpreterValue> val, TupleType resultType) {
+  return Tuple(val, resultType);
 }
 
 SmallVector<InterpreterValue> evalWhileOp(SmallVector<InterpreterValue> operand,

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -97,6 +97,7 @@ Tensor evalGatherOp(const Tensor &operand, const Tensor &startIndices,
                     ShapedType resultType);
 Tensor evalGetDimensionSizeOp(const Tensor &operand, Axis dimension,
                               ShapedType resultType);
+InterpreterValue evalGetTupleElementOp(const Tuple &operand, int32_t index);
 SmallVector<InterpreterValue> evalIfOp(const Tensor &pred, Region &trueBranch,
                                        Region &falseBranch, Process *process,
                                        Scope &scope);
@@ -185,6 +186,7 @@ Tensor evalSubtractOp(const Tensor &lhs, const Tensor &rhs,
 Tensor evalTanhOp(const Tensor &operand, ShapedType resultType);
 Tensor evalTransposeOp(const Tensor &operand, const Axes &permutation,
                        ShapedType resultType);
+Tuple evalTupleOp(ArrayRef<InterpreterValue> val, TupleType resultType);
 SmallVector<InterpreterValue> evalWhileOp(SmallVector<InterpreterValue> operand,
                                           Region &cond, Region &body,
                                           Process *process, Scope &scope);

--- a/stablehlo/reference/Scope.cpp
+++ b/stablehlo/reference/Scope.cpp
@@ -44,6 +44,10 @@ void Scope::add(Value ssaValue, Token runtimeValue) {
   add(ssaValue, InterpreterValue(runtimeValue));
 }
 
+void Scope::add(Value ssaValue, Tuple runtimeValue) {
+  add(ssaValue, InterpreterValue(runtimeValue));
+}
+
 void Scope::add(ValueRange ssaValues,
                 ArrayRef<InterpreterValue> runtimeValues) {
   assert(ssaValues.size() == runtimeValues.size());
@@ -96,6 +100,10 @@ Token Scope::findToken(Value ssaValue) const {
 SmallVector<Token> Scope::findTokens(ValueRange ssaValues) const {
   return llvm::to_vector(llvm::map_range(
       ssaValues, [&](Value value) { return find(value).getToken(); }));
+}
+
+Tuple Scope::findTuple(Value ssaValue) const {
+  return find(ssaValue).getTuple();
 }
 
 }  // namespace stablehlo

--- a/stablehlo/reference/Scope.h
+++ b/stablehlo/reference/Scope.h
@@ -49,6 +49,10 @@ class Scope {
   /// evaluated runtime value (`runtimeValue`).
   void add(Value ssaValue, Token runtimeValue);
 
+  /// Add the mapping from SSA value (`ssaValue`), defined in a region, to its
+  /// evaluated runtime value (`runtimeValue`).
+  void add(Value ssaValue, Tuple runtimeValue);
+
   /// Add the mapping from SSA values (`ssaValues`), defined in a region, to its
   /// evaluated runtime values (`runtimeValues`).
   void add(ValueRange ssaValues, ArrayRef<InterpreterValue> runtimeValues);
@@ -84,6 +88,11 @@ class Scope {
 
   /// Find the runtime values mapped to SSA values `ssaValues`.
   SmallVector<Token> findTokens(ValueRange ssaValues) const;
+
+  /// Find the runtime value mapped to SSA value `ssaValue`. The search starts
+  /// with the current scope and then recursively continues over to the scope
+  /// defined by `parent_`.
+  Tuple findTuple(Value ssaValue) const;
 
  private:
   /// Internal store for mapping from SSA values to runtime `InterpreterValue`

--- a/stablehlo/testdata/igamma_broadcasting_lhs_float32_1_20__rhs_float32_20_20.mlir
+++ b/stablehlo/testdata/igamma_broadcasting_lhs_float32_1_20__rhs_float32_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/igamma_broadcasting_lhs_float32_20_20__rhs_float32_1_20.mlir
+++ b/stablehlo/testdata/igamma_broadcasting_lhs_float32_20_20__rhs_float32_1_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/igamma_dtypes_lhs_bfloat16_20_20__rhs_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/igamma_dtypes_lhs_bfloat16_20_20__rhs_bfloat16_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/igamma_dtypes_lhs_float16_20_20__rhs_float16_20_20.mlir
+++ b/stablehlo/testdata/igamma_dtypes_lhs_float16_20_20__rhs_float16_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/igamma_dtypes_lhs_float32_20_20__rhs_float32_20_20.mlir
+++ b/stablehlo/testdata/igamma_dtypes_lhs_float32_20_20__rhs_float32_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/igammac_broadcasting_lhs_float32_1_20__rhs_float32_20_20.mlir
+++ b/stablehlo/testdata/igammac_broadcasting_lhs_float32_1_20__rhs_float32_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/igammac_broadcasting_lhs_float32_20_20__rhs_float32_1_20.mlir
+++ b/stablehlo/testdata/igammac_broadcasting_lhs_float32_20_20__rhs_float32_1_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/igammac_dtypes_lhs_bfloat16_20_20__rhs_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/igammac_dtypes_lhs_bfloat16_20_20__rhs_bfloat16_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/igammac_dtypes_lhs_float16_20_20__rhs_float16_20_20.mlir
+++ b/stablehlo/testdata/igammac_dtypes_lhs_float16_20_20__rhs_float16_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/igammac_dtypes_lhs_float32_20_20__rhs_float32_20_20.mlir
+++ b/stablehlo/testdata/igammac_dtypes_lhs_float32_20_20__rhs_float32_20_20.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/regularized_incomplete_beta__bfloat16.mlir
+++ b/stablehlo/testdata/regularized_incomplete_beta__bfloat16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/regularized_incomplete_beta__float16.mlir
+++ b/stablehlo/testdata/regularized_incomplete_beta__float16.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/testdata/regularized_incomplete_beta__float32.mlir
+++ b/stablehlo/testdata/regularized_incomplete_beta__float32.mlir
@@ -1,4 +1,4 @@
-// RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
+// RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
 // RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
 
 module @jit_testcase {

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -664,6 +664,24 @@ func.func @scatter_bounds(%input_tensor: tensor<200x?x?xf32, #stablehlo.bounds<?
 
 // -----
 
+func.func @tuple_c1(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tuple<tensor<f32>, tensor<f32>, tensor<f32>> {
+  // expected-error@+2 {{failed to infer returned types}}
+  // expected-error@+1 {{'tuple<tensor<f32>, tensor<f32>>' are incompatible with return type(s) of operation 'tuple<tensor<f32>, tensor<f32>, tensor<f32>>'}}
+  %0 = "stablehlo.tuple"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tuple<tensor<f32>, tensor<f32>, tensor<f32>>
+  func.return %0 : tuple<tensor<f32>, tensor<f32>, tensor<f32>>
+}
+
+// -----
+
+func.func @get_tuple_element_c2(%arg0: tuple<tensor<f32>, tensor<i32>>) -> tensor<i32> {
+  // expected-error@+2 {{failed to infer returned types}}
+  // expected-error@+1 {{inferred type(s) 'tensor<f32>' are incompatible with return type(s) of operation 'tensor<i32>'}}
+  %0 = "stablehlo.get_tuple_element"(%arg0) {index = 0 : i32} : (tuple<tensor<f32>, tensor<i32>>) -> tensor<i32>
+  func.return %0 : tensor<i32>
+}
+
+// -----
+
 // CHECK-LABEL: func @get_dimension_size
 func.func @get_dimension_size(%arg0: tensor<4x2xf32>) -> tensor<index> {
   %0 = "stablehlo.get_dimension_size"(%arg0) {dimension = 1 : i64} : (tensor<4x2xf32>) -> tensor<i32>

--- a/stablehlo/tests/interpret_tuple_and_get_tuple_element.mlir
+++ b/stablehlo/tests/interpret_tuple_and_get_tuple_element.mlir
@@ -2,8 +2,8 @@
 
 func.func @tuple() {
   %val0 = stablehlo.constant dense<[1.0, 2.0]> : tensor<2xf64>
-  %val00 = stablehlo.constant dense<3> : tensor<i64>
-  %val1 = stablehlo.tuple %val00 : tuple<tensor<i64>>
+  %tmp = stablehlo.constant dense<3> : tensor<i64>
+  %val1 = stablehlo.tuple %tmp : tuple<tensor<i64>>
   %operand = stablehlo.tuple %val0, %val1 : tuple<tensor<2xf64>, tuple<tensor<i64>>>
   func.return
 }
@@ -12,14 +12,13 @@ func.func @tuple() {
 
 func.func @get_tuple_element() {
   %val0 = stablehlo.constant dense<[1.0, 2.0]> : tensor<2xf64>
-  %val00 = stablehlo.constant dense<3> : tensor<i64>
-  %val1 = stablehlo.tuple %val00 : tuple<tensor<i64>>
+  %tmp0 = stablehlo.constant dense<3> : tensor<i64>
+  %val1 = stablehlo.tuple %tmp0 : tuple<tensor<i64>>
   %operand = stablehlo.tuple %val0, %val1 : tuple<tensor<2xf64>, tuple<tensor<i64>>>
   %result0 = stablehlo.get_tuple_element %operand[0] : (tuple<tensor<2xf64>, tuple<tensor<i64>>>) -> tensor<2xf64>
-  %result00 = stablehlo.get_tuple_element %operand[1] : (tuple<tensor<2xf64>, tuple<tensor<i64>>>) -> tuple<tensor<i64>>
-  %result1 = stablehlo.get_tuple_element %result00[0] : (tuple<tensor<i64>>) -> tensor<i64>
+  %tmp1 = stablehlo.get_tuple_element %operand[1] : (tuple<tensor<2xf64>, tuple<tensor<i64>>>) -> tuple<tensor<i64>>
+  %result1 = stablehlo.get_tuple_element %tmp1[0] : (tuple<tensor<i64>>) -> tensor<i64>
   check.expect_almost_eq_const %result0, dense<[1.0, 2.0]> : tensor<2xf64>
   check.expect_eq_const %result1, dense<3> : tensor<i64>
   func.return
 }
-

--- a/stablehlo/tests/interpret_tuple_and_get_tuple_element.mlir
+++ b/stablehlo/tests/interpret_tuple_and_get_tuple_element.mlir
@@ -1,0 +1,25 @@
+// RUN: stablehlo-translate --interpret -split-input-file %s
+
+func.func @tuple() {
+  %val0 = stablehlo.constant dense<[1.0, 2.0]> : tensor<2xf64>
+  %val00 = stablehlo.constant dense<3> : tensor<i64>
+  %val1 = stablehlo.tuple %val00 : tuple<tensor<i64>>
+  %operand = stablehlo.tuple %val0, %val1 : tuple<tensor<2xf64>, tuple<tensor<i64>>>
+  func.return
+}
+
+// -----
+
+func.func @get_tuple_element() {
+  %val0 = stablehlo.constant dense<[1.0, 2.0]> : tensor<2xf64>
+  %val00 = stablehlo.constant dense<3> : tensor<i64>
+  %val1 = stablehlo.tuple %val00 : tuple<tensor<i64>>
+  %operand = stablehlo.tuple %val0, %val1 : tuple<tensor<2xf64>, tuple<tensor<i64>>>
+  %result0 = stablehlo.get_tuple_element %operand[0] : (tuple<tensor<2xf64>, tuple<tensor<i64>>>) -> tensor<2xf64>
+  %result00 = stablehlo.get_tuple_element %operand[1] : (tuple<tensor<2xf64>, tuple<tensor<i64>>>) -> tuple<tensor<i64>>
+  %result1 = stablehlo.get_tuple_element %result00[0] : (tuple<tensor<i64>>) -> tensor<i64>
+  check.expect_almost_eq_const %result0, dense<[1.0, 2.0]> : tensor<2xf64>
+  check.expect_eq_const %result1, dense<3> : tensor<i64>
+  func.return
+}
+

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -2618,38 +2618,14 @@ func.func @triangular_solve(%arg0: tensor<10x5x4x4xf32>, %arg1: tensor<10x5x4x4x
 // -----
 
 // CHECK-LABEL: func @tuple
-func.func @tuple(%arg0: tensor<1xi32>, %arg1: tensor<1x2xf32>) -> tuple<tensor<1xi32>, tensor<1x2xf32>> {
-  %0 = "stablehlo.tuple"(%arg0, %arg1) : (tensor<1xi32>, tensor<1x2xf32>) -> tuple<tensor<1xi32>, tensor<1x2xf32>>
-  func.return %0: tuple<tensor<1xi32>, tensor<1x2xf32>>
+func.func @tuple(%arg0: tensor<1xi32>, %arg1: !stablehlo.token, %arg2: tuple<!stablehlo.token>) -> tuple<tensor<1xi32>, !stablehlo.token, tuple<!stablehlo.token>> {
+  %0 = "stablehlo.tuple"(%arg0, %arg1, %arg2) : (tensor<1xi32>, !stablehlo.token, tuple<!stablehlo.token>) -> tuple<tensor<1xi32>, !stablehlo.token, tuple<!stablehlo.token>>
+  func.return %0: tuple<tensor<1xi32>, !stablehlo.token, tuple<!stablehlo.token>>
 }
 
 // -----
 
-func.func @tuple_token(%arg0: tensor<f32>, %arg1: !stablehlo.token) -> tuple<tensor<f32>, !stablehlo.token> {
-  %0 = "stablehlo.tuple"(%arg0, %arg1) : (tensor<f32>, !stablehlo.token) -> tuple<tensor<f32>, !stablehlo.token>
-  func.return %0 : tuple<tensor<f32>, !stablehlo.token>
-}
-
-// -----
-
-func.func @tuple_arg_size_mismatch(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tuple<tensor<f32>, tensor<f32>, tensor<f32>> {
-  // expected-error@+2 {{failed to infer returned types}}
-  // expected-error@+1 {{'tuple<tensor<f32>, tensor<f32>>' are incompatible with return type(s) of operation 'tuple<tensor<f32>, tensor<f32>, tensor<f32>>'}}
-  %0 = "stablehlo.tuple"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tuple<tensor<f32>, tensor<f32>, tensor<f32>>
-  func.return %0 : tuple<tensor<f32>, tensor<f32>, tensor<f32>>
-}
-
-// -----
-
-func.func @tuple_type_mismatch(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tuple<tensor<f32>, tensor<i32>> {
-  // expected-error@+2 {{failed to infer returned types}}
-  // expected-error@+1 {{inferred type(s) 'tuple<tensor<f32>, tensor<f32>>' are incompatible with return type(s) of operation 'tuple<tensor<f32>, tensor<i32>>'}}
-  %0 = "stablehlo.tuple"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tuple<tensor<f32>, tensor<i32>>
-  func.return %0 : tuple<tensor<f32>, tensor<i32>>
-}
-
-// -----
-
+// CHECK-LABEL: func @get_tuple_element
 func.func @get_tuple_element(%arg0: tuple<tensor<f32>, tensor<i32>>) -> tensor<f32> {
   %0 = "stablehlo.get_tuple_element"(%arg0) {index = 0 : i32} : (tuple<tensor<f32>, tensor<i32>>) -> tensor<f32>
   func.return %0 : tensor<f32>
@@ -2657,23 +2633,16 @@ func.func @get_tuple_element(%arg0: tuple<tensor<f32>, tensor<i32>>) -> tensor<f
 
 // -----
 
-func.func @get_tuple_element_token(%arg0: tuple<tensor<f32>, !stablehlo.token>) -> !stablehlo.token {
-  %0 = "stablehlo.get_tuple_element"(%arg0) {index = 1 : i32} : (tuple<tensor<f32>, !stablehlo.token>) -> !stablehlo.token
-  func.return %0 : !stablehlo.token
-}
-
-// -----
-
-func.func @get_tuple_element_bad_type(%arg0: tuple<tensor<f32>, tensor<i32>>) -> tensor<i32> {
+func.func @get_tuple_element_c1(%arg0: tuple<tensor<f32>, tensor<i32>>) -> tensor<f32> {
   // expected-error@+2 {{failed to infer returned types}}
-  // expected-error@+1 {{inferred type(s) 'tensor<f32>' are incompatible with return type(s) of operation 'tensor<i32>'}}
-  %0 = "stablehlo.get_tuple_element"(%arg0) {index = 0 : i32} : (tuple<tensor<f32>, tensor<i32>>) -> tensor<i32>
-  func.return %0 : tensor<i32>
+  // expected-error@+1 {{index -1 is out of bounds of operand with size 2}}
+  %0 = "stablehlo.get_tuple_element"(%arg0) {index = -1 : i32} : (tuple<tensor<f32>, tensor<i32>>) -> tensor<f32>
+  func.return %0 : tensor<f32>
 }
 
 // -----
 
-func.func @get_tuple_element_index_out_of_bounds(%arg0: tuple<tensor<f32>, tensor<i32>>) -> tensor<f32> {
+func.func @get_tuple_element_c1(%arg0: tuple<tensor<f32>, tensor<i32>>) -> tensor<f32> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{index 2 is out of bounds of operand with size 2}}
   %0 = "stablehlo.get_tuple_element"(%arg0) {index = 2 : i32} : (tuple<tensor<f32>, tensor<i32>>) -> tensor<f32>

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -2618,9 +2618,9 @@ func.func @triangular_solve(%arg0: tensor<10x5x4x4xf32>, %arg1: tensor<10x5x4x4x
 // -----
 
 // CHECK-LABEL: func @tuple
-func.func @tuple(%arg0: tensor<1xi32>, %arg1: !stablehlo.token, %arg2: tuple<!stablehlo.token>) -> tuple<tensor<1xi32>, !stablehlo.token, tuple<!stablehlo.token>> {
-  %0 = "stablehlo.tuple"(%arg0, %arg1, %arg2) : (tensor<1xi32>, !stablehlo.token, tuple<!stablehlo.token>) -> tuple<tensor<1xi32>, !stablehlo.token, tuple<!stablehlo.token>>
-  func.return %0: tuple<tensor<1xi32>, !stablehlo.token, tuple<!stablehlo.token>>
+func.func @tuple(%arg0: tensor<1xi32>, %arg1: !stablehlo.token, %arg2: tuple<>) -> tuple<tensor<1xi32>, !stablehlo.token, tuple<>> {
+  %0 = "stablehlo.tuple"(%arg0, %arg1, %arg2) : (tensor<1xi32>, !stablehlo.token, tuple<>) -> tuple<tensor<1xi32>, !stablehlo.token, tuple<>>
+  func.return %0: tuple<tensor<1xi32>, !stablehlo.token, tuple<>>
 }
 
 // -----


### PR DESCRIPTION
TupleOp:
We have the following constraints in the spec:

```
(I1) `val` is a variadic number of values.
(C1) `result` has type `tuple<E0, ..., EN-1>` where `Ei = type(val[i])`.
```

These constraints will be comprehensively covered by the following tests:

```
I1: a) `val` is not a variadic number of values. (Covered by ODS).
C1: a) `result` does not have type `tuple<E0, ..., EN-1>` where `Ei = type(val[i])`.
```

If we drop the "Covered by ODS" pieces, this will leave us with the following test cases:

```
C1: a) `result` does not have type `tuple<E0, ..., EN-1>` where `Ei = type(val[i])`.
```

closes #1139

GetTupleElementOp:
We have the following constraints in the spec:

```
(I1) `operand` is a tuple.
(I2) `index` is a constant of type `si32`.
(C1) `0 <= index < size(operand)`.
(C2) `type(result) = tuple_element_types(operand)[index]`.
```

These constraints will be comprehensively covered by the following tests:

```
I1: a) `operand` is not a tuple. (Covered by ODS).
I2: a) `index` is not a constant of type `si32`. (Covered by ODS).
C1: a) `index < 0`.
C1: b) `index >= size(operand)`.
C2: a) `type(result) != tuple_element_types(operand)[index]`.
```

If we drop the "Covered by ODS" pieces, this will leave us with the following test cases:

```
C1: a) `index < 0`.
C1: b) `index >= size(operand)`.
C2: a) `type(result) != tuple_element_types(operand)[index]`.
```

closes #1127