### PR TITLE
Disable multithreaded tests

### DIFF
--- a/stablehlo/tests/interpret_all_gather.mlir
+++ b/stablehlo/tests/interpret_all_gather.mlir
@@ -1,4 +1,5 @@
-// RUN: stablehlo-translate --interpret -split-input-file %s
+// RUN: echo 'DISABLED'
+// RUN-DISABLED: stablehlo-translate --interpret -split-input-file %s
 
 module @cross_replica {
   func.func public @all_gather(%arg0 : tensor<2x2xi64>) -> tensor<2x4xi64> {

--- a/stablehlo/tests/interpret_all_reduce.mlir
+++ b/stablehlo/tests/interpret_all_reduce.mlir
@@ -1,4 +1,5 @@
-// RUN: stablehlo-translate --interpret -split-input-file %s
+// RUN: echo 'DISABLED'
+// RUN-DISABLED: stablehlo-translate --interpret -split-input-file %s
 
 module @cross_replica {
   func.func public @all_reduce(%operand : tensor<4xi64>) -> tensor<4xi64> {

--- a/stablehlo/tests/interpret_all_to_all.mlir
+++ b/stablehlo/tests/interpret_all_to_all.mlir
@@ -1,4 +1,5 @@
-// RUN: stablehlo-translate --interpret -split-input-file %s
+// RUN: echo 'DISABLED'
+// RUN-DISABLED: stablehlo-translate --interpret -split-input-file %s
 
 module @cross_replica {
   func.func public @all_to_all(%operand : tensor<2x4xi64>) -> tensor<4x2xi64> {

--- a/stablehlo/tests/interpret_collective_permute.mlir
+++ b/stablehlo/tests/interpret_collective_permute.mlir
@@ -1,4 +1,5 @@
-// RUN: stablehlo-translate --interpret -split-input-file %s
+// RUN: echo 'DISABLED'
+// RUN-DISABLED: stablehlo-translate --interpret -split-input-file %s
 
 module @cross_replica {
   func.func public @collective_permute(%operand : tensor<2x2xi64>) -> tensor<2x2xi64> {

--- a/stablehlo/tests/interpret_outfeed.mlir
+++ b/stablehlo/tests/interpret_outfeed.mlir
@@ -1,4 +1,5 @@
-// RUN: stablehlo-translate --interpret -split-input-file %s
+// RUN: echo 'DISABLED'
+// RUN-DISABLED: stablehlo-translate --interpret -split-input-file %s
 
 module @distribution_ops {
   func.func public @outfeed(%inputs0 : tensor<2x2x2xi64>, %token : !stablehlo.token) -> !stablehlo.token {

--- a/stablehlo/tests/interpret_reduce_scatter.mlir
+++ b/stablehlo/tests/interpret_reduce_scatter.mlir
@@ -1,4 +1,5 @@
-// RUN: stablehlo-translate --interpret -split-input-file %s
+// RUN: echo 'DISABLED'
+// RUN-DISABLED: stablehlo-translate --interpret -split-input-file %s
 
 module @cross_replica {
   func.func public @reduce_scatter(%operand : tensor<2x4xi64>) -> tensor<2x2xi64> {


### PR DESCRIPTION
There are TSAN violations for multithreaded tests. I've added #1755 to address it, and we should disable it in the meantime.