### PR TITLE
build: use 64-bit integer literals across all platforms

### DIFF
--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2515,7 +2515,7 @@ LogicalResult inferPadOp(std::optional<Location> location, Type operandType,
       int64_t operandSizeOrBound = isStaticDim ? inputShape[i] : inputBounds[i];
       int64_t resultSizeOrBound =
           operandSizeOrBound + paddingLowVal + paddingHighVal +
-          std::max<int64_t>(operandSizeOrBound - 1, 0LL) * paddingInteriorVal;
+          std::max<int64_t>(operandSizeOrBound - 1, 0ll) * paddingInteriorVal;
 
       // pad_c4
       if (resultSizeOrBound < 0) {

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -953,7 +953,7 @@ Element reducePrecision(const Element &el, int32_t exponentBits,
   int32_t srcMantissaBits = type.getFPMantissaWidth() - 1;
   auto destMantissaBits = mantissaBits;
   if (destMantissaBits < srcMantissaBits) {
-    auto lastMantissaBitMask = 1UL << (srcMantissaBits - destMantissaBits);
+    auto lastMantissaBitMask = 1ull << (srcMantissaBits - destMantissaBits);
 
     // Compute rounding bias for round-to-nearest with ties to even.
     auto baseRoundingBias = (lastMantissaBitMask >> 1) - 1;
@@ -971,15 +971,15 @@ Element reducePrecision(const Element &el, int32_t exponentBits,
   auto srcExponentBits = bitWidth - srcMantissaBits - 1;
   auto destExponentBits = exponentBits;
   if (destExponentBits < srcExponentBits) {
-    auto signBitMask = 1UL << (bitWidth - 1);
-    auto expBitsMask = ((1UL << srcExponentBits) - 1) << srcMantissaBits;
+    auto signBitMask = 1ull << (bitWidth - 1);
+    auto expBitsMask = ((1ull << srcExponentBits) - 1) << srcMantissaBits;
 
     // An exponent of 2^(n-1)-1 (i.e. 0b0111...) with 0 being the most
     // significant bit is equal to 1.0f for all exponent sizes. Adding 2^(n-1)-1
     // to this results in highest non-infinite exponent, and subtracting
     // 2^(n-1)-1 results in lowest exponent (i.e. 0.0f) for a bit size of n.
-    auto exponentBias = (1UL << (srcExponentBits - 1)) - 1;
-    auto reducedExponentBias = (1UL << (destExponentBits - 1)) - 1;
+    auto exponentBias = (1ull << (srcExponentBits - 1)) - 1;
+    auto reducedExponentBias = (1ull << (destExponentBits - 1)) - 1;
     auto reducedMaxExponent = exponentBias + reducedExponentBias;
     auto reducedMinExponent = exponentBias - reducedExponentBias;
 

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -1317,7 +1317,7 @@ Tensor evalGatherOp(const Tensor &operand, const Tensor &startIndices,
       if (dStartIt == startIndexMap.end()) continue;
       auto dStart = dStartIt - startIndexMap.begin();
       fullStartIndex[dOperand] = std::clamp<int64_t>(
-          startIndex[dStart], 0L,
+          startIndex[dStart], 0ll,
           operand.getShape()[dOperand] - sliceSizes[dOperand]);
     }
 

--- a/stablehlo/transforms/StablehloLegalizeToVhlo.cpp
+++ b/stablehlo/transforms/StablehloLegalizeToVhlo.cpp
@@ -602,21 +602,21 @@ LogicalResult addDefaults(const OpConversionPattern<StablehloOpTy>& pattern,
     if (!stablehloOp.getWindowStridesAttr())
       addDefaultAttr("window_strides",
                      builder.getI64TensorAttr(
-                         SmallVector<int64_t>(numSpatialDimensions, 1l)));
+                         SmallVector<int64_t>(numSpatialDimensions, 1ll)));
     if (!stablehloOp.getPaddingAttr())
       addDefaultAttr("padding",
                      DenseIntElementsAttr::get(
                          RankedTensorType::get({numSpatialDimensions, 2},
                                                builder.getI64Type()),
-                         SmallVector<int64_t>(numSpatialDimensions * 2, 0l)));
+                         SmallVector<int64_t>(numSpatialDimensions * 2, 0ll)));
     if (!stablehloOp.getLhsDilationAttr())
       addDefaultAttr("lhs_dilation",
                      builder.getI64TensorAttr(
-                         SmallVector<int64_t>(numSpatialDimensions, 1l)));
+                         SmallVector<int64_t>(numSpatialDimensions, 1ll)));
     if (!stablehloOp.getRhsDilationAttr())
       addDefaultAttr("rhs_dilation",
                      builder.getI64TensorAttr(
-                         SmallVector<int64_t>(numSpatialDimensions, 1l)));
+                         SmallVector<int64_t>(numSpatialDimensions, 1ll)));
     if (!stablehloOp.getWindowReversalAttr())
       addDefaultAttr("window_reversal",
                      DenseIntElementsAttr::get(
@@ -699,21 +699,21 @@ LogicalResult addDefaults(const OpConversionPattern<StablehloOpTy>& pattern,
     if (!stablehloOp.getWindowStridesAttr())
       addDefaultAttr("window_strides",
                      builder.getI64TensorAttr(
-                         SmallVector<int64_t>(numWindowDimensions, 1l)));
+                         SmallVector<int64_t>(numWindowDimensions, 1ll)));
     if (!stablehloOp.getBaseDilationsAttr())
       addDefaultAttr("base_dilations",
                      builder.getI64TensorAttr(
-                         SmallVector<int64_t>(numWindowDimensions, 1l)));
+                         SmallVector<int64_t>(numWindowDimensions, 1ll)));
     if (!stablehloOp.getWindowDilationsAttr())
       addDefaultAttr("window_dilations",
                      builder.getI64TensorAttr(
-                         SmallVector<int64_t>(numWindowDimensions, 1l)));
+                         SmallVector<int64_t>(numWindowDimensions, 1ll)));
     if (!stablehloOp.getPaddingAttr())
       addDefaultAttr("padding",
                      DenseIntElementsAttr::get(
                          RankedTensorType::get({numWindowDimensions, 2},
                                                builder.getI64Type()),
-                         SmallVector<int64_t>(numWindowDimensions * 2, 0l)));
+                         SmallVector<int64_t>(numWindowDimensions * 2, 0ll)));
   }
   if constexpr (std::is_same<StablehloOpTy, stablehlo::ScatterOp>::value) {
     if (!stablehloOp.getIndicesAreSortedAttr())
@@ -731,13 +731,13 @@ LogicalResult addDefaults(const OpConversionPattern<StablehloOpTy>& pattern,
     if (!stablehloOp.getWindowStridesAttr())
       addDefaultAttr("window_strides",
                      builder.getI64TensorAttr(
-                         SmallVector<int64_t>(numWindowDimensions, 1l)));
+                         SmallVector<int64_t>(numWindowDimensions, 1ll)));
     if (!stablehloOp.getPaddingAttr())
       addDefaultAttr("padding",
                      DenseIntElementsAttr::get(
                          RankedTensorType::get({numWindowDimensions, 2},
                                                builder.getI64Type()),
-                         SmallVector<int64_t>(numWindowDimensions * 2, 0l)));
+                         SmallVector<int64_t>(numWindowDimensions * 2, 0ll)));
   }
   if constexpr (std::is_same<StablehloOpTy, stablehlo::SortOp>::value) {
     if (!stablehloOp.getDimensionAttr())

--- a/stablehlo/transforms/VhloLegalizeToStablehlo.cpp
+++ b/stablehlo/transforms/VhloLegalizeToStablehlo.cpp
@@ -565,13 +565,13 @@ LogicalResult removeDefaults(const OpConversionPattern<VhloOpTy>& pattern,
   }
   if constexpr (std::is_same<VhloOpTy, vhlo::ConvolutionOpV1>::value ||
                 std::is_same<VhloOpTy, vhlo::DynamicConvOpV1>::value) {
-    if (isSplatTensor(pattern, vhloOp.getWindowStridesAttr(), 1l))
+    if (isSplatTensor(pattern, vhloOp.getWindowStridesAttr(), 1ll))
       eraseAttrs(vhloAttrs, "window_strides");
-    if (isSplatTensor(pattern, vhloOp.getPaddingAttr(), 0l))
+    if (isSplatTensor(pattern, vhloOp.getPaddingAttr(), 0ll))
       eraseAttrs(vhloAttrs, "padding");
-    if (isSplatTensor(pattern, vhloOp.getLhsDilationAttr(), 1l))
+    if (isSplatTensor(pattern, vhloOp.getLhsDilationAttr(), 1ll))
       eraseAttrs(vhloAttrs, "lhs_dilation");
-    if (isSplatTensor(pattern, vhloOp.getRhsDilationAttr(), 1l))
+    if (isSplatTensor(pattern, vhloOp.getRhsDilationAttr(), 1ll))
       eraseAttrs(vhloAttrs, "rhs_dilation");
     if (isSplatTensor(pattern, vhloOp.getWindowReversalAttr(), false))
       eraseAttrs(vhloAttrs, "window_reversal");
@@ -633,13 +633,13 @@ LogicalResult removeDefaults(const OpConversionPattern<VhloOpTy>& pattern,
       eraseAttrs(vhloAttrs, "is_host_transfer");
   }
   if constexpr (std::is_same<VhloOpTy, vhlo::ReduceWindowOpV1>::value) {
-    if (isSplatTensor(pattern, vhloOp.getWindowStridesAttr(), 1l))
+    if (isSplatTensor(pattern, vhloOp.getWindowStridesAttr(), 1ll))
       eraseAttrs(vhloAttrs, "window_strides");
-    if (isSplatTensor(pattern, vhloOp.getBaseDilationsAttr(), 1l))
+    if (isSplatTensor(pattern, vhloOp.getBaseDilationsAttr(), 1ll))
       eraseAttrs(vhloAttrs, "base_dilations");
-    if (isSplatTensor(pattern, vhloOp.getWindowDilationsAttr(), 1l))
+    if (isSplatTensor(pattern, vhloOp.getWindowDilationsAttr(), 1ll))
       eraseAttrs(vhloAttrs, "window_dilations");
-    if (isSplatTensor(pattern, vhloOp.getPaddingAttr(), 0l))
+    if (isSplatTensor(pattern, vhloOp.getPaddingAttr(), 0ll))
       eraseAttrs(vhloAttrs, "padding");
   }
   if constexpr (std::is_same<VhloOpTy, vhlo::ScatterOpV1>::value) {
@@ -649,9 +649,9 @@ LogicalResult removeDefaults(const OpConversionPattern<VhloOpTy>& pattern,
       eraseAttrs(vhloAttrs, "unique_indices");
   }
   if constexpr (std::is_same<VhloOpTy, vhlo::SelectAndScatterOpV1>::value) {
-    if (isSplatTensor(pattern, vhloOp.getWindowStridesAttr(), 1l))
+    if (isSplatTensor(pattern, vhloOp.getWindowStridesAttr(), 1ll))
       eraseAttrs(vhloAttrs, "window_strides");
-    if (isSplatTensor(pattern, vhloOp.getPaddingAttr(), 0l))
+    if (isSplatTensor(pattern, vhloOp.getPaddingAttr(), 0ll))
       eraseAttrs(vhloAttrs, "padding");
   }
   if constexpr (std::is_same<VhloOpTy, vhlo::SortOpV1>::value) {


### PR DESCRIPTION
The `long` type is 32 bits wide on Windows, either 32 or 64 bits wide on
Linux (depending on x86 or x64), and 64 bits wide on macOS.
Consequently, when we use bit-shift operators to construct 64-bit
integers or when we check for splat tensors, using (signed or unsigned)
`long` integers can produce incorrect values.

This patch replaces signed and unsigned `long` integer literals with
signed and unsigned `long long` values respectively, so that the
they are always 64 bits wide on all platforms.  As a minor change, this
patch uses the lower-case suffixes (`{u}ll` instead of `{U}LL`) for
consistency.

This patch is in anticipation of downstream users of StableHlo, like
Torch-MLIR (which use Windows and macOS builds), swapping MLIR-HLO with
StableHlo.