### PR TITLE
tests: avoid sub-shells in lit commands for correct use on Windows

### DIFF
--- a/stablehlo/testdata/abs_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/abs_shape_bfloat16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/abs_shape_complex64_20_20.mlir
+++ b/stablehlo/testdata/abs_shape_complex64_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/abs_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/abs_shape_float16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/abs_shape_float32_20_20.mlir
+++ b/stablehlo/testdata/abs_shape_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/abs_shape_int16_20_20.mlir
+++ b/stablehlo/testdata/abs_shape_int16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/abs_shape_int32_20_20.mlir
+++ b/stablehlo/testdata/abs_shape_int32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/abs_shape_int8_20_20.mlir
+++ b/stablehlo/testdata/abs_shape_int8_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/acos_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/acos_shape_bfloat16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/acos_shape_complex64_20_20.mlir
+++ b/stablehlo/testdata/acos_shape_complex64_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/acos_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/acos_shape_float16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/acos_shape_float32_20_20.mlir
+++ b/stablehlo/testdata/acos_shape_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/acosh_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/acosh_shape_bfloat16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/acosh_shape_complex64_20_20.mlir
+++ b/stablehlo/testdata/acosh_shape_complex64_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/acosh_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/acosh_shape_float16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/acosh_shape_float32_20_20.mlir
+++ b/stablehlo/testdata/acosh_shape_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/add_any_dtypes_lhs_bfloat16_2__rhs_bfloat16_2.mlir
+++ b/stablehlo/testdata/add_any_dtypes_lhs_bfloat16_2__rhs_bfloat16_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/add_any_dtypes_lhs_complex64_2__rhs_complex64_2.mlir
+++ b/stablehlo/testdata/add_any_dtypes_lhs_complex64_2__rhs_complex64_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/add_any_dtypes_lhs_float16_2__rhs_float16_2.mlir
+++ b/stablehlo/testdata/add_any_dtypes_lhs_float16_2__rhs_float16_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/add_any_dtypes_lhs_float32_2__rhs_float32_2.mlir
+++ b/stablehlo/testdata/add_any_dtypes_lhs_float32_2__rhs_float32_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/add_any_dtypes_lhs_int16_2__rhs_int16_2.mlir
+++ b/stablehlo/testdata/add_any_dtypes_lhs_int16_2__rhs_int16_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/add_any_dtypes_lhs_int32_2__rhs_int32_2.mlir
+++ b/stablehlo/testdata/add_any_dtypes_lhs_int32_2__rhs_int32_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/add_any_dtypes_lhs_int8_2__rhs_int8_2.mlir
+++ b/stablehlo/testdata/add_any_dtypes_lhs_int8_2__rhs_int8_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/add_any_dtypes_lhs_uint16_2__rhs_uint16_2.mlir
+++ b/stablehlo/testdata/add_any_dtypes_lhs_uint16_2__rhs_uint16_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/add_any_dtypes_lhs_uint32_2__rhs_uint32_2.mlir
+++ b/stablehlo/testdata/add_any_dtypes_lhs_uint32_2__rhs_uint32_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/add_any_dtypes_lhs_uint8_2__rhs_uint8_2.mlir
+++ b/stablehlo/testdata/add_any_dtypes_lhs_uint8_2__rhs_uint8_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/add_broadcasting_lhs_float32_1_20__rhs_float32_20_20.mlir
+++ b/stablehlo/testdata/add_broadcasting_lhs_float32_1_20__rhs_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/add_broadcasting_lhs_float32_20_20__rhs_float32_1_20.mlir
+++ b/stablehlo/testdata/add_broadcasting_lhs_float32_20_20__rhs_float32_1_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/add_dtypes_lhs_bfloat16_20_20__rhs_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/add_dtypes_lhs_bfloat16_20_20__rhs_bfloat16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/add_dtypes_lhs_complex64_20_20__rhs_complex64_20_20.mlir
+++ b/stablehlo/testdata/add_dtypes_lhs_complex64_20_20__rhs_complex64_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/add_dtypes_lhs_float16_20_20__rhs_float16_20_20.mlir
+++ b/stablehlo/testdata/add_dtypes_lhs_float16_20_20__rhs_float16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/add_dtypes_lhs_float32_20_20__rhs_float32_20_20.mlir
+++ b/stablehlo/testdata/add_dtypes_lhs_float32_20_20__rhs_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/add_dtypes_lhs_int16_20_20__rhs_int16_20_20.mlir
+++ b/stablehlo/testdata/add_dtypes_lhs_int16_20_20__rhs_int16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/add_dtypes_lhs_int32_20_20__rhs_int32_20_20.mlir
+++ b/stablehlo/testdata/add_dtypes_lhs_int32_20_20__rhs_int32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/add_dtypes_lhs_int8_20_20__rhs_int8_20_20.mlir
+++ b/stablehlo/testdata/add_dtypes_lhs_int8_20_20__rhs_int8_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/add_dtypes_lhs_uint16_20_20__rhs_uint16_20_20.mlir
+++ b/stablehlo/testdata/add_dtypes_lhs_uint16_20_20__rhs_uint16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/add_dtypes_lhs_uint32_20_20__rhs_uint32_20_20.mlir
+++ b/stablehlo/testdata/add_dtypes_lhs_uint32_20_20__rhs_uint32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/add_dtypes_lhs_uint8_20_20__rhs_uint8_20_20.mlir
+++ b/stablehlo/testdata/add_dtypes_lhs_uint8_20_20__rhs_uint8_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/add_dynamic.mlir
+++ b/stablehlo/testdata/add_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}, %arg2: tensor<2x?x4xf32> {mhlo.sharding = ""}) -> tensor<2x?x4xf32> {

--- a/stablehlo/testdata/add_transpose_dynamic.mlir
+++ b/stablehlo/testdata/add_transpose_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}) -> tensor<?x4xf32> {

--- a/stablehlo/testdata/and_broadcasting_lhs_int32_1_20__rhs_int32_20_20.mlir
+++ b/stablehlo/testdata/and_broadcasting_lhs_int32_1_20__rhs_int32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/and_broadcasting_lhs_int32_20_20__rhs_int32_1_20.mlir
+++ b/stablehlo/testdata/and_broadcasting_lhs_int32_20_20__rhs_int32_1_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/and_dtypes_lhs_bool_20_20__rhs_bool_20_20.mlir
+++ b/stablehlo/testdata/and_dtypes_lhs_bool_20_20__rhs_bool_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/and_dtypes_lhs_int16_20_20__rhs_int16_20_20.mlir
+++ b/stablehlo/testdata/and_dtypes_lhs_int16_20_20__rhs_int16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/and_dtypes_lhs_int32_20_20__rhs_int32_20_20.mlir
+++ b/stablehlo/testdata/and_dtypes_lhs_int32_20_20__rhs_int32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/and_dtypes_lhs_int8_20_20__rhs_int8_20_20.mlir
+++ b/stablehlo/testdata/and_dtypes_lhs_int8_20_20__rhs_int8_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/and_dtypes_lhs_uint16_20_20__rhs_uint16_20_20.mlir
+++ b/stablehlo/testdata/and_dtypes_lhs_uint16_20_20__rhs_uint16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/and_dtypes_lhs_uint32_20_20__rhs_uint32_20_20.mlir
+++ b/stablehlo/testdata/and_dtypes_lhs_uint32_20_20__rhs_uint32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/and_dtypes_lhs_uint8_20_20__rhs_uint8_20_20.mlir
+++ b/stablehlo/testdata/and_dtypes_lhs_uint8_20_20__rhs_uint8_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/arange_start_enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/arange_start_enable_xla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?xf32> {mhlo.sharding = ""}) -> tensor<?xf32> {

--- a/stablehlo/testdata/arange_start_no_dtype_dynamic.mlir
+++ b/stablehlo/testdata/arange_start_no_dtype_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?xf32> {mhlo.sharding = ""}) -> tensor<?xf32> {

--- a/stablehlo/testdata/argmax_0_enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/argmax_0_enable_xla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x5xf32> {mhlo.sharding = ""}) -> tensor<4x5xi32> {

--- a/stablehlo/testdata/argmax_1_enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/argmax_1_enable_xla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x5xf32> {mhlo.sharding = ""}) -> tensor<?x5xi32> {

--- a/stablehlo/testdata/argmax_axes_shape_float32_18_12__axes__1___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmax_axes_shape_float32_18_12__axes__1___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmax_dtypes_shape_bfloat16_15__axes__0___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmax_dtypes_shape_bfloat16_15__axes__0___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmax_dtypes_shape_bool_15__axes__0___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmax_dtypes_shape_bool_15__axes__0___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmax_dtypes_shape_float16_15__axes__0___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmax_dtypes_shape_float16_15__axes__0___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmax_dtypes_shape_float32_15__axes__0___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmax_dtypes_shape_float32_15__axes__0___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmax_dtypes_shape_int16_15__axes__0___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmax_dtypes_shape_int16_15__axes__0___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmax_dtypes_shape_int32_15__axes__0___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmax_dtypes_shape_int32_15__axes__0___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmax_dtypes_shape_int8_15__axes__0___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmax_dtypes_shape_int8_15__axes__0___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmax_dtypes_shape_uint16_15__axes__0___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmax_dtypes_shape_uint16_15__axes__0___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmax_dtypes_shape_uint32_15__axes__0___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmax_dtypes_shape_uint32_15__axes__0___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmax_dtypes_shape_uint8_15__axes__0___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmax_dtypes_shape_uint8_15__axes__0___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmax_index_dtype_shape_float32_15__axes__0___indexdtype_int16_enablexla_True.mlir
+++ b/stablehlo/testdata/argmax_index_dtype_shape_float32_15__axes__0___indexdtype_int16_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmax_index_dtype_shape_float32_15__axes__0___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmax_index_dtype_shape_float32_15__axes__0___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmax_index_dtype_shape_float32_15__axes__0___indexdtype_int8_enablexla_True.mlir
+++ b/stablehlo/testdata/argmax_index_dtype_shape_float32_15__axes__0___indexdtype_int8_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmax_index_dtype_shape_float32_15__axes__0___indexdtype_uint16_enablexla_True.mlir
+++ b/stablehlo/testdata/argmax_index_dtype_shape_float32_15__axes__0___indexdtype_uint16_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmax_index_dtype_shape_float32_15__axes__0___indexdtype_uint32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmax_index_dtype_shape_float32_15__axes__0___indexdtype_uint32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmax_index_dtype_shape_float32_15__axes__0___indexdtype_uint8_enablexla_True.mlir
+++ b/stablehlo/testdata/argmax_index_dtype_shape_float32_15__axes__0___indexdtype_uint8_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmax_special_equal_shape_int32_3__axes__0___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmax_special_equal_shape_int32_3__axes__0___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmax_special_inf_0_shape_float32_4__axes__0___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmax_special_inf_0_shape_float32_4__axes__0___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmax_special_inf_1_shape_float32_4__axes__0___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmax_special_inf_1_shape_float32_4__axes__0___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmax_special_inf_2_shape_float32_4__axes__0___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmax_special_inf_2_shape_float32_4__axes__0___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmax_special_inf_3_shape_float32_4__axes__0___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmax_special_inf_3_shape_float32_4__axes__0___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmax_special_nan_0_shape_float32_6__axes__0___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmax_special_nan_0_shape_float32_6__axes__0___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmax_special_nan_1_shape_float32_4__axes__0___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmax_special_nan_1_shape_float32_4__axes__0___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmax_special_nan_inf_0_shape_float32_4__axes__0___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmax_special_nan_inf_0_shape_float32_4__axes__0___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmax_special_nan_inf_1_shape_float32_4__axes__0___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmax_special_nan_inf_1_shape_float32_4__axes__0___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmax_special_singleton_shape_float32_1__axes__0___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmax_special_singleton_shape_float32_1__axes__0___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmin_axes_shape_float32_18_12__axes__1___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmin_axes_shape_float32_18_12__axes__1___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmin_dtypes_shape_bfloat16_15__axes__0___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmin_dtypes_shape_bfloat16_15__axes__0___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmin_dtypes_shape_bool_15__axes__0___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmin_dtypes_shape_bool_15__axes__0___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmin_dtypes_shape_float16_15__axes__0___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmin_dtypes_shape_float16_15__axes__0___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmin_dtypes_shape_float32_15__axes__0___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmin_dtypes_shape_float32_15__axes__0___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmin_dtypes_shape_int16_15__axes__0___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmin_dtypes_shape_int16_15__axes__0___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmin_dtypes_shape_int32_15__axes__0___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmin_dtypes_shape_int32_15__axes__0___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmin_dtypes_shape_int8_15__axes__0___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmin_dtypes_shape_int8_15__axes__0___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmin_dtypes_shape_uint16_15__axes__0___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmin_dtypes_shape_uint16_15__axes__0___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmin_dtypes_shape_uint32_15__axes__0___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmin_dtypes_shape_uint32_15__axes__0___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmin_dtypes_shape_uint8_15__axes__0___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmin_dtypes_shape_uint8_15__axes__0___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmin_index_dtype_shape_float32_15__axes__0___indexdtype_int16_enablexla_True.mlir
+++ b/stablehlo/testdata/argmin_index_dtype_shape_float32_15__axes__0___indexdtype_int16_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmin_index_dtype_shape_float32_15__axes__0___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmin_index_dtype_shape_float32_15__axes__0___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmin_index_dtype_shape_float32_15__axes__0___indexdtype_int8_enablexla_True.mlir
+++ b/stablehlo/testdata/argmin_index_dtype_shape_float32_15__axes__0___indexdtype_int8_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmin_index_dtype_shape_float32_15__axes__0___indexdtype_uint16_enablexla_True.mlir
+++ b/stablehlo/testdata/argmin_index_dtype_shape_float32_15__axes__0___indexdtype_uint16_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmin_index_dtype_shape_float32_15__axes__0___indexdtype_uint32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmin_index_dtype_shape_float32_15__axes__0___indexdtype_uint32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmin_index_dtype_shape_float32_15__axes__0___indexdtype_uint8_enablexla_True.mlir
+++ b/stablehlo/testdata/argmin_index_dtype_shape_float32_15__axes__0___indexdtype_uint8_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmin_special_equal_shape_int32_3__axes__0___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmin_special_equal_shape_int32_3__axes__0___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmin_special_inf_0_shape_float32_4__axes__0___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmin_special_inf_0_shape_float32_4__axes__0___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmin_special_inf_1_shape_float32_4__axes__0___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmin_special_inf_1_shape_float32_4__axes__0___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmin_special_inf_2_shape_float32_4__axes__0___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmin_special_inf_2_shape_float32_4__axes__0___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmin_special_inf_3_shape_float32_4__axes__0___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmin_special_inf_3_shape_float32_4__axes__0___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmin_special_nan_0_shape_float32_6__axes__0___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmin_special_nan_0_shape_float32_6__axes__0___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmin_special_nan_1_shape_float32_4__axes__0___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmin_special_nan_1_shape_float32_4__axes__0___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmin_special_nan_inf_0_shape_float32_4__axes__0___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmin_special_nan_inf_0_shape_float32_4__axes__0___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmin_special_nan_inf_1_shape_float32_4__axes__0___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmin_special_nan_inf_1_shape_float32_4__axes__0___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/argmin_special_singleton_shape_float32_1__axes__0___indexdtype_int32_enablexla_True.mlir
+++ b/stablehlo/testdata/argmin_special_singleton_shape_float32_1__axes__0___indexdtype_int32_enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/asin_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/asin_shape_bfloat16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/asin_shape_complex64_20_20.mlir
+++ b/stablehlo/testdata/asin_shape_complex64_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/asin_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/asin_shape_float16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/asin_shape_float32_20_20.mlir
+++ b/stablehlo/testdata/asin_shape_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/asinh_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/asinh_shape_bfloat16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/asinh_shape_complex64_20_20.mlir
+++ b/stablehlo/testdata/asinh_shape_complex64_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/asinh_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/asinh_shape_float16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/asinh_shape_float32_20_20.mlir
+++ b/stablehlo/testdata/asinh_shape_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/atan2_broadcasting_lhs_float32_1_20__rhs_float32_20_20.mlir
+++ b/stablehlo/testdata/atan2_broadcasting_lhs_float32_1_20__rhs_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/atan2_broadcasting_lhs_float32_20_20__rhs_float32_1_20.mlir
+++ b/stablehlo/testdata/atan2_broadcasting_lhs_float32_20_20__rhs_float32_1_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/atan2_dtypes_lhs_bfloat16_20_20__rhs_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/atan2_dtypes_lhs_bfloat16_20_20__rhs_bfloat16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/atan2_dtypes_lhs_float16_20_20__rhs_float16_20_20.mlir
+++ b/stablehlo/testdata/atan2_dtypes_lhs_float16_20_20__rhs_float16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/atan2_dtypes_lhs_float32_20_20__rhs_float32_20_20.mlir
+++ b/stablehlo/testdata/atan2_dtypes_lhs_float32_20_20__rhs_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/atan_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/atan_shape_bfloat16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/atan_shape_complex64_20_20.mlir
+++ b/stablehlo/testdata/atan_shape_complex64_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/atan_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/atan_shape_float16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/atan_shape_float32_20_20.mlir
+++ b/stablehlo/testdata/atan_shape_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/atanh_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/atanh_shape_bfloat16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/atanh_shape_complex64_20_20.mlir
+++ b/stablehlo/testdata/atanh_shape_complex64_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/atanh_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/atanh_shape_float16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/atanh_shape_float32_20_20.mlir
+++ b/stablehlo/testdata/atanh_shape_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/average_axis_0_weights_None_dynamic.mlir
+++ b/stablehlo/testdata/average_axis_0_weights_None_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8x4xf32> {mhlo.sharding = ""}) -> tensor<8x4xf32> {

--- a/stablehlo/testdata/average_axis_0_weights_Some_dynamic.mlir
+++ b/stablehlo/testdata/average_axis_0_weights_Some_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8x4xf32> {mhlo.sharding = ""}, %arg2: tensor<?x8x4xf32> {mhlo.sharding = ""}) -> tensor<8x4xf32> {

--- a/stablehlo/testdata/average_axis_1_weights_None_dynamic.mlir
+++ b/stablehlo/testdata/average_axis_1_weights_None_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8x4xf32> {mhlo.sharding = ""}) -> tensor<?x4xf32> {

--- a/stablehlo/testdata/average_axis_1_weights_Some_dynamic.mlir
+++ b/stablehlo/testdata/average_axis_1_weights_Some_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8x4xf32> {mhlo.sharding = ""}, %arg2: tensor<?x8x4xf32> {mhlo.sharding = ""}) -> tensor<?x4xf32> {

--- a/stablehlo/testdata/average_axis_None_weights_None_dynamic.mlir
+++ b/stablehlo/testdata/average_axis_None_weights_None_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8x4xf32> {mhlo.sharding = ""}) -> tensor<f32> {

--- a/stablehlo/testdata/average_axis_None_weights_Some_dynamic.mlir
+++ b/stablehlo/testdata/average_axis_None_weights_Some_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8x4xf32> {mhlo.sharding = ""}, %arg2: tensor<?x8x4xf32> {mhlo.sharding = ""}) -> tensor<f32> {

--- a/stablehlo/testdata/bessel_i0e_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/bessel_i0e_shape_bfloat16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/bessel_i0e_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/bessel_i0e_shape_float16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/bessel_i0e_shape_float32_20_20.mlir
+++ b/stablehlo/testdata/bessel_i0e_shape_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/bessel_i1e_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/bessel_i1e_shape_bfloat16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/bessel_i1e_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/bessel_i1e_shape_float16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/bessel_i1e_shape_float32_20_20.mlir
+++ b/stablehlo/testdata/bessel_i1e_shape_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_bfloat16_2_3__newdtype_bfloat16.mlir
+++ b/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_bfloat16_2_3__newdtype_bfloat16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_bfloat16_2_3__newdtype_float16.mlir
+++ b/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_bfloat16_2_3__newdtype_float16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_bfloat16_2_3__newdtype_int16.mlir
+++ b/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_bfloat16_2_3__newdtype_int16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_bfloat16_2_3__newdtype_uint16.mlir
+++ b/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_bfloat16_2_3__newdtype_uint16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_bool_2_3__newdtype_bool.mlir
+++ b/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_bool_2_3__newdtype_bool.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_complex64_2_3__newdtype_complex64.mlir
+++ b/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_complex64_2_3__newdtype_complex64.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_float16_2_3__newdtype_bfloat16.mlir
+++ b/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_float16_2_3__newdtype_bfloat16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_float16_2_3__newdtype_float16.mlir
+++ b/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_float16_2_3__newdtype_float16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_float16_2_3__newdtype_int16.mlir
+++ b/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_float16_2_3__newdtype_int16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_float16_2_3__newdtype_uint16.mlir
+++ b/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_float16_2_3__newdtype_uint16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_float32_2_3__newdtype_float32.mlir
+++ b/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_float32_2_3__newdtype_float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_float32_2_3__newdtype_int32.mlir
+++ b/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_float32_2_3__newdtype_int32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_float32_2_3__newdtype_uint32.mlir
+++ b/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_float32_2_3__newdtype_uint32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_int16_2_3__newdtype_bfloat16.mlir
+++ b/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_int16_2_3__newdtype_bfloat16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_int16_2_3__newdtype_float16.mlir
+++ b/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_int16_2_3__newdtype_float16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_int16_2_3__newdtype_int16.mlir
+++ b/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_int16_2_3__newdtype_int16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_int16_2_3__newdtype_uint16.mlir
+++ b/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_int16_2_3__newdtype_uint16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_int32_2_3__newdtype_float32.mlir
+++ b/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_int32_2_3__newdtype_float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_int32_2_3__newdtype_int32.mlir
+++ b/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_int32_2_3__newdtype_int32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_int32_2_3__newdtype_uint32.mlir
+++ b/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_int32_2_3__newdtype_uint32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_int8_2_3__newdtype_int8.mlir
+++ b/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_int8_2_3__newdtype_int8.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_int8_2_3__newdtype_uint8.mlir
+++ b/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_int8_2_3__newdtype_uint8.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_uint16_2_3__newdtype_bfloat16.mlir
+++ b/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_uint16_2_3__newdtype_bfloat16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_uint16_2_3__newdtype_float16.mlir
+++ b/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_uint16_2_3__newdtype_float16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_uint16_2_3__newdtype_int16.mlir
+++ b/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_uint16_2_3__newdtype_int16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_uint16_2_3__newdtype_uint16.mlir
+++ b/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_uint16_2_3__newdtype_uint16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_uint32_2_3__newdtype_float32.mlir
+++ b/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_uint32_2_3__newdtype_float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_uint32_2_3__newdtype_int32.mlir
+++ b/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_uint32_2_3__newdtype_int32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_uint32_2_3__newdtype_uint32.mlir
+++ b/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_uint32_2_3__newdtype_uint32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_uint8_2_3__newdtype_int8.mlir
+++ b/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_uint8_2_3__newdtype_int8.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_uint8_2_3__newdtype_uint8.mlir
+++ b/stablehlo/testdata/bitcast_convert_type_dtypes_to_new_dtypes_shape_uint8_2_3__newdtype_uint8.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/broadcast_in_dim_0_dynamic.mlir
+++ b/stablehlo/testdata/broadcast_in_dim_0_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x6xf32> {mhlo.sharding = ""}) -> tensor<?x4x5x6xf32> {

--- a/stablehlo/testdata/broadcast_in_dim_dtypes_shape_bfloat16_2__outshape__2___broadcastdimensions__0.mlir
+++ b/stablehlo/testdata/broadcast_in_dim_dtypes_shape_bfloat16_2__outshape__2___broadcastdimensions__0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/broadcast_in_dim_dtypes_shape_bool_2__outshape__2___broadcastdimensions__0.mlir
+++ b/stablehlo/testdata/broadcast_in_dim_dtypes_shape_bool_2__outshape__2___broadcastdimensions__0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/broadcast_in_dim_dtypes_shape_complex64_2__outshape__2___broadcastdimensions__0.mlir
+++ b/stablehlo/testdata/broadcast_in_dim_dtypes_shape_complex64_2__outshape__2___broadcastdimensions__0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/broadcast_in_dim_dtypes_shape_float16_2__outshape__2___broadcastdimensions__0.mlir
+++ b/stablehlo/testdata/broadcast_in_dim_dtypes_shape_float16_2__outshape__2___broadcastdimensions__0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/broadcast_in_dim_dtypes_shape_float32_2__outshape__2___broadcastdimensions__0.mlir
+++ b/stablehlo/testdata/broadcast_in_dim_dtypes_shape_float32_2__outshape__2___broadcastdimensions__0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/broadcast_in_dim_dtypes_shape_int16_2__outshape__2___broadcastdimensions__0.mlir
+++ b/stablehlo/testdata/broadcast_in_dim_dtypes_shape_int16_2__outshape__2___broadcastdimensions__0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/broadcast_in_dim_dtypes_shape_int32_2__outshape__2___broadcastdimensions__0.mlir
+++ b/stablehlo/testdata/broadcast_in_dim_dtypes_shape_int32_2__outshape__2___broadcastdimensions__0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/broadcast_in_dim_dtypes_shape_int8_2__outshape__2___broadcastdimensions__0.mlir
+++ b/stablehlo/testdata/broadcast_in_dim_dtypes_shape_int8_2__outshape__2___broadcastdimensions__0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/broadcast_in_dim_dtypes_shape_uint16_2__outshape__2___broadcastdimensions__0.mlir
+++ b/stablehlo/testdata/broadcast_in_dim_dtypes_shape_uint16_2__outshape__2___broadcastdimensions__0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/broadcast_in_dim_dtypes_shape_uint32_2__outshape__2___broadcastdimensions__0.mlir
+++ b/stablehlo/testdata/broadcast_in_dim_dtypes_shape_uint32_2__outshape__2___broadcastdimensions__0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/broadcast_in_dim_dtypes_shape_uint8_2__outshape__2___broadcastdimensions__0.mlir
+++ b/stablehlo/testdata/broadcast_in_dim_dtypes_shape_uint8_2__outshape__2___broadcastdimensions__0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/broadcast_in_dim_parameter_combinations_shape_float32_1_2__outshape__4__3__2__broadcastdimensions__0__2.mlir
+++ b/stablehlo/testdata/broadcast_in_dim_parameter_combinations_shape_float32_1_2__outshape__4__3__2__broadcastdimensions__0__2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/broadcast_in_dim_parameter_combinations_shape_float32_2__outshape__2__3__broadcastdimensions__0.mlir
+++ b/stablehlo/testdata/broadcast_in_dim_parameter_combinations_shape_float32_2__outshape__2__3__broadcastdimensions__0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/broadcast_in_dim_parameter_combinations_shape_float32_2__outshape__3__2__broadcastdimensions__1.mlir
+++ b/stablehlo/testdata/broadcast_in_dim_parameter_combinations_shape_float32_2__outshape__3__2__broadcastdimensions__1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/broadcast_in_dim_parameter_combinations_shape_float32___outshape__2__3__broadcastdimensions.mlir
+++ b/stablehlo/testdata/broadcast_in_dim_parameter_combinations_shape_float32___outshape__2__3__broadcastdimensions.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/broadcast_in_dim_poly2_dynamic.mlir
+++ b/stablehlo/testdata/broadcast_in_dim_poly2_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<i64>, %arg2: tensor<?x1x?xf32> {mhlo.sharding = ""}) -> tensor<?x5x6x?x4xf32> {

--- a/stablehlo/testdata/broadcast_in_dim_poly_dynamic.mlir
+++ b/stablehlo/testdata/broadcast_in_dim_poly_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x4xf32> {mhlo.sharding = ""}) -> tensor<?x?x4xf32> {

--- a/stablehlo/testdata/broadcast_in_dim_transpose_dynamic.mlir
+++ b/stablehlo/testdata/broadcast_in_dim_transpose_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<i64>, %arg2: tensor<?x1x?xf32> {mhlo.sharding = ""}) -> tensor<?x1x?xf32> {

--- a/stablehlo/testdata/broadcast_to_dynamic.mlir
+++ b/stablehlo/testdata/broadcast_to_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}) -> tensor<?x?x4xf32> {

--- a/stablehlo/testdata/cbrt_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/cbrt_shape_bfloat16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cbrt_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/cbrt_shape_float16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cbrt_shape_float32_20_20.mlir
+++ b/stablehlo/testdata/cbrt_shape_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/ceil_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/ceil_shape_bfloat16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/ceil_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/ceil_shape_float16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/ceil_shape_float32_20_20.mlir
+++ b/stablehlo/testdata/ceil_shape_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/clamp_broadcasting_min_float32_2_3__operand_float32_2_3__max_float32.mlir
+++ b/stablehlo/testdata/clamp_broadcasting_min_float32_2_3__operand_float32_2_3__max_float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/clamp_broadcasting_min_float32_2_3__operand_float32_2_3__max_float32_2_3.mlir
+++ b/stablehlo/testdata/clamp_broadcasting_min_float32_2_3__operand_float32_2_3__max_float32_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/clamp_broadcasting_min_float32___operand_float32_2_3__max_float32_2_3.mlir
+++ b/stablehlo/testdata/clamp_broadcasting_min_float32___operand_float32_2_3__max_float32_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/clamp_dtypes_min_bfloat16___operand_bfloat16_2_3__max_bfloat16.mlir
+++ b/stablehlo/testdata/clamp_dtypes_min_bfloat16___operand_bfloat16_2_3__max_bfloat16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/clamp_dtypes_min_float16___operand_float16_2_3__max_float16.mlir
+++ b/stablehlo/testdata/clamp_dtypes_min_float16___operand_float16_2_3__max_float16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/clamp_dtypes_min_float32___operand_float32_2_3__max_float32.mlir
+++ b/stablehlo/testdata/clamp_dtypes_min_float32___operand_float32_2_3__max_float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/clamp_dtypes_min_int16___operand_int16_2_3__max_int16.mlir
+++ b/stablehlo/testdata/clamp_dtypes_min_int16___operand_int16_2_3__max_int16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/clamp_dtypes_min_int32___operand_int32_2_3__max_int32.mlir
+++ b/stablehlo/testdata/clamp_dtypes_min_int32___operand_int32_2_3__max_int32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/clamp_dtypes_min_int8___operand_int8_2_3__max_int8.mlir
+++ b/stablehlo/testdata/clamp_dtypes_min_int8___operand_int8_2_3__max_int8.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/clamp_dtypes_min_uint16___operand_uint16_2_3__max_uint16.mlir
+++ b/stablehlo/testdata/clamp_dtypes_min_uint16___operand_uint16_2_3__max_uint16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/clamp_dtypes_min_uint32___operand_uint32_2_3__max_uint32.mlir
+++ b/stablehlo/testdata/clamp_dtypes_min_uint32___operand_uint32_2_3__max_uint32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/clamp_dtypes_min_uint8___operand_uint8_2_3__max_uint8.mlir
+++ b/stablehlo/testdata/clamp_dtypes_min_uint8___operand_uint8_2_3__max_uint8.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/clamp_dynamic.mlir
+++ b/stablehlo/testdata/clamp_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x5xf32> {mhlo.sharding = ""}, %arg2: tensor<?x4x5xf32> {mhlo.sharding = ""}, %arg3: tensor<?x4x5xf32> {mhlo.sharding = ""}) -> tensor<?x4x5xf32> {

--- a/stablehlo/testdata/clamp_order_False_min_float32___operand_float32_2_3__max_float32.mlir
+++ b/stablehlo/testdata/clamp_order_False_min_float32___operand_float32_2_3__max_float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/clamp_order_True_min_float32___operand_float32_2_3__max_float32.mlir
+++ b/stablehlo/testdata/clamp_order_True_min_float32___operand_float32_2_3__max_float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/collapse_dynamic.mlir
+++ b/stablehlo/testdata/collapse_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<i64>, %arg2: tensor<i64>, %arg3: tensor<?x?x5x?x7xf32> {mhlo.sharding = ""}) -> tensor<?x?x7xf32> {

--- a/stablehlo/testdata/complex_broadcast_lhs_float32_3_1__rhs_float32_3_2.mlir
+++ b/stablehlo/testdata/complex_broadcast_lhs_float32_3_1__rhs_float32_3_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/complex_broadcast_lhs_float32_3_2__rhs_float32_3_1.mlir
+++ b/stablehlo/testdata/complex_broadcast_lhs_float32_3_2__rhs_float32_3_1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/complex_dtypes_lhs_float32_3_4__rhs_float32_3_4.mlir
+++ b/stablehlo/testdata/complex_dtypes_lhs_float32_3_4__rhs_float32_3_4.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/concatenate_dimension_shapes_float32_2_3__float32_2_3__dimension_1.mlir
+++ b/stablehlo/testdata/concatenate_dimension_shapes_float32_2_3__float32_2_3__dimension_1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/concatenate_dtypes_shapes_bfloat16_2_3__bfloat16_2_3__dimension_0.mlir
+++ b/stablehlo/testdata/concatenate_dtypes_shapes_bfloat16_2_3__bfloat16_2_3__dimension_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/concatenate_dtypes_shapes_bool_2_3__bool_2_3__dimension_0.mlir
+++ b/stablehlo/testdata/concatenate_dtypes_shapes_bool_2_3__bool_2_3__dimension_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/concatenate_dtypes_shapes_complex64_2_3__complex64_2_3__dimension_0.mlir
+++ b/stablehlo/testdata/concatenate_dtypes_shapes_complex64_2_3__complex64_2_3__dimension_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/concatenate_dtypes_shapes_float16_2_3__float16_2_3__dimension_0.mlir
+++ b/stablehlo/testdata/concatenate_dtypes_shapes_float16_2_3__float16_2_3__dimension_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/concatenate_dtypes_shapes_float32_2_3__float32_2_3__dimension_0.mlir
+++ b/stablehlo/testdata/concatenate_dtypes_shapes_float32_2_3__float32_2_3__dimension_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/concatenate_dtypes_shapes_int16_2_3__int16_2_3__dimension_0.mlir
+++ b/stablehlo/testdata/concatenate_dtypes_shapes_int16_2_3__int16_2_3__dimension_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/concatenate_dtypes_shapes_int32_2_3__int32_2_3__dimension_0.mlir
+++ b/stablehlo/testdata/concatenate_dtypes_shapes_int32_2_3__int32_2_3__dimension_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/concatenate_dtypes_shapes_int8_2_3__int8_2_3__dimension_0.mlir
+++ b/stablehlo/testdata/concatenate_dtypes_shapes_int8_2_3__int8_2_3__dimension_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/concatenate_dtypes_shapes_uint16_2_3__uint16_2_3__dimension_0.mlir
+++ b/stablehlo/testdata/concatenate_dtypes_shapes_uint16_2_3__uint16_2_3__dimension_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/concatenate_dtypes_shapes_uint32_2_3__uint32_2_3__dimension_0.mlir
+++ b/stablehlo/testdata/concatenate_dtypes_shapes_uint32_2_3__uint32_2_3__dimension_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/concatenate_dtypes_shapes_uint8_2_3__uint8_2_3__dimension_0.mlir
+++ b/stablehlo/testdata/concatenate_dtypes_shapes_uint8_2_3__uint8_2_3__dimension_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/concatenate_dynamic.mlir
+++ b/stablehlo/testdata/concatenate_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<i64>, %arg2: tensor<?x?x5xf32> {mhlo.sharding = ""}) -> tensor<?x?x5xf32> {

--- a/stablehlo/testdata/concatenate_grad_dynamic.mlir
+++ b/stablehlo/testdata/concatenate_grad_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<i64>, %arg2: tensor<?x?x5xf32> {mhlo.sharding = ""}) -> tensor<?x?x5xf32> {

--- a/stablehlo/testdata/concatenate_nb_operands_shapes_float32_2_3_4__float32_3_3_4__float32_4_3_4__dimension_0.mlir
+++ b/stablehlo/testdata/concatenate_nb_operands_shapes_float32_2_3_4__float32_3_3_4__float32_4_3_4__dimension_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conj_dtypes_operand_complex64_3_4__kwargs.mlir
+++ b/stablehlo/testdata/conj_dtypes_operand_complex64_3_4__kwargs.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conj_dtypes_operand_float32_3_4__kwargs.mlir
+++ b/stablehlo/testdata/conj_dtypes_operand_float32_3_4__kwargs.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conj_kwargs_operand_float32_3_4__kwargs____input_dtype___class_numpy_float32.mlir
+++ b/stablehlo/testdata/conj_kwargs_operand_float32_3_4__kwargs____input_dtype___class_numpy_float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_1d_2_enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/conv_general_dilated_1d_2_enable_xla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x12x16xf32> {mhlo.sharding = ""}, %arg2: tensor<4x16x16xf32> {mhlo.sharding = ""}) -> tensor<?x24x16xf32> {

--- a/stablehlo/testdata/conv_general_dilated_1d_3_enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/conv_general_dilated_1d_3_enable_xla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<5x?x16xf32> {mhlo.sharding = ""}, %arg2: tensor<4x16x16xf32> {mhlo.sharding = ""}) -> tensor<5x?x16xf32> {

--- a/stablehlo/testdata/conv_general_dilated_1d_stride_1_enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/conv_general_dilated_1d_stride_1_enable_xla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<1x?x16xf32> {mhlo.sharding = ""}, %arg2: tensor<4x16x16xf32> {mhlo.sharding = ""}) -> tensor<1x?x16xf32> {

--- a/stablehlo/testdata/conv_general_dilated_1d_stride_2_even_enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/conv_general_dilated_1d_stride_2_even_enable_xla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<1x?x16xf32> {mhlo.sharding = ""}, %arg2: tensor<4x16x16xf32> {mhlo.sharding = ""}) -> tensor<1x?x16xf32> {

--- a/stablehlo/testdata/conv_general_dilated_1d_stride_2_odd_enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/conv_general_dilated_1d_stride_2_odd_enable_xla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<1x?x16xf32> {mhlo.sharding = ""}, %arg2: tensor<4x16x16xf32> {mhlo.sharding = ""}) -> tensor<1x?x16xf32> {

--- a/stablehlo/testdata/conv_general_dilated__enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/conv_general_dilated__enable_xla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x3x9x10xf32> {mhlo.sharding = ""}, %arg2: tensor<3x3x4x5xf32> {mhlo.sharding = ""}) -> tensor<?x3x3x1xf32> {

--- a/stablehlo/testdata/conv_general_dilated_conv1d_lhs_float32_2_3_10__rhs_float32_3_3_5__windowstrides__1___padding___0_0_3336387849681708224.mlir
+++ b/stablehlo/testdata/conv_general_dilated_conv1d_lhs_float32_2_3_10__rhs_float32_3_3_5__windowstrides__1___padding___0_0_3336387849681708224.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_conv_tranpose1d_same_padding_lhs_float32_1_16_2__rhs_float32_3_2_2__windowstrid-2801039169040378295.mlir
+++ b/stablehlo/testdata/conv_general_dilated_conv_tranpose1d_same_padding_lhs_float32_1_16_2__rhs_float32_3_2_2__windowstrid-2801039169040378295.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_conv_tranpose1d_valid_padding_lhs_float32_1_16_2__rhs_float32_3_2_2__windowstri-8415303397313720110.mlir
+++ b/stablehlo/testdata/conv_general_dilated_conv_tranpose1d_valid_padding_lhs_float32_1_16_2__rhs_float32_3_2_2__windowstri-8415303397313720110.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_conv_tranpose2d_same_padding_lhs_float32_1_16_16_2__rhs_float32_2_3_2_2__window-296817466026258822.mlir
+++ b/stablehlo/testdata/conv_general_dilated_conv_tranpose2d_same_padding_lhs_float32_1_16_16_2__rhs_float32_2_3_2_2__window-296817466026258822.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_conv_tranpose2d_valid_padding_lhs_float32_1_16_16_2__rhs_float32_2_3_2_2__windo216554503587864094.mlir
+++ b/stablehlo/testdata/conv_general_dilated_conv_tranpose2d_valid_padding_lhs_float32_1_16_16_2__rhs_float32_2_3_2_2__windo216554503587864094.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_depthwise1d_dilated_lhs_float32_2_3_9__rhs_float32_12_1_3__windowstrides__1___p4726467912149865720.mlir
+++ b/stablehlo/testdata/conv_general_dilated_depthwise1d_dilated_lhs_float32_2_3_9__rhs_float32_12_1_3__windowstrides__1___p4726467912149865720.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_depthwise1d_lhs_float32_2_3_9__rhs_float32_12_1_3__windowstrides__1___padding__2025442285785167829.mlir
+++ b/stablehlo/testdata/conv_general_dilated_depthwise1d_lhs_float32_2_3_9__rhs_float32_12_1_3__windowstrides__1___padding__2025442285785167829.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_depthwise2d_dilated_lhs_float32_2_3_9_9__rhs_float32_12_1_3_3__windowstrides__1-5299255563318388077.mlir
+++ b/stablehlo/testdata/conv_general_dilated_depthwise2d_dilated_lhs_float32_2_3_9_9__rhs_float32_12_1_3_3__windowstrides__1-5299255563318388077.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_depthwise2d_lhs_float32_2_3_9_9__rhs_float32_12_1_3_3__windowstrides__1_1__padd-5494580149111736437.mlir
+++ b/stablehlo/testdata/conv_general_dilated_depthwise2d_lhs_float32_2_3_9_9__rhs_float32_12_1_3_3__windowstrides__1_1__padd-5494580149111736437.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_dilations_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__paddin-940783895638600378.mlir
+++ b/stablehlo/testdata/conv_general_dilated_dilations_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__paddin-940783895638600378.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_dilations_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__paddin7803468828575064957.mlir
+++ b/stablehlo/testdata/conv_general_dilated_dilations_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__paddin7803468828575064957.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_dilations_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__paddin8362069580368565836.mlir
+++ b/stablehlo/testdata/conv_general_dilated_dilations_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__paddin8362069580368565836.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_dimension_numbers_lhs_float32_2_3_9_10__rhs_float32_4_5_3_3__windowstrides__1_1-8327739261064575227.mlir
+++ b/stablehlo/testdata/conv_general_dilated_dimension_numbers_lhs_float32_2_3_9_10__rhs_float32_4_5_3_3__windowstrides__1_1-8327739261064575227.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_dimension_numbers_lhs_float32_2_9_10_3__rhs_float32_4_5_3_3__windowstrides__1_1-6479296361709234045.mlir
+++ b/stablehlo/testdata/conv_general_dilated_dimension_numbers_lhs_float32_2_9_10_3__rhs_float32_4_5_3_3__windowstrides__1_1-6479296361709234045.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_dtype_precision_lhs_bfloat16_2_3_9_10__rhs_bfloat16_3_3_4_5__windowstrides__1_1-2828133577370001365.mlir
+++ b/stablehlo/testdata/conv_general_dilated_dtype_precision_lhs_bfloat16_2_3_9_10__rhs_bfloat16_3_3_4_5__windowstrides__1_1-2828133577370001365.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_dtype_precision_lhs_bfloat16_2_3_9_10__rhs_bfloat16_3_3_4_5__windowstrides__1_1-4096332469216216157.mlir
+++ b/stablehlo/testdata/conv_general_dilated_dtype_precision_lhs_bfloat16_2_3_9_10__rhs_bfloat16_3_3_4_5__windowstrides__1_1-4096332469216216157.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_dtype_precision_lhs_bfloat16_2_3_9_10__rhs_bfloat16_3_3_4_5__windowstrides__1_14716098117894185845.mlir
+++ b/stablehlo/testdata/conv_general_dilated_dtype_precision_lhs_bfloat16_2_3_9_10__rhs_bfloat16_3_3_4_5__windowstrides__1_14716098117894185845.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_dtype_precision_lhs_bfloat16_2_3_9_10__rhs_bfloat16_3_3_4_5__windowstrides__1_14934651048175383267.mlir
+++ b/stablehlo/testdata/conv_general_dilated_dtype_precision_lhs_bfloat16_2_3_9_10__rhs_bfloat16_3_3_4_5__windowstrides__1_14934651048175383267.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_dtype_precision_lhs_complex64_2_3_9_10__rhs_complex64_3_3_4_5__windowstrides__1-3832152131603412380.mlir
+++ b/stablehlo/testdata/conv_general_dilated_dtype_precision_lhs_complex64_2_3_9_10__rhs_complex64_3_3_4_5__windowstrides__1-3832152131603412380.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_dtype_precision_lhs_complex64_2_3_9_10__rhs_complex64_3_3_4_5__windowstrides__11475331900101565681.mlir
+++ b/stablehlo/testdata/conv_general_dilated_dtype_precision_lhs_complex64_2_3_9_10__rhs_complex64_3_3_4_5__windowstrides__11475331900101565681.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_dtype_precision_lhs_complex64_2_3_9_10__rhs_complex64_3_3_4_5__windowstrides__13249141611080884059.mlir
+++ b/stablehlo/testdata/conv_general_dilated_dtype_precision_lhs_complex64_2_3_9_10__rhs_complex64_3_3_4_5__windowstrides__13249141611080884059.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_dtype_precision_lhs_complex64_2_3_9_10__rhs_complex64_3_3_4_5__windowstrides__14747341168071649850.mlir
+++ b/stablehlo/testdata/conv_general_dilated_dtype_precision_lhs_complex64_2_3_9_10__rhs_complex64_3_3_4_5__windowstrides__14747341168071649850.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_dtype_precision_lhs_float16_2_3_9_10__rhs_float16_3_3_4_5__windowstrides__1_1__-4794221138256364792.mlir
+++ b/stablehlo/testdata/conv_general_dilated_dtype_precision_lhs_float16_2_3_9_10__rhs_float16_3_3_4_5__windowstrides__1_1__-4794221138256364792.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_dtype_precision_lhs_float16_2_3_9_10__rhs_float16_3_3_4_5__windowstrides__1_1__3664647178268688516.mlir
+++ b/stablehlo/testdata/conv_general_dilated_dtype_precision_lhs_float16_2_3_9_10__rhs_float16_3_3_4_5__windowstrides__1_1__3664647178268688516.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_dtype_precision_lhs_float16_2_3_9_10__rhs_float16_3_3_4_5__windowstrides__1_1__3697618175235149009.mlir
+++ b/stablehlo/testdata/conv_general_dilated_dtype_precision_lhs_float16_2_3_9_10__rhs_float16_3_3_4_5__windowstrides__1_1__3697618175235149009.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_dtype_precision_lhs_float16_2_3_9_10__rhs_float16_3_3_4_5__windowstrides__1_1__5625420534524084937.mlir
+++ b/stablehlo/testdata/conv_general_dilated_dtype_precision_lhs_float16_2_3_9_10__rhs_float16_3_3_4_5__windowstrides__1_1__5625420534524084937.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_dtype_precision_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__-1572008590406220780.mlir
+++ b/stablehlo/testdata/conv_general_dilated_dtype_precision_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__-1572008590406220780.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_dtype_precision_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__-4848375839726769119.mlir
+++ b/stablehlo/testdata/conv_general_dilated_dtype_precision_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__-4848375839726769119.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_dtype_precision_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__-6463715315589295392.mlir
+++ b/stablehlo/testdata/conv_general_dilated_dtype_precision_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__-6463715315589295392.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_dtype_precision_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__-7128650963837464321.mlir
+++ b/stablehlo/testdata/conv_general_dilated_dtype_precision_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__-7128650963837464321.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_group_counts_lhs_float32_2_6_9_10__rhs_float32_6_3_4_5__windowstrides__1_1__pad-2212136815070163245.mlir
+++ b/stablehlo/testdata/conv_general_dilated_group_counts_lhs_float32_2_6_9_10__rhs_float32_6_3_4_5__windowstrides__1_1__pad-2212136815070163245.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_group_counts_lhs_float32_4_3_9_10__rhs_float32_6_3_4_5__windowstrides__1_1__pad2141518546713332984.mlir
+++ b/stablehlo/testdata/conv_general_dilated_group_counts_lhs_float32_4_3_9_10__rhs_float32_6_3_4_5__windowstrides__1_1__pad2141518546713332984.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_padding_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__padding_-5318452038191342786.mlir
+++ b/stablehlo/testdata/conv_general_dilated_padding_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__padding_-5318452038191342786.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_padding_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__padding_5050050053143756869.mlir
+++ b/stablehlo/testdata/conv_general_dilated_padding_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__padding_5050050053143756869.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_preferred_lhs_bfloat16_2_3_9_10__rhs_bfloat16_3_3_4_5__windowstrides__1_1__padd-2901261004378861047.mlir
+++ b/stablehlo/testdata/conv_general_dilated_preferred_lhs_bfloat16_2_3_9_10__rhs_bfloat16_3_3_4_5__windowstrides__1_1__padd-2901261004378861047.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_preferred_lhs_bfloat16_2_3_9_10__rhs_bfloat16_3_3_4_5__windowstrides__1_1__padd1308736537156067954.mlir
+++ b/stablehlo/testdata/conv_general_dilated_preferred_lhs_bfloat16_2_3_9_10__rhs_bfloat16_3_3_4_5__windowstrides__1_1__padd1308736537156067954.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_preferred_lhs_complex64_2_3_9_10__rhs_complex64_3_3_4_5__windowstrides__1_1__pa6616031714311913514.mlir
+++ b/stablehlo/testdata/conv_general_dilated_preferred_lhs_complex64_2_3_9_10__rhs_complex64_3_3_4_5__windowstrides__1_1__pa6616031714311913514.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_preferred_lhs_float16_2_3_9_10__rhs_float16_3_3_4_5__windowstrides__1_1__paddin-2219904838312979188.mlir
+++ b/stablehlo/testdata/conv_general_dilated_preferred_lhs_float16_2_3_9_10__rhs_float16_3_3_4_5__windowstrides__1_1__paddin-2219904838312979188.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_preferred_lhs_float16_2_3_9_10__rhs_float16_3_3_4_5__windowstrides__1_1__paddin1019309252113751266.mlir
+++ b/stablehlo/testdata/conv_general_dilated_preferred_lhs_float16_2_3_9_10__rhs_float16_3_3_4_5__windowstrides__1_1__paddin1019309252113751266.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_preferred_lhs_float16_2_3_9_10__rhs_float16_3_3_4_5__windowstrides__1_1__paddin6385582932860122911.mlir
+++ b/stablehlo/testdata/conv_general_dilated_preferred_lhs_float16_2_3_9_10__rhs_float16_3_3_4_5__windowstrides__1_1__paddin6385582932860122911.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_preferred_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__paddin-8230831430534381289.mlir
+++ b/stablehlo/testdata/conv_general_dilated_preferred_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__paddin-8230831430534381289.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_preferred_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__paddin2430556623423240398.mlir
+++ b/stablehlo/testdata/conv_general_dilated_preferred_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__1_1__paddin2430556623423240398.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_preferred_lhs_int16_2_3_9_10__rhs_int16_3_3_4_5__windowstrides__1_1__padding___5949278899002149214.mlir
+++ b/stablehlo/testdata/conv_general_dilated_preferred_lhs_int16_2_3_9_10__rhs_int16_3_3_4_5__windowstrides__1_1__padding___5949278899002149214.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_preferred_lhs_int16_2_3_9_10__rhs_int16_3_3_4_5__windowstrides__1_1__padding___6746758574017113717.mlir
+++ b/stablehlo/testdata/conv_general_dilated_preferred_lhs_int16_2_3_9_10__rhs_int16_3_3_4_5__windowstrides__1_1__padding___6746758574017113717.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_preferred_lhs_int32_2_3_9_10__rhs_int32_3_3_4_5__windowstrides__1_1__padding___-7077764382968112509.mlir
+++ b/stablehlo/testdata/conv_general_dilated_preferred_lhs_int32_2_3_9_10__rhs_int32_3_3_4_5__windowstrides__1_1__padding___-7077764382968112509.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_preferred_lhs_int32_2_3_9_10__rhs_int32_3_3_4_5__windowstrides__1_1__padding___8425439145703732762.mlir
+++ b/stablehlo/testdata/conv_general_dilated_preferred_lhs_int32_2_3_9_10__rhs_int32_3_3_4_5__windowstrides__1_1__padding___8425439145703732762.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_preferred_lhs_int8_2_3_9_10__rhs_int8_3_3_4_5__windowstrides__1_1__padding___0_-5137067581667430942.mlir
+++ b/stablehlo/testdata/conv_general_dilated_preferred_lhs_int8_2_3_9_10__rhs_int8_3_3_4_5__windowstrides__1_1__padding___0_-5137067581667430942.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_preferred_lhs_int8_2_3_9_10__rhs_int8_3_3_4_5__windowstrides__1_1__padding___0_6435492073626895996.mlir
+++ b/stablehlo/testdata/conv_general_dilated_preferred_lhs_int8_2_3_9_10__rhs_int8_3_3_4_5__windowstrides__1_1__padding___0_6435492073626895996.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_preferred_lhs_int8_2_3_9_10__rhs_int8_3_3_4_5__windowstrides__1_1__padding___0_8051815987805818453.mlir
+++ b/stablehlo/testdata/conv_general_dilated_preferred_lhs_int8_2_3_9_10__rhs_int8_3_3_4_5__windowstrides__1_1__padding___0_8051815987805818453.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_rhs_oob_after_dilation_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides2604570134889024577.mlir
+++ b/stablehlo/testdata/conv_general_dilated_rhs_oob_after_dilation_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides2604570134889024577.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_rhs_oob_after_pading_lhs_float32_1_3_2_2__rhs_float32_64_3_7_7__windowstrides__5476883256254674781.mlir
+++ b/stablehlo/testdata/conv_general_dilated_rhs_oob_after_pading_lhs_float32_1_3_2_2__rhs_float32_64_3_7_7__windowstrides__5476883256254674781.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_rhs_oob_lhs_float32_2_3_9_10__rhs_float32_3_3_10_5__windowstrides__1_1__padding-7028470013130116023.mlir
+++ b/stablehlo/testdata/conv_general_dilated_rhs_oob_lhs_float32_2_3_9_10__rhs_float32_3_3_10_5__windowstrides__1_1__padding-7028470013130116023.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_rhs_oob_same_padding_lhs_float32_1_1_16_1__rhs_float32_4_1_1_2__windowstrides__-5378230060959849233.mlir
+++ b/stablehlo/testdata/conv_general_dilated_rhs_oob_same_padding_lhs_float32_1_1_16_1__rhs_float32_4_1_1_2__windowstrides__-5378230060959849233.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_tf_conversion_path_1d_lhs_float32_1_28_1__rhs_float32_3_1_16__windowstrides__1_-3327288011231887622.mlir
+++ b/stablehlo/testdata/conv_general_dilated_tf_conversion_path_1d_lhs_float32_1_28_1__rhs_float32_3_1_16__windowstrides__1_-3327288011231887622.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_tf_conversion_path_1d_lhs_float32_1_28_1__rhs_float32_3_1_16__windowstrides__1_-3622729120410096886.mlir
+++ b/stablehlo/testdata/conv_general_dilated_tf_conversion_path_1d_lhs_float32_1_28_1__rhs_float32_3_1_16__windowstrides__1_-3622729120410096886.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_tf_conversion_path_1d_lhs_float32_1_28_1__rhs_float32_3_1_16__windowstrides__1_-6986955039250405512.mlir
+++ b/stablehlo/testdata/conv_general_dilated_tf_conversion_path_1d_lhs_float32_1_28_1__rhs_float32_3_1_16__windowstrides__1_-6986955039250405512.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_tf_conversion_path_1d_lhs_float32_1_28_1__rhs_float32_3_1_16__windowstrides__1_-9029857704645127306.mlir
+++ b/stablehlo/testdata/conv_general_dilated_tf_conversion_path_1d_lhs_float32_1_28_1__rhs_float32_3_1_16__windowstrides__1_-9029857704645127306.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_tf_conversion_path_2d_lhs_float32_1_1_28_28__rhs_float32_3_3_1_16__windowstride-2949258448720886117.mlir
+++ b/stablehlo/testdata/conv_general_dilated_tf_conversion_path_2d_lhs_float32_1_1_28_28__rhs_float32_3_3_1_16__windowstride-2949258448720886117.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_tf_conversion_path_2d_lhs_float32_1_1_28_28__rhs_float32_3_3_1_16__windowstride-3150713558304940791.mlir
+++ b/stablehlo/testdata/conv_general_dilated_tf_conversion_path_2d_lhs_float32_1_1_28_28__rhs_float32_3_3_1_16__windowstride-3150713558304940791.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_tf_conversion_path_2d_lhs_float32_1_1_28_28__rhs_float32_3_3_1_16__windowstride-4268834939663085007.mlir
+++ b/stablehlo/testdata/conv_general_dilated_tf_conversion_path_2d_lhs_float32_1_1_28_28__rhs_float32_3_3_1_16__windowstride-4268834939663085007.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_tf_conversion_path_2d_lhs_float32_1_1_28_28__rhs_float32_3_3_1_16__windowstride-4823547473556881342.mlir
+++ b/stablehlo/testdata/conv_general_dilated_tf_conversion_path_2d_lhs_float32_1_1_28_28__rhs_float32_3_3_1_16__windowstride-4823547473556881342.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_tf_conversion_path_2d_lhs_float32_1_1_28_28__rhs_float32_3_3_1_16__windowstride6887804375295982821.mlir
+++ b/stablehlo/testdata/conv_general_dilated_tf_conversion_path_2d_lhs_float32_1_1_28_28__rhs_float32_3_3_1_16__windowstride6887804375295982821.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_tf_conversion_path_2d_lhs_float32_1_28_28_1__rhs_float32_3_3_1_16__windowstride-5370080226275098061.mlir
+++ b/stablehlo/testdata/conv_general_dilated_tf_conversion_path_2d_lhs_float32_1_28_28_1__rhs_float32_3_3_1_16__windowstride-5370080226275098061.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_tf_conversion_path_2d_lhs_float32_1_28_28_1__rhs_float32_3_3_1_16__windowstride3500806609840728678.mlir
+++ b/stablehlo/testdata/conv_general_dilated_tf_conversion_path_2d_lhs_float32_1_28_28_1__rhs_float32_3_3_1_16__windowstride3500806609840728678.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_tf_conversion_path_2d_lhs_float32_1_28_28_1__rhs_float32_3_3_1_16__windowstride5787494791845602941.mlir
+++ b/stablehlo/testdata/conv_general_dilated_tf_conversion_path_2d_lhs_float32_1_28_28_1__rhs_float32_3_3_1_16__windowstride5787494791845602941.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_tf_conversion_path_2d_lhs_float32_1_28_28_1__rhs_float32_3_3_1_16__windowstride6312536791243051545.mlir
+++ b/stablehlo/testdata/conv_general_dilated_tf_conversion_path_2d_lhs_float32_1_28_28_1__rhs_float32_3_3_1_16__windowstride6312536791243051545.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_tf_conversion_path_2d_lhs_float32_1_28_28_1__rhs_float32_3_3_1_16__windowstride8472832706066243053.mlir
+++ b/stablehlo/testdata/conv_general_dilated_tf_conversion_path_2d_lhs_float32_1_28_28_1__rhs_float32_3_3_1_16__windowstride8472832706066243053.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_tf_conversion_path_3d_lhs_float32_1_4_28_28_1__rhs_float32_2_3_3_1_16__windowst-8282934958224398022.mlir
+++ b/stablehlo/testdata/conv_general_dilated_tf_conversion_path_3d_lhs_float32_1_4_28_28_1__rhs_float32_2_3_3_1_16__windowst-8282934958224398022.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_tf_conversion_path_3d_lhs_float32_1_4_28_28_1__rhs_float32_2_3_3_1_16__windowst3167308923230843499.mlir
+++ b/stablehlo/testdata/conv_general_dilated_tf_conversion_path_3d_lhs_float32_1_4_28_28_1__rhs_float32_2_3_3_1_16__windowst3167308923230843499.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_tf_conversion_path_3d_lhs_float32_1_4_28_28_1__rhs_float32_2_3_3_1_16__windowst6072174321640638276.mlir
+++ b/stablehlo/testdata/conv_general_dilated_tf_conversion_path_3d_lhs_float32_1_4_28_28_1__rhs_float32_2_3_3_1_16__windowst6072174321640638276.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_tf_conversion_path_3d_lhs_float32_1_4_28_28_1__rhs_float32_2_3_3_1_16__windowst8524424959485066052.mlir
+++ b/stablehlo/testdata/conv_general_dilated_tf_conversion_path_3d_lhs_float32_1_4_28_28_1__rhs_float32_2_3_3_1_16__windowst8524424959485066052.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/conv_general_dilated_window_strides_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__2_3__p-3051008093469972974.mlir
+++ b/stablehlo/testdata/conv_general_dilated_window_strides_lhs_float32_2_3_9_10__rhs_float32_3_3_4_5__windowstrides__2_3__p-3051008093469972974.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bfloat16_100_100__olddtype_bfloat16_newdtype_bfloat16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bfloat16_100_100__olddtype_bfloat16_newdtype_bfloat16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bfloat16_100_100__olddtype_bfloat16_newdtype_bool.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bfloat16_100_100__olddtype_bfloat16_newdtype_bool.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bfloat16_100_100__olddtype_bfloat16_newdtype_complex64.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bfloat16_100_100__olddtype_bfloat16_newdtype_complex64.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bfloat16_100_100__olddtype_bfloat16_newdtype_float16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bfloat16_100_100__olddtype_bfloat16_newdtype_float16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bfloat16_100_100__olddtype_bfloat16_newdtype_float32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bfloat16_100_100__olddtype_bfloat16_newdtype_float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bfloat16_100_100__olddtype_bfloat16_newdtype_int16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bfloat16_100_100__olddtype_bfloat16_newdtype_int16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bfloat16_100_100__olddtype_bfloat16_newdtype_int32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bfloat16_100_100__olddtype_bfloat16_newdtype_int32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bfloat16_100_100__olddtype_bfloat16_newdtype_int8.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bfloat16_100_100__olddtype_bfloat16_newdtype_int8.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bool_100_100__olddtype_bool_newdtype_bfloat16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bool_100_100__olddtype_bool_newdtype_bfloat16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bool_100_100__olddtype_bool_newdtype_bool.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bool_100_100__olddtype_bool_newdtype_bool.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bool_100_100__olddtype_bool_newdtype_complex64.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bool_100_100__olddtype_bool_newdtype_complex64.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bool_100_100__olddtype_bool_newdtype_float16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bool_100_100__olddtype_bool_newdtype_float16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bool_100_100__olddtype_bool_newdtype_float32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bool_100_100__olddtype_bool_newdtype_float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bool_100_100__olddtype_bool_newdtype_int16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bool_100_100__olddtype_bool_newdtype_int16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bool_100_100__olddtype_bool_newdtype_int32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bool_100_100__olddtype_bool_newdtype_int32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bool_100_100__olddtype_bool_newdtype_int8.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bool_100_100__olddtype_bool_newdtype_int8.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bool_100_100__olddtype_bool_newdtype_uint16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bool_100_100__olddtype_bool_newdtype_uint16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bool_100_100__olddtype_bool_newdtype_uint32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bool_100_100__olddtype_bool_newdtype_uint32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bool_100_100__olddtype_bool_newdtype_uint8.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_bool_100_100__olddtype_bool_newdtype_uint8.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_complex64_100_100__olddtype_complex64_newdtype_bfloat16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_complex64_100_100__olddtype_complex64_newdtype_bfloat16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_complex64_100_100__olddtype_complex64_newdtype_bool.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_complex64_100_100__olddtype_complex64_newdtype_bool.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_complex64_100_100__olddtype_complex64_newdtype_complex64.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_complex64_100_100__olddtype_complex64_newdtype_complex64.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_complex64_100_100__olddtype_complex64_newdtype_float16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_complex64_100_100__olddtype_complex64_newdtype_float16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_complex64_100_100__olddtype_complex64_newdtype_float32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_complex64_100_100__olddtype_complex64_newdtype_float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_complex64_100_100__olddtype_complex64_newdtype_int16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_complex64_100_100__olddtype_complex64_newdtype_int16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_complex64_100_100__olddtype_complex64_newdtype_int32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_complex64_100_100__olddtype_complex64_newdtype_int32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_complex64_100_100__olddtype_complex64_newdtype_int8.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_complex64_100_100__olddtype_complex64_newdtype_int8.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float16_100_100__olddtype_float16_newdtype_bfloat16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float16_100_100__olddtype_float16_newdtype_bfloat16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float16_100_100__olddtype_float16_newdtype_bool.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float16_100_100__olddtype_float16_newdtype_bool.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float16_100_100__olddtype_float16_newdtype_complex64.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float16_100_100__olddtype_float16_newdtype_complex64.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float16_100_100__olddtype_float16_newdtype_float16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float16_100_100__olddtype_float16_newdtype_float16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float16_100_100__olddtype_float16_newdtype_float32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float16_100_100__olddtype_float16_newdtype_float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float16_100_100__olddtype_float16_newdtype_int16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float16_100_100__olddtype_float16_newdtype_int16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float16_100_100__olddtype_float16_newdtype_int32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float16_100_100__olddtype_float16_newdtype_int32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float16_100_100__olddtype_float16_newdtype_int8.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float16_100_100__olddtype_float16_newdtype_int8.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float32_100_100__olddtype_float32_newdtype_bfloat16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float32_100_100__olddtype_float32_newdtype_bfloat16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float32_100_100__olddtype_float32_newdtype_bool.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float32_100_100__olddtype_float32_newdtype_bool.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float32_100_100__olddtype_float32_newdtype_complex64.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float32_100_100__olddtype_float32_newdtype_complex64.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float32_100_100__olddtype_float32_newdtype_float16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float32_100_100__olddtype_float32_newdtype_float16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float32_100_100__olddtype_float32_newdtype_float32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float32_100_100__olddtype_float32_newdtype_float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float32_100_100__olddtype_float32_newdtype_int16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float32_100_100__olddtype_float32_newdtype_int16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float32_100_100__olddtype_float32_newdtype_int32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float32_100_100__olddtype_float32_newdtype_int32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float32_100_100__olddtype_float32_newdtype_int8.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_float32_100_100__olddtype_float32_newdtype_int8.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int16_100_100__olddtype_int16_newdtype_bfloat16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int16_100_100__olddtype_int16_newdtype_bfloat16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int16_100_100__olddtype_int16_newdtype_bool.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int16_100_100__olddtype_int16_newdtype_bool.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int16_100_100__olddtype_int16_newdtype_complex64.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int16_100_100__olddtype_int16_newdtype_complex64.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int16_100_100__olddtype_int16_newdtype_float16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int16_100_100__olddtype_int16_newdtype_float16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int16_100_100__olddtype_int16_newdtype_float32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int16_100_100__olddtype_int16_newdtype_float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int16_100_100__olddtype_int16_newdtype_int16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int16_100_100__olddtype_int16_newdtype_int16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int16_100_100__olddtype_int16_newdtype_int32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int16_100_100__olddtype_int16_newdtype_int32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int16_100_100__olddtype_int16_newdtype_int8.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int16_100_100__olddtype_int16_newdtype_int8.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int16_100_100__olddtype_int16_newdtype_uint16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int16_100_100__olddtype_int16_newdtype_uint16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int16_100_100__olddtype_int16_newdtype_uint32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int16_100_100__olddtype_int16_newdtype_uint32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int16_100_100__olddtype_int16_newdtype_uint8.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int16_100_100__olddtype_int16_newdtype_uint8.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int32_100_100__olddtype_int32_newdtype_bfloat16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int32_100_100__olddtype_int32_newdtype_bfloat16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int32_100_100__olddtype_int32_newdtype_bool.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int32_100_100__olddtype_int32_newdtype_bool.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int32_100_100__olddtype_int32_newdtype_complex64.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int32_100_100__olddtype_int32_newdtype_complex64.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int32_100_100__olddtype_int32_newdtype_float16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int32_100_100__olddtype_int32_newdtype_float16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int32_100_100__olddtype_int32_newdtype_float32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int32_100_100__olddtype_int32_newdtype_float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int32_100_100__olddtype_int32_newdtype_int16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int32_100_100__olddtype_int32_newdtype_int16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int32_100_100__olddtype_int32_newdtype_int32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int32_100_100__olddtype_int32_newdtype_int32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int32_100_100__olddtype_int32_newdtype_int8.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int32_100_100__olddtype_int32_newdtype_int8.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int32_100_100__olddtype_int32_newdtype_uint16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int32_100_100__olddtype_int32_newdtype_uint16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int32_100_100__olddtype_int32_newdtype_uint32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int32_100_100__olddtype_int32_newdtype_uint32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int32_100_100__olddtype_int32_newdtype_uint8.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int32_100_100__olddtype_int32_newdtype_uint8.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_bfloat16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_bfloat16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_bool.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_bool.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_complex64.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_complex64.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_float16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_float16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_float32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_int16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_int16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_int32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_int32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_int8.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_int8.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_uint16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_uint16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_uint32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_uint32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_uint8.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_uint8.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint16_100_100__olddtype_uint16_newdtype_bfloat16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint16_100_100__olddtype_uint16_newdtype_bfloat16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint16_100_100__olddtype_uint16_newdtype_bool.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint16_100_100__olddtype_uint16_newdtype_bool.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint16_100_100__olddtype_uint16_newdtype_complex64.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint16_100_100__olddtype_uint16_newdtype_complex64.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint16_100_100__olddtype_uint16_newdtype_float16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint16_100_100__olddtype_uint16_newdtype_float16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint16_100_100__olddtype_uint16_newdtype_float32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint16_100_100__olddtype_uint16_newdtype_float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint16_100_100__olddtype_uint16_newdtype_int16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint16_100_100__olddtype_uint16_newdtype_int16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint16_100_100__olddtype_uint16_newdtype_int32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint16_100_100__olddtype_uint16_newdtype_int32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint16_100_100__olddtype_uint16_newdtype_int8.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint16_100_100__olddtype_uint16_newdtype_int8.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint16_100_100__olddtype_uint16_newdtype_uint16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint16_100_100__olddtype_uint16_newdtype_uint16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint16_100_100__olddtype_uint16_newdtype_uint32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint16_100_100__olddtype_uint16_newdtype_uint32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint16_100_100__olddtype_uint16_newdtype_uint8.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint16_100_100__olddtype_uint16_newdtype_uint8.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint32_100_100__olddtype_uint32_newdtype_bfloat16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint32_100_100__olddtype_uint32_newdtype_bfloat16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint32_100_100__olddtype_uint32_newdtype_bool.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint32_100_100__olddtype_uint32_newdtype_bool.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint32_100_100__olddtype_uint32_newdtype_complex64.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint32_100_100__olddtype_uint32_newdtype_complex64.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint32_100_100__olddtype_uint32_newdtype_float16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint32_100_100__olddtype_uint32_newdtype_float16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint32_100_100__olddtype_uint32_newdtype_float32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint32_100_100__olddtype_uint32_newdtype_float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint32_100_100__olddtype_uint32_newdtype_int16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint32_100_100__olddtype_uint32_newdtype_int16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint32_100_100__olddtype_uint32_newdtype_int32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint32_100_100__olddtype_uint32_newdtype_int32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint32_100_100__olddtype_uint32_newdtype_int8.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint32_100_100__olddtype_uint32_newdtype_int8.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint32_100_100__olddtype_uint32_newdtype_uint16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint32_100_100__olddtype_uint32_newdtype_uint16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint32_100_100__olddtype_uint32_newdtype_uint32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint32_100_100__olddtype_uint32_newdtype_uint32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint32_100_100__olddtype_uint32_newdtype_uint8.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint32_100_100__olddtype_uint32_newdtype_uint8.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint8_100_100__olddtype_uint8_newdtype_bfloat16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint8_100_100__olddtype_uint8_newdtype_bfloat16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint8_100_100__olddtype_uint8_newdtype_bool.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint8_100_100__olddtype_uint8_newdtype_bool.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint8_100_100__olddtype_uint8_newdtype_complex64.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint8_100_100__olddtype_uint8_newdtype_complex64.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint8_100_100__olddtype_uint8_newdtype_float16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint8_100_100__olddtype_uint8_newdtype_float16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint8_100_100__olddtype_uint8_newdtype_float32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint8_100_100__olddtype_uint8_newdtype_float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint8_100_100__olddtype_uint8_newdtype_int16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint8_100_100__olddtype_uint8_newdtype_int16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint8_100_100__olddtype_uint8_newdtype_int32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint8_100_100__olddtype_uint8_newdtype_int32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint8_100_100__olddtype_uint8_newdtype_int8.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint8_100_100__olddtype_uint8_newdtype_int8.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint8_100_100__olddtype_uint8_newdtype_uint16.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint8_100_100__olddtype_uint8_newdtype_uint16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint8_100_100__olddtype_uint8_newdtype_uint32.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint8_100_100__olddtype_uint8_newdtype_uint32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint8_100_100__olddtype_uint8_newdtype_uint8.mlir
+++ b/stablehlo/testdata/convert_element_type_dtypes_to_dtypes_shape_uint8_100_100__olddtype_uint8_newdtype_uint8.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cos_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/cos_shape_bfloat16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cos_shape_complex64_20_20.mlir
+++ b/stablehlo/testdata/cos_shape_complex64_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cos_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/cos_shape_float16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cos_shape_float32_20_20.mlir
+++ b/stablehlo/testdata/cos_shape_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cosh_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/cosh_shape_bfloat16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cosh_shape_complex64_20_20.mlir
+++ b/stablehlo/testdata/cosh_shape_complex64_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cosh_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/cosh_shape_float16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cosh_shape_float32_20_20.mlir
+++ b/stablehlo/testdata/cosh_shape_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumlogsumexp_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumlogsumexp_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumlogsumexp_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_1_reverse_False.mlir
+++ b/stablehlo/testdata/cumlogsumexp_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_1_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumlogsumexp_axis_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumlogsumexp_axis_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumlogsumexp_axis_by_fun_shape_float32_8_9__axis_1_reverse_False.mlir
+++ b/stablehlo/testdata/cumlogsumexp_axis_by_fun_shape_float32_8_9__axis_1_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumlogsumexp_dtype_by_fun_shape_float16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumlogsumexp_dtype_by_fun_shape_float16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumlogsumexp_dtype_by_fun_shape_float16_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumlogsumexp_dtype_by_fun_shape_float16_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumlogsumexp_dtype_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumlogsumexp_dtype_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumlogsumexp_dtype_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumlogsumexp_dtype_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumlogsumexp_reverse_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_True.mlir
+++ b/stablehlo/testdata/cumlogsumexp_reverse_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumlogsumexp_reverse_shape_float32_8_9__axis_0_reverse_True.mlir
+++ b/stablehlo/testdata/cumlogsumexp_reverse_shape_float32_8_9__axis_0_reverse_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummax_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummax_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_1_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_1_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummax_axis_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_axis_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummax_axis_by_fun_shape_float32_8_9__axis_1_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_axis_by_fun_shape_float32_8_9__axis_1_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummax_dtype_by_fun_shape_bfloat16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_dtype_by_fun_shape_bfloat16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummax_dtype_by_fun_shape_bfloat16_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_dtype_by_fun_shape_bfloat16_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummax_dtype_by_fun_shape_complex64_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_dtype_by_fun_shape_complex64_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummax_dtype_by_fun_shape_complex64_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_dtype_by_fun_shape_complex64_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummax_dtype_by_fun_shape_float16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_dtype_by_fun_shape_float16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummax_dtype_by_fun_shape_float16_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_dtype_by_fun_shape_float16_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummax_dtype_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_dtype_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummax_dtype_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_dtype_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummax_dtype_by_fun_shape_int16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_dtype_by_fun_shape_int16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummax_dtype_by_fun_shape_int16_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_dtype_by_fun_shape_int16_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummax_dtype_by_fun_shape_int32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_dtype_by_fun_shape_int32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummax_dtype_by_fun_shape_int32_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_dtype_by_fun_shape_int32_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummax_dtype_by_fun_shape_int8_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_dtype_by_fun_shape_int8_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummax_dtype_by_fun_shape_int8_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_dtype_by_fun_shape_int8_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummax_dtype_by_fun_shape_uint16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_dtype_by_fun_shape_uint16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummax_dtype_by_fun_shape_uint16_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_dtype_by_fun_shape_uint16_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummax_dtype_by_fun_shape_uint32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_dtype_by_fun_shape_uint32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummax_dtype_by_fun_shape_uint32_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_dtype_by_fun_shape_uint32_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummax_dtype_by_fun_shape_uint8_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_dtype_by_fun_shape_uint8_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummax_dtype_by_fun_shape_uint8_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_dtype_by_fun_shape_uint8_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummax_dynamic.mlir
+++ b/stablehlo/testdata/cummax_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/cummax_reverse_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_True.mlir
+++ b/stablehlo/testdata/cummax_reverse_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummax_reverse_shape_float32_8_9__axis_0_reverse_True.mlir
+++ b/stablehlo/testdata/cummax_reverse_shape_float32_8_9__axis_0_reverse_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummin_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummin_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_1_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_1_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummin_axis_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_axis_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummin_axis_by_fun_shape_float32_8_9__axis_1_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_axis_by_fun_shape_float32_8_9__axis_1_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummin_dtype_by_fun_shape_bfloat16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_dtype_by_fun_shape_bfloat16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummin_dtype_by_fun_shape_bfloat16_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_dtype_by_fun_shape_bfloat16_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummin_dtype_by_fun_shape_complex64_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_dtype_by_fun_shape_complex64_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummin_dtype_by_fun_shape_complex64_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_dtype_by_fun_shape_complex64_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummin_dtype_by_fun_shape_float16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_dtype_by_fun_shape_float16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummin_dtype_by_fun_shape_float16_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_dtype_by_fun_shape_float16_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummin_dtype_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_dtype_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummin_dtype_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_dtype_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummin_dtype_by_fun_shape_int16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_dtype_by_fun_shape_int16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummin_dtype_by_fun_shape_int16_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_dtype_by_fun_shape_int16_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummin_dtype_by_fun_shape_int32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_dtype_by_fun_shape_int32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummin_dtype_by_fun_shape_int32_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_dtype_by_fun_shape_int32_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummin_dtype_by_fun_shape_int8_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_dtype_by_fun_shape_int8_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummin_dtype_by_fun_shape_int8_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_dtype_by_fun_shape_int8_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummin_dtype_by_fun_shape_uint16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_dtype_by_fun_shape_uint16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummin_dtype_by_fun_shape_uint16_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_dtype_by_fun_shape_uint16_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummin_dtype_by_fun_shape_uint32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_dtype_by_fun_shape_uint32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummin_dtype_by_fun_shape_uint32_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_dtype_by_fun_shape_uint32_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummin_dtype_by_fun_shape_uint8_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_dtype_by_fun_shape_uint8_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummin_dtype_by_fun_shape_uint8_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_dtype_by_fun_shape_uint8_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummin_reverse_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_True.mlir
+++ b/stablehlo/testdata/cummin_reverse_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cummin_reverse_shape_float32_8_9__axis_0_reverse_True.mlir
+++ b/stablehlo/testdata/cummin_reverse_shape_float32_8_9__axis_0_reverse_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumprod_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumprod_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_1_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_1_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumprod_axis_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_axis_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumprod_axis_by_fun_shape_float32_8_9__axis_1_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_axis_by_fun_shape_float32_8_9__axis_1_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumprod_dtype_by_fun_shape_bfloat16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_dtype_by_fun_shape_bfloat16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumprod_dtype_by_fun_shape_bfloat16_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_dtype_by_fun_shape_bfloat16_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumprod_dtype_by_fun_shape_complex64_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_dtype_by_fun_shape_complex64_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumprod_dtype_by_fun_shape_complex64_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_dtype_by_fun_shape_complex64_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumprod_dtype_by_fun_shape_float16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_dtype_by_fun_shape_float16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumprod_dtype_by_fun_shape_float16_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_dtype_by_fun_shape_float16_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumprod_dtype_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_dtype_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumprod_dtype_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_dtype_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumprod_dtype_by_fun_shape_int16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_dtype_by_fun_shape_int16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumprod_dtype_by_fun_shape_int16_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_dtype_by_fun_shape_int16_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumprod_dtype_by_fun_shape_int32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_dtype_by_fun_shape_int32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumprod_dtype_by_fun_shape_int32_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_dtype_by_fun_shape_int32_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumprod_dtype_by_fun_shape_int8_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_dtype_by_fun_shape_int8_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumprod_dtype_by_fun_shape_int8_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_dtype_by_fun_shape_int8_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumprod_dtype_by_fun_shape_uint16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_dtype_by_fun_shape_uint16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumprod_dtype_by_fun_shape_uint16_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_dtype_by_fun_shape_uint16_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumprod_dtype_by_fun_shape_uint32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_dtype_by_fun_shape_uint32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumprod_dtype_by_fun_shape_uint32_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_dtype_by_fun_shape_uint32_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumprod_dtype_by_fun_shape_uint8_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_dtype_by_fun_shape_uint8_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumprod_dtype_by_fun_shape_uint8_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_dtype_by_fun_shape_uint8_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumprod_reverse_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_True.mlir
+++ b/stablehlo/testdata/cumprod_reverse_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumprod_reverse_shape_float32_8_9__axis_0_reverse_True.mlir
+++ b/stablehlo/testdata/cumprod_reverse_shape_float32_8_9__axis_0_reverse_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumsum_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumsum_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_1_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_1_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumsum_axis_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_axis_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumsum_axis_by_fun_shape_float32_8_9__axis_1_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_axis_by_fun_shape_float32_8_9__axis_1_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumsum_dtype_by_fun_shape_bfloat16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_dtype_by_fun_shape_bfloat16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumsum_dtype_by_fun_shape_bfloat16_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_dtype_by_fun_shape_bfloat16_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumsum_dtype_by_fun_shape_complex64_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_dtype_by_fun_shape_complex64_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumsum_dtype_by_fun_shape_complex64_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_dtype_by_fun_shape_complex64_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumsum_dtype_by_fun_shape_float16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_dtype_by_fun_shape_float16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumsum_dtype_by_fun_shape_float16_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_dtype_by_fun_shape_float16_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumsum_dtype_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_dtype_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumsum_dtype_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_dtype_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumsum_dtype_by_fun_shape_int16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_dtype_by_fun_shape_int16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumsum_dtype_by_fun_shape_int16_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_dtype_by_fun_shape_int16_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumsum_dtype_by_fun_shape_int32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_dtype_by_fun_shape_int32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumsum_dtype_by_fun_shape_int32_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_dtype_by_fun_shape_int32_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumsum_dtype_by_fun_shape_int8_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_dtype_by_fun_shape_int8_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumsum_dtype_by_fun_shape_int8_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_dtype_by_fun_shape_int8_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumsum_dtype_by_fun_shape_uint16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_dtype_by_fun_shape_uint16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumsum_dtype_by_fun_shape_uint16_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_dtype_by_fun_shape_uint16_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumsum_dtype_by_fun_shape_uint32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_dtype_by_fun_shape_uint32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumsum_dtype_by_fun_shape_uint32_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_dtype_by_fun_shape_uint32_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumsum_dtype_by_fun_shape_uint8_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_dtype_by_fun_shape_uint8_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumsum_dtype_by_fun_shape_uint8_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_dtype_by_fun_shape_uint8_8_9__axis_0_reverse_False.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumsum_reverse_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_True.mlir
+++ b/stablehlo/testdata/cumsum_reverse_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/cumsum_reverse_shape_float32_8_9__axis_0_reverse_True.mlir
+++ b/stablehlo/testdata/cumsum_reverse_shape_float32_8_9__axis_0_reverse_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/delta_0_dynamic.mlir
+++ b/stablehlo/testdata/delta_0_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1xf32> {mhlo.sharding = ""}) -> tensor<?x1xf32> {

--- a/stablehlo/testdata/device_put_devices_shape_float32_3_4__device__cpu.mlir
+++ b/stablehlo/testdata/device_put_devices_shape_float32_3_4__device__cpu.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/device_put_dtypes_shape_bfloat16_3_4__device_None.mlir
+++ b/stablehlo/testdata/device_put_dtypes_shape_bfloat16_3_4__device_None.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/device_put_dtypes_shape_bool_3_4__device_None.mlir
+++ b/stablehlo/testdata/device_put_dtypes_shape_bool_3_4__device_None.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/device_put_dtypes_shape_complex64_3_4__device_None.mlir
+++ b/stablehlo/testdata/device_put_dtypes_shape_complex64_3_4__device_None.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/device_put_dtypes_shape_float16_3_4__device_None.mlir
+++ b/stablehlo/testdata/device_put_dtypes_shape_float16_3_4__device_None.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/device_put_dtypes_shape_float32_3_4__device_None.mlir
+++ b/stablehlo/testdata/device_put_dtypes_shape_float32_3_4__device_None.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/device_put_dtypes_shape_int16_3_4__device_None.mlir
+++ b/stablehlo/testdata/device_put_dtypes_shape_int16_3_4__device_None.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/device_put_dtypes_shape_int32_3_4__device_None.mlir
+++ b/stablehlo/testdata/device_put_dtypes_shape_int32_3_4__device_None.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/device_put_dtypes_shape_int8_3_4__device_None.mlir
+++ b/stablehlo/testdata/device_put_dtypes_shape_int8_3_4__device_None.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/device_put_dtypes_shape_uint16_3_4__device_None.mlir
+++ b/stablehlo/testdata/device_put_dtypes_shape_uint16_3_4__device_None.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/device_put_dtypes_shape_uint32_3_4__device_None.mlir
+++ b/stablehlo/testdata/device_put_dtypes_shape_uint32_3_4__device_None.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/device_put_dtypes_shape_uint8_3_4__device_None.mlir
+++ b/stablehlo/testdata/device_put_dtypes_shape_uint8_3_4__device_None.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/digamma_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/digamma_shape_bfloat16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/digamma_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/digamma_shape_float16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/digamma_shape_float32_20_20.mlir
+++ b/stablehlo/testdata/digamma_shape_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/div_broadcast_lhs_float32_2_1_3__rhs_float32_2_4_3.mlir
+++ b/stablehlo/testdata/div_broadcast_lhs_float32_2_1_3__rhs_float32_2_4_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/div_broadcast_lhs_float32_2_4_3__rhs_float32_2_1_3.mlir
+++ b/stablehlo/testdata/div_broadcast_lhs_float32_2_4_3__rhs_float32_2_1_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/div_dtypes_lhs_bfloat16_2__rhs_bfloat16_2.mlir
+++ b/stablehlo/testdata/div_dtypes_lhs_bfloat16_2__rhs_bfloat16_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/div_dtypes_lhs_complex64_2__rhs_complex64_2.mlir
+++ b/stablehlo/testdata/div_dtypes_lhs_complex64_2__rhs_complex64_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/div_dtypes_lhs_float16_2__rhs_float16_2.mlir
+++ b/stablehlo/testdata/div_dtypes_lhs_float16_2__rhs_float16_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/div_dtypes_lhs_float32_2__rhs_float32_2.mlir
+++ b/stablehlo/testdata/div_dtypes_lhs_float32_2__rhs_float32_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/div_dtypes_lhs_int16_2__rhs_int16_2.mlir
+++ b/stablehlo/testdata/div_dtypes_lhs_int16_2__rhs_int16_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/div_dtypes_lhs_int32_2__rhs_int32_2.mlir
+++ b/stablehlo/testdata/div_dtypes_lhs_int32_2__rhs_int32_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/div_dtypes_lhs_int8_2__rhs_int8_2.mlir
+++ b/stablehlo/testdata/div_dtypes_lhs_int8_2__rhs_int8_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/div_dtypes_lhs_uint16_2__rhs_uint16_2.mlir
+++ b/stablehlo/testdata/div_dtypes_lhs_uint16_2__rhs_uint16_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/div_dtypes_lhs_uint32_2__rhs_uint32_2.mlir
+++ b/stablehlo/testdata/div_dtypes_lhs_uint32_2__rhs_uint32_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/div_dtypes_lhs_uint8_2__rhs_uint8_2.mlir
+++ b/stablehlo/testdata/div_dtypes_lhs_uint8_2__rhs_uint8_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/div_singularity_0_by_0_lhs_float32_2__rhs_float32_2.mlir
+++ b/stablehlo/testdata/div_singularity_0_by_0_lhs_float32_2__rhs_float32_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/div_singularity_inf_by_inf_lhs_float32_1__rhs_float32_1.mlir
+++ b/stablehlo/testdata/div_singularity_inf_by_inf_lhs_float32_1__rhs_float32_1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/div_singularity_negative_by_0_lhs_float32_2__rhs_float32_2.mlir
+++ b/stablehlo/testdata/div_singularity_negative_by_0_lhs_float32_2__rhs_float32_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/div_singularity_positive_by_0_lhs_float32_2__rhs_float32_2.mlir
+++ b/stablehlo/testdata/div_singularity_positive_by_0_lhs_float32_2__rhs_float32_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_batch_dimensions_lhs_float32_4_4_3_3_4__rhs_float32_4_4_3_4_2__dimensionnumbers____4____3______0_1_2___0_1_2.mlir
+++ b/stablehlo/testdata/dot_general_batch_dimensions_lhs_float32_4_4_3_3_4__rhs_float32_4_4_3_4_2__dimensionnumbers____4____3______0_1_2___0_1_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_batch_dimensions_lhs_float32_8_4_3_3_4__rhs_float32_4_8_3_4_2__dimensionnumbers____4_3___3_2_____0_1___1_0.mlir
+++ b/stablehlo/testdata/dot_general_batch_dimensions_lhs_float32_8_4_3_3_4__rhs_float32_4_8_3_4_2__dimensionnumbers____4_3___3_2_____0_1___1_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_1_3_4__rhs_bfloat16_1_4_3__dimensionnumbers____2_1___1-3488071595538934629.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_1_3_4__rhs_bfloat16_1_4_3__dimensionnumbers____2_1___1-3488071595538934629.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_1_3_4__rhs_bfloat16_1_4_3__dimensionnumbers____2_1___1-3776297041219061363.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_1_3_4__rhs_bfloat16_1_4_3__dimensionnumbers____2_1___1-3776297041219061363.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_1_3_4__rhs_bfloat16_1_4_3__dimensionnumbers____2_1___14414396846507850540.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_1_3_4__rhs_bfloat16_1_4_3__dimensionnumbers____2_1___14414396846507850540.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_1_3_4__rhs_bfloat16_1_4_3__dimensionnumbers____2_1___1_2_____0____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_1_3_4__rhs_bfloat16_1_4_3__dimensionnumbers____2_1___1_2_____0____0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_3_4__rhs_bfloat16_4_2__dimensionnumbers____1____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_3_4__rhs_bfloat16_4_2__dimensionnumbers____1____0.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_3_4__rhs_bfloat16_4_2__dimensionnumbers____1____0_____-1754126126588226380.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_3_4__rhs_bfloat16_4_2__dimensionnumbers____1____0_____-1754126126588226380.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_3_4__rhs_bfloat16_4_2__dimensionnumbers____1____0_____-2296794117335230406.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_3_4__rhs_bfloat16_4_2__dimensionnumbers____1____0_____-2296794117335230406.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_3_4__rhs_bfloat16_4_2__dimensionnumbers____1____0_____-7202245725599589690.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_3_4__rhs_bfloat16_4_2__dimensionnumbers____1____0_____-7202245725599589690.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_7_3_4__rhs_bfloat16_7_4__dimensionnumbers____2____1___-1057231342150989035.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_7_3_4__rhs_bfloat16_7_4__dimensionnumbers____2____1___-1057231342150989035.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_7_3_4__rhs_bfloat16_7_4__dimensionnumbers____2____1___-3405297742316790041.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_7_3_4__rhs_bfloat16_7_4__dimensionnumbers____2____1___-3405297742316790041.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_7_3_4__rhs_bfloat16_7_4__dimensionnumbers____2____1___7892347291040569893.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_7_3_4__rhs_bfloat16_7_4__dimensionnumbers____2____1___7892347291040569893.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_7_3_4__rhs_bfloat16_7_4__dimensionnumbers____2____1______0____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bfloat16_7_3_4__rhs_bfloat16_7_4__dimensionnumbers____2____1______0____0.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_1_3_4__rhs_bool_1_4_3__dimensionnumbers____2_1___1_2_____0-3484588224050375727.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_1_3_4__rhs_bool_1_4_3__dimensionnumbers____2_1___1_2_____0-3484588224050375727.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_1_3_4__rhs_bool_1_4_3__dimensionnumbers____2_1___1_2_____0-4108919279260287054.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_1_3_4__rhs_bool_1_4_3__dimensionnumbers____2_1___1_2_____0-4108919279260287054.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_1_3_4__rhs_bool_1_4_3__dimensionnumbers____2_1___1_2_____0-4878328097352283363.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_1_3_4__rhs_bool_1_4_3__dimensionnumbers____2_1___1_2_____0-4878328097352283363.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_1_3_4__rhs_bool_1_4_3__dimensionnumbers____2_1___1_2_____0____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_1_3_4__rhs_bool_1_4_3__dimensionnumbers____2_1___1_2_____0____0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_3_4__rhs_bool_4_2__dimensionnumbers____1____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_3_4__rhs_bool_4_2__dimensionnumbers____1____0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_3_4__rhs_bool_4_2__dimensionnumbers____1____0_____________-8168146190025525366.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_3_4__rhs_bool_4_2__dimensionnumbers____1____0_____________-8168146190025525366.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_3_4__rhs_bool_4_2__dimensionnumbers____1____0_____________-8768711742441429271.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_3_4__rhs_bool_4_2__dimensionnumbers____1____0_____________-8768711742441429271.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_3_4__rhs_bool_4_2__dimensionnumbers____1____0_____________3842350780159274364.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_3_4__rhs_bool_4_2__dimensionnumbers____1____0_____________3842350780159274364.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_7_3_4__rhs_bool_7_4__dimensionnumbers____2____1______0____-2740531727885652483.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_7_3_4__rhs_bool_7_4__dimensionnumbers____2____1______0____-2740531727885652483.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_7_3_4__rhs_bool_7_4__dimensionnumbers____2____1______0____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_7_3_4__rhs_bool_7_4__dimensionnumbers____2____1______0____0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_7_3_4__rhs_bool_7_4__dimensionnumbers____2____1______0____2897938142369644973.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_7_3_4__rhs_bool_7_4__dimensionnumbers____2____1______0____2897938142369644973.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_7_3_4__rhs_bool_7_4__dimensionnumbers____2____1______0____7336872569949371587.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_bool_7_3_4__rhs_bool_7_4__dimensionnumbers____2____1______0____7336872569949371587.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_1_3_4__rhs_complex64_1_4_3__dimensionnumbers____2_1__-735411287416952288.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_1_3_4__rhs_complex64_1_4_3__dimensionnumbers____2_1__-735411287416952288.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_1_3_4__rhs_complex64_1_4_3__dimensionnumbers____2_1__-784191692831253394.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_1_3_4__rhs_complex64_1_4_3__dimensionnumbers____2_1__-784191692831253394.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_1_3_4__rhs_complex64_1_4_3__dimensionnumbers____2_1__-8165666907376519597.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_1_3_4__rhs_complex64_1_4_3__dimensionnumbers____2_1__-8165666907376519597.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_1_3_4__rhs_complex64_1_4_3__dimensionnumbers____2_1___1_2_____0____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_1_3_4__rhs_complex64_1_4_3__dimensionnumbers____2_1___1_2_____0____0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_3_4__rhs_complex64_4_2__dimensionnumbers____1____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_3_4__rhs_complex64_4_2__dimensionnumbers____1____0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_3_4__rhs_complex64_4_2__dimensionnumbers____1____0___-2036095829843401162.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_3_4__rhs_complex64_4_2__dimensionnumbers____1____0___-2036095829843401162.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_3_4__rhs_complex64_4_2__dimensionnumbers____1____0___3282598972180177227.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_3_4__rhs_complex64_4_2__dimensionnumbers____1____0___3282598972180177227.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_3_4__rhs_complex64_4_2__dimensionnumbers____1____0___6322139621408956459.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_3_4__rhs_complex64_4_2__dimensionnumbers____1____0___6322139621408956459.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_7_3_4__rhs_complex64_7_4__dimensionnumbers____2____1_-3568690752099311792.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_7_3_4__rhs_complex64_7_4__dimensionnumbers____2____1_-3568690752099311792.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_7_3_4__rhs_complex64_7_4__dimensionnumbers____2____1_6996122032990541190.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_7_3_4__rhs_complex64_7_4__dimensionnumbers____2____1_6996122032990541190.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_7_3_4__rhs_complex64_7_4__dimensionnumbers____2____1_7256596681599443155.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_7_3_4__rhs_complex64_7_4__dimensionnumbers____2____1_7256596681599443155.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_7_3_4__rhs_complex64_7_4__dimensionnumbers____2____1______0____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_complex64_7_3_4__rhs_complex64_7_4__dimensionnumbers____2____1______0____0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float16_1_3_4__rhs_float16_1_4_3__dimensionnumbers____2_1___1_2-5921596014272431301.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float16_1_3_4__rhs_float16_1_4_3__dimensionnumbers____2_1___1_2-5921596014272431301.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float16_1_3_4__rhs_float16_1_4_3__dimensionnumbers____2_1___1_2-6403074408941076884.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float16_1_3_4__rhs_float16_1_4_3__dimensionnumbers____2_1___1_2-6403074408941076884.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float16_1_3_4__rhs_float16_1_4_3__dimensionnumbers____2_1___1_25368203653113481261.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float16_1_3_4__rhs_float16_1_4_3__dimensionnumbers____2_1___1_25368203653113481261.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float16_1_3_4__rhs_float16_1_4_3__dimensionnumbers____2_1___1_2_____0____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float16_1_3_4__rhs_float16_1_4_3__dimensionnumbers____2_1___1_2_____0____0.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float16_3_4__rhs_float16_4_2__dimensionnumbers____1____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float16_3_4__rhs_float16_4_2__dimensionnumbers____1____0.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float16_3_4__rhs_float16_4_2__dimensionnumbers____1____0_______-7388364319283628312.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float16_3_4__rhs_float16_4_2__dimensionnumbers____1____0_______-7388364319283628312.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float16_3_4__rhs_float16_4_2__dimensionnumbers____1____0_______8029402052741705387.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float16_3_4__rhs_float16_4_2__dimensionnumbers____1____0_______8029402052741705387.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float16_3_4__rhs_float16_4_2__dimensionnumbers____1____0_______8128671494384340964.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float16_3_4__rhs_float16_4_2__dimensionnumbers____1____0_______8128671494384340964.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float16_7_3_4__rhs_float16_7_4__dimensionnumbers____2____1_____-4939131732003714788.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float16_7_3_4__rhs_float16_7_4__dimensionnumbers____2____1_____-4939131732003714788.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float16_7_3_4__rhs_float16_7_4__dimensionnumbers____2____1_____-6133721521964233097.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float16_7_3_4__rhs_float16_7_4__dimensionnumbers____2____1_____-6133721521964233097.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float16_7_3_4__rhs_float16_7_4__dimensionnumbers____2____1_____2091924050327567664.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float16_7_3_4__rhs_float16_7_4__dimensionnumbers____2____1_____2091924050327567664.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float16_7_3_4__rhs_float16_7_4__dimensionnumbers____2____1______0____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float16_7_3_4__rhs_float16_7_4__dimensionnumbers____2____1______0____0.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_1_3_4__rhs_float32_1_4_3__dimensionnumbers____2_1___1_2-3746161505671304111.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_1_3_4__rhs_float32_1_4_3__dimensionnumbers____2_1___1_2-3746161505671304111.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_1_3_4__rhs_float32_1_4_3__dimensionnumbers____2_1___1_2-601699960869302464.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_1_3_4__rhs_float32_1_4_3__dimensionnumbers____2_1___1_2-601699960869302464.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_1_3_4__rhs_float32_1_4_3__dimensionnumbers____2_1___1_26892231390636518787.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_1_3_4__rhs_float32_1_4_3__dimensionnumbers____2_1___1_26892231390636518787.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_1_3_4__rhs_float32_1_4_3__dimensionnumbers____2_1___1_2_____0____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_1_3_4__rhs_float32_1_4_3__dimensionnumbers____2_1___1_2_____0____0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_3_4__rhs_float32_4_2__dimensionnumbers____1____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_3_4__rhs_float32_4_2__dimensionnumbers____1____0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_3_4__rhs_float32_4_2__dimensionnumbers____1____0_______2515748806464509716.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_3_4__rhs_float32_4_2__dimensionnumbers____1____0_______2515748806464509716.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_3_4__rhs_float32_4_2__dimensionnumbers____1____0_______3286318053268167699.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_3_4__rhs_float32_4_2__dimensionnumbers____1____0_______3286318053268167699.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_3_4__rhs_float32_4_2__dimensionnumbers____1____0_______3732210740950592224.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_3_4__rhs_float32_4_2__dimensionnumbers____1____0_______3732210740950592224.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_7_3_4__rhs_float32_7_4__dimensionnumbers____2____1_____-3197832446988830601.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_7_3_4__rhs_float32_7_4__dimensionnumbers____2____1_____-3197832446988830601.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_7_3_4__rhs_float32_7_4__dimensionnumbers____2____1_____3738222238009994556.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_7_3_4__rhs_float32_7_4__dimensionnumbers____2____1_____3738222238009994556.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_7_3_4__rhs_float32_7_4__dimensionnumbers____2____1_____3780030947611086597.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_7_3_4__rhs_float32_7_4__dimensionnumbers____2____1_____3780030947611086597.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_7_3_4__rhs_float32_7_4__dimensionnumbers____2____1______0____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_float32_7_3_4__rhs_float32_7_4__dimensionnumbers____2____1______0____0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_1_3_4__rhs_int16_1_4_3__dimensionnumbers____2_1___1_2____-4742864369009872129.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_1_3_4__rhs_int16_1_4_3__dimensionnumbers____2_1___1_2____-4742864369009872129.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_1_3_4__rhs_int16_1_4_3__dimensionnumbers____2_1___1_2____-7158034838136709443.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_1_3_4__rhs_int16_1_4_3__dimensionnumbers____2_1___1_2____-7158034838136709443.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_1_3_4__rhs_int16_1_4_3__dimensionnumbers____2_1___1_2____1922628071420239357.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_1_3_4__rhs_int16_1_4_3__dimensionnumbers____2_1___1_2____1922628071420239357.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_1_3_4__rhs_int16_1_4_3__dimensionnumbers____2_1___1_2_____0____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_1_3_4__rhs_int16_1_4_3__dimensionnumbers____2_1___1_2_____0____0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_3_4__rhs_int16_4_2__dimensionnumbers____1____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_3_4__rhs_int16_4_2__dimensionnumbers____1____0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_3_4__rhs_int16_4_2__dimensionnumbers____1____0___________-2271803244152339341.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_3_4__rhs_int16_4_2__dimensionnumbers____1____0___________-2271803244152339341.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_3_4__rhs_int16_4_2__dimensionnumbers____1____0___________2101610351464245948.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_3_4__rhs_int16_4_2__dimensionnumbers____1____0___________2101610351464245948.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_3_4__rhs_int16_4_2__dimensionnumbers____1____0___________7896444752678988294.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_3_4__rhs_int16_4_2__dimensionnumbers____1____0___________7896444752678988294.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_7_3_4__rhs_int16_7_4__dimensionnumbers____2____1______0__-8124740806626215928.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_7_3_4__rhs_int16_7_4__dimensionnumbers____2____1______0__-8124740806626215928.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_7_3_4__rhs_int16_7_4__dimensionnumbers____2____1______0__289753334994817081.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_7_3_4__rhs_int16_7_4__dimensionnumbers____2____1______0__289753334994817081.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_7_3_4__rhs_int16_7_4__dimensionnumbers____2____1______0__3337013416783310431.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_7_3_4__rhs_int16_7_4__dimensionnumbers____2____1______0__3337013416783310431.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_7_3_4__rhs_int16_7_4__dimensionnumbers____2____1______0____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int16_7_3_4__rhs_int16_7_4__dimensionnumbers____2____1______0____0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_1_3_4__rhs_int32_1_4_3__dimensionnumbers____2_1___1_2____-231006999036771167.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_1_3_4__rhs_int32_1_4_3__dimensionnumbers____2_1___1_2____-231006999036771167.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_1_3_4__rhs_int32_1_4_3__dimensionnumbers____2_1___1_2____-7694624932495008475.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_1_3_4__rhs_int32_1_4_3__dimensionnumbers____2_1___1_2____-7694624932495008475.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_1_3_4__rhs_int32_1_4_3__dimensionnumbers____2_1___1_2____7986672474430827476.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_1_3_4__rhs_int32_1_4_3__dimensionnumbers____2_1___1_2____7986672474430827476.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_1_3_4__rhs_int32_1_4_3__dimensionnumbers____2_1___1_2_____0____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_1_3_4__rhs_int32_1_4_3__dimensionnumbers____2_1___1_2_____0____0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_3_4__rhs_int32_4_2__dimensionnumbers____1____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_3_4__rhs_int32_4_2__dimensionnumbers____1____0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_3_4__rhs_int32_4_2__dimensionnumbers____1____0___________-3174156855870199286.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_3_4__rhs_int32_4_2__dimensionnumbers____1____0___________-3174156855870199286.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_3_4__rhs_int32_4_2__dimensionnumbers____1____0___________-5353411001541942402.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_3_4__rhs_int32_4_2__dimensionnumbers____1____0___________-5353411001541942402.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_3_4__rhs_int32_4_2__dimensionnumbers____1____0___________1165017806469887730.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_3_4__rhs_int32_4_2__dimensionnumbers____1____0___________1165017806469887730.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_7_3_4__rhs_int32_7_4__dimensionnumbers____2____1______0__-9076583839040242713.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_7_3_4__rhs_int32_7_4__dimensionnumbers____2____1______0__-9076583839040242713.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_7_3_4__rhs_int32_7_4__dimensionnumbers____2____1______0__4165376091224852052.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_7_3_4__rhs_int32_7_4__dimensionnumbers____2____1______0__4165376091224852052.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_7_3_4__rhs_int32_7_4__dimensionnumbers____2____1______0__7424163616416445021.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_7_3_4__rhs_int32_7_4__dimensionnumbers____2____1______0__7424163616416445021.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_7_3_4__rhs_int32_7_4__dimensionnumbers____2____1______0____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int32_7_3_4__rhs_int32_7_4__dimensionnumbers____2____1______0____0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_1_3_4__rhs_int8_1_4_3__dimensionnumbers____2_1___1_2_____0-3853546448610067655.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_1_3_4__rhs_int8_1_4_3__dimensionnumbers____2_1___1_2_____0-3853546448610067655.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_1_3_4__rhs_int8_1_4_3__dimensionnumbers____2_1___1_2_____0-4928777745320269696.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_1_3_4__rhs_int8_1_4_3__dimensionnumbers____2_1___1_2_____0-4928777745320269696.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_1_3_4__rhs_int8_1_4_3__dimensionnumbers____2_1___1_2_____0-8601469441317250057.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_1_3_4__rhs_int8_1_4_3__dimensionnumbers____2_1___1_2_____0-8601469441317250057.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_1_3_4__rhs_int8_1_4_3__dimensionnumbers____2_1___1_2_____0____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_1_3_4__rhs_int8_1_4_3__dimensionnumbers____2_1___1_2_____0____0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_3_4__rhs_int8_4_2__dimensionnumbers____1____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_3_4__rhs_int8_4_2__dimensionnumbers____1____0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_3_4__rhs_int8_4_2__dimensionnumbers____1____0_____________-2611634671922146939.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_3_4__rhs_int8_4_2__dimensionnumbers____1____0_____________-2611634671922146939.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_3_4__rhs_int8_4_2__dimensionnumbers____1____0_____________3394615931814532441.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_3_4__rhs_int8_4_2__dimensionnumbers____1____0_____________3394615931814532441.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_3_4__rhs_int8_4_2__dimensionnumbers____1____0_____________5154403401871514821.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_3_4__rhs_int8_4_2__dimensionnumbers____1____0_____________5154403401871514821.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_7_3_4__rhs_int8_7_4__dimensionnumbers____2____1______0____-6266355234981290645.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_7_3_4__rhs_int8_7_4__dimensionnumbers____2____1______0____-6266355234981290645.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_7_3_4__rhs_int8_7_4__dimensionnumbers____2____1______0____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_7_3_4__rhs_int8_7_4__dimensionnumbers____2____1______0____0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_7_3_4__rhs_int8_7_4__dimensionnumbers____2____1______0____263428595008059154.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_7_3_4__rhs_int8_7_4__dimensionnumbers____2____1______0____263428595008059154.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_7_3_4__rhs_int8_7_4__dimensionnumbers____2____1______0____4702378364613486236.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_int8_7_3_4__rhs_int8_7_4__dimensionnumbers____2____1______0____4702378364613486236.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_1_3_4__rhs_uint16_1_4_3__dimensionnumbers____2_1___1_2__-146653715732496678.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_1_3_4__rhs_uint16_1_4_3__dimensionnumbers____2_1___1_2__-146653715732496678.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_1_3_4__rhs_uint16_1_4_3__dimensionnumbers____2_1___1_2__-2338360034038796500.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_1_3_4__rhs_uint16_1_4_3__dimensionnumbers____2_1___1_2__-2338360034038796500.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_1_3_4__rhs_uint16_1_4_3__dimensionnumbers____2_1___1_2__7305651858029495209.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_1_3_4__rhs_uint16_1_4_3__dimensionnumbers____2_1___1_2__7305651858029495209.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_1_3_4__rhs_uint16_1_4_3__dimensionnumbers____2_1___1_2_____0____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_1_3_4__rhs_uint16_1_4_3__dimensionnumbers____2_1___1_2_____0____0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_3_4__rhs_uint16_4_2__dimensionnumbers____1____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_3_4__rhs_uint16_4_2__dimensionnumbers____1____0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_3_4__rhs_uint16_4_2__dimensionnumbers____1____0_________-1866955430630412412.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_3_4__rhs_uint16_4_2__dimensionnumbers____1____0_________-1866955430630412412.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_3_4__rhs_uint16_4_2__dimensionnumbers____1____0_________-387512258616889308.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_3_4__rhs_uint16_4_2__dimensionnumbers____1____0_________-387512258616889308.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_3_4__rhs_uint16_4_2__dimensionnumbers____1____0_________-5278629355353596549.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_3_4__rhs_uint16_4_2__dimensionnumbers____1____0_________-5278629355353596549.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_7_3_4__rhs_uint16_7_4__dimensionnumbers____2____1______0-1122680703579366098.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_7_3_4__rhs_uint16_7_4__dimensionnumbers____2____1______0-1122680703579366098.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_7_3_4__rhs_uint16_7_4__dimensionnumbers____2____1______0-2540294669593821117.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_7_3_4__rhs_uint16_7_4__dimensionnumbers____2____1______0-2540294669593821117.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_7_3_4__rhs_uint16_7_4__dimensionnumbers____2____1______02143288615622397436.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_7_3_4__rhs_uint16_7_4__dimensionnumbers____2____1______02143288615622397436.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_7_3_4__rhs_uint16_7_4__dimensionnumbers____2____1______0____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint16_7_3_4__rhs_uint16_7_4__dimensionnumbers____2____1______0____0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_1_3_4__rhs_uint32_1_4_3__dimensionnumbers____2_1___1_2__-3828685614544935607.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_1_3_4__rhs_uint32_1_4_3__dimensionnumbers____2_1___1_2__-3828685614544935607.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_1_3_4__rhs_uint32_1_4_3__dimensionnumbers____2_1___1_2__1983506021040082421.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_1_3_4__rhs_uint32_1_4_3__dimensionnumbers____2_1___1_2__1983506021040082421.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_1_3_4__rhs_uint32_1_4_3__dimensionnumbers____2_1___1_2__4074853676794110911.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_1_3_4__rhs_uint32_1_4_3__dimensionnumbers____2_1___1_2__4074853676794110911.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_1_3_4__rhs_uint32_1_4_3__dimensionnumbers____2_1___1_2_____0____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_1_3_4__rhs_uint32_1_4_3__dimensionnumbers____2_1___1_2_____0____0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_3_4__rhs_uint32_4_2__dimensionnumbers____1____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_3_4__rhs_uint32_4_2__dimensionnumbers____1____0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_3_4__rhs_uint32_4_2__dimensionnumbers____1____0_________-7142718517056468988.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_3_4__rhs_uint32_4_2__dimensionnumbers____1____0_________-7142718517056468988.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_3_4__rhs_uint32_4_2__dimensionnumbers____1____0_________3265766190081922835.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_3_4__rhs_uint32_4_2__dimensionnumbers____1____0_________3265766190081922835.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_3_4__rhs_uint32_4_2__dimensionnumbers____1____0_________4943295620416399626.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_3_4__rhs_uint32_4_2__dimensionnumbers____1____0_________4943295620416399626.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_7_3_4__rhs_uint32_7_4__dimensionnumbers____2____1______0-2439260603686590970.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_7_3_4__rhs_uint32_7_4__dimensionnumbers____2____1______0-2439260603686590970.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_7_3_4__rhs_uint32_7_4__dimensionnumbers____2____1______0-3523542059064547826.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_7_3_4__rhs_uint32_7_4__dimensionnumbers____2____1______0-3523542059064547826.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_7_3_4__rhs_uint32_7_4__dimensionnumbers____2____1______02825204705189971310.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_7_3_4__rhs_uint32_7_4__dimensionnumbers____2____1______02825204705189971310.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_7_3_4__rhs_uint32_7_4__dimensionnumbers____2____1______0____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint32_7_3_4__rhs_uint32_7_4__dimensionnumbers____2____1______0____0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_1_3_4__rhs_uint8_1_4_3__dimensionnumbers____2_1___1_2____-3976120861674915517.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_1_3_4__rhs_uint8_1_4_3__dimensionnumbers____2_1___1_2____-3976120861674915517.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_1_3_4__rhs_uint8_1_4_3__dimensionnumbers____2_1___1_2____469616114700916203.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_1_3_4__rhs_uint8_1_4_3__dimensionnumbers____2_1___1_2____469616114700916203.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_1_3_4__rhs_uint8_1_4_3__dimensionnumbers____2_1___1_2____6468279395723435326.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_1_3_4__rhs_uint8_1_4_3__dimensionnumbers____2_1___1_2____6468279395723435326.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_1_3_4__rhs_uint8_1_4_3__dimensionnumbers____2_1___1_2_____0____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_1_3_4__rhs_uint8_1_4_3__dimensionnumbers____2_1___1_2_____0____0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_3_4__rhs_uint8_4_2__dimensionnumbers____1____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_3_4__rhs_uint8_4_2__dimensionnumbers____1____0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_3_4__rhs_uint8_4_2__dimensionnumbers____1____0___________-1252152727279771837.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_3_4__rhs_uint8_4_2__dimensionnumbers____1____0___________-1252152727279771837.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_3_4__rhs_uint8_4_2__dimensionnumbers____1____0___________-2234047840108169469.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_3_4__rhs_uint8_4_2__dimensionnumbers____1____0___________-2234047840108169469.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_3_4__rhs_uint8_4_2__dimensionnumbers____1____0___________-4506489744827934724.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_3_4__rhs_uint8_4_2__dimensionnumbers____1____0___________-4506489744827934724.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_7_3_4__rhs_uint8_7_4__dimensionnumbers____2____1______0__-2500540846752821341.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_7_3_4__rhs_uint8_7_4__dimensionnumbers____2____1______0__-2500540846752821341.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_7_3_4__rhs_uint8_7_4__dimensionnumbers____2____1______0__2563221986579472778.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_7_3_4__rhs_uint8_7_4__dimensionnumbers____2____1______0__2563221986579472778.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_7_3_4__rhs_uint8_7_4__dimensionnumbers____2____1______0__2721838283221210166.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_7_3_4__rhs_uint8_7_4__dimensionnumbers____2____1______0__2721838283221210166.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_7_3_4__rhs_uint8_7_4__dimensionnumbers____2____1______0____0.mlir
+++ b/stablehlo/testdata/dot_general_dtypes_and_precision_lhs_uint8_7_3_4__rhs_uint8_7_4__dimensionnumbers____2____1______0____0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_dynamic.mlir
+++ b/stablehlo/testdata/dot_general_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x4xf32> {mhlo.sharding = ""}, %arg2: tensor<?x4xf32> {mhlo.sharding = ""}) -> tensor<?x4xf32> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_bfloat16_3__rhs_bfloat16_3_6__dimensionnumbers____0____0_____________preferred_float32.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_bfloat16_3__rhs_bfloat16_3_6__dimensionnumbers____0____0_____________preferred_float32.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_bfloat16_3__rhs_bfloat16_3_6__dimensionnumbers____0____0_____________preferred_float64.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_bfloat16_3__rhs_bfloat16_3_6__dimensionnumbers____0____0_____________preferred_float64.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_bfloat16_3__rhs_bfloat16_3__dimensionnumbers____0____0_____________preferred_float32.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_bfloat16_3__rhs_bfloat16_3__dimensionnumbers____0____0_____________preferred_float32.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_bfloat16_3__rhs_bfloat16_3__dimensionnumbers____0____0_____________preferred_float64.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_bfloat16_3__rhs_bfloat16_3__dimensionnumbers____0____0_____________preferred_float64.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_bfloat16_4_3__rhs_bfloat16_3_6__dimensionnumbers____1____0_____________preferred_float32.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_bfloat16_4_3__rhs_bfloat16_3_6__dimensionnumbers____1____0_____________preferred_float32.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_bfloat16_4_3__rhs_bfloat16_3_6__dimensionnumbers____1____0_____________preferred_float64.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_bfloat16_4_3__rhs_bfloat16_3_6__dimensionnumbers____1____0_____________preferred_float64.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_bfloat16_4_3__rhs_bfloat16_3__dimensionnumbers____1____0_____________preferred_float32.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_bfloat16_4_3__rhs_bfloat16_3__dimensionnumbers____1____0_____________preferred_float32.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_bfloat16_4_3__rhs_bfloat16_3__dimensionnumbers____1____0_____________preferred_float64.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_bfloat16_4_3__rhs_bfloat16_3__dimensionnumbers____1____0_____________preferred_float64.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_complex64_3__rhs_complex64_3_6__dimensionnumbers____0____0_____________preferred_complex128.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_complex64_3__rhs_complex64_3_6__dimensionnumbers____0____0_____________preferred_complex128.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_complex64_3__rhs_complex64_3__dimensionnumbers____0____0_____________preferred_complex128.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_complex64_3__rhs_complex64_3__dimensionnumbers____0____0_____________preferred_complex128.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_complex64_4_3__rhs_complex64_3_6__dimensionnumbers____1____0_____________preferred_complex128.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_complex64_4_3__rhs_complex64_3_6__dimensionnumbers____1____0_____________preferred_complex128.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_complex64_4_3__rhs_complex64_3__dimensionnumbers____1____0_____________preferred_complex128.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_complex64_4_3__rhs_complex64_3__dimensionnumbers____1____0_____________preferred_complex128.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_float16_3__rhs_float16_3_6__dimensionnumbers____0____0_____________preferred_float16.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_float16_3__rhs_float16_3_6__dimensionnumbers____0____0_____________preferred_float16.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_float16_3__rhs_float16_3_6__dimensionnumbers____0____0_____________preferred_float32.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_float16_3__rhs_float16_3_6__dimensionnumbers____0____0_____________preferred_float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_float16_3__rhs_float16_3_6__dimensionnumbers____0____0_____________preferred_float64.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_float16_3__rhs_float16_3_6__dimensionnumbers____0____0_____________preferred_float64.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_float16_3__rhs_float16_3__dimensionnumbers____0____0_____________preferred_float16.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_float16_3__rhs_float16_3__dimensionnumbers____0____0_____________preferred_float16.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_float16_3__rhs_float16_3__dimensionnumbers____0____0_____________preferred_float32.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_float16_3__rhs_float16_3__dimensionnumbers____0____0_____________preferred_float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_float16_3__rhs_float16_3__dimensionnumbers____0____0_____________preferred_float64.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_float16_3__rhs_float16_3__dimensionnumbers____0____0_____________preferred_float64.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_float16_4_3__rhs_float16_3_6__dimensionnumbers____1____0_____________preferred_float16.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_float16_4_3__rhs_float16_3_6__dimensionnumbers____1____0_____________preferred_float16.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_float16_4_3__rhs_float16_3_6__dimensionnumbers____1____0_____________preferred_float32.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_float16_4_3__rhs_float16_3_6__dimensionnumbers____1____0_____________preferred_float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_float16_4_3__rhs_float16_3_6__dimensionnumbers____1____0_____________preferred_float64.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_float16_4_3__rhs_float16_3_6__dimensionnumbers____1____0_____________preferred_float64.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_float16_4_3__rhs_float16_3__dimensionnumbers____1____0_____________preferred_float16.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_float16_4_3__rhs_float16_3__dimensionnumbers____1____0_____________preferred_float16.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_float16_4_3__rhs_float16_3__dimensionnumbers____1____0_____________preferred_float32.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_float16_4_3__rhs_float16_3__dimensionnumbers____1____0_____________preferred_float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_float16_4_3__rhs_float16_3__dimensionnumbers____1____0_____________preferred_float64.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_float16_4_3__rhs_float16_3__dimensionnumbers____1____0_____________preferred_float64.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_float32_3__rhs_float32_3_6__dimensionnumbers____0____0_____________preferred_float32.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_float32_3__rhs_float32_3_6__dimensionnumbers____0____0_____________preferred_float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_float32_3__rhs_float32_3_6__dimensionnumbers____0____0_____________preferred_float64.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_float32_3__rhs_float32_3_6__dimensionnumbers____0____0_____________preferred_float64.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_float32_3__rhs_float32_3__dimensionnumbers____0____0_____________preferred_float32.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_float32_3__rhs_float32_3__dimensionnumbers____0____0_____________preferred_float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_float32_3__rhs_float32_3__dimensionnumbers____0____0_____________preferred_float64.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_float32_3__rhs_float32_3__dimensionnumbers____0____0_____________preferred_float64.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_float32_4_3__rhs_float32_3_6__dimensionnumbers____1____0_____________preferred_float32.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_float32_4_3__rhs_float32_3_6__dimensionnumbers____1____0_____________preferred_float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_float32_4_3__rhs_float32_3_6__dimensionnumbers____1____0_____________preferred_float64.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_float32_4_3__rhs_float32_3_6__dimensionnumbers____1____0_____________preferred_float64.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_float32_4_3__rhs_float32_3__dimensionnumbers____1____0_____________preferred_float32.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_float32_4_3__rhs_float32_3__dimensionnumbers____1____0_____________preferred_float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_float32_4_3__rhs_float32_3__dimensionnumbers____1____0_____________preferred_float64.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_float32_4_3__rhs_float32_3__dimensionnumbers____1____0_____________preferred_float64.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_int16_3__rhs_int16_3_6__dimensionnumbers____0____0_____________preferred_int32.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_int16_3__rhs_int16_3_6__dimensionnumbers____0____0_____________preferred_int32.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_int16_3__rhs_int16_3_6__dimensionnumbers____0____0_____________preferred_int64.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_int16_3__rhs_int16_3_6__dimensionnumbers____0____0_____________preferred_int64.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_int16_3__rhs_int16_3__dimensionnumbers____0____0_____________preferred_int32.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_int16_3__rhs_int16_3__dimensionnumbers____0____0_____________preferred_int32.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_int16_3__rhs_int16_3__dimensionnumbers____0____0_____________preferred_int64.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_int16_3__rhs_int16_3__dimensionnumbers____0____0_____________preferred_int64.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_int16_4_3__rhs_int16_3_6__dimensionnumbers____1____0_____________preferred_int32.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_int16_4_3__rhs_int16_3_6__dimensionnumbers____1____0_____________preferred_int32.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_int16_4_3__rhs_int16_3_6__dimensionnumbers____1____0_____________preferred_int64.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_int16_4_3__rhs_int16_3_6__dimensionnumbers____1____0_____________preferred_int64.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_int16_4_3__rhs_int16_3__dimensionnumbers____1____0_____________preferred_int32.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_int16_4_3__rhs_int16_3__dimensionnumbers____1____0_____________preferred_int32.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_int16_4_3__rhs_int16_3__dimensionnumbers____1____0_____________preferred_int64.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_int16_4_3__rhs_int16_3__dimensionnumbers____1____0_____________preferred_int64.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_int32_3__rhs_int32_3_6__dimensionnumbers____0____0_____________preferred_int32.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_int32_3__rhs_int32_3_6__dimensionnumbers____0____0_____________preferred_int32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_int32_3__rhs_int32_3_6__dimensionnumbers____0____0_____________preferred_int64.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_int32_3__rhs_int32_3_6__dimensionnumbers____0____0_____________preferred_int64.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_int32_3__rhs_int32_3__dimensionnumbers____0____0_____________preferred_int32.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_int32_3__rhs_int32_3__dimensionnumbers____0____0_____________preferred_int32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_int32_3__rhs_int32_3__dimensionnumbers____0____0_____________preferred_int64.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_int32_3__rhs_int32_3__dimensionnumbers____0____0_____________preferred_int64.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_int32_4_3__rhs_int32_3_6__dimensionnumbers____1____0_____________preferred_int32.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_int32_4_3__rhs_int32_3_6__dimensionnumbers____1____0_____________preferred_int32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_int32_4_3__rhs_int32_3_6__dimensionnumbers____1____0_____________preferred_int64.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_int32_4_3__rhs_int32_3_6__dimensionnumbers____1____0_____________preferred_int64.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_int32_4_3__rhs_int32_3__dimensionnumbers____1____0_____________preferred_int32.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_int32_4_3__rhs_int32_3__dimensionnumbers____1____0_____________preferred_int32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_int32_4_3__rhs_int32_3__dimensionnumbers____1____0_____________preferred_int64.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_int32_4_3__rhs_int32_3__dimensionnumbers____1____0_____________preferred_int64.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_int8_3__rhs_int8_3_6__dimensionnumbers____0____0_____________preferred_int16.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_int8_3__rhs_int8_3_6__dimensionnumbers____0____0_____________preferred_int16.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_int8_3__rhs_int8_3_6__dimensionnumbers____0____0_____________preferred_int32.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_int8_3__rhs_int8_3_6__dimensionnumbers____0____0_____________preferred_int32.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_int8_3__rhs_int8_3_6__dimensionnumbers____0____0_____________preferred_int64.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_int8_3__rhs_int8_3_6__dimensionnumbers____0____0_____________preferred_int64.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_int8_3__rhs_int8_3__dimensionnumbers____0____0_____________preferred_int16.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_int8_3__rhs_int8_3__dimensionnumbers____0____0_____________preferred_int16.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_int8_3__rhs_int8_3__dimensionnumbers____0____0_____________preferred_int32.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_int8_3__rhs_int8_3__dimensionnumbers____0____0_____________preferred_int32.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_int8_3__rhs_int8_3__dimensionnumbers____0____0_____________preferred_int64.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_int8_3__rhs_int8_3__dimensionnumbers____0____0_____________preferred_int64.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_int8_4_3__rhs_int8_3_6__dimensionnumbers____1____0_____________preferred_int16.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_int8_4_3__rhs_int8_3_6__dimensionnumbers____1____0_____________preferred_int16.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_int8_4_3__rhs_int8_3_6__dimensionnumbers____1____0_____________preferred_int32.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_int8_4_3__rhs_int8_3_6__dimensionnumbers____1____0_____________preferred_int32.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_int8_4_3__rhs_int8_3_6__dimensionnumbers____1____0_____________preferred_int64.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_int8_4_3__rhs_int8_3_6__dimensionnumbers____1____0_____________preferred_int64.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_int8_4_3__rhs_int8_3__dimensionnumbers____1____0_____________preferred_int16.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_int8_4_3__rhs_int8_3__dimensionnumbers____1____0_____________preferred_int16.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_int8_4_3__rhs_int8_3__dimensionnumbers____1____0_____________preferred_int32.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_int8_4_3__rhs_int8_3__dimensionnumbers____1____0_____________preferred_int32.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_preferred_lhs_int8_4_3__rhs_int8_3__dimensionnumbers____1____0_____________preferred_int64.mlir
+++ b/stablehlo/testdata/dot_general_preferred_lhs_int8_4_3__rhs_int8_3__dimensionnumbers____1____0_____________preferred_int64.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_squeeze_lhs_float32_4_4__rhs_float32_4__dimensionnumbers____1____0.mlir
+++ b/stablehlo/testdata/dot_general_squeeze_lhs_float32_4_4__rhs_float32_4__dimensionnumbers____1____0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_squeeze_lhs_float32_4__rhs_float32_4_4__dimensionnumbers____0____0.mlir
+++ b/stablehlo/testdata/dot_general_squeeze_lhs_float32_4__rhs_float32_4_4__dimensionnumbers____0____0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dot_general_squeeze_lhs_float32_4__rhs_float32_4__dimensionnumbers____0____0.mlir
+++ b/stablehlo/testdata/dot_general_squeeze_lhs_float32_4__rhs_float32_4__dimensionnumbers____0____0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_slice_dtypes_a_bfloat16_3__start_indices__1___limit_indices__2___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_dtypes_a_bfloat16_3__start_indices__1___limit_indices__2___enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_slice_dtypes_a_bool_3__start_indices__1___limit_indices__2___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_dtypes_a_bool_3__start_indices__1___limit_indices__2___enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_slice_dtypes_a_complex64_3__start_indices__1___limit_indices__2___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_dtypes_a_complex64_3__start_indices__1___limit_indices__2___enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_slice_dtypes_a_float16_3__start_indices__1___limit_indices__2___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_dtypes_a_float16_3__start_indices__1___limit_indices__2___enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_slice_dtypes_a_float32_3__start_indices__1___limit_indices__2___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_dtypes_a_float32_3__start_indices__1___limit_indices__2___enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_slice_dtypes_a_int16_3__start_indices__1___limit_indices__2___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_dtypes_a_int16_3__start_indices__1___limit_indices__2___enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_slice_dtypes_a_int32_3__start_indices__1___limit_indices__2___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_dtypes_a_int32_3__start_indices__1___limit_indices__2___enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_slice_dtypes_a_int8_3__start_indices__1___limit_indices__2___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_dtypes_a_int8_3__start_indices__1___limit_indices__2___enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_slice_dtypes_a_uint16_3__start_indices__1___limit_indices__2___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_dtypes_a_uint16_3__start_indices__1___limit_indices__2___enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_slice_dtypes_a_uint32_3__start_indices__1___limit_indices__2___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_dtypes_a_uint32_3__start_indices__1___limit_indices__2___enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_slice_dtypes_a_uint8_3__start_indices__1___limit_indices__2___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_dtypes_a_uint8_3__start_indices__1___limit_indices__2___enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_slice_idx_array_enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/dynamic_slice_idx_array_enable_xla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}, %arg2: tensor<2xi32> {mhlo.sharding = ""}) -> tensor<?x2xf32> {

--- a/stablehlo/testdata/dynamic_slice_idx_tuple_arg_enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/dynamic_slice_idx_tuple_arg_enable_xla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}, %arg2: tensor<i32> {mhlo.sharding = ""}) -> tensor<?x2xf32> {

--- a/stablehlo/testdata/dynamic_slice_idx_tuple_int_enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/dynamic_slice_idx_tuple_int_enable_xla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}) -> tensor<?x2xf32> {

--- a/stablehlo/testdata/dynamic_slice_in_dim_idx_0_enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/dynamic_slice_in_dim_idx_0_enable_xla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}) -> tensor<?x4xf32> {

--- a/stablehlo/testdata/dynamic_slice_shapes_a_float32_3__start_indices__1___limit_indices__2___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_shapes_a_float32_3__start_indices__1___limit_indices__2___enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_slice_shapes_a_float32_3__start_indices__array_1__dtype_uint32____limit_indices__array_2__dt566174576596150437.mlir
+++ b/stablehlo/testdata/dynamic_slice_shapes_a_float32_3__start_indices__array_1__dtype_uint32____limit_indices__array_2__dt566174576596150437.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_slice_shapes_a_float32_3__start_indices__array_1__dtype_uint8____limit_indices__array_2__dtype_uint8____enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_shapes_a_float32_3__start_indices__array_1__dtype_uint8____limit_indices__array_2__dtype_uint8____enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_slice_shapes_a_float32_5_3__start_indices__1__1__limit_indices__2__1__enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_shapes_a_float32_5_3__start_indices__1__1__limit_indices__2__1__enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_slice_shapes_a_float32_5_3__start_indices__1__1__limit_indices__3__2__enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_shapes_a_float32_5_3__start_indices__1__1__limit_indices__3__2__enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__-100___limit_indices__-99___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__-100___limit_indices__-99___enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__-10___limit_indices__-9___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__-10___limit_indices__-9___enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__-1___limit_indices__0___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__-1___limit_indices__0___enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__-1___limit_indices__1___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__-1___limit_indices__1___enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__-4___limit_indices__-2___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__-4___limit_indices__-2___enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__-5___limit_indices__-2___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__-5___limit_indices__-2___enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__-6___limit_indices__-5___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__-6___limit_indices__-5___enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__10___limit_indices__11___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__10___limit_indices__11___enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__1___limit_indices__5___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__1___limit_indices__5___enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__3___limit_indices__6___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__3___limit_indices__6___enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__5___limit_indices__6___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__5___limit_indices__6___enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_slice_shapes_a_float32_7_5_3__start_indices__4__0__1__limit_indices__7__1__3__enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_shapes_a_float32_7_5_3__start_indices__4__0__1__limit_indices__7__1__3__enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_slice_shapes_a_float32_7__start_indices__4___limit_indices__7___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_shapes_a_float32_7__start_indices__4___limit_indices__7___enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_slice_shapes_a_float32_8__start_indices__1___limit_indices__6___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_shapes_a_float32_8__start_indices__1___limit_indices__6___enablexla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_update_slice_dtypes_operand_bfloat16_3__update_bfloat16_1__start_indices__1___enable_xla_True.mlir
+++ b/stablehlo/testdata/dynamic_update_slice_dtypes_operand_bfloat16_3__update_bfloat16_1__start_indices__1___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_update_slice_dtypes_operand_bool_3__update_bool_1__start_indices__1___enable_xla_True.mlir
+++ b/stablehlo/testdata/dynamic_update_slice_dtypes_operand_bool_3__update_bool_1__start_indices__1___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_update_slice_dtypes_operand_complex64_3__update_complex64_1__start_indices__1___enable_xla_True.mlir
+++ b/stablehlo/testdata/dynamic_update_slice_dtypes_operand_complex64_3__update_complex64_1__start_indices__1___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_update_slice_dtypes_operand_float16_3__update_float16_1__start_indices__1___enable_xla_True.mlir
+++ b/stablehlo/testdata/dynamic_update_slice_dtypes_operand_float16_3__update_float16_1__start_indices__1___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_update_slice_dtypes_operand_float32_3__update_float32_1__start_indices__1___enable_xla_True.mlir
+++ b/stablehlo/testdata/dynamic_update_slice_dtypes_operand_float32_3__update_float32_1__start_indices__1___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_update_slice_dtypes_operand_int16_3__update_int16_1__start_indices__1___enable_xla_True.mlir
+++ b/stablehlo/testdata/dynamic_update_slice_dtypes_operand_int16_3__update_int16_1__start_indices__1___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_update_slice_dtypes_operand_int32_3__update_int32_1__start_indices__1___enable_xla_True.mlir
+++ b/stablehlo/testdata/dynamic_update_slice_dtypes_operand_int32_3__update_int32_1__start_indices__1___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_update_slice_dtypes_operand_int8_3__update_int8_1__start_indices__1___enable_xla_True.mlir
+++ b/stablehlo/testdata/dynamic_update_slice_dtypes_operand_int8_3__update_int8_1__start_indices__1___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_update_slice_dtypes_operand_uint16_3__update_uint16_1__start_indices__1___enable_xla_True.mlir
+++ b/stablehlo/testdata/dynamic_update_slice_dtypes_operand_uint16_3__update_uint16_1__start_indices__1___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_update_slice_dtypes_operand_uint32_3__update_uint32_1__start_indices__1___enable_xla_True.mlir
+++ b/stablehlo/testdata/dynamic_update_slice_dtypes_operand_uint32_3__update_uint32_1__start_indices__1___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_update_slice_dtypes_operand_uint8_3__update_uint8_1__start_indices__1___enable_xla_True.mlir
+++ b/stablehlo/testdata/dynamic_update_slice_dtypes_operand_uint8_3__update_uint8_1__start_indices__1___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_update_slice_idx_array_enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/dynamic_update_slice_idx_array_enable_xla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}, %arg2: tensor<2xi32> {mhlo.sharding = ""}) -> tensor<?x4xf32> {

--- a/stablehlo/testdata/dynamic_update_slice_idx_tuple_arg_enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/dynamic_update_slice_idx_tuple_arg_enable_xla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}, %arg2: tensor<i32> {mhlo.sharding = ""}) -> tensor<?x4xf32> {

--- a/stablehlo/testdata/dynamic_update_slice_idx_tuple_int_enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/dynamic_update_slice_idx_tuple_int_enable_xla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}) -> tensor<?x4xf32> {

--- a/stablehlo/testdata/dynamic_update_slice_shapes_operand_float32_3__update_float32_1__start_indices__-1___enable_xla_True.mlir
+++ b/stablehlo/testdata/dynamic_update_slice_shapes_operand_float32_3__update_float32_1__start_indices__-1___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_update_slice_shapes_operand_float32_3__update_float32_1__start_indices__10___enable_xla_True.mlir
+++ b/stablehlo/testdata/dynamic_update_slice_shapes_operand_float32_3__update_float32_1__start_indices__10___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_update_slice_shapes_operand_float32_3__update_float32_1__start_indices__1___enable_xla_True.mlir
+++ b/stablehlo/testdata/dynamic_update_slice_shapes_operand_float32_3__update_float32_1__start_indices__1___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_update_slice_shapes_operand_float32_3__update_float32_1__start_indices__array_1__dtype_uint32____enable_xla_True.mlir
+++ b/stablehlo/testdata/dynamic_update_slice_shapes_operand_float32_3__update_float32_1__start_indices__array_1__dtype_uint32____enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_update_slice_shapes_operand_float32_3__update_float32_1__start_indices__array_1__dtype_uint8____enable_xla_True.mlir
+++ b/stablehlo/testdata/dynamic_update_slice_shapes_operand_float32_3__update_float32_1__start_indices__array_1__dtype_uint8____enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_update_slice_shapes_operand_float32_3__update_float32_2__start_indices__10___enable_xla_True.mlir
+++ b/stablehlo/testdata/dynamic_update_slice_shapes_operand_float32_3__update_float32_2__start_indices__10___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_update_slice_shapes_operand_float32_5_3__update_float32_3_1__start_indices__1__1__enable_xla_True.mlir
+++ b/stablehlo/testdata/dynamic_update_slice_shapes_operand_float32_5_3__update_float32_3_1__start_indices__1__1__enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/dynamic_update_slice_shapes_operand_float32_7_5_3__update_float32_2_0_1__start_indices__4__1__0__enable_xla_True.mlir
+++ b/stablehlo/testdata/dynamic_update_slice_shapes_operand_float32_7_5_3__update_float32_2_0_1__start_indices__4__1__0__enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/einsum_0_alt_dynamic.mlir
+++ b/stablehlo/testdata/einsum_0_alt_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}) -> tensor<?xf32> {

--- a/stablehlo/testdata/einsum_0_dynamic.mlir
+++ b/stablehlo/testdata/einsum_0_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}) -> tensor<?xf32> {

--- a/stablehlo/testdata/einsum_1_alt_dynamic.mlir
+++ b/stablehlo/testdata/einsum_1_alt_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x5xf32> {mhlo.sharding = ""}, %arg2: tensor<?x5x6xf32> {mhlo.sharding = ""}) -> tensor<?x4x6xf32> {

--- a/stablehlo/testdata/einsum_1_dynamic.mlir
+++ b/stablehlo/testdata/einsum_1_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x5xf32> {mhlo.sharding = ""}, %arg2: tensor<?x5x6xf32> {mhlo.sharding = ""}) -> tensor<?x4x6xf32> {

--- a/stablehlo/testdata/einsum_2_alt_dynamic.mlir
+++ b/stablehlo/testdata/einsum_2_alt_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x5xf32> {mhlo.sharding = ""}, %arg2: tensor<5x6xf32> {mhlo.sharding = ""}) -> tensor<?x4x6xf32> {

--- a/stablehlo/testdata/einsum_2_dynamic.mlir
+++ b/stablehlo/testdata/einsum_2_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x5xf32> {mhlo.sharding = ""}, %arg2: tensor<5x6xf32> {mhlo.sharding = ""}) -> tensor<?x4x6xf32> {

--- a/stablehlo/testdata/einsum_3_alt_dynamic.mlir
+++ b/stablehlo/testdata/einsum_3_alt_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<3x?xf32> {mhlo.sharding = ""}, %arg2: tensor<?x5xf32> {mhlo.sharding = ""}) -> tensor<3x5xf32> {

--- a/stablehlo/testdata/einsum_3_dynamic.mlir
+++ b/stablehlo/testdata/einsum_3_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<3x?xf32> {mhlo.sharding = ""}, %arg2: tensor<?x5xf32> {mhlo.sharding = ""}) -> tensor<3x5xf32> {

--- a/stablehlo/testdata/einsum_4_alt_dynamic.mlir
+++ b/stablehlo/testdata/einsum_4_alt_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<3x?xf32> {mhlo.sharding = ""}, %arg2: tensor<?x5xf32> {mhlo.sharding = ""}) -> tensor<3x5xf32> {

--- a/stablehlo/testdata/einsum_4_dynamic.mlir
+++ b/stablehlo/testdata/einsum_4_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<3x?xf32> {mhlo.sharding = ""}, %arg2: tensor<?x5xf32> {mhlo.sharding = ""}) -> tensor<3x5xf32> {

--- a/stablehlo/testdata/einsum_multiple_contractions_dynamic.mlir
+++ b/stablehlo/testdata/einsum_multiple_contractions_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2xf32> {mhlo.sharding = ""}, %arg2: tensor<2x3xf32> {mhlo.sharding = ""}, %arg3: tensor<3x4xf32> {mhlo.sharding = ""}) -> tensor<?x4xf32> {

--- a/stablehlo/testdata/eq_broadcasting_lhs_float32_1_2__rhs_float32_3_2.mlir
+++ b/stablehlo/testdata/eq_broadcasting_lhs_float32_1_2__rhs_float32_3_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/eq_broadcasting_lhs_float32___rhs_float32_2_3.mlir
+++ b/stablehlo/testdata/eq_broadcasting_lhs_float32___rhs_float32_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/eq_dtypes_lhs_bfloat16___rhs_bfloat16.mlir
+++ b/stablehlo/testdata/eq_dtypes_lhs_bfloat16___rhs_bfloat16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/eq_dtypes_lhs_bool___rhs_bool.mlir
+++ b/stablehlo/testdata/eq_dtypes_lhs_bool___rhs_bool.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/eq_dtypes_lhs_complex64___rhs_complex64.mlir
+++ b/stablehlo/testdata/eq_dtypes_lhs_complex64___rhs_complex64.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/eq_dtypes_lhs_float16___rhs_float16.mlir
+++ b/stablehlo/testdata/eq_dtypes_lhs_float16___rhs_float16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/eq_dtypes_lhs_float32___rhs_float32.mlir
+++ b/stablehlo/testdata/eq_dtypes_lhs_float32___rhs_float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/eq_dtypes_lhs_int16___rhs_int16.mlir
+++ b/stablehlo/testdata/eq_dtypes_lhs_int16___rhs_int16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/eq_dtypes_lhs_int32___rhs_int32.mlir
+++ b/stablehlo/testdata/eq_dtypes_lhs_int32___rhs_int32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/eq_dtypes_lhs_int8___rhs_int8.mlir
+++ b/stablehlo/testdata/eq_dtypes_lhs_int8___rhs_int8.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/eq_dtypes_lhs_uint16___rhs_uint16.mlir
+++ b/stablehlo/testdata/eq_dtypes_lhs_uint16___rhs_uint16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/eq_dtypes_lhs_uint32___rhs_uint32.mlir
+++ b/stablehlo/testdata/eq_dtypes_lhs_uint32___rhs_uint32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/eq_dtypes_lhs_uint8___rhs_uint8.mlir
+++ b/stablehlo/testdata/eq_dtypes_lhs_uint8___rhs_uint8.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/erf_inv_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/erf_inv_shape_bfloat16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/erf_inv_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/erf_inv_shape_float16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/erf_inv_shape_float32_20_20.mlir
+++ b/stablehlo/testdata/erf_inv_shape_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/erf_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/erf_shape_bfloat16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/erf_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/erf_shape_float16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/erf_shape_float32_20_20.mlir
+++ b/stablehlo/testdata/erf_shape_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/erfc_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/erfc_shape_bfloat16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/erfc_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/erfc_shape_float16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/erfc_shape_float32_20_20.mlir
+++ b/stablehlo/testdata/erfc_shape_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/exp_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/exp_shape_bfloat16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/exp_shape_complex64_20_20.mlir
+++ b/stablehlo/testdata/exp_shape_complex64_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/exp_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/exp_shape_float16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/exp_shape_float32_20_20.mlir
+++ b/stablehlo/testdata/exp_shape_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/expm1_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/expm1_shape_bfloat16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/expm1_shape_complex64_20_20.mlir
+++ b/stablehlo/testdata/expm1_shape_complex64_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/expm1_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/expm1_shape_float16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/expm1_shape_float32_20_20.mlir
+++ b/stablehlo/testdata/expm1_shape_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/eye_N_poly_M_None_dynamic.mlir
+++ b/stablehlo/testdata/eye_N_poly_M_None_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1xf32> {mhlo.sharding = ""}) -> tensor<?x?xf64> {

--- a/stablehlo/testdata/eye_N_poly_M_poly_dynamic.mlir
+++ b/stablehlo/testdata/eye_N_poly_M_poly_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1xf32> {mhlo.sharding = ""}) -> tensor<?x?xf64> {

--- a/stablehlo/testdata/floor_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/floor_shape_bfloat16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/floor_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/floor_shape_float16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/floor_shape_float32_20_20.mlir
+++ b/stablehlo/testdata/floor_shape_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/full_dynamic.mlir
+++ b/stablehlo/testdata/full_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1xf32> {mhlo.sharding = ""}) -> tensor<?x2xf32> {

--- a/stablehlo/testdata/gather_batchdims_shape__1__2__start_indices_shape__1__2__slice_sizes__1__1__enable_xla_True.mlir
+++ b/stablehlo/testdata/gather_batchdims_shape__1__2__start_indices_shape__1__2__slice_sizes__1__1__enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_batchdims_shape__2__3__3__start_indices_shape__2__3__slice_sizes__1__3__2__enable_xla_True.mlir
+++ b/stablehlo/testdata/gather_batchdims_shape__2__3__3__start_indices_shape__2__3__slice_sizes__1__3__2__enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_batchdims_shape__2__6__3__start_indices_shape__2__3__slice_sizes__1__3__3__enable_xla_True.mlir
+++ b/stablehlo/testdata/gather_batchdims_shape__2__6__3__start_indices_shape__2__3__slice_sizes__1__3__3__enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_batchdims_shape__3__10__start_indices_shape__3__2__slice_sizes__1__5__enable_xla_True.mlir
+++ b/stablehlo/testdata/gather_batchdims_shape__3__10__start_indices_shape__3__2__slice_sizes__1__5__enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_batchdims_shape__4__6__start_indices_shape__4__2__slice_sizes__1__3__enable_xla_True.mlir
+++ b/stablehlo/testdata/gather_batchdims_shape__4__6__start_indices_shape__4__2__slice_sizes__1__3__enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_dtypes_shape_bfloat16_10__axis_0_enable_xla_True.mlir
+++ b/stablehlo/testdata/gather_dtypes_shape_bfloat16_10__axis_0_enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_dtypes_shape_bool_10__axis_0_enable_xla_True.mlir
+++ b/stablehlo/testdata/gather_dtypes_shape_bool_10__axis_0_enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_dtypes_shape_complex64_10__axis_0_enable_xla_True.mlir
+++ b/stablehlo/testdata/gather_dtypes_shape_complex64_10__axis_0_enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_dtypes_shape_float16_10__axis_0_enable_xla_True.mlir
+++ b/stablehlo/testdata/gather_dtypes_shape_float16_10__axis_0_enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_dtypes_shape_float32_10__axis_0_enable_xla_True.mlir
+++ b/stablehlo/testdata/gather_dtypes_shape_float32_10__axis_0_enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_dtypes_shape_int16_10__axis_0_enable_xla_True.mlir
+++ b/stablehlo/testdata/gather_dtypes_shape_int16_10__axis_0_enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_dtypes_shape_int32_10__axis_0_enable_xla_True.mlir
+++ b/stablehlo/testdata/gather_dtypes_shape_int32_10__axis_0_enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_dtypes_shape_int8_10__axis_0_enable_xla_True.mlir
+++ b/stablehlo/testdata/gather_dtypes_shape_int8_10__axis_0_enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_dtypes_shape_uint16_10__axis_0_enable_xla_True.mlir
+++ b/stablehlo/testdata/gather_dtypes_shape_uint16_10__axis_0_enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_dtypes_shape_uint32_10__axis_0_enable_xla_True.mlir
+++ b/stablehlo/testdata/gather_dtypes_shape_uint32_10__axis_0_enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_dtypes_shape_uint8_10__axis_0_enable_xla_True.mlir
+++ b/stablehlo/testdata/gather_dtypes_shape_uint8_10__axis_0_enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_slicing_name___-1_-5_-200___enable_xla_True.mlir
+++ b/stablehlo/testdata/gather_from_slicing_name___-1_-5_-200___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_slicing_name___0_1___enable_xla_True.mlir
+++ b/stablehlo/testdata/gather_from_slicing_name___0_1___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_slicing_name___0___enable_xla_True.mlir
+++ b/stablehlo/testdata/gather_from_slicing_name___0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_slicing_name___2_5_5___enable_xla_True.mlir
+++ b/stablehlo/testdata/gather_from_slicing_name___2_5_5___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_slicing_name___5_-2_300___enable_xla_True.mlir
+++ b/stablehlo/testdata/gather_from_slicing_name___5_-2_300___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_slicing_name______2_____enable_xla_True.mlir
+++ b/stablehlo/testdata/gather_from_slicing_name______2_____enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__1__axis_0_enable_xla_True_mode_clip.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__1__axis_0_enable_xla_True_mode_clip.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__1__axis_0_enable_xla_True_mode_fill.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__1__axis_0_enable_xla_True_mode_fill.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__1__axis_1_enable_xla_True_mode_clip.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__1__axis_1_enable_xla_True_mode_clip.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__1__axis_1_enable_xla_True_mode_fill.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__1__axis_1_enable_xla_True_mode_fill.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__1__axis_2_enable_xla_True_mode_clip.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__1__axis_2_enable_xla_True_mode_clip.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__1__axis_2_enable_xla_True_mode_fill.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__1__axis_2_enable_xla_True_mode_fill.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__2__axis_0_enable_xla_True_mode_clip.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__2__axis_0_enable_xla_True_mode_clip.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__2__axis_0_enable_xla_True_mode_fill.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__2__axis_0_enable_xla_True_mode_fill.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__2__axis_1_enable_xla_True_mode_clip.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__2__axis_1_enable_xla_True_mode_clip.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__2__axis_1_enable_xla_True_mode_fill.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__2__axis_1_enable_xla_True_mode_fill.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__2__axis_2_enable_xla_True_mode_clip.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__2__axis_2_enable_xla_True_mode_clip.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__2__axis_2_enable_xla_True_mode_fill.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__2__axis_2_enable_xla_True_mode_fill.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__3__axis_0_enable_xla_True_mode_clip.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__3__axis_0_enable_xla_True_mode_clip.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__3__axis_0_enable_xla_True_mode_fill.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__3__axis_0_enable_xla_True_mode_fill.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__3__axis_1_enable_xla_True_mode_clip.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__3__axis_1_enable_xla_True_mode_clip.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__3__axis_1_enable_xla_True_mode_fill.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__3__axis_1_enable_xla_True_mode_fill.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__3__axis_2_enable_xla_True_mode_clip.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__3__axis_2_enable_xla_True_mode_clip.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__3__axis_2_enable_xla_True_mode_fill.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__3__axis_2_enable_xla_True_mode_fill.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__3_uint32__axis_0_enable_xla_True_mode_clip.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__3_uint32__axis_0_enable_xla_True_mode_clip.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__3_uint32__axis_0_enable_xla_True_mode_fill.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__3_uint32__axis_0_enable_xla_True_mode_fill.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__3_uint32__axis_1_enable_xla_True_mode_clip.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__3_uint32__axis_1_enable_xla_True_mode_clip.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__3_uint32__axis_1_enable_xla_True_mode_fill.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__3_uint32__axis_1_enable_xla_True_mode_fill.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__3_uint32__axis_2_enable_xla_True_mode_clip.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__3_uint32__axis_2_enable_xla_True_mode_clip.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__3_uint32__axis_2_enable_xla_True_mode_fill.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__3_uint32__axis_2_enable_xla_True_mode_fill.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__4__axis_0_enable_xla_True_mode_clip.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__4__axis_0_enable_xla_True_mode_clip.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__4__axis_0_enable_xla_True_mode_fill.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__4__axis_0_enable_xla_True_mode_fill.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__4__axis_1_enable_xla_True_mode_clip.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__4__axis_1_enable_xla_True_mode_clip.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__4__axis_1_enable_xla_True_mode_fill.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__4__axis_1_enable_xla_True_mode_fill.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__4__axis_2_enable_xla_True_mode_clip.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__4__axis_2_enable_xla_True_mode_clip.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__4__axis_2_enable_xla_True_mode_fill.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__4__axis_2_enable_xla_True_mode_fill.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__5_oob__axis_0_enable_xla_True_mode_clip.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__5_oob__axis_0_enable_xla_True_mode_clip.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__5_oob__axis_0_enable_xla_True_mode_fill.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__5_oob__axis_0_enable_xla_True_mode_fill.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__5_oob__axis_1_enable_xla_True_mode_clip.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__5_oob__axis_1_enable_xla_True_mode_clip.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__5_oob__axis_1_enable_xla_True_mode_fill.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__5_oob__axis_1_enable_xla_True_mode_fill.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__5_oob__axis_2_enable_xla_True_mode_clip.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__5_oob__axis_2_enable_xla_True_mode_clip.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__5_oob__axis_2_enable_xla_True_mode_fill.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__5_oob__axis_2_enable_xla_True_mode_fill.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__6_neg__axis_0_enable_xla_True_mode_clip.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__6_neg__axis_0_enable_xla_True_mode_clip.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__6_neg__axis_0_enable_xla_True_mode_fill.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__6_neg__axis_0_enable_xla_True_mode_fill.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__6_neg__axis_1_enable_xla_True_mode_clip.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__6_neg__axis_1_enable_xla_True_mode_clip.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__6_neg__axis_1_enable_xla_True_mode_fill.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__6_neg__axis_1_enable_xla_True_mode_fill.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__6_neg__axis_2_enable_xla_True_mode_clip.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__6_neg__axis_2_enable_xla_True_mode_clip.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__6_neg__axis_2_enable_xla_True_mode_fill.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__6_neg__axis_2_enable_xla_True_mode_fill.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__7_neg__axis_0_enable_xla_True_mode_clip.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__7_neg__axis_0_enable_xla_True_mode_clip.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__7_neg__axis_0_enable_xla_True_mode_fill.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__7_neg__axis_0_enable_xla_True_mode_fill.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__7_neg__axis_1_enable_xla_True_mode_clip.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__7_neg__axis_1_enable_xla_True_mode_clip.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__7_neg__axis_1_enable_xla_True_mode_fill.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__7_neg__axis_1_enable_xla_True_mode_fill.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__7_neg__axis_2_enable_xla_True_mode_clip.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__7_neg__axis_2_enable_xla_True_mode_clip.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__7_neg__axis_2_enable_xla_True_mode_fill.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__7_neg__axis_2_enable_xla_True_mode_fill.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__8_neg_oob__axis_0_enable_xla_True_mode_clip.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__8_neg_oob__axis_0_enable_xla_True_mode_clip.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__8_neg_oob__axis_0_enable_xla_True_mode_fill.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__8_neg_oob__axis_0_enable_xla_True_mode_fill.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__8_neg_oob__axis_1_enable_xla_True_mode_clip.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__8_neg_oob__axis_1_enable_xla_True_mode_clip.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__8_neg_oob__axis_1_enable_xla_True_mode_fill.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__8_neg_oob__axis_1_enable_xla_True_mode_fill.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__8_neg_oob__axis_2_enable_xla_True_mode_clip.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__8_neg_oob__axis_2_enable_xla_True_mode_clip.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_from_take_indices_name__8_neg_oob__axis_2_enable_xla_True_mode_fill.mlir
+++ b/stablehlo/testdata/gather_from_take_indices_name__8_neg_oob__axis_2_enable_xla_True_mode_fill.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_shape__10__5__idxs_shape__3__1__dnums_GatherDimensionNumbers_offset_dims__1____collapsed_slic5975718671559903784.mlir
+++ b/stablehlo/testdata/gather_shape__10__5__idxs_shape__3__1__dnums_GatherDimensionNumbers_offset_dims__1____collapsed_slic5975718671559903784.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_shape__10__6__idxs_shape__2__2__dnums_GatherDimensionNumbers_offset_dims__1____collapsed_slic-7762956558939593001.mlir
+++ b/stablehlo/testdata/gather_shape__10__6__idxs_shape__2__2__dnums_GatherDimensionNumbers_offset_dims__1____collapsed_slic-7762956558939593001.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_shape__10___idxs_shape__3__1__dnums_GatherDimensionNumbers_offset_dims__1____collapsed_slice_-4284776541264791777.mlir
+++ b/stablehlo/testdata/gather_shape__10___idxs_shape__3__1__dnums_GatherDimensionNumbers_offset_dims__1____collapsed_slice_-4284776541264791777.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gather_shape__5___idxs_shape__2__1__dnums_GatherDimensionNumbers_offset_dims_____collapsed_slice_dim-7698694031974320657.mlir
+++ b/stablehlo/testdata/gather_shape__5___idxs_shape__2__1__dnums_GatherDimensionNumbers_offset_dims_____collapsed_slice_dim-7698694031974320657.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/ge_broadcasting_lhs_float32_1_2__rhs_float32_3_2.mlir
+++ b/stablehlo/testdata/ge_broadcasting_lhs_float32_1_2__rhs_float32_3_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/ge_broadcasting_lhs_float32___rhs_float32_2_3.mlir
+++ b/stablehlo/testdata/ge_broadcasting_lhs_float32___rhs_float32_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/ge_dtypes_lhs_bfloat16___rhs_bfloat16.mlir
+++ b/stablehlo/testdata/ge_dtypes_lhs_bfloat16___rhs_bfloat16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/ge_dtypes_lhs_bool___rhs_bool.mlir
+++ b/stablehlo/testdata/ge_dtypes_lhs_bool___rhs_bool.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/ge_dtypes_lhs_complex64___rhs_complex64.mlir
+++ b/stablehlo/testdata/ge_dtypes_lhs_complex64___rhs_complex64.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/ge_dtypes_lhs_float16___rhs_float16.mlir
+++ b/stablehlo/testdata/ge_dtypes_lhs_float16___rhs_float16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/ge_dtypes_lhs_float32___rhs_float32.mlir
+++ b/stablehlo/testdata/ge_dtypes_lhs_float32___rhs_float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/ge_dtypes_lhs_int16___rhs_int16.mlir
+++ b/stablehlo/testdata/ge_dtypes_lhs_int16___rhs_int16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/ge_dtypes_lhs_int32___rhs_int32.mlir
+++ b/stablehlo/testdata/ge_dtypes_lhs_int32___rhs_int32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/ge_dtypes_lhs_int8___rhs_int8.mlir
+++ b/stablehlo/testdata/ge_dtypes_lhs_int8___rhs_int8.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/ge_dtypes_lhs_uint16___rhs_uint16.mlir
+++ b/stablehlo/testdata/ge_dtypes_lhs_uint16___rhs_uint16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/ge_dtypes_lhs_uint32___rhs_uint32.mlir
+++ b/stablehlo/testdata/ge_dtypes_lhs_uint32___rhs_uint32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/ge_dtypes_lhs_uint8___rhs_uint8.mlir
+++ b/stablehlo/testdata/ge_dtypes_lhs_uint8___rhs_uint8.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/getitem_op_poly_idx_const_enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/getitem_op_poly_idx_const_enable_xla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}) -> tensor<4xf32> {

--- a/stablehlo/testdata/getitem_op_poly_idx_dim_enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/getitem_op_poly_idx_dim_enable_xla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}) -> tensor<4xf32> {

--- a/stablehlo/testdata/getitem_op_poly_idx_poly_enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/getitem_op_poly_idx_poly_enable_xla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}, %arg2: tensor<?xi32> {mhlo.sharding = ""}) -> tensor<?x4xf32> {

--- a/stablehlo/testdata/getitem_op_poly_idx_slice-None-1_enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/getitem_op_poly_idx_slice-None-1_enable_xla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}) -> tensor<?x4xf32> {

--- a/stablehlo/testdata/getitem_op_poly_idx_slice-all_enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/getitem_op_poly_idx_slice-all_enable_xla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}) -> tensor<?x4xf32> {

--- a/stablehlo/testdata/getitem_op_poly_idx_slice-ct-2_enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/getitem_op_poly_idx_slice-ct-2_enable_xla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}) -> tensor<?x2xf32> {

--- a/stablehlo/testdata/getitem_op_static_idx_poly_enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/getitem_op_static_idx_poly_enable_xla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<3x4xf32> {mhlo.sharding = ""}, %arg2: tensor<?xi32> {mhlo.sharding = ""}) -> tensor<?x4xf32> {

--- a/stablehlo/testdata/gt_broadcasting_lhs_float32_1_2__rhs_float32_3_2.mlir
+++ b/stablehlo/testdata/gt_broadcasting_lhs_float32_1_2__rhs_float32_3_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gt_broadcasting_lhs_float32___rhs_float32_2_3.mlir
+++ b/stablehlo/testdata/gt_broadcasting_lhs_float32___rhs_float32_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gt_dtypes_lhs_bfloat16___rhs_bfloat16.mlir
+++ b/stablehlo/testdata/gt_dtypes_lhs_bfloat16___rhs_bfloat16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gt_dtypes_lhs_bool___rhs_bool.mlir
+++ b/stablehlo/testdata/gt_dtypes_lhs_bool___rhs_bool.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gt_dtypes_lhs_complex64___rhs_complex64.mlir
+++ b/stablehlo/testdata/gt_dtypes_lhs_complex64___rhs_complex64.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gt_dtypes_lhs_float16___rhs_float16.mlir
+++ b/stablehlo/testdata/gt_dtypes_lhs_float16___rhs_float16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gt_dtypes_lhs_float32___rhs_float32.mlir
+++ b/stablehlo/testdata/gt_dtypes_lhs_float32___rhs_float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gt_dtypes_lhs_int16___rhs_int16.mlir
+++ b/stablehlo/testdata/gt_dtypes_lhs_int16___rhs_int16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gt_dtypes_lhs_int32___rhs_int32.mlir
+++ b/stablehlo/testdata/gt_dtypes_lhs_int32___rhs_int32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gt_dtypes_lhs_int8___rhs_int8.mlir
+++ b/stablehlo/testdata/gt_dtypes_lhs_int8___rhs_int8.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gt_dtypes_lhs_uint16___rhs_uint16.mlir
+++ b/stablehlo/testdata/gt_dtypes_lhs_uint16___rhs_uint16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gt_dtypes_lhs_uint32___rhs_uint32.mlir
+++ b/stablehlo/testdata/gt_dtypes_lhs_uint32___rhs_uint32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/gt_dtypes_lhs_uint8___rhs_uint8.mlir
+++ b/stablehlo/testdata/gt_dtypes_lhs_uint8___rhs_uint8.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/igamma_broadcasting_lhs_float32_1_20__rhs_float32_20_20.mlir
+++ b/stablehlo/testdata/igamma_broadcasting_lhs_float32_1_20__rhs_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/igamma_broadcasting_lhs_float32_20_20__rhs_float32_1_20.mlir
+++ b/stablehlo/testdata/igamma_broadcasting_lhs_float32_20_20__rhs_float32_1_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/igamma_dtypes_lhs_bfloat16_20_20__rhs_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/igamma_dtypes_lhs_bfloat16_20_20__rhs_bfloat16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/igamma_dtypes_lhs_float16_20_20__rhs_float16_20_20.mlir
+++ b/stablehlo/testdata/igamma_dtypes_lhs_float16_20_20__rhs_float16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/igamma_dtypes_lhs_float32_20_20__rhs_float32_20_20.mlir
+++ b/stablehlo/testdata/igamma_dtypes_lhs_float32_20_20__rhs_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/igammac_broadcasting_lhs_float32_1_20__rhs_float32_20_20.mlir
+++ b/stablehlo/testdata/igammac_broadcasting_lhs_float32_1_20__rhs_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/igammac_broadcasting_lhs_float32_20_20__rhs_float32_1_20.mlir
+++ b/stablehlo/testdata/igammac_broadcasting_lhs_float32_20_20__rhs_float32_1_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/igammac_dtypes_lhs_bfloat16_20_20__rhs_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/igammac_dtypes_lhs_bfloat16_20_20__rhs_bfloat16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/igammac_dtypes_lhs_float16_20_20__rhs_float16_20_20.mlir
+++ b/stablehlo/testdata/igammac_dtypes_lhs_float16_20_20__rhs_float16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/igammac_dtypes_lhs_float32_20_20__rhs_float32_20_20.mlir
+++ b/stablehlo/testdata/igammac_dtypes_lhs_float32_20_20__rhs_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/imag_dtypes_shape_complex64_2_3.mlir
+++ b/stablehlo/testdata/imag_dtypes_shape_complex64_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/image_resize_linear_0_dynamic.mlir
+++ b/stablehlo/testdata/image_resize_linear_0_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/image_resize_linear_to_fixed_dim_dynamic.mlir
+++ b/stablehlo/testdata/image_resize_linear_to_fixed_dim_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/image_resize_nearest_0_dynamic.mlir
+++ b/stablehlo/testdata/image_resize_nearest_0_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<i64>, %arg2: tensor<3x?x?x3xf32> {mhlo.sharding = ""}) -> tensor<3x?x?x3xf32> {

--- a/stablehlo/testdata/index_in_dim_0_dynamic.mlir
+++ b/stablehlo/testdata/index_in_dim_0_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}) -> tensor<4xf32> {

--- a/stablehlo/testdata/index_in_dim_idx_last_dynamic.mlir
+++ b/stablehlo/testdata/index_in_dim_idx_last_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}) -> tensor<4xf32> {

--- a/stablehlo/testdata/index_in_dim_idx_neg_dynamic.mlir
+++ b/stablehlo/testdata/index_in_dim_idx_neg_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}) -> tensor<4xf32> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_bfloat16_20_30__y_-1.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_bfloat16_20_30__y_-1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_bfloat16_20_30__y_-2.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_bfloat16_20_30__y_-2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_bfloat16_20_30__y_-3.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_bfloat16_20_30__y_-3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_bfloat16_20_30__y_0.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_bfloat16_20_30__y_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_bfloat16_20_30__y_1.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_bfloat16_20_30__y_1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_bfloat16_20_30__y_2.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_bfloat16_20_30__y_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_bfloat16_20_30__y_3.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_bfloat16_20_30__y_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_bfloat16_20_30__y_4.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_bfloat16_20_30__y_4.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_complex64_20_30__y_-1.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_complex64_20_30__y_-1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_complex64_20_30__y_-2.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_complex64_20_30__y_-2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_complex64_20_30__y_-3.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_complex64_20_30__y_-3.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_complex64_20_30__y_0.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_complex64_20_30__y_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_complex64_20_30__y_1.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_complex64_20_30__y_1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_complex64_20_30__y_2.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_complex64_20_30__y_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_complex64_20_30__y_3.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_complex64_20_30__y_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_complex64_20_30__y_4.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_complex64_20_30__y_4.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_float16_20_30__y_-1.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_float16_20_30__y_-1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_float16_20_30__y_-2.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_float16_20_30__y_-2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_float16_20_30__y_-3.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_float16_20_30__y_-3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_float16_20_30__y_0.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_float16_20_30__y_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_float16_20_30__y_1.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_float16_20_30__y_1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_float16_20_30__y_2.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_float16_20_30__y_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_float16_20_30__y_3.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_float16_20_30__y_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_float16_20_30__y_4.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_float16_20_30__y_4.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_float32_20_30__y_-1.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_float32_20_30__y_-1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_float32_20_30__y_-2.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_float32_20_30__y_-2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_float32_20_30__y_-3.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_float32_20_30__y_-3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_float32_20_30__y_0.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_float32_20_30__y_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_float32_20_30__y_1.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_float32_20_30__y_1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_float32_20_30__y_2.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_float32_20_30__y_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_float32_20_30__y_3.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_float32_20_30__y_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_float32_20_30__y_4.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_float32_20_30__y_4.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_int16_20_30__y_0.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_int16_20_30__y_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_int16_20_30__y_1.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_int16_20_30__y_1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_int16_20_30__y_2.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_int16_20_30__y_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_int16_20_30__y_3.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_int16_20_30__y_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_int16_20_30__y_4.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_int16_20_30__y_4.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_int32_20_30__y_0.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_int32_20_30__y_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_int32_20_30__y_1.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_int32_20_30__y_1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_int32_20_30__y_2.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_int32_20_30__y_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_int32_20_30__y_3.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_int32_20_30__y_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_int32_20_30__y_4.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_int32_20_30__y_4.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_int8_20_30__y_0.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_int8_20_30__y_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_int8_20_30__y_1.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_int8_20_30__y_1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_int8_20_30__y_2.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_int8_20_30__y_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_int8_20_30__y_3.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_int8_20_30__y_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_int8_20_30__y_4.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_int8_20_30__y_4.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_uint16_20_30__y_0.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_uint16_20_30__y_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_uint16_20_30__y_1.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_uint16_20_30__y_1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_uint16_20_30__y_2.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_uint16_20_30__y_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_uint16_20_30__y_3.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_uint16_20_30__y_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_uint16_20_30__y_4.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_uint16_20_30__y_4.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_uint32_20_30__y_0.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_uint32_20_30__y_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_uint32_20_30__y_1.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_uint32_20_30__y_1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_uint32_20_30__y_2.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_uint32_20_30__y_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_uint32_20_30__y_3.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_uint32_20_30__y_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_uint32_20_30__y_4.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_uint32_20_30__y_4.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_uint8_20_30__y_0.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_uint8_20_30__y_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_uint8_20_30__y_1.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_uint8_20_30__y_1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_uint8_20_30__y_2.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_uint8_20_30__y_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_uint8_20_30__y_3.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_uint8_20_30__y_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_dtypes_shape_uint8_20_30__y_4.mlir
+++ b/stablehlo/testdata/integer_pow_dtypes_shape_uint8_20_30__y_4.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_negative_overflow_shape_bfloat16_20_30__y_-127.mlir
+++ b/stablehlo/testdata/integer_pow_negative_overflow_shape_bfloat16_20_30__y_-127.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_negative_overflow_shape_complex64_20_30__y_-127.mlir
+++ b/stablehlo/testdata/integer_pow_negative_overflow_shape_complex64_20_30__y_-127.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_negative_overflow_shape_float16_20_30__y_-127.mlir
+++ b/stablehlo/testdata/integer_pow_negative_overflow_shape_float16_20_30__y_-127.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_negative_overflow_shape_float32_20_30__y_-127.mlir
+++ b/stablehlo/testdata/integer_pow_negative_overflow_shape_float32_20_30__y_-127.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_overflow_shape_bfloat16_20_30__y_127.mlir
+++ b/stablehlo/testdata/integer_pow_overflow_shape_bfloat16_20_30__y_127.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_overflow_shape_complex64_20_30__y_127.mlir
+++ b/stablehlo/testdata/integer_pow_overflow_shape_complex64_20_30__y_127.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_overflow_shape_float16_20_30__y_127.mlir
+++ b/stablehlo/testdata/integer_pow_overflow_shape_float16_20_30__y_127.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_overflow_shape_float32_20_30__y_127.mlir
+++ b/stablehlo/testdata/integer_pow_overflow_shape_float32_20_30__y_127.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_overflow_shape_int16_20_30__y_127.mlir
+++ b/stablehlo/testdata/integer_pow_overflow_shape_int16_20_30__y_127.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_overflow_shape_int32_20_30__y_127.mlir
+++ b/stablehlo/testdata/integer_pow_overflow_shape_int32_20_30__y_127.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_overflow_shape_int8_20_30__y_127.mlir
+++ b/stablehlo/testdata/integer_pow_overflow_shape_int8_20_30__y_127.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_overflow_shape_uint16_20_30__y_127.mlir
+++ b/stablehlo/testdata/integer_pow_overflow_shape_uint16_20_30__y_127.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_overflow_shape_uint32_20_30__y_127.mlir
+++ b/stablehlo/testdata/integer_pow_overflow_shape_uint32_20_30__y_127.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/integer_pow_overflow_shape_uint8_20_30__y_127.mlir
+++ b/stablehlo/testdata/integer_pow_overflow_shape_uint8_20_30__y_127.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/iota_broadcasting_shape_float32_4_8_1_1__dimension_1.mlir
+++ b/stablehlo/testdata/iota_broadcasting_shape_float32_4_8_1_1__dimension_1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/iota_broadcasting_shape_float32_4_8_1_1__dimension_2.mlir
+++ b/stablehlo/testdata/iota_broadcasting_shape_float32_4_8_1_1__dimension_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/iota_dtypes_shape_bfloat16_2_3__dimension_0.mlir
+++ b/stablehlo/testdata/iota_dtypes_shape_bfloat16_2_3__dimension_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/iota_dtypes_shape_complex64_2_3__dimension_0.mlir
+++ b/stablehlo/testdata/iota_dtypes_shape_complex64_2_3__dimension_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/iota_dtypes_shape_float16_2_3__dimension_0.mlir
+++ b/stablehlo/testdata/iota_dtypes_shape_float16_2_3__dimension_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/iota_dtypes_shape_float32_2_3__dimension_0.mlir
+++ b/stablehlo/testdata/iota_dtypes_shape_float32_2_3__dimension_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/iota_dtypes_shape_int16_2_3__dimension_0.mlir
+++ b/stablehlo/testdata/iota_dtypes_shape_int16_2_3__dimension_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/iota_dtypes_shape_int32_2_3__dimension_0.mlir
+++ b/stablehlo/testdata/iota_dtypes_shape_int32_2_3__dimension_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/iota_dtypes_shape_int8_2_3__dimension_0.mlir
+++ b/stablehlo/testdata/iota_dtypes_shape_int8_2_3__dimension_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/iota_dtypes_shape_uint16_2_3__dimension_0.mlir
+++ b/stablehlo/testdata/iota_dtypes_shape_uint16_2_3__dimension_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/iota_dtypes_shape_uint32_2_3__dimension_0.mlir
+++ b/stablehlo/testdata/iota_dtypes_shape_uint32_2_3__dimension_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/iota_dtypes_shape_uint8_2_3__dimension_0.mlir
+++ b/stablehlo/testdata/iota_dtypes_shape_uint8_2_3__dimension_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/iota_dynamic.mlir
+++ b/stablehlo/testdata/iota_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?xf32> {mhlo.sharding = ""}) -> tensor<?xf32> {

--- a/stablehlo/testdata/is_finite_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/is_finite_shape_bfloat16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/is_finite_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/is_finite_shape_float16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/is_finite_shape_float32_20_20.mlir
+++ b/stablehlo/testdata/is_finite_shape_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/jnp_pad_mode_constant_bminus1_dynamic.mlir
+++ b/stablehlo/testdata/jnp_pad_mode_constant_bminus1_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5xf32> {mhlo.sharding = ""}) -> tensor<?x11xf32> {

--- a/stablehlo/testdata/jnp_pad_mode_constant_dynamic.mlir
+++ b/stablehlo/testdata/jnp_pad_mode_constant_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5xf32> {mhlo.sharding = ""}) -> tensor<?x11xf32> {

--- a/stablehlo/testdata/jnp_pad_mode_edge_dynamic.mlir
+++ b/stablehlo/testdata/jnp_pad_mode_edge_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/le_broadcasting_lhs_float32_1_2__rhs_float32_3_2.mlir
+++ b/stablehlo/testdata/le_broadcasting_lhs_float32_1_2__rhs_float32_3_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/le_broadcasting_lhs_float32___rhs_float32_2_3.mlir
+++ b/stablehlo/testdata/le_broadcasting_lhs_float32___rhs_float32_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/le_dtypes_lhs_bfloat16___rhs_bfloat16.mlir
+++ b/stablehlo/testdata/le_dtypes_lhs_bfloat16___rhs_bfloat16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/le_dtypes_lhs_bool___rhs_bool.mlir
+++ b/stablehlo/testdata/le_dtypes_lhs_bool___rhs_bool.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/le_dtypes_lhs_complex64___rhs_complex64.mlir
+++ b/stablehlo/testdata/le_dtypes_lhs_complex64___rhs_complex64.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/le_dtypes_lhs_float16___rhs_float16.mlir
+++ b/stablehlo/testdata/le_dtypes_lhs_float16___rhs_float16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/le_dtypes_lhs_float32___rhs_float32.mlir
+++ b/stablehlo/testdata/le_dtypes_lhs_float32___rhs_float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/le_dtypes_lhs_int16___rhs_int16.mlir
+++ b/stablehlo/testdata/le_dtypes_lhs_int16___rhs_int16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/le_dtypes_lhs_int32___rhs_int32.mlir
+++ b/stablehlo/testdata/le_dtypes_lhs_int32___rhs_int32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/le_dtypes_lhs_int8___rhs_int8.mlir
+++ b/stablehlo/testdata/le_dtypes_lhs_int8___rhs_int8.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/le_dtypes_lhs_uint16___rhs_uint16.mlir
+++ b/stablehlo/testdata/le_dtypes_lhs_uint16___rhs_uint16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/le_dtypes_lhs_uint32___rhs_uint32.mlir
+++ b/stablehlo/testdata/le_dtypes_lhs_uint32___rhs_uint32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/le_dtypes_lhs_uint8___rhs_uint8.mlir
+++ b/stablehlo/testdata/le_dtypes_lhs_uint8___rhs_uint8.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/lgamma_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/lgamma_shape_bfloat16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/lgamma_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/lgamma_shape_float16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/lgamma_shape_float32_20_20.mlir
+++ b/stablehlo/testdata/lgamma_shape_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/log1p_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/log1p_shape_bfloat16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/log1p_shape_complex64_20_20.mlir
+++ b/stablehlo/testdata/log1p_shape_complex64_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/log1p_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/log1p_shape_float16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/log1p_shape_float32_20_20.mlir
+++ b/stablehlo/testdata/log1p_shape_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/log_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/log_shape_bfloat16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/log_shape_complex64_20_20.mlir
+++ b/stablehlo/testdata/log_shape_complex64_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/log_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/log_shape_float16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/log_shape_float32_20_20.mlir
+++ b/stablehlo/testdata/log_shape_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/logistic_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/logistic_shape_bfloat16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/logistic_shape_complex64_20_20.mlir
+++ b/stablehlo/testdata/logistic_shape_complex64_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/logistic_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/logistic_shape_float16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/logistic_shape_float32_20_20.mlir
+++ b/stablehlo/testdata/logistic_shape_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/lt_broadcasting_lhs_float32_1_2__rhs_float32_3_2.mlir
+++ b/stablehlo/testdata/lt_broadcasting_lhs_float32_1_2__rhs_float32_3_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/lt_broadcasting_lhs_float32___rhs_float32_2_3.mlir
+++ b/stablehlo/testdata/lt_broadcasting_lhs_float32___rhs_float32_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/lt_dtypes_lhs_bfloat16___rhs_bfloat16.mlir
+++ b/stablehlo/testdata/lt_dtypes_lhs_bfloat16___rhs_bfloat16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/lt_dtypes_lhs_bool___rhs_bool.mlir
+++ b/stablehlo/testdata/lt_dtypes_lhs_bool___rhs_bool.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/lt_dtypes_lhs_complex64___rhs_complex64.mlir
+++ b/stablehlo/testdata/lt_dtypes_lhs_complex64___rhs_complex64.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/lt_dtypes_lhs_float16___rhs_float16.mlir
+++ b/stablehlo/testdata/lt_dtypes_lhs_float16___rhs_float16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/lt_dtypes_lhs_float32___rhs_float32.mlir
+++ b/stablehlo/testdata/lt_dtypes_lhs_float32___rhs_float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/lt_dtypes_lhs_int16___rhs_int16.mlir
+++ b/stablehlo/testdata/lt_dtypes_lhs_int16___rhs_int16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/lt_dtypes_lhs_int32___rhs_int32.mlir
+++ b/stablehlo/testdata/lt_dtypes_lhs_int32___rhs_int32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/lt_dtypes_lhs_int8___rhs_int8.mlir
+++ b/stablehlo/testdata/lt_dtypes_lhs_int8___rhs_int8.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/lt_dtypes_lhs_uint16___rhs_uint16.mlir
+++ b/stablehlo/testdata/lt_dtypes_lhs_uint16___rhs_uint16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/lt_dtypes_lhs_uint32___rhs_uint32.mlir
+++ b/stablehlo/testdata/lt_dtypes_lhs_uint32___rhs_uint32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/lt_dtypes_lhs_uint8___rhs_uint8.mlir
+++ b/stablehlo/testdata/lt_dtypes_lhs_uint8___rhs_uint8.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/matmul_0_dynamic.mlir
+++ b/stablehlo/testdata/matmul_0_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8x4xf32> {mhlo.sharding = ""}, %arg2: tensor<?x4x5xf32> {mhlo.sharding = ""}) -> tensor<?x8x5xf32> {

--- a/stablehlo/testdata/matmul_1_dynamic.mlir
+++ b/stablehlo/testdata/matmul_1_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8x4xf32> {mhlo.sharding = ""}, %arg2: tensor<4x5xf32> {mhlo.sharding = ""}) -> tensor<?x8x5xf32> {

--- a/stablehlo/testdata/max_broadcasting_lhs_complex128_1_20__rhs_complex128_20_20.mlir
+++ b/stablehlo/testdata/max_broadcasting_lhs_complex128_1_20__rhs_complex128_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/max_broadcasting_lhs_complex128_20_20__rhs_complex128_1_20.mlir
+++ b/stablehlo/testdata/max_broadcasting_lhs_complex128_20_20__rhs_complex128_1_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/max_broadcasting_lhs_complex64_1_20__rhs_complex64_20_20.mlir
+++ b/stablehlo/testdata/max_broadcasting_lhs_complex64_1_20__rhs_complex64_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/max_broadcasting_lhs_complex64_20_20__rhs_complex64_1_20.mlir
+++ b/stablehlo/testdata/max_broadcasting_lhs_complex64_20_20__rhs_complex64_1_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/max_broadcasting_lhs_float32_1_20__rhs_float32_20_20.mlir
+++ b/stablehlo/testdata/max_broadcasting_lhs_float32_1_20__rhs_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/max_broadcasting_lhs_float32_20_20__rhs_float32_1_20.mlir
+++ b/stablehlo/testdata/max_broadcasting_lhs_float32_20_20__rhs_float32_1_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/max_dtypes_lhs_bfloat16_20_20__rhs_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/max_dtypes_lhs_bfloat16_20_20__rhs_bfloat16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/max_dtypes_lhs_bool_20_20__rhs_bool_20_20.mlir
+++ b/stablehlo/testdata/max_dtypes_lhs_bool_20_20__rhs_bool_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/max_dtypes_lhs_complex64_20_20__rhs_complex64_20_20.mlir
+++ b/stablehlo/testdata/max_dtypes_lhs_complex64_20_20__rhs_complex64_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/max_dtypes_lhs_float16_20_20__rhs_float16_20_20.mlir
+++ b/stablehlo/testdata/max_dtypes_lhs_float16_20_20__rhs_float16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/max_dtypes_lhs_float32_20_20__rhs_float32_20_20.mlir
+++ b/stablehlo/testdata/max_dtypes_lhs_float32_20_20__rhs_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/max_dtypes_lhs_int16_20_20__rhs_int16_20_20.mlir
+++ b/stablehlo/testdata/max_dtypes_lhs_int16_20_20__rhs_int16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/max_dtypes_lhs_int32_20_20__rhs_int32_20_20.mlir
+++ b/stablehlo/testdata/max_dtypes_lhs_int32_20_20__rhs_int32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/max_dtypes_lhs_int8_20_20__rhs_int8_20_20.mlir
+++ b/stablehlo/testdata/max_dtypes_lhs_int8_20_20__rhs_int8_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/max_dtypes_lhs_uint16_20_20__rhs_uint16_20_20.mlir
+++ b/stablehlo/testdata/max_dtypes_lhs_uint16_20_20__rhs_uint16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/max_dtypes_lhs_uint32_20_20__rhs_uint32_20_20.mlir
+++ b/stablehlo/testdata/max_dtypes_lhs_uint32_20_20__rhs_uint32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/max_dtypes_lhs_uint8_20_20__rhs_uint8_20_20.mlir
+++ b/stablehlo/testdata/max_dtypes_lhs_uint8_20_20__rhs_uint8_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/max_inf_nan_bfloat16.mlir
+++ b/stablehlo/testdata/max_inf_nan_bfloat16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/max_inf_nan_complex64.mlir
+++ b/stablehlo/testdata/max_inf_nan_complex64.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/max_inf_nan_float16.mlir
+++ b/stablehlo/testdata/max_inf_nan_float16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/max_inf_nan_float32.mlir
+++ b/stablehlo/testdata/max_inf_nan_float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/mean_axis_None_keepdims_False_where_None_dynamic.mlir
+++ b/stablehlo/testdata/mean_axis_None_keepdims_False_where_None_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8x4xf32> {mhlo.sharding = ""}) -> tensor<f32> {

--- a/stablehlo/testdata/mean_axis_None_keepdims_False_where_Some_dynamic.mlir
+++ b/stablehlo/testdata/mean_axis_None_keepdims_False_where_Some_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8x4xf32> {mhlo.sharding = ""}, %arg2: tensor<?x8x4xi1> {mhlo.sharding = ""}) -> tensor<f32> {

--- a/stablehlo/testdata/mean_axis_None_keepdims_True_where_None_dynamic.mlir
+++ b/stablehlo/testdata/mean_axis_None_keepdims_True_where_None_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8x4xf32> {mhlo.sharding = ""}) -> tensor<1x1x1xf32> {

--- a/stablehlo/testdata/mean_axis_None_keepdims_True_where_Some_dynamic.mlir
+++ b/stablehlo/testdata/mean_axis_None_keepdims_True_where_Some_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8x4xf32> {mhlo.sharding = ""}, %arg2: tensor<?x8x4xi1> {mhlo.sharding = ""}) -> tensor<1x1x1xf32> {

--- a/stablehlo/testdata/mean_axis__0__1__keepdims_False_where_None_dynamic.mlir
+++ b/stablehlo/testdata/mean_axis__0__1__keepdims_False_where_None_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8x4xf32> {mhlo.sharding = ""}) -> tensor<4xf32> {

--- a/stablehlo/testdata/mean_axis__0__1__keepdims_False_where_Some_dynamic.mlir
+++ b/stablehlo/testdata/mean_axis__0__1__keepdims_False_where_Some_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8x4xf32> {mhlo.sharding = ""}, %arg2: tensor<?x8x4xi1> {mhlo.sharding = ""}) -> tensor<4xf32> {

--- a/stablehlo/testdata/mean_axis__0__1__keepdims_True_where_None_dynamic.mlir
+++ b/stablehlo/testdata/mean_axis__0__1__keepdims_True_where_None_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8x4xf32> {mhlo.sharding = ""}) -> tensor<1x1x4xf32> {

--- a/stablehlo/testdata/mean_axis__0__1__keepdims_True_where_Some_dynamic.mlir
+++ b/stablehlo/testdata/mean_axis__0__1__keepdims_True_where_Some_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8x4xf32> {mhlo.sharding = ""}, %arg2: tensor<?x8x4xi1> {mhlo.sharding = ""}) -> tensor<1x1x4xf32> {

--- a/stablehlo/testdata/mean_axis__0___keepdims_False_where_None_dynamic.mlir
+++ b/stablehlo/testdata/mean_axis__0___keepdims_False_where_None_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8x4xf32> {mhlo.sharding = ""}) -> tensor<8x4xf32> {

--- a/stablehlo/testdata/mean_axis__0___keepdims_False_where_Some_dynamic.mlir
+++ b/stablehlo/testdata/mean_axis__0___keepdims_False_where_Some_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8x4xf32> {mhlo.sharding = ""}, %arg2: tensor<?x8x4xi1> {mhlo.sharding = ""}) -> tensor<8x4xf32> {

--- a/stablehlo/testdata/mean_axis__0___keepdims_True_where_None_dynamic.mlir
+++ b/stablehlo/testdata/mean_axis__0___keepdims_True_where_None_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8x4xf32> {mhlo.sharding = ""}) -> tensor<1x8x4xf32> {

--- a/stablehlo/testdata/mean_axis__0___keepdims_True_where_Some_dynamic.mlir
+++ b/stablehlo/testdata/mean_axis__0___keepdims_True_where_Some_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8x4xf32> {mhlo.sharding = ""}, %arg2: tensor<?x8x4xi1> {mhlo.sharding = ""}) -> tensor<1x8x4xf32> {

--- a/stablehlo/testdata/mean_axis__1___keepdims_False_where_None_dynamic.mlir
+++ b/stablehlo/testdata/mean_axis__1___keepdims_False_where_None_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8x4xf32> {mhlo.sharding = ""}) -> tensor<?x4xf32> {

--- a/stablehlo/testdata/mean_axis__1___keepdims_False_where_Some_dynamic.mlir
+++ b/stablehlo/testdata/mean_axis__1___keepdims_False_where_Some_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8x4xf32> {mhlo.sharding = ""}, %arg2: tensor<?x8x4xi1> {mhlo.sharding = ""}) -> tensor<?x4xf32> {

--- a/stablehlo/testdata/mean_axis__1___keepdims_True_where_None_dynamic.mlir
+++ b/stablehlo/testdata/mean_axis__1___keepdims_True_where_None_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8x4xf32> {mhlo.sharding = ""}) -> tensor<?x1x4xf32> {

--- a/stablehlo/testdata/mean_axis__1___keepdims_True_where_Some_dynamic.mlir
+++ b/stablehlo/testdata/mean_axis__1___keepdims_True_where_Some_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8x4xf32> {mhlo.sharding = ""}, %arg2: tensor<?x8x4xi1> {mhlo.sharding = ""}) -> tensor<?x1x4xf32> {

--- a/stablehlo/testdata/min_broadcasting_lhs_complex128_1_20__rhs_complex128_20_20.mlir
+++ b/stablehlo/testdata/min_broadcasting_lhs_complex128_1_20__rhs_complex128_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/min_broadcasting_lhs_complex128_20_20__rhs_complex128_1_20.mlir
+++ b/stablehlo/testdata/min_broadcasting_lhs_complex128_20_20__rhs_complex128_1_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/min_broadcasting_lhs_complex64_1_20__rhs_complex64_20_20.mlir
+++ b/stablehlo/testdata/min_broadcasting_lhs_complex64_1_20__rhs_complex64_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/min_broadcasting_lhs_complex64_20_20__rhs_complex64_1_20.mlir
+++ b/stablehlo/testdata/min_broadcasting_lhs_complex64_20_20__rhs_complex64_1_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/min_broadcasting_lhs_float32_1_20__rhs_float32_20_20.mlir
+++ b/stablehlo/testdata/min_broadcasting_lhs_float32_1_20__rhs_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/min_broadcasting_lhs_float32_20_20__rhs_float32_1_20.mlir
+++ b/stablehlo/testdata/min_broadcasting_lhs_float32_20_20__rhs_float32_1_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/min_dtypes_lhs_bfloat16_20_20__rhs_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/min_dtypes_lhs_bfloat16_20_20__rhs_bfloat16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/min_dtypes_lhs_bool_20_20__rhs_bool_20_20.mlir
+++ b/stablehlo/testdata/min_dtypes_lhs_bool_20_20__rhs_bool_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/min_dtypes_lhs_complex64_20_20__rhs_complex64_20_20.mlir
+++ b/stablehlo/testdata/min_dtypes_lhs_complex64_20_20__rhs_complex64_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/min_dtypes_lhs_float16_20_20__rhs_float16_20_20.mlir
+++ b/stablehlo/testdata/min_dtypes_lhs_float16_20_20__rhs_float16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/min_dtypes_lhs_float32_20_20__rhs_float32_20_20.mlir
+++ b/stablehlo/testdata/min_dtypes_lhs_float32_20_20__rhs_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/min_dtypes_lhs_int16_20_20__rhs_int16_20_20.mlir
+++ b/stablehlo/testdata/min_dtypes_lhs_int16_20_20__rhs_int16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/min_dtypes_lhs_int32_20_20__rhs_int32_20_20.mlir
+++ b/stablehlo/testdata/min_dtypes_lhs_int32_20_20__rhs_int32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/min_dtypes_lhs_int8_20_20__rhs_int8_20_20.mlir
+++ b/stablehlo/testdata/min_dtypes_lhs_int8_20_20__rhs_int8_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/min_dtypes_lhs_uint16_20_20__rhs_uint16_20_20.mlir
+++ b/stablehlo/testdata/min_dtypes_lhs_uint16_20_20__rhs_uint16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/min_dtypes_lhs_uint32_20_20__rhs_uint32_20_20.mlir
+++ b/stablehlo/testdata/min_dtypes_lhs_uint32_20_20__rhs_uint32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/min_dtypes_lhs_uint8_20_20__rhs_uint8_20_20.mlir
+++ b/stablehlo/testdata/min_dtypes_lhs_uint8_20_20__rhs_uint8_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/min_inf_nan_bfloat16.mlir
+++ b/stablehlo/testdata/min_inf_nan_bfloat16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/min_inf_nan_complex64.mlir
+++ b/stablehlo/testdata/min_inf_nan_complex64.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/min_inf_nan_float16.mlir
+++ b/stablehlo/testdata/min_inf_nan_float16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/min_inf_nan_float32.mlir
+++ b/stablehlo/testdata/min_inf_nan_float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/mul_broadcasting_lhs_float32_1_20__rhs_float32_20_20.mlir
+++ b/stablehlo/testdata/mul_broadcasting_lhs_float32_1_20__rhs_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/mul_broadcasting_lhs_float32_20_20__rhs_float32_1_20.mlir
+++ b/stablehlo/testdata/mul_broadcasting_lhs_float32_20_20__rhs_float32_1_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/mul_dtypes_lhs_bfloat16_20_20__rhs_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/mul_dtypes_lhs_bfloat16_20_20__rhs_bfloat16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/mul_dtypes_lhs_complex64_20_20__rhs_complex64_20_20.mlir
+++ b/stablehlo/testdata/mul_dtypes_lhs_complex64_20_20__rhs_complex64_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/mul_dtypes_lhs_float16_20_20__rhs_float16_20_20.mlir
+++ b/stablehlo/testdata/mul_dtypes_lhs_float16_20_20__rhs_float16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/mul_dtypes_lhs_float32_20_20__rhs_float32_20_20.mlir
+++ b/stablehlo/testdata/mul_dtypes_lhs_float32_20_20__rhs_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/mul_dtypes_lhs_int16_20_20__rhs_int16_20_20.mlir
+++ b/stablehlo/testdata/mul_dtypes_lhs_int16_20_20__rhs_int16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/mul_dtypes_lhs_int32_20_20__rhs_int32_20_20.mlir
+++ b/stablehlo/testdata/mul_dtypes_lhs_int32_20_20__rhs_int32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/mul_dtypes_lhs_int8_20_20__rhs_int8_20_20.mlir
+++ b/stablehlo/testdata/mul_dtypes_lhs_int8_20_20__rhs_int8_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/mul_dtypes_lhs_uint16_20_20__rhs_uint16_20_20.mlir
+++ b/stablehlo/testdata/mul_dtypes_lhs_uint16_20_20__rhs_uint16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/mul_dtypes_lhs_uint32_20_20__rhs_uint32_20_20.mlir
+++ b/stablehlo/testdata/mul_dtypes_lhs_uint32_20_20__rhs_uint32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/mul_dtypes_lhs_uint8_20_20__rhs_uint8_20_20.mlir
+++ b/stablehlo/testdata/mul_dtypes_lhs_uint8_20_20__rhs_uint8_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/nanquantile_axis_0_dynamic.mlir
+++ b/stablehlo/testdata/nanquantile_axis_0_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/nanquantile_axis_None_dynamic.mlir
+++ b/stablehlo/testdata/nanquantile_axis_None_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5xf32> {mhlo.sharding = ""}) -> tensor<f32> {

--- a/stablehlo/testdata/ne_broadcasting_lhs_float32_1_2__rhs_float32_3_2.mlir
+++ b/stablehlo/testdata/ne_broadcasting_lhs_float32_1_2__rhs_float32_3_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/ne_broadcasting_lhs_float32___rhs_float32_2_3.mlir
+++ b/stablehlo/testdata/ne_broadcasting_lhs_float32___rhs_float32_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/ne_dtypes_lhs_bfloat16___rhs_bfloat16.mlir
+++ b/stablehlo/testdata/ne_dtypes_lhs_bfloat16___rhs_bfloat16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/ne_dtypes_lhs_bool___rhs_bool.mlir
+++ b/stablehlo/testdata/ne_dtypes_lhs_bool___rhs_bool.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/ne_dtypes_lhs_complex64___rhs_complex64.mlir
+++ b/stablehlo/testdata/ne_dtypes_lhs_complex64___rhs_complex64.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/ne_dtypes_lhs_float16___rhs_float16.mlir
+++ b/stablehlo/testdata/ne_dtypes_lhs_float16___rhs_float16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/ne_dtypes_lhs_float32___rhs_float32.mlir
+++ b/stablehlo/testdata/ne_dtypes_lhs_float32___rhs_float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/ne_dtypes_lhs_int16___rhs_int16.mlir
+++ b/stablehlo/testdata/ne_dtypes_lhs_int16___rhs_int16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/ne_dtypes_lhs_int32___rhs_int32.mlir
+++ b/stablehlo/testdata/ne_dtypes_lhs_int32___rhs_int32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/ne_dtypes_lhs_int8___rhs_int8.mlir
+++ b/stablehlo/testdata/ne_dtypes_lhs_int8___rhs_int8.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/ne_dtypes_lhs_uint16___rhs_uint16.mlir
+++ b/stablehlo/testdata/ne_dtypes_lhs_uint16___rhs_uint16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/ne_dtypes_lhs_uint32___rhs_uint32.mlir
+++ b/stablehlo/testdata/ne_dtypes_lhs_uint32___rhs_uint32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/ne_dtypes_lhs_uint8___rhs_uint8.mlir
+++ b/stablehlo/testdata/ne_dtypes_lhs_uint8___rhs_uint8.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/neg_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/neg_shape_bfloat16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/neg_shape_complex64_20_20.mlir
+++ b/stablehlo/testdata/neg_shape_complex64_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/neg_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/neg_shape_float16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/neg_shape_float32_20_20.mlir
+++ b/stablehlo/testdata/neg_shape_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/neg_shape_int16_20_20.mlir
+++ b/stablehlo/testdata/neg_shape_int16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/neg_shape_int32_20_20.mlir
+++ b/stablehlo/testdata/neg_shape_int32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/neg_shape_int8_20_20.mlir
+++ b/stablehlo/testdata/neg_shape_int8_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/neg_shape_uint16_20_20.mlir
+++ b/stablehlo/testdata/neg_shape_uint16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/neg_shape_uint32_20_20.mlir
+++ b/stablehlo/testdata/neg_shape_uint32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/neg_shape_uint8_20_20.mlir
+++ b/stablehlo/testdata/neg_shape_uint8_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/nextafter_broadcasting_lhs_float32_1_20__rhs_float32_20_20.mlir
+++ b/stablehlo/testdata/nextafter_broadcasting_lhs_float32_1_20__rhs_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/nextafter_broadcasting_lhs_float32_20_20__rhs_float32_1_20.mlir
+++ b/stablehlo/testdata/nextafter_broadcasting_lhs_float32_20_20__rhs_float32_1_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/nextafter_dtypes_lhs_bfloat16_20_20__rhs_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/nextafter_dtypes_lhs_bfloat16_20_20__rhs_bfloat16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/nextafter_dtypes_lhs_float16_20_20__rhs_float16_20_20.mlir
+++ b/stablehlo/testdata/nextafter_dtypes_lhs_float16_20_20__rhs_float16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/nextafter_dtypes_lhs_float32_20_20__rhs_float32_20_20.mlir
+++ b/stablehlo/testdata/nextafter_dtypes_lhs_float32_20_20__rhs_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/ones_dynamic.mlir
+++ b/stablehlo/testdata/ones_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2x4xf32> {mhlo.sharding = ""}) -> tensor<?x2x4xf32> {

--- a/stablehlo/testdata/or_broadcasting_lhs_int32_1_20__rhs_int32_20_20.mlir
+++ b/stablehlo/testdata/or_broadcasting_lhs_int32_1_20__rhs_int32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/or_broadcasting_lhs_int32_20_20__rhs_int32_1_20.mlir
+++ b/stablehlo/testdata/or_broadcasting_lhs_int32_20_20__rhs_int32_1_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/or_dtypes_lhs_bool_20_20__rhs_bool_20_20.mlir
+++ b/stablehlo/testdata/or_dtypes_lhs_bool_20_20__rhs_bool_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/or_dtypes_lhs_int16_20_20__rhs_int16_20_20.mlir
+++ b/stablehlo/testdata/or_dtypes_lhs_int16_20_20__rhs_int16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/or_dtypes_lhs_int32_20_20__rhs_int32_20_20.mlir
+++ b/stablehlo/testdata/or_dtypes_lhs_int32_20_20__rhs_int32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/or_dtypes_lhs_int8_20_20__rhs_int8_20_20.mlir
+++ b/stablehlo/testdata/or_dtypes_lhs_int8_20_20__rhs_int8_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/or_dtypes_lhs_uint16_20_20__rhs_uint16_20_20.mlir
+++ b/stablehlo/testdata/or_dtypes_lhs_uint16_20_20__rhs_uint16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/or_dtypes_lhs_uint32_20_20__rhs_uint32_20_20.mlir
+++ b/stablehlo/testdata/or_dtypes_lhs_uint32_20_20__rhs_uint32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/or_dtypes_lhs_uint8_20_20__rhs_uint8_20_20.mlir
+++ b/stablehlo/testdata/or_dtypes_lhs_uint8_20_20__rhs_uint8_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_dynamic.mlir
+++ b/stablehlo/testdata/pad_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2x5xf32> {mhlo.sharding = ""}, %arg2: tensor<f32> {mhlo.sharding = ""}) -> tensor<?x2x11xf32> {

--- a/stablehlo/testdata/pad_inshape_bfloat16_2_3__pads___0__0__0____-1__-1__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_bfloat16_2_3__pads___0__0__0____-1__-1__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_bfloat16_2_3__pads___0__0__0____-2__-2__4___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_bfloat16_2_3__pads___0__0__0____-2__-2__4___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_bfloat16_2_3__pads___0__0__0____-2__-3__1___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_bfloat16_2_3__pads___0__0__0____-2__-3__1___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_bfloat16_2_3__pads___0__0__0____0__0__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_bfloat16_2_3__pads___0__0__0____0__0__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_bfloat16_2_3__pads___1__1__0____2__2__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_bfloat16_2_3__pads___1__1__0____2__2__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_bfloat16_2_3__pads___1__2__1____0__1__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_bfloat16_2_3__pads___1__2__1____0__1__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_bool_2_3__pads___0__0__0____-1__-1__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_bool_2_3__pads___0__0__0____-1__-1__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_bool_2_3__pads___0__0__0____-2__-2__4___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_bool_2_3__pads___0__0__0____-2__-2__4___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_bool_2_3__pads___0__0__0____-2__-3__1___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_bool_2_3__pads___0__0__0____-2__-3__1___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_bool_2_3__pads___0__0__0____0__0__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_bool_2_3__pads___0__0__0____0__0__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_bool_2_3__pads___1__1__0____2__2__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_bool_2_3__pads___1__1__0____2__2__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_bool_2_3__pads___1__2__1____0__1__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_bool_2_3__pads___1__2__1____0__1__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_complex64_2_3__pads___0__0__0____-1__-1__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_complex64_2_3__pads___0__0__0____-1__-1__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_complex64_2_3__pads___0__0__0____-2__-2__4___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_complex64_2_3__pads___0__0__0____-2__-2__4___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_complex64_2_3__pads___0__0__0____-2__-3__1___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_complex64_2_3__pads___0__0__0____-2__-3__1___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_complex64_2_3__pads___0__0__0____0__0__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_complex64_2_3__pads___0__0__0____0__0__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_complex64_2_3__pads___1__1__0____2__2__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_complex64_2_3__pads___1__1__0____2__2__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_complex64_2_3__pads___1__2__1____0__1__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_complex64_2_3__pads___1__2__1____0__1__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_float16_2_3__pads___0__0__0____-1__-1__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_float16_2_3__pads___0__0__0____-1__-1__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_float16_2_3__pads___0__0__0____-2__-2__4___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_float16_2_3__pads___0__0__0____-2__-2__4___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_float16_2_3__pads___0__0__0____-2__-3__1___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_float16_2_3__pads___0__0__0____-2__-3__1___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_float16_2_3__pads___0__0__0____0__0__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_float16_2_3__pads___0__0__0____0__0__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_float16_2_3__pads___1__1__0____2__2__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_float16_2_3__pads___1__1__0____2__2__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_float16_2_3__pads___1__2__1____0__1__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_float16_2_3__pads___1__2__1____0__1__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_float32_2_3__pads___0__0__0____-1__-1__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_float32_2_3__pads___0__0__0____-1__-1__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_float32_2_3__pads___0__0__0____-2__-2__4___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_float32_2_3__pads___0__0__0____-2__-2__4___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_float32_2_3__pads___0__0__0____-2__-3__1___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_float32_2_3__pads___0__0__0____-2__-3__1___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_float32_2_3__pads___0__0__0____0__0__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_float32_2_3__pads___0__0__0____0__0__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_float32_2_3__pads___1__1__0____2__2__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_float32_2_3__pads___1__1__0____2__2__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_float32_2_3__pads___1__2__1____0__1__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_float32_2_3__pads___1__2__1____0__1__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_int16_2_3__pads___0__0__0____-1__-1__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_int16_2_3__pads___0__0__0____-1__-1__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_int16_2_3__pads___0__0__0____-2__-2__4___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_int16_2_3__pads___0__0__0____-2__-2__4___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_int16_2_3__pads___0__0__0____-2__-3__1___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_int16_2_3__pads___0__0__0____-2__-3__1___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_int16_2_3__pads___0__0__0____0__0__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_int16_2_3__pads___0__0__0____0__0__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_int16_2_3__pads___1__1__0____2__2__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_int16_2_3__pads___1__1__0____2__2__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_int16_2_3__pads___1__2__1____0__1__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_int16_2_3__pads___1__2__1____0__1__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_int32_2_3__pads___0__0__0____-1__-1__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_int32_2_3__pads___0__0__0____-1__-1__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_int32_2_3__pads___0__0__0____-2__-2__4___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_int32_2_3__pads___0__0__0____-2__-2__4___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_int32_2_3__pads___0__0__0____-2__-3__1___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_int32_2_3__pads___0__0__0____-2__-3__1___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_int32_2_3__pads___0__0__0____0__0__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_int32_2_3__pads___0__0__0____0__0__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_int32_2_3__pads___1__1__0____2__2__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_int32_2_3__pads___1__1__0____2__2__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_int32_2_3__pads___1__2__1____0__1__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_int32_2_3__pads___1__2__1____0__1__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_int8_2_3__pads___0__0__0____-1__-1__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_int8_2_3__pads___0__0__0____-1__-1__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_int8_2_3__pads___0__0__0____-2__-2__4___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_int8_2_3__pads___0__0__0____-2__-2__4___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_int8_2_3__pads___0__0__0____-2__-3__1___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_int8_2_3__pads___0__0__0____-2__-3__1___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_int8_2_3__pads___0__0__0____0__0__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_int8_2_3__pads___0__0__0____0__0__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_int8_2_3__pads___1__1__0____2__2__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_int8_2_3__pads___1__1__0____2__2__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_int8_2_3__pads___1__2__1____0__1__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_int8_2_3__pads___1__2__1____0__1__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_uint16_2_3__pads___0__0__0____-1__-1__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_uint16_2_3__pads___0__0__0____-1__-1__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_uint16_2_3__pads___0__0__0____-2__-2__4___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_uint16_2_3__pads___0__0__0____-2__-2__4___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_uint16_2_3__pads___0__0__0____-2__-3__1___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_uint16_2_3__pads___0__0__0____-2__-3__1___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_uint16_2_3__pads___0__0__0____0__0__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_uint16_2_3__pads___0__0__0____0__0__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_uint16_2_3__pads___1__1__0____2__2__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_uint16_2_3__pads___1__1__0____2__2__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_uint16_2_3__pads___1__2__1____0__1__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_uint16_2_3__pads___1__2__1____0__1__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_uint32_2_3__pads___0__0__0____-1__-1__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_uint32_2_3__pads___0__0__0____-1__-1__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_uint32_2_3__pads___0__0__0____-2__-2__4___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_uint32_2_3__pads___0__0__0____-2__-2__4___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_uint32_2_3__pads___0__0__0____-2__-3__1___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_uint32_2_3__pads___0__0__0____-2__-3__1___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_uint32_2_3__pads___0__0__0____0__0__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_uint32_2_3__pads___0__0__0____0__0__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_uint32_2_3__pads___1__1__0____2__2__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_uint32_2_3__pads___1__1__0____2__2__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_uint32_2_3__pads___1__2__1____0__1__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_uint32_2_3__pads___1__2__1____0__1__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_uint8_2_3__pads___0__0__0____-1__-1__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_uint8_2_3__pads___0__0__0____-1__-1__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_uint8_2_3__pads___0__0__0____-2__-2__4___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_uint8_2_3__pads___0__0__0____-2__-2__4___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_uint8_2_3__pads___0__0__0____-2__-3__1___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_uint8_2_3__pads___0__0__0____-2__-3__1___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_uint8_2_3__pads___0__0__0____0__0__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_uint8_2_3__pads___0__0__0____0__0__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_uint8_2_3__pads___1__1__0____2__2__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_uint8_2_3__pads___1__1__0____2__2__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_inshape_uint8_2_3__pads___1__2__1____0__1__0___enable_xla_True.mlir
+++ b/stablehlo/testdata/pad_inshape_uint8_2_3__pads___1__2__1____0__1__0___enable_xla_True.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pad_poly_padding_config_dynamic.mlir
+++ b/stablehlo/testdata/pad_poly_padding_config_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2xf32> {mhlo.sharding = ""}) -> tensor<?x2xf32> {

--- a/stablehlo/testdata/percentile_axis_0_dynamic.mlir
+++ b/stablehlo/testdata/percentile_axis_0_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/percentile_axis_None_dynamic.mlir
+++ b/stablehlo/testdata/percentile_axis_None_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5xf32> {mhlo.sharding = ""}) -> tensor<f32> {

--- a/stablehlo/testdata/population_count_int16.mlir
+++ b/stablehlo/testdata/population_count_int16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/population_count_int32.mlir
+++ b/stablehlo/testdata/population_count_int32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/population_count_int8.mlir
+++ b/stablehlo/testdata/population_count_int8.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/population_count_uint16.mlir
+++ b/stablehlo/testdata/population_count_uint16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/population_count_uint32.mlir
+++ b/stablehlo/testdata/population_count_uint32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/population_count_uint8.mlir
+++ b/stablehlo/testdata/population_count_uint8.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pow_broadcast_lhs_float32_4_1_6__rhs_float32_4_5_6.mlir
+++ b/stablehlo/testdata/pow_broadcast_lhs_float32_4_1_6__rhs_float32_4_5_6.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pow_broadcast_lhs_float32_4_5_6__rhs_float32.mlir
+++ b/stablehlo/testdata/pow_broadcast_lhs_float32_4_5_6__rhs_float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pow_broadcast_lhs_float32_4_5_6__rhs_float32_4_1_6.mlir
+++ b/stablehlo/testdata/pow_broadcast_lhs_float32_4_5_6__rhs_float32_4_1_6.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pow_broadcast_lhs_float32___rhs_float32_4_5_6.mlir
+++ b/stablehlo/testdata/pow_broadcast_lhs_float32___rhs_float32_4_5_6.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pow_dtypes_lhs_bfloat16_20_30__rhs_bfloat16_20_30.mlir
+++ b/stablehlo/testdata/pow_dtypes_lhs_bfloat16_20_30__rhs_bfloat16_20_30.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pow_dtypes_lhs_complex64_20_30__rhs_complex64_20_30.mlir
+++ b/stablehlo/testdata/pow_dtypes_lhs_complex64_20_30__rhs_complex64_20_30.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pow_dtypes_lhs_float16_20_30__rhs_float16_20_30.mlir
+++ b/stablehlo/testdata/pow_dtypes_lhs_float16_20_30__rhs_float16_20_30.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/pow_dtypes_lhs_float32_20_30__rhs_float32_20_30.mlir
+++ b/stablehlo/testdata/pow_dtypes_lhs_float32_20_30__rhs_float32_20_30.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/random_categorical_0_dim_dynamic.mlir
+++ b/stablehlo/testdata/random_categorical_0_dim_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/random_categorical_axis_0_dynamic.mlir
+++ b/stablehlo/testdata/random_categorical_axis_0_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/random_categorical_axis_1_dynamic.mlir
+++ b/stablehlo/testdata/random_categorical_axis_1_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/random_categorical_axis_1_then_reshape_dynamic.mlir
+++ b/stablehlo/testdata/random_categorical_axis_1_then_reshape_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/random_categorical_shape_bfloat16_5_4__axis_0.mlir
+++ b/stablehlo/testdata/random_categorical_shape_bfloat16_5_4__axis_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/random_categorical_shape_bfloat16_5_4__axis_1.mlir
+++ b/stablehlo/testdata/random_categorical_shape_bfloat16_5_4__axis_1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/random_categorical_shape_bfloat16_8__axis_0.mlir
+++ b/stablehlo/testdata/random_categorical_shape_bfloat16_8__axis_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/random_categorical_shape_float16_5_4__axis_0.mlir
+++ b/stablehlo/testdata/random_categorical_shape_float16_5_4__axis_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/random_categorical_shape_float16_5_4__axis_1.mlir
+++ b/stablehlo/testdata/random_categorical_shape_float16_5_4__axis_1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/random_categorical_shape_float16_8__axis_0.mlir
+++ b/stablehlo/testdata/random_categorical_shape_float16_8__axis_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/random_categorical_shape_float32_5_4__axis_0.mlir
+++ b/stablehlo/testdata/random_categorical_shape_float32_5_4__axis_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/random_categorical_shape_float32_5_4__axis_1.mlir
+++ b/stablehlo/testdata/random_categorical_shape_float32_5_4__axis_1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/random_categorical_shape_float32_8__axis_0.mlir
+++ b/stablehlo/testdata/random_categorical_shape_float32_8__axis_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/random_gamma_dynamic.mlir
+++ b/stablehlo/testdata/random_gamma_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/random_gamma_shape_float32.mlir
+++ b/stablehlo/testdata/random_gamma_shape_float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/random_gamma_shape_float32_3.mlir
+++ b/stablehlo/testdata/random_gamma_shape_float32_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/random_gamma_shape_float64.mlir
+++ b/stablehlo/testdata/random_gamma_shape_float64.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/random_gamma_shape_float64_3.mlir
+++ b/stablehlo/testdata/random_gamma_shape_float64_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/random_randint_shape_int16.mlir
+++ b/stablehlo/testdata/random_randint_shape_int16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/random_randint_shape_int16_32.mlir
+++ b/stablehlo/testdata/random_randint_shape_int16_32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/random_randint_shape_int16_5_4.mlir
+++ b/stablehlo/testdata/random_randint_shape_int16_5_4.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/random_randint_shape_int32.mlir
+++ b/stablehlo/testdata/random_randint_shape_int32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/random_randint_shape_int32_32.mlir
+++ b/stablehlo/testdata/random_randint_shape_int32_32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/random_randint_shape_int32_5_4.mlir
+++ b/stablehlo/testdata/random_randint_shape_int32_5_4.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/random_randint_shape_int8.mlir
+++ b/stablehlo/testdata/random_randint_shape_int8.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/random_randint_shape_int8_32.mlir
+++ b/stablehlo/testdata/random_randint_shape_int8_32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/random_randint_shape_int8_5_4.mlir
+++ b/stablehlo/testdata/random_randint_shape_int8_5_4.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/random_split_i_0.mlir
+++ b/stablehlo/testdata/random_split_i_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/random_split_i_1.mlir
+++ b/stablehlo/testdata/random_split_i_1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/random_split_i_2.mlir
+++ b/stablehlo/testdata/random_split_i_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/random_split_i_3.mlir
+++ b/stablehlo/testdata/random_split_i_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/random_split_i_4.mlir
+++ b/stablehlo/testdata/random_split_i_4.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/random_uniform_even_1_dynamic.mlir
+++ b/stablehlo/testdata/random_uniform_even_1_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/random_uniform_even_2_dynamic.mlir
+++ b/stablehlo/testdata/random_uniform_even_2_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/random_uniform_shape_bfloat16.mlir
+++ b/stablehlo/testdata/random_uniform_shape_bfloat16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/random_uniform_shape_bfloat16_32.mlir
+++ b/stablehlo/testdata/random_uniform_shape_bfloat16_32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/random_uniform_shape_bfloat16_5_4.mlir
+++ b/stablehlo/testdata/random_uniform_shape_bfloat16_5_4.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/random_uniform_shape_float16.mlir
+++ b/stablehlo/testdata/random_uniform_shape_float16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/random_uniform_shape_float16_32.mlir
+++ b/stablehlo/testdata/random_uniform_shape_float16_32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/random_uniform_shape_float16_5_4.mlir
+++ b/stablehlo/testdata/random_uniform_shape_float16_5_4.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/random_uniform_shape_float32.mlir
+++ b/stablehlo/testdata/random_uniform_shape_float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/random_uniform_shape_float32_32.mlir
+++ b/stablehlo/testdata/random_uniform_shape_float32_32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/random_uniform_shape_float32_5_4.mlir
+++ b/stablehlo/testdata/random_uniform_shape_float32_5_4.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/real_dtypes_shape_complex64_2_3.mlir
+++ b/stablehlo/testdata/real_dtypes_shape_complex64_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_all_dynamic.mlir
+++ b/stablehlo/testdata/reduce_all_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5xf32> {mhlo.sharding = ""}) -> tensor<?x1xf32> {

--- a/stablehlo/testdata/reduce_amax_dynamic.mlir
+++ b/stablehlo/testdata/reduce_amax_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5xf32> {mhlo.sharding = ""}) -> tensor<?x1xf32> {

--- a/stablehlo/testdata/reduce_amin_dynamic.mlir
+++ b/stablehlo/testdata/reduce_amin_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5xf32> {mhlo.sharding = ""}) -> tensor<?x1xf32> {

--- a/stablehlo/testdata/reduce_and_dtypes_shape_bool_2_3.mlir
+++ b/stablehlo/testdata/reduce_and_dtypes_shape_bool_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_any_dynamic.mlir
+++ b/stablehlo/testdata/reduce_any_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5xf32> {mhlo.sharding = ""}) -> tensor<?x1xf32> {

--- a/stablehlo/testdata/reduce_max_dtypes_shape_bfloat16_2_3.mlir
+++ b/stablehlo/testdata/reduce_max_dtypes_shape_bfloat16_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_max_dtypes_shape_bool_2_3.mlir
+++ b/stablehlo/testdata/reduce_max_dtypes_shape_bool_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_max_dtypes_shape_complex64_2_3.mlir
+++ b/stablehlo/testdata/reduce_max_dtypes_shape_complex64_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_max_dtypes_shape_float16_2_3.mlir
+++ b/stablehlo/testdata/reduce_max_dtypes_shape_float16_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_max_dtypes_shape_float32_2_3.mlir
+++ b/stablehlo/testdata/reduce_max_dtypes_shape_float32_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_max_dtypes_shape_int16_2_3.mlir
+++ b/stablehlo/testdata/reduce_max_dtypes_shape_int16_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_max_dtypes_shape_int32_2_3.mlir
+++ b/stablehlo/testdata/reduce_max_dtypes_shape_int32_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_max_dtypes_shape_int8_2_3.mlir
+++ b/stablehlo/testdata/reduce_max_dtypes_shape_int8_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_max_dtypes_shape_uint16_2_3.mlir
+++ b/stablehlo/testdata/reduce_max_dtypes_shape_uint16_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_max_dtypes_shape_uint32_2_3.mlir
+++ b/stablehlo/testdata/reduce_max_dtypes_shape_uint32_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_max_dtypes_shape_uint8_2_3.mlir
+++ b/stablehlo/testdata/reduce_max_dtypes_shape_uint8_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_min_dtypes_shape_bfloat16_2_3.mlir
+++ b/stablehlo/testdata/reduce_min_dtypes_shape_bfloat16_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_min_dtypes_shape_bool_2_3.mlir
+++ b/stablehlo/testdata/reduce_min_dtypes_shape_bool_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_min_dtypes_shape_complex64_2_3.mlir
+++ b/stablehlo/testdata/reduce_min_dtypes_shape_complex64_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_min_dtypes_shape_float16_2_3.mlir
+++ b/stablehlo/testdata/reduce_min_dtypes_shape_float16_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_min_dtypes_shape_float32_2_3.mlir
+++ b/stablehlo/testdata/reduce_min_dtypes_shape_float32_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_min_dtypes_shape_int16_2_3.mlir
+++ b/stablehlo/testdata/reduce_min_dtypes_shape_int16_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_min_dtypes_shape_int32_2_3.mlir
+++ b/stablehlo/testdata/reduce_min_dtypes_shape_int32_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_min_dtypes_shape_int8_2_3.mlir
+++ b/stablehlo/testdata/reduce_min_dtypes_shape_int8_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_min_dtypes_shape_uint16_2_3.mlir
+++ b/stablehlo/testdata/reduce_min_dtypes_shape_uint16_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_min_dtypes_shape_uint32_2_3.mlir
+++ b/stablehlo/testdata/reduce_min_dtypes_shape_uint32_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_min_dtypes_shape_uint8_2_3.mlir
+++ b/stablehlo/testdata/reduce_min_dtypes_shape_uint8_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_or_dtypes_shape_bool_2_3.mlir
+++ b/stablehlo/testdata/reduce_or_dtypes_shape_bool_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_precision_in_bfloat16_5_7__out_bfloat16_5_7.mlir
+++ b/stablehlo/testdata/reduce_precision_in_bfloat16_5_7__out_bfloat16_5_7.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_precision_in_bfloat16_5_7__out_float16_5_7.mlir
+++ b/stablehlo/testdata/reduce_precision_in_bfloat16_5_7__out_float16_5_7.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_precision_in_bfloat16_5_7__out_float32_5_7.mlir
+++ b/stablehlo/testdata/reduce_precision_in_bfloat16_5_7__out_float32_5_7.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_precision_in_bfloat16___out_bfloat16.mlir
+++ b/stablehlo/testdata/reduce_precision_in_bfloat16___out_bfloat16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_precision_in_bfloat16___out_float16.mlir
+++ b/stablehlo/testdata/reduce_precision_in_bfloat16___out_float16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_precision_in_bfloat16___out_float32.mlir
+++ b/stablehlo/testdata/reduce_precision_in_bfloat16___out_float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_precision_in_float16_5_7__out_bfloat16_5_7.mlir
+++ b/stablehlo/testdata/reduce_precision_in_float16_5_7__out_bfloat16_5_7.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_precision_in_float16_5_7__out_float16_5_7.mlir
+++ b/stablehlo/testdata/reduce_precision_in_float16_5_7__out_float16_5_7.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_precision_in_float16_5_7__out_float32_5_7.mlir
+++ b/stablehlo/testdata/reduce_precision_in_float16_5_7__out_float32_5_7.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_precision_in_float16___out_bfloat16.mlir
+++ b/stablehlo/testdata/reduce_precision_in_float16___out_bfloat16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_precision_in_float16___out_float16.mlir
+++ b/stablehlo/testdata/reduce_precision_in_float16___out_float16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_precision_in_float16___out_float32.mlir
+++ b/stablehlo/testdata/reduce_precision_in_float16___out_float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_precision_in_float32_5_7__out_bfloat16_5_7.mlir
+++ b/stablehlo/testdata/reduce_precision_in_float32_5_7__out_bfloat16_5_7.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_precision_in_float32_5_7__out_float16_5_7.mlir
+++ b/stablehlo/testdata/reduce_precision_in_float32_5_7__out_float16_5_7.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_precision_in_float32___out_bfloat16.mlir
+++ b/stablehlo/testdata/reduce_precision_in_float32___out_bfloat16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_precision_in_float32___out_float16.mlir
+++ b/stablehlo/testdata/reduce_precision_in_float32___out_float16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_precision_in_float32___out_float32.mlir
+++ b/stablehlo/testdata/reduce_precision_in_float32___out_float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_prod_dtypes_shape_bfloat16_2_3.mlir
+++ b/stablehlo/testdata/reduce_prod_dtypes_shape_bfloat16_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_prod_dtypes_shape_complex64_2_3.mlir
+++ b/stablehlo/testdata/reduce_prod_dtypes_shape_complex64_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_prod_dtypes_shape_float16_2_3.mlir
+++ b/stablehlo/testdata/reduce_prod_dtypes_shape_float16_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_prod_dtypes_shape_float32_2_3.mlir
+++ b/stablehlo/testdata/reduce_prod_dtypes_shape_float32_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_prod_dtypes_shape_int16_2_3.mlir
+++ b/stablehlo/testdata/reduce_prod_dtypes_shape_int16_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_prod_dtypes_shape_int32_2_3.mlir
+++ b/stablehlo/testdata/reduce_prod_dtypes_shape_int32_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_prod_dtypes_shape_int8_2_3.mlir
+++ b/stablehlo/testdata/reduce_prod_dtypes_shape_int8_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_prod_dtypes_shape_uint16_2_3.mlir
+++ b/stablehlo/testdata/reduce_prod_dtypes_shape_uint16_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_prod_dtypes_shape_uint32_2_3.mlir
+++ b/stablehlo/testdata/reduce_prod_dtypes_shape_uint32_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_prod_dtypes_shape_uint8_2_3.mlir
+++ b/stablehlo/testdata/reduce_prod_dtypes_shape_uint8_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_prod_dynamic.mlir
+++ b/stablehlo/testdata/reduce_prod_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5xf32> {mhlo.sharding = ""}) -> tensor<?x1xf32> {

--- a/stablehlo/testdata/reduce_sum_dtypes_shape_bfloat16_2_3.mlir
+++ b/stablehlo/testdata/reduce_sum_dtypes_shape_bfloat16_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_sum_dtypes_shape_complex64_2_3.mlir
+++ b/stablehlo/testdata/reduce_sum_dtypes_shape_complex64_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_sum_dtypes_shape_float16_2_3.mlir
+++ b/stablehlo/testdata/reduce_sum_dtypes_shape_float16_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_sum_dtypes_shape_float32_2_3.mlir
+++ b/stablehlo/testdata/reduce_sum_dtypes_shape_float32_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_sum_dtypes_shape_int16_2_3.mlir
+++ b/stablehlo/testdata/reduce_sum_dtypes_shape_int16_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_sum_dtypes_shape_int32_2_3.mlir
+++ b/stablehlo/testdata/reduce_sum_dtypes_shape_int32_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_sum_dtypes_shape_int8_2_3.mlir
+++ b/stablehlo/testdata/reduce_sum_dtypes_shape_int8_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_sum_dtypes_shape_uint16_2_3.mlir
+++ b/stablehlo/testdata/reduce_sum_dtypes_shape_uint16_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_sum_dtypes_shape_uint32_2_3.mlir
+++ b/stablehlo/testdata/reduce_sum_dtypes_shape_uint32_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_sum_dtypes_shape_uint8_2_3.mlir
+++ b/stablehlo/testdata/reduce_sum_dtypes_shape_uint8_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_sum_dynamic.mlir
+++ b/stablehlo/testdata/reduce_sum_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5xf32> {mhlo.sharding = ""}) -> tensor<?x1xf32> {

--- a/stablehlo/testdata/reduce_window_add_0_enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/reduce_window_add_0_enable_xla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8xf32> {mhlo.sharding = ""}) -> tensor<?x7xf32> {

--- a/stablehlo/testdata/reduce_window_add_1_enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/reduce_window_add_1_enable_xla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<1x?x16xf32> {mhlo.sharding = ""}) -> tensor<1x?x1xf32> {

--- a/stablehlo/testdata/reduce_window_add_base_dilation_shape_float32_4_6__initvalue_0_windowdimensions__2_2__windowstrides_7986328860834552647.mlir
+++ b/stablehlo/testdata/reduce_window_add_base_dilation_shape_float32_4_6__initvalue_0_windowdimensions__2_2__windowstrides_7986328860834552647.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_add_dtypes_shape_bfloat16_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__-2220972298967194594.mlir
+++ b/stablehlo/testdata/reduce_window_add_dtypes_shape_bfloat16_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__-2220972298967194594.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_add_dtypes_shape_bfloat16_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__-1428448145173401924.mlir
+++ b/stablehlo/testdata/reduce_window_add_dtypes_shape_bfloat16_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__-1428448145173401924.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_add_dtypes_shape_complex64_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1_-4698468758011440787.mlir
+++ b/stablehlo/testdata/reduce_window_add_dtypes_shape_complex64_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1_-4698468758011440787.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_add_dtypes_shape_complex64_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1_8225502087604216949.mlir
+++ b/stablehlo/testdata/reduce_window_add_dtypes_shape_complex64_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1_8225502087604216949.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_add_dtypes_shape_float16_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__p2993120393378492976.mlir
+++ b/stablehlo/testdata/reduce_window_add_dtypes_shape_float16_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__p2993120393378492976.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_add_dtypes_shape_float16_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__p1727597624205542039.mlir
+++ b/stablehlo/testdata/reduce_window_add_dtypes_shape_float16_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__p1727597624205542039.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_add_dtypes_shape_float32_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__p3586290205775842300.mlir
+++ b/stablehlo/testdata/reduce_window_add_dtypes_shape_float32_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__p3586290205775842300.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_add_dtypes_shape_float32_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__p-4032734852119941554.mlir
+++ b/stablehlo/testdata/reduce_window_add_dtypes_shape_float32_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__p-4032734852119941554.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_add_dtypes_shape_int16_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__pad7635044839543803654.mlir
+++ b/stablehlo/testdata/reduce_window_add_dtypes_shape_int16_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__pad7635044839543803654.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_add_dtypes_shape_int16_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__pad6961367239774059619.mlir
+++ b/stablehlo/testdata/reduce_window_add_dtypes_shape_int16_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__pad6961367239774059619.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_add_dtypes_shape_int32_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__pad-42586455448778120.mlir
+++ b/stablehlo/testdata/reduce_window_add_dtypes_shape_int32_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__pad-42586455448778120.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_add_dtypes_shape_int32_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__pad-4840663732946877279.mlir
+++ b/stablehlo/testdata/reduce_window_add_dtypes_shape_int32_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__pad-4840663732946877279.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_add_dtypes_shape_int8_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__padd-4938290008184005060.mlir
+++ b/stablehlo/testdata/reduce_window_add_dtypes_shape_int8_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__padd-4938290008184005060.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_add_dtypes_shape_int8_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__padd879372096543558505.mlir
+++ b/stablehlo/testdata/reduce_window_add_dtypes_shape_int8_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__padd879372096543558505.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_add_dtypes_shape_uint16_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__pa-5953571789298025160.mlir
+++ b/stablehlo/testdata/reduce_window_add_dtypes_shape_uint16_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__pa-5953571789298025160.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_add_dtypes_shape_uint16_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__pa8824143900020308206.mlir
+++ b/stablehlo/testdata/reduce_window_add_dtypes_shape_uint16_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__pa8824143900020308206.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_add_dtypes_shape_uint32_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__pa9076128080492083436.mlir
+++ b/stablehlo/testdata/reduce_window_add_dtypes_shape_uint32_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__pa9076128080492083436.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_add_dtypes_shape_uint32_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__pa408729289442029153.mlir
+++ b/stablehlo/testdata/reduce_window_add_dtypes_shape_uint32_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__pa408729289442029153.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_add_dtypes_shape_uint8_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__pad6324563894280027939.mlir
+++ b/stablehlo/testdata/reduce_window_add_dtypes_shape_uint8_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__pad6324563894280027939.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_add_dtypes_shape_uint8_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__pad-7116931799215120108.mlir
+++ b/stablehlo/testdata/reduce_window_add_dtypes_shape_uint8_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__pad-7116931799215120108.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_add_manual_padding_shape_float32_12_12__initvalue_0_0_windowdimensions__13_13__windows-691859033508160866.mlir
+++ b/stablehlo/testdata/reduce_window_add_manual_padding_shape_float32_12_12__initvalue_0_0_windowdimensions__13_13__windows-691859033508160866.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_add_manual_padding_shape_float32_12_12__initvalue_0_0_windowdimensions__2_2__windowstr6046687465413193911.mlir
+++ b/stablehlo/testdata/reduce_window_add_manual_padding_shape_float32_12_12__initvalue_0_0_windowdimensions__2_2__windowstr6046687465413193911.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_add_manual_padding_shape_float32_12_12__initvalue_0_0_windowdimensions__3_3__windowstr-4104859581547667440.mlir
+++ b/stablehlo/testdata/reduce_window_add_manual_padding_shape_float32_12_12__initvalue_0_0_windowdimensions__3_3__windowstr-4104859581547667440.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_add_padding_shape_float32_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__5080188771172348269.mlir
+++ b/stablehlo/testdata/reduce_window_add_padding_shape_float32_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__5080188771172348269.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_add_same_padding_shape_float32_112_112__initvalue_0_0_windowdimensions__3_3__windowstr-3365744398050275565.mlir
+++ b/stablehlo/testdata/reduce_window_add_same_padding_shape_float32_112_112__initvalue_0_0_windowdimensions__3_3__windowstr-3365744398050275565.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_add_window_dilation_shape_float32_4_6__initvalue_0_windowdimensions__2_2__windowstride1490052185320441557.mlir
+++ b/stablehlo/testdata/reduce_window_add_window_dilation_shape_float32_4_6__initvalue_0_windowdimensions__2_2__windowstride1490052185320441557.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_add_window_dimensions_shape_float32_4_6__initvalue_0_windowdimensions__1_1__windowstri-9144278943768635611.mlir
+++ b/stablehlo/testdata/reduce_window_add_window_dimensions_shape_float32_4_6__initvalue_0_windowdimensions__1_1__windowstri-9144278943768635611.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_add_window_strides_shape_float32_4_6__initvalue_0_windowdimensions__2_2__windowstrides-3887130791349734568.mlir
+++ b/stablehlo/testdata/reduce_window_add_window_strides_shape_float32_4_6__initvalue_0_windowdimensions__2_2__windowstrides-3887130791349734568.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_max_batch_channel_dims_shape_float32_1_2_1__initvalue_-inf_windowdimensions__1_2_1__wi2907722705369048493.mlir
+++ b/stablehlo/testdata/reduce_window_max_batch_channel_dims_shape_float32_1_2_1__initvalue_-inf_windowdimensions__1_2_1__wi2907722705369048493.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_max_batch_channel_dims_shape_float32_1_2_4_1__initvalue_-inf_windowdimensions__1_2_2_1-5111631298771835819.mlir
+++ b/stablehlo/testdata/reduce_window_max_batch_channel_dims_shape_float32_1_2_4_1__initvalue_-inf_windowdimensions__1_2_2_1-5111631298771835819.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_max_batch_channel_dims_shape_float32_1_2__initvalue_-inf_windowdimensions__1_2__window-1636693082974747423.mlir
+++ b/stablehlo/testdata/reduce_window_max_batch_channel_dims_shape_float32_1_2__initvalue_-inf_windowdimensions__1_2__window-1636693082974747423.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_max_batch_channel_dims_shape_float32_1_4_3_2_1__initvalue_-inf_windowdimensions__1_2_2-7793407312160842848.mlir
+++ b/stablehlo/testdata/reduce_window_max_batch_channel_dims_shape_float32_1_4_3_2_1__initvalue_-inf_windowdimensions__1_2_2-7793407312160842848.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_max_batch_channel_dims_shape_float32_2_1__initvalue_-inf_windowdimensions__2_1__window7224370613358112198.mlir
+++ b/stablehlo/testdata/reduce_window_max_batch_channel_dims_shape_float32_2_1__initvalue_-inf_windowdimensions__2_1__window7224370613358112198.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_max_batch_channel_dims_shape_float32_2_4_3__initvalue_-inf_windowdimensions__2_2_2__wi2460382255230330798.mlir
+++ b/stablehlo/testdata/reduce_window_max_batch_channel_dims_shape_float32_2_4_3__initvalue_-inf_windowdimensions__2_2_2__wi2460382255230330798.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_max_batch_channel_dims_shape_float32_2_4__initvalue_-inf_windowdimensions__2_2__window3880194203908208615.mlir
+++ b/stablehlo/testdata/reduce_window_max_batch_channel_dims_shape_float32_2_4__initvalue_-inf_windowdimensions__2_2__window3880194203908208615.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_max_batch_channel_dims_shape_float32_2__initvalue_-inf_windowdimensions__2___windowstr-4386488581234318633.mlir
+++ b/stablehlo/testdata/reduce_window_max_batch_channel_dims_shape_float32_2__initvalue_-inf_windowdimensions__2___windowstr-4386488581234318633.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_max_dtypes_shape_bfloat16_4_6__initvalue_-inf_windowdimensions__2_2__windowstrides__1_-6216933667409612517.mlir
+++ b/stablehlo/testdata/reduce_window_max_dtypes_shape_bfloat16_4_6__initvalue_-inf_windowdimensions__2_2__windowstrides__1_-6216933667409612517.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_max_dtypes_shape_bfloat16_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__-4994625811150598768.mlir
+++ b/stablehlo/testdata/reduce_window_max_dtypes_shape_bfloat16_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__-4994625811150598768.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_max_dtypes_shape_bool_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__padd5379111250118667329.mlir
+++ b/stablehlo/testdata/reduce_window_max_dtypes_shape_bool_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__padd5379111250118667329.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_max_dtypes_shape_bool_4_6__initvalue_False_windowdimensions__2_2__windowstrides__1_1__8072758898254897225.mlir
+++ b/stablehlo/testdata/reduce_window_max_dtypes_shape_bool_4_6__initvalue_False_windowdimensions__2_2__windowstrides__1_1__8072758898254897225.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_max_dtypes_shape_complex64_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1_4291849701066239869.mlir
+++ b/stablehlo/testdata/reduce_window_max_dtypes_shape_complex64_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1_4291849701066239869.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_max_dtypes_shape_complex64_4_6__initvalue__-inf_0j__windowdimensions__2_2__windowstrid-7363942699456202060.mlir
+++ b/stablehlo/testdata/reduce_window_max_dtypes_shape_complex64_4_6__initvalue__-inf_0j__windowdimensions__2_2__windowstrid-7363942699456202060.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_max_dtypes_shape_float16_4_6__initvalue_-inf_windowdimensions__2_2__windowstrides__1_11557672409746689732.mlir
+++ b/stablehlo/testdata/reduce_window_max_dtypes_shape_float16_4_6__initvalue_-inf_windowdimensions__2_2__windowstrides__1_11557672409746689732.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_max_dtypes_shape_float16_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__p-7750873517905381577.mlir
+++ b/stablehlo/testdata/reduce_window_max_dtypes_shape_float16_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__p-7750873517905381577.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_max_dtypes_shape_float32_4_6__initvalue_-inf_windowdimensions__2_2__windowstrides__1_15005027447381495146.mlir
+++ b/stablehlo/testdata/reduce_window_max_dtypes_shape_float32_4_6__initvalue_-inf_windowdimensions__2_2__windowstrides__1_15005027447381495146.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_max_dtypes_shape_float32_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__p-5323860118055166118.mlir
+++ b/stablehlo/testdata/reduce_window_max_dtypes_shape_float32_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__p-5323860118055166118.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_max_dtypes_shape_int16_4_6__initvalue_-32768_windowdimensions__2_2__windowstrides__1_1-3971969563239728636.mlir
+++ b/stablehlo/testdata/reduce_window_max_dtypes_shape_int16_4_6__initvalue_-32768_windowdimensions__2_2__windowstrides__1_1-3971969563239728636.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_max_dtypes_shape_int16_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__pad3937654242282090133.mlir
+++ b/stablehlo/testdata/reduce_window_max_dtypes_shape_int16_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__pad3937654242282090133.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_max_dtypes_shape_int32_4_6__initvalue_-2147483648_windowdimensions__2_2__windowstrides-6104600437082556539.mlir
+++ b/stablehlo/testdata/reduce_window_max_dtypes_shape_int32_4_6__initvalue_-2147483648_windowdimensions__2_2__windowstrides-6104600437082556539.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_max_dtypes_shape_int32_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__pad-4758189359533826695.mlir
+++ b/stablehlo/testdata/reduce_window_max_dtypes_shape_int32_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__pad-4758189359533826695.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_max_dtypes_shape_int8_4_6__initvalue_-128_windowdimensions__2_2__windowstrides__1_1__p-1721685740020350494.mlir
+++ b/stablehlo/testdata/reduce_window_max_dtypes_shape_int8_4_6__initvalue_-128_windowdimensions__2_2__windowstrides__1_1__p-1721685740020350494.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_max_dtypes_shape_int8_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__padd3921525681822021249.mlir
+++ b/stablehlo/testdata/reduce_window_max_dtypes_shape_int8_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__padd3921525681822021249.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_max_dtypes_shape_uint16_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__pa-6688282750744868505.mlir
+++ b/stablehlo/testdata/reduce_window_max_dtypes_shape_uint16_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__pa-6688282750744868505.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_max_dtypes_shape_uint16_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__pa5793043271262126639.mlir
+++ b/stablehlo/testdata/reduce_window_max_dtypes_shape_uint16_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__pa5793043271262126639.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_max_dtypes_shape_uint32_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__pa-6195221688489426534.mlir
+++ b/stablehlo/testdata/reduce_window_max_dtypes_shape_uint32_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__pa-6195221688489426534.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_max_dtypes_shape_uint32_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__pa-2745576375630020475.mlir
+++ b/stablehlo/testdata/reduce_window_max_dtypes_shape_uint32_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__pa-2745576375630020475.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_max_dtypes_shape_uint8_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__pad617319801188093086.mlir
+++ b/stablehlo/testdata/reduce_window_max_dtypes_shape_uint8_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__pad617319801188093086.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_max_dtypes_shape_uint8_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__pad7930015827732118891.mlir
+++ b/stablehlo/testdata/reduce_window_max_dtypes_shape_uint8_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__pad7930015827732118891.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_max_same_padding_shape_float32_112_112__initvalue_-inf_windowdimensions__3_3__windowst-4354541867574846756.mlir
+++ b/stablehlo/testdata/reduce_window_max_same_padding_shape_float32_112_112__initvalue_-inf_windowdimensions__3_3__windowst-4354541867574846756.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_min_dtypes_shape_bfloat16_4_6__initvalue_inf_windowdimensions__2_2__windowstrides__1_13309700146959997041.mlir
+++ b/stablehlo/testdata/reduce_window_min_dtypes_shape_bfloat16_4_6__initvalue_inf_windowdimensions__2_2__windowstrides__1_13309700146959997041.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_min_dtypes_shape_bool_4_6__initvalue_True_windowdimensions__2_2__windowstrides__1_1__p-1453727971620327298.mlir
+++ b/stablehlo/testdata/reduce_window_min_dtypes_shape_bool_4_6__initvalue_True_windowdimensions__2_2__windowstrides__1_1__p-1453727971620327298.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_min_dtypes_shape_complex64_4_6__initvalue__inf_0j__windowdimensions__2_2__windowstride4144686377792404619.mlir
+++ b/stablehlo/testdata/reduce_window_min_dtypes_shape_complex64_4_6__initvalue__inf_0j__windowdimensions__2_2__windowstride4144686377792404619.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_min_dtypes_shape_float16_4_6__initvalue_inf_windowdimensions__2_2__windowstrides__1_1_9069967543444044853.mlir
+++ b/stablehlo/testdata/reduce_window_min_dtypes_shape_float16_4_6__initvalue_inf_windowdimensions__2_2__windowstrides__1_1_9069967543444044853.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_min_dtypes_shape_float32_4_6__initvalue_inf_windowdimensions__2_2__windowstrides__1_1_-3090946471386215849.mlir
+++ b/stablehlo/testdata/reduce_window_min_dtypes_shape_float32_4_6__initvalue_inf_windowdimensions__2_2__windowstrides__1_1_-3090946471386215849.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_min_dtypes_shape_int16_4_6__initvalue_32767_windowdimensions__2_2__windowstrides__1_1_-5773481113145828258.mlir
+++ b/stablehlo/testdata/reduce_window_min_dtypes_shape_int16_4_6__initvalue_32767_windowdimensions__2_2__windowstrides__1_1_-5773481113145828258.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_min_dtypes_shape_int32_4_6__initvalue_2147483647_windowdimensions__2_2__windowstrides_7936915878546705934.mlir
+++ b/stablehlo/testdata/reduce_window_min_dtypes_shape_int32_4_6__initvalue_2147483647_windowdimensions__2_2__windowstrides_7936915878546705934.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_min_dtypes_shape_int8_4_6__initvalue_127_windowdimensions__2_2__windowstrides__1_1__pa-2505694084141416255.mlir
+++ b/stablehlo/testdata/reduce_window_min_dtypes_shape_int8_4_6__initvalue_127_windowdimensions__2_2__windowstrides__1_1__pa-2505694084141416255.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_min_dtypes_shape_uint16_4_6__initvalue_65535_windowdimensions__2_2__windowstrides__1_1-4410384324890600071.mlir
+++ b/stablehlo/testdata/reduce_window_min_dtypes_shape_uint16_4_6__initvalue_65535_windowdimensions__2_2__windowstrides__1_1-4410384324890600071.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_min_dtypes_shape_uint32_4_6__initvalue_4294967295_windowdimensions__2_2__windowstrides3362483014574803263.mlir
+++ b/stablehlo/testdata/reduce_window_min_dtypes_shape_uint32_4_6__initvalue_4294967295_windowdimensions__2_2__windowstrides3362483014574803263.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_min_dtypes_shape_uint8_4_6__initvalue_255_windowdimensions__2_2__windowstrides__1_1__p-1965134471500928525.mlir
+++ b/stablehlo/testdata/reduce_window_min_dtypes_shape_uint8_4_6__initvalue_255_windowdimensions__2_2__windowstrides__1_1__p-1965134471500928525.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_min_enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/reduce_window_min_enable_xla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8xf32> {mhlo.sharding = ""}) -> tensor<?x7xf32> {

--- a/stablehlo/testdata/reduce_window_min_init_value_1d_shape_float32_1_16000__initvalue_1_0_windowdimensions__1_401__window2830952238904064054.mlir
+++ b/stablehlo/testdata/reduce_window_min_init_value_1d_shape_float32_1_16000__initvalue_1_0_windowdimensions__1_401__window2830952238904064054.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_min_same_padding_shape_float32_112_112__initvalue_inf_windowdimensions__3_3__windowstr-2492685243049766723.mlir
+++ b/stablehlo/testdata/reduce_window_min_same_padding_shape_float32_112_112__initvalue_inf_windowdimensions__3_3__windowstr-2492685243049766723.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_mul_dtypes_shape_bfloat16_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__3340519855672632656.mlir
+++ b/stablehlo/testdata/reduce_window_mul_dtypes_shape_bfloat16_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__3340519855672632656.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_mul_dtypes_shape_bfloat16_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__-7707877832553282312.mlir
+++ b/stablehlo/testdata/reduce_window_mul_dtypes_shape_bfloat16_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__-7707877832553282312.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_mul_dtypes_shape_bfloat16_4_6__initvalue_2_windowdimensions__2_2__windowstrides__1_1__-4352332529828279679.mlir
+++ b/stablehlo/testdata/reduce_window_mul_dtypes_shape_bfloat16_4_6__initvalue_2_windowdimensions__2_2__windowstrides__1_1__-4352332529828279679.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_mul_dtypes_shape_complex64_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1_2680457227484159444.mlir
+++ b/stablehlo/testdata/reduce_window_mul_dtypes_shape_complex64_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1_2680457227484159444.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_mul_dtypes_shape_complex64_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1_-8749826146171525914.mlir
+++ b/stablehlo/testdata/reduce_window_mul_dtypes_shape_complex64_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1_-8749826146171525914.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_mul_dtypes_shape_complex64_4_6__initvalue_2_windowdimensions__2_2__windowstrides__1_1_-4418219444220371989.mlir
+++ b/stablehlo/testdata/reduce_window_mul_dtypes_shape_complex64_4_6__initvalue_2_windowdimensions__2_2__windowstrides__1_1_-4418219444220371989.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_mul_dtypes_shape_float16_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__p8588115838297523173.mlir
+++ b/stablehlo/testdata/reduce_window_mul_dtypes_shape_float16_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__p8588115838297523173.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_mul_dtypes_shape_float16_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__p-722024604699842952.mlir
+++ b/stablehlo/testdata/reduce_window_mul_dtypes_shape_float16_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__p-722024604699842952.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_mul_dtypes_shape_float16_4_6__initvalue_2_windowdimensions__2_2__windowstrides__1_1__p3251667528106744236.mlir
+++ b/stablehlo/testdata/reduce_window_mul_dtypes_shape_float16_4_6__initvalue_2_windowdimensions__2_2__windowstrides__1_1__p3251667528106744236.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_mul_dtypes_shape_float32_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__p-9219300395209946880.mlir
+++ b/stablehlo/testdata/reduce_window_mul_dtypes_shape_float32_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__p-9219300395209946880.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_mul_dtypes_shape_float32_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__p-1170997397628138029.mlir
+++ b/stablehlo/testdata/reduce_window_mul_dtypes_shape_float32_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__p-1170997397628138029.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_mul_dtypes_shape_float32_4_6__initvalue_2_windowdimensions__2_2__windowstrides__1_1__p5865330874643232007.mlir
+++ b/stablehlo/testdata/reduce_window_mul_dtypes_shape_float32_4_6__initvalue_2_windowdimensions__2_2__windowstrides__1_1__p5865330874643232007.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_mul_dtypes_shape_int16_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__pad6936816701131227392.mlir
+++ b/stablehlo/testdata/reduce_window_mul_dtypes_shape_int16_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__pad6936816701131227392.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_mul_dtypes_shape_int16_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__pad-877041750945830425.mlir
+++ b/stablehlo/testdata/reduce_window_mul_dtypes_shape_int16_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__pad-877041750945830425.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_mul_dtypes_shape_int16_4_6__initvalue_2_windowdimensions__2_2__windowstrides__1_1__pad-4255861490662115505.mlir
+++ b/stablehlo/testdata/reduce_window_mul_dtypes_shape_int16_4_6__initvalue_2_windowdimensions__2_2__windowstrides__1_1__pad-4255861490662115505.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_mul_dtypes_shape_int32_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__pad-7315803323352185471.mlir
+++ b/stablehlo/testdata/reduce_window_mul_dtypes_shape_int32_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__pad-7315803323352185471.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_mul_dtypes_shape_int32_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__pad-3200229493467114834.mlir
+++ b/stablehlo/testdata/reduce_window_mul_dtypes_shape_int32_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__pad-3200229493467114834.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_mul_dtypes_shape_int32_4_6__initvalue_2_windowdimensions__2_2__windowstrides__1_1__pad-6349420869970636753.mlir
+++ b/stablehlo/testdata/reduce_window_mul_dtypes_shape_int32_4_6__initvalue_2_windowdimensions__2_2__windowstrides__1_1__pad-6349420869970636753.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_mul_dtypes_shape_int8_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__padd-3968434153936355982.mlir
+++ b/stablehlo/testdata/reduce_window_mul_dtypes_shape_int8_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__padd-3968434153936355982.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_mul_dtypes_shape_int8_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__padd2549091231254646447.mlir
+++ b/stablehlo/testdata/reduce_window_mul_dtypes_shape_int8_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__padd2549091231254646447.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_mul_dtypes_shape_int8_4_6__initvalue_2_windowdimensions__2_2__windowstrides__1_1__padd6734116708708925884.mlir
+++ b/stablehlo/testdata/reduce_window_mul_dtypes_shape_int8_4_6__initvalue_2_windowdimensions__2_2__windowstrides__1_1__padd6734116708708925884.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_mul_dtypes_shape_uint16_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__pa2377140915067044416.mlir
+++ b/stablehlo/testdata/reduce_window_mul_dtypes_shape_uint16_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__pa2377140915067044416.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_mul_dtypes_shape_uint16_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__pa-9053278640616598724.mlir
+++ b/stablehlo/testdata/reduce_window_mul_dtypes_shape_uint16_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__pa-9053278640616598724.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_mul_dtypes_shape_uint16_4_6__initvalue_2_windowdimensions__2_2__windowstrides__1_1__pa-2883905225725849680.mlir
+++ b/stablehlo/testdata/reduce_window_mul_dtypes_shape_uint16_4_6__initvalue_2_windowdimensions__2_2__windowstrides__1_1__pa-2883905225725849680.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_mul_dtypes_shape_uint32_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__pa-8516304739392392826.mlir
+++ b/stablehlo/testdata/reduce_window_mul_dtypes_shape_uint32_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__pa-8516304739392392826.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_mul_dtypes_shape_uint32_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__pa8716816771292110437.mlir
+++ b/stablehlo/testdata/reduce_window_mul_dtypes_shape_uint32_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__pa8716816771292110437.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_mul_dtypes_shape_uint32_4_6__initvalue_2_windowdimensions__2_2__windowstrides__1_1__pa-2670986806077945892.mlir
+++ b/stablehlo/testdata/reduce_window_mul_dtypes_shape_uint32_4_6__initvalue_2_windowdimensions__2_2__windowstrides__1_1__pa-2670986806077945892.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_mul_dtypes_shape_uint8_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__pad8624066883509500227.mlir
+++ b/stablehlo/testdata/reduce_window_mul_dtypes_shape_uint8_4_6__initvalue_0_windowdimensions__2_2__windowstrides__1_1__pad8624066883509500227.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_mul_dtypes_shape_uint8_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__pad5922828822890250003.mlir
+++ b/stablehlo/testdata/reduce_window_mul_dtypes_shape_uint8_4_6__initvalue_1_windowdimensions__2_2__windowstrides__1_1__pad5922828822890250003.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reduce_window_mul_dtypes_shape_uint8_4_6__initvalue_2_windowdimensions__2_2__windowstrides__1_1__pad5589770953477007003.mlir
+++ b/stablehlo/testdata/reduce_window_mul_dtypes_shape_uint8_4_6__initvalue_2_windowdimensions__2_2__windowstrides__1_1__pad5589770953477007003.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/regularized_incomplete_beta__bfloat16.mlir
+++ b/stablehlo/testdata/regularized_incomplete_beta__bfloat16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/regularized_incomplete_beta__float16.mlir
+++ b/stablehlo/testdata/regularized_incomplete_beta__float16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/regularized_incomplete_beta__float32.mlir
+++ b/stablehlo/testdata/regularized_incomplete_beta__float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/rem_broadcast_lhs_float32_2_1_3__rhs_float32_2_4_3.mlir
+++ b/stablehlo/testdata/rem_broadcast_lhs_float32_2_1_3__rhs_float32_2_4_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/rem_broadcast_lhs_float32_2_4_3__rhs_float32_2_1_3.mlir
+++ b/stablehlo/testdata/rem_broadcast_lhs_float32_2_4_3__rhs_float32_2_1_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/rem_dtypes_lhs_bfloat16_2__rhs_bfloat16_2.mlir
+++ b/stablehlo/testdata/rem_dtypes_lhs_bfloat16_2__rhs_bfloat16_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/rem_dtypes_lhs_float16_2__rhs_float16_2.mlir
+++ b/stablehlo/testdata/rem_dtypes_lhs_float16_2__rhs_float16_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/rem_dtypes_lhs_float32_2__rhs_float32_2.mlir
+++ b/stablehlo/testdata/rem_dtypes_lhs_float32_2__rhs_float32_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/rem_dtypes_lhs_int16_2__rhs_int16_2.mlir
+++ b/stablehlo/testdata/rem_dtypes_lhs_int16_2__rhs_int16_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/rem_dtypes_lhs_int32_2__rhs_int32_2.mlir
+++ b/stablehlo/testdata/rem_dtypes_lhs_int32_2__rhs_int32_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/rem_dtypes_lhs_int8_2__rhs_int8_2.mlir
+++ b/stablehlo/testdata/rem_dtypes_lhs_int8_2__rhs_int8_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/rem_dtypes_lhs_uint16_2__rhs_uint16_2.mlir
+++ b/stablehlo/testdata/rem_dtypes_lhs_uint16_2__rhs_uint16_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/rem_dtypes_lhs_uint32_2__rhs_uint32_2.mlir
+++ b/stablehlo/testdata/rem_dtypes_lhs_uint32_2__rhs_uint32_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/rem_dtypes_lhs_uint8_2__rhs_uint8_2.mlir
+++ b/stablehlo/testdata/rem_dtypes_lhs_uint8_2__rhs_uint8_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/rem_singularity_0_by_0_lhs_float32_2__rhs_float32_2.mlir
+++ b/stablehlo/testdata/rem_singularity_0_by_0_lhs_float32_2__rhs_float32_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/rem_singularity_inf_by_inf_lhs_float32_1__rhs_float32_1.mlir
+++ b/stablehlo/testdata/rem_singularity_inf_by_inf_lhs_float32_1__rhs_float32_1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/rem_singularity_negative_by_0_lhs_float32_2__rhs_float32_2.mlir
+++ b/stablehlo/testdata/rem_singularity_negative_by_0_lhs_float32_2__rhs_float32_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/rem_singularity_positive_by_0_lhs_float32_2__rhs_float32_2.mlir
+++ b/stablehlo/testdata/rem_singularity_positive_by_0_lhs_float32_2__rhs_float32_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/repeat_repeats_int_axis_0_dynamic.mlir
+++ b/stablehlo/testdata/repeat_repeats_int_axis_0_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2xf32> {mhlo.sharding = ""}) -> tensor<?x2xf32> {

--- a/stablehlo/testdata/repeat_repeats_poly_axis_0_dynamic.mlir
+++ b/stablehlo/testdata/repeat_repeats_poly_axis_0_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2xf32> {mhlo.sharding = ""}) -> tensor<?x2xf32> {

--- a/stablehlo/testdata/repeat_repeats_poly_axis_None_dynamic.mlir
+++ b/stablehlo/testdata/repeat_repeats_poly_axis_None_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2xf32> {mhlo.sharding = ""}) -> tensor<?xf32> {

--- a/stablehlo/testdata/repeat_repeats_poly_axis_None_scalar_dynamic.mlir
+++ b/stablehlo/testdata/repeat_repeats_poly_axis_None_scalar_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<f32> {mhlo.sharding = ""}, %arg2: tensor<?x1xf32> {mhlo.sharding = ""}) -> tensor<?x?xf32> {

--- a/stablehlo/testdata/reshape_0_dynamic.mlir
+++ b/stablehlo/testdata/reshape_0_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2x3xf32> {mhlo.sharding = ""}) -> tensor<?x6xf32> {

--- a/stablehlo/testdata/reshape_1_dynamic.mlir
+++ b/stablehlo/testdata/reshape_1_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<i64>, %arg2: tensor<?x?x3xf32> {mhlo.sharding = ""}) -> tensor<?x?xf32> {

--- a/stablehlo/testdata/reshape_2_dynamic.mlir
+++ b/stablehlo/testdata/reshape_2_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<i64>, %arg2: tensor<i64>, %arg3: tensor<?x4x?x?x7xf32> {mhlo.sharding = ""}) -> tensor<?x28x?x?xf32> {

--- a/stablehlo/testdata/reshape_3_dynamic.mlir
+++ b/stablehlo/testdata/reshape_3_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<i64>, %arg2: tensor<?x4x?x6x7xf32> {mhlo.sharding = ""}) -> tensor<2x?xf32> {

--- a/stablehlo/testdata/reshape__issue_9975_dynamic.mlir
+++ b/stablehlo/testdata/reshape__issue_9975_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}) -> tensor<?xf32> {

--- a/stablehlo/testdata/reshape_dimensions_shape_float32_3_4_5__newsizes__3__20__dimensions__2__0__1.mlir
+++ b/stablehlo/testdata/reshape_dimensions_shape_float32_3_4_5__newsizes__3__20__dimensions__2__0__1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reshape_dimensions_shape_float32_3_4_5__newsizes__3__20__dimensions__2__1__0.mlir
+++ b/stablehlo/testdata/reshape_dimensions_shape_float32_3_4_5__newsizes__3__20__dimensions__2__1__0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reshape_dtypes_shape_bfloat16_2_3__newsizes__3__2__dimensions__0__1.mlir
+++ b/stablehlo/testdata/reshape_dtypes_shape_bfloat16_2_3__newsizes__3__2__dimensions__0__1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reshape_dtypes_shape_bool_2_3__newsizes__3__2__dimensions__0__1.mlir
+++ b/stablehlo/testdata/reshape_dtypes_shape_bool_2_3__newsizes__3__2__dimensions__0__1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reshape_dtypes_shape_complex64_2_3__newsizes__3__2__dimensions__0__1.mlir
+++ b/stablehlo/testdata/reshape_dtypes_shape_complex64_2_3__newsizes__3__2__dimensions__0__1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reshape_dtypes_shape_float16_2_3__newsizes__3__2__dimensions__0__1.mlir
+++ b/stablehlo/testdata/reshape_dtypes_shape_float16_2_3__newsizes__3__2__dimensions__0__1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reshape_dtypes_shape_float32_2_3__newsizes__3__2__dimensions__0__1.mlir
+++ b/stablehlo/testdata/reshape_dtypes_shape_float32_2_3__newsizes__3__2__dimensions__0__1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reshape_dtypes_shape_int16_2_3__newsizes__3__2__dimensions__0__1.mlir
+++ b/stablehlo/testdata/reshape_dtypes_shape_int16_2_3__newsizes__3__2__dimensions__0__1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reshape_dtypes_shape_int32_2_3__newsizes__3__2__dimensions__0__1.mlir
+++ b/stablehlo/testdata/reshape_dtypes_shape_int32_2_3__newsizes__3__2__dimensions__0__1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reshape_dtypes_shape_int8_2_3__newsizes__3__2__dimensions__0__1.mlir
+++ b/stablehlo/testdata/reshape_dtypes_shape_int8_2_3__newsizes__3__2__dimensions__0__1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reshape_dtypes_shape_uint16_2_3__newsizes__3__2__dimensions__0__1.mlir
+++ b/stablehlo/testdata/reshape_dtypes_shape_uint16_2_3__newsizes__3__2__dimensions__0__1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reshape_dtypes_shape_uint32_2_3__newsizes__3__2__dimensions__0__1.mlir
+++ b/stablehlo/testdata/reshape_dtypes_shape_uint32_2_3__newsizes__3__2__dimensions__0__1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reshape_dtypes_shape_uint8_2_3__newsizes__3__2__dimensions__0__1.mlir
+++ b/stablehlo/testdata/reshape_dtypes_shape_uint8_2_3__newsizes__3__2__dimensions__0__1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reshape_new_sizes_shape_float32_3_4_5__newsizes__3__20__dimensions__0__1__2.mlir
+++ b/stablehlo/testdata/reshape_new_sizes_shape_float32_3_4_5__newsizes__3__20__dimensions__0__1__2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/reshape_new_sizes_shape_float32_3_4_5__newsizes__4__15__dimensions__0__1__2.mlir
+++ b/stablehlo/testdata/reshape_new_sizes_shape_float32_3_4_5__newsizes__4__15__dimensions__0__1__2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/rev_dimensions_shape_float32_3_4_5__dimensions.mlir
+++ b/stablehlo/testdata/rev_dimensions_shape_float32_3_4_5__dimensions.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/rev_dimensions_shape_float32_3_4_5__dimensions__0__1__2.mlir
+++ b/stablehlo/testdata/rev_dimensions_shape_float32_3_4_5__dimensions__0__1__2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/rev_dimensions_shape_float32_3_4_5__dimensions__0__2.mlir
+++ b/stablehlo/testdata/rev_dimensions_shape_float32_3_4_5__dimensions__0__2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/rev_dimensions_shape_float32_3_4_5__dimensions__2__0__1.mlir
+++ b/stablehlo/testdata/rev_dimensions_shape_float32_3_4_5__dimensions__2__0__1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/rev_dtypes_shape_bfloat16_4_5__dimensions__0.mlir
+++ b/stablehlo/testdata/rev_dtypes_shape_bfloat16_4_5__dimensions__0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/rev_dtypes_shape_bool_4_5__dimensions__0.mlir
+++ b/stablehlo/testdata/rev_dtypes_shape_bool_4_5__dimensions__0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/rev_dtypes_shape_complex64_4_5__dimensions__0.mlir
+++ b/stablehlo/testdata/rev_dtypes_shape_complex64_4_5__dimensions__0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/rev_dtypes_shape_float16_4_5__dimensions__0.mlir
+++ b/stablehlo/testdata/rev_dtypes_shape_float16_4_5__dimensions__0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/rev_dtypes_shape_float32_4_5__dimensions__0.mlir
+++ b/stablehlo/testdata/rev_dtypes_shape_float32_4_5__dimensions__0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/rev_dtypes_shape_int16_4_5__dimensions__0.mlir
+++ b/stablehlo/testdata/rev_dtypes_shape_int16_4_5__dimensions__0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/rev_dtypes_shape_int32_4_5__dimensions__0.mlir
+++ b/stablehlo/testdata/rev_dtypes_shape_int32_4_5__dimensions__0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/rev_dtypes_shape_int8_4_5__dimensions__0.mlir
+++ b/stablehlo/testdata/rev_dtypes_shape_int8_4_5__dimensions__0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/rev_dtypes_shape_uint16_4_5__dimensions__0.mlir
+++ b/stablehlo/testdata/rev_dtypes_shape_uint16_4_5__dimensions__0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/rev_dtypes_shape_uint32_4_5__dimensions__0.mlir
+++ b/stablehlo/testdata/rev_dtypes_shape_uint32_4_5__dimensions__0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/rev_dtypes_shape_uint8_4_5__dimensions__0.mlir
+++ b/stablehlo/testdata/rev_dtypes_shape_uint8_4_5__dimensions__0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/roll_axis_0_dynamic.mlir
+++ b/stablehlo/testdata/roll_axis_0_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}) -> tensor<?x4xf32> {

--- a/stablehlo/testdata/roll_axis_None_dynamic.mlir
+++ b/stablehlo/testdata/roll_axis_None_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}) -> tensor<?x4xf32> {

--- a/stablehlo/testdata/round_dtypes_shape_bfloat16_100_100__roundingmethod_0.mlir
+++ b/stablehlo/testdata/round_dtypes_shape_bfloat16_100_100__roundingmethod_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/round_dtypes_shape_float16_100_100__roundingmethod_0.mlir
+++ b/stablehlo/testdata/round_dtypes_shape_float16_100_100__roundingmethod_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/round_dtypes_shape_float32_100_100__roundingmethod_0.mlir
+++ b/stablehlo/testdata/round_dtypes_shape_float32_100_100__roundingmethod_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/round_rounding_methods_shape_float32_2_5__roundingmethod_0.mlir
+++ b/stablehlo/testdata/round_rounding_methods_shape_float32_2_5__roundingmethod_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/round_rounding_methods_shape_float32_2_5__roundingmethod_1.mlir
+++ b/stablehlo/testdata/round_rounding_methods_shape_float32_2_5__roundingmethod_1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/rsqrt_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/rsqrt_shape_bfloat16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/rsqrt_shape_complex64_20_20.mlir
+++ b/stablehlo/testdata/rsqrt_shape_complex64_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/rsqrt_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/rsqrt_shape_float16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/rsqrt_shape_float32_20_20.mlir
+++ b/stablehlo/testdata/rsqrt_shape_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_clip0_dynamic.mlir
+++ b/stablehlo/testdata/scatter_add_clip0_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}, %arg2: tensor<2x1xi32> {mhlo.sharding = ""}, %arg3: tensor<?x2xf32> {mhlo.sharding = ""}) -> tensor<?x4xf32> {

--- a/stablehlo/testdata/scatter_add_clip1_dynamic.mlir
+++ b/stablehlo/testdata/scatter_add_clip1_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2xi32> {mhlo.sharding = ""}, %arg3: tensor<?x1xf32> {mhlo.sharding = ""}) -> tensor<?x4xf32> {

--- a/stablehlo/testdata/scatter_add_dtypes_shape_bfloat16_5__scatterindices___0___2___updateshape__2___updatewindowdims____i3105365873972993397.mlir
+++ b/stablehlo/testdata/scatter_add_dtypes_shape_bfloat16_5__scatterindices___0___2___updateshape__2___updatewindowdims____i3105365873972993397.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_dtypes_shape_complex64_5__scatterindices___0___2___updateshape__2___updatewindowdims____6907187575661564349.mlir
+++ b/stablehlo/testdata/scatter_add_dtypes_shape_complex64_5__scatterindices___0___2___updateshape__2___updatewindowdims____6907187575661564349.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_dtypes_shape_float16_5__scatterindices___0___2___updateshape__2___updatewindowdims____in7460671499809967899.mlir
+++ b/stablehlo/testdata/scatter_add_dtypes_shape_float16_5__scatterindices___0___2___updateshape__2___updatewindowdims____in7460671499809967899.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_dtypes_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowdims____in6239340358948408549.mlir
+++ b/stablehlo/testdata/scatter_add_dtypes_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowdims____in6239340358948408549.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_dtypes_shape_int16_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse5866428584412663600.mlir
+++ b/stablehlo/testdata/scatter_add_dtypes_shape_int16_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse5866428584412663600.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_dtypes_shape_int32_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse3748619223488839328.mlir
+++ b/stablehlo/testdata/scatter_add_dtypes_shape_int32_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse3748619223488839328.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_dtypes_shape_int8_5__scatterindices___0___2___updateshape__2___updatewindowdims____inser6830291740956972723.mlir
+++ b/stablehlo/testdata/scatter_add_dtypes_shape_int8_5__scatterindices___0___2___updateshape__2___updatewindowdims____inser6830291740956972723.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_dtypes_shape_uint16_5__scatterindices___0___2___updateshape__2___updatewindowdims____ins-4520383806230198953.mlir
+++ b/stablehlo/testdata/scatter_add_dtypes_shape_uint16_5__scatterindices___0___2___updateshape__2___updatewindowdims____ins-4520383806230198953.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_dtypes_shape_uint32_5__scatterindices___0___2___updateshape__2___updatewindowdims____ins8809450043985603953.mlir
+++ b/stablehlo/testdata/scatter_add_dtypes_shape_uint32_5__scatterindices___0___2___updateshape__2___updatewindowdims____ins8809450043985603953.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_dtypes_shape_uint8_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse-4255998206634939686.mlir
+++ b/stablehlo/testdata/scatter_add_dtypes_shape_uint8_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse-4255998206634939686.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_dynamic.mlir
+++ b/stablehlo/testdata/scatter_add_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}, %arg2: tensor<2x1xi32> {mhlo.sharding = ""}, %arg3: tensor<?x2xf32> {mhlo.sharding = ""}) -> tensor<?x4xf32> {

--- a/stablehlo/testdata/scatter_add_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowd-348874080094627888.mlir
+++ b/stablehlo/testdata/scatter_add_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowd-348874080094627888.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowd7837153478809077655.mlir
+++ b/stablehlo/testdata/scatter_add_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowd7837153478809077655.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatewindow-8890984274374571387.mlir
+++ b/stablehlo/testdata/scatter_add_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatewindow-8890984274374571387.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatewindow5145962309437161874.mlir
+++ b/stablehlo/testdata/scatter_add_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatewindow5145962309437161874.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_bfloat16_1__scatterindices___0___0___updateshape__2___up-860494462789908425.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_bfloat16_1__scatterindices___0___0___updateshape__2___up-860494462789908425.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_bfloat16_1__scatterindices___0___0___updateshape__2___up7001784831726631490.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_bfloat16_1__scatterindices___0___0___updateshape__2___up7001784831726631490.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_bfloat16_2_3__scatterindices____2___2___2____updateshape-1496787690744292757.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_bfloat16_2_3__scatterindices____2___2___2____updateshape-1496787690744292757.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_bfloat16_2_3__scatterindices____2___2___2____updateshape-9089921811327946742.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_bfloat16_2_3__scatterindices____2___2___2____updateshape-9089921811327946742.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_bfloat16_3_5_40__scatterindices___1___1___updateshape__3-4274570454554491320.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_bfloat16_3_5_40__scatterindices___1___1___updateshape__3-4274570454554491320.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_bfloat16_3_5_40__scatterindices___1___1___updateshape__3137750960248060622.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_bfloat16_3_5_40__scatterindices___1___1___updateshape__3137750960248060622.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_bfloat16_3_5_4__scatterindices___1___1___updateshape__3_-4030463377469015899.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_bfloat16_3_5_4__scatterindices___1___1___updateshape__3_-4030463377469015899.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_bfloat16_3_5_4__scatterindices___1___1___updateshape__3_-889038016403856146.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_bfloat16_3_5_4__scatterindices___1___1___updateshape__3_-889038016403856146.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_bfloat16_3__scatterindices___1___0___1___updateshape__3_-1234331839929869546.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_bfloat16_3__scatterindices___1___0___1___updateshape__3_-1234331839929869546.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_bfloat16_3__scatterindices___1___0___1___updateshape__3_5983491590639358181.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_bfloat16_3__scatterindices___1___0___1___updateshape__3_5983491590639358181.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float16_1__scatterindices___0___0___updateshape__2___upd2891107003300082920.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float16_1__scatterindices___0___0___updateshape__2___upd2891107003300082920.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float16_1__scatterindices___0___0___updateshape__2___upd5362217514454606368.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float16_1__scatterindices___0___0___updateshape__2___upd5362217514454606368.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float16_2_3__scatterindices____2___2___2____updateshape_-3011851052689734097.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float16_2_3__scatterindices____2___2___2____updateshape_-3011851052689734097.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float16_2_3__scatterindices____2___2___2____updateshape_-8817597417694097826.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float16_2_3__scatterindices____2___2___2____updateshape_-8817597417694097826.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float16_3_5_40__scatterindices___1___1___updateshape__3_2912963089951762273.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float16_3_5_40__scatterindices___1___1___updateshape__3_2912963089951762273.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float16_3_5_40__scatterindices___1___1___updateshape__3_6681012509515424778.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float16_3_5_40__scatterindices___1___1___updateshape__3_6681012509515424778.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float16_3_5_4__scatterindices___1___1___updateshape__3_2-7988231109437691189.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float16_3_5_4__scatterindices___1___1___updateshape__3_2-7988231109437691189.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float16_3_5_4__scatterindices___1___1___updateshape__3_24396378064620439122.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float16_3_5_4__scatterindices___1___1___updateshape__3_24396378064620439122.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float16_3__scatterindices___1___0___1___updateshape__3__-6279399558626821175.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float16_3__scatterindices___1___0___1___updateshape__3__-6279399558626821175.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float16_3__scatterindices___1___0___1___updateshape__3__6927296407968934904.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float16_3__scatterindices___1___0___1___updateshape__3__6927296407968934904.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float32_1__scatterindices___0___0___updateshape__2___upd2596591008964205253.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float32_1__scatterindices___0___0___updateshape__2___upd2596591008964205253.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float32_1__scatterindices___0___0___updateshape__2___upd6619490232226873879.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float32_1__scatterindices___0___0___updateshape__2___upd6619490232226873879.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float32_2_3__scatterindices____2___2___2____updateshape_5036259221516710960.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float32_2_3__scatterindices____2___2___2____updateshape_5036259221516710960.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float32_2_3__scatterindices____2___2___2____updateshape_8345937081755116116.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float32_2_3__scatterindices____2___2___2____updateshape_8345937081755116116.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float32_3_5_40__scatterindices___1___1___updateshape__3_2951455025951434844.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float32_3_5_40__scatterindices___1___1___updateshape__3_2951455025951434844.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float32_3_5_40__scatterindices___1___1___updateshape__3_695726925484014410.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float32_3_5_40__scatterindices___1___1___updateshape__3_695726925484014410.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float32_3_5_4__scatterindices___1___1___updateshape__3_2-2774173445130720861.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float32_3_5_4__scatterindices___1___1___updateshape__3_2-2774173445130720861.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float32_3_5_4__scatterindices___1___1___updateshape__3_28218316950594479828.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float32_3_5_4__scatterindices___1___1___updateshape__3_28218316950594479828.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float32_3__scatterindices___1___0___1___updateshape__3__-4842756244488458473.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float32_3__scatterindices___1___0___1___updateshape__3__-4842756244488458473.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float32_3__scatterindices___1___0___1___updateshape__3__3611438175516175350.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_float32_3__scatterindices___1___0___1___updateshape__3__3611438175516175350.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int16_1__scatterindices___0___0___updateshape__2___updat-7524018678144949761.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int16_1__scatterindices___0___0___updateshape__2___updat-7524018678144949761.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int16_1__scatterindices___0___0___updateshape__2___updat-9078878771811985072.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int16_1__scatterindices___0___0___updateshape__2___updat-9078878771811985072.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int16_2_3__scatterindices____2___2___2____updateshape__2-4916360558570014198.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int16_2_3__scatterindices____2___2___2____updateshape__2-4916360558570014198.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int16_2_3__scatterindices____2___2___2____updateshape__29001944072476716824.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int16_2_3__scatterindices____2___2___2____updateshape__29001944072476716824.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int16_3_5_40__scatterindices___1___1___updateshape__3_5_-3725043703956117426.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int16_3_5_40__scatterindices___1___1___updateshape__3_5_-3725043703956117426.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int16_3_5_40__scatterindices___1___1___updateshape__3_5_2656247344843304422.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int16_3_5_40__scatterindices___1___1___updateshape__3_5_2656247344843304422.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int16_3_5_4__scatterindices___1___1___updateshape__3_2_4-4264486373892608709.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int16_3_5_4__scatterindices___1___1___updateshape__3_2_4-4264486373892608709.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int16_3_5_4__scatterindices___1___1___updateshape__3_2_46479284842160210040.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int16_3_5_4__scatterindices___1___1___updateshape__3_2_46479284842160210040.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int16_3__scatterindices___1___0___1___updateshape__3___u-3591021005421900346.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int16_3__scatterindices___1___0___1___updateshape__3___u-3591021005421900346.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int16_3__scatterindices___1___0___1___updateshape__3___u-3594753372927687050.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int16_3__scatterindices___1___0___1___updateshape__3___u-3594753372927687050.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int32_1__scatterindices___0___0___updateshape__2___updat-354485824406248366.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int32_1__scatterindices___0___0___updateshape__2___updat-354485824406248366.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int32_1__scatterindices___0___0___updateshape__2___updat2266301288346060632.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int32_1__scatterindices___0___0___updateshape__2___updat2266301288346060632.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int32_2_3__scatterindices____2___2___2____updateshape__2-5393776790984240080.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int32_2_3__scatterindices____2___2___2____updateshape__2-5393776790984240080.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int32_2_3__scatterindices____2___2___2____updateshape__28847096142656084415.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int32_2_3__scatterindices____2___2___2____updateshape__28847096142656084415.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int32_3_5_40__scatterindices___1___1___updateshape__3_5_-7756335029081939712.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int32_3_5_40__scatterindices___1___1___updateshape__3_5_-7756335029081939712.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int32_3_5_40__scatterindices___1___1___updateshape__3_5_3678348900362642354.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int32_3_5_40__scatterindices___1___1___updateshape__3_5_3678348900362642354.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int32_3_5_4__scatterindices___1___1___updateshape__3_2_4-4098679572412113546.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int32_3_5_4__scatterindices___1___1___updateshape__3_2_4-4098679572412113546.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int32_3_5_4__scatterindices___1___1___updateshape__3_2_47476426858270645314.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int32_3_5_4__scatterindices___1___1___updateshape__3_2_47476426858270645314.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int32_3__scatterindices___1___0___1___updateshape__3___u-1822849126982343243.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int32_3__scatterindices___1___0___1___updateshape__3___u-1822849126982343243.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int32_3__scatterindices___1___0___1___updateshape__3___u3328846888780048830.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int32_3__scatterindices___1___0___1___updateshape__3___u3328846888780048830.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int8_1__scatterindices___0___0___updateshape__2___update1622126439350557293.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int8_1__scatterindices___0___0___updateshape__2___update1622126439350557293.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int8_1__scatterindices___0___0___updateshape__2___update3597746049988735779.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int8_1__scatterindices___0___0___updateshape__2___update3597746049988735779.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int8_2_3__scatterindices____2___2___2____updateshape__2_6362923774714678977.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int8_2_3__scatterindices____2___2___2____updateshape__2_6362923774714678977.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int8_2_3__scatterindices____2___2___2____updateshape__2_8103024994792774978.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int8_2_3__scatterindices____2___2___2____updateshape__2_8103024994792774978.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int8_3_5_40__scatterindices___1___1___updateshape__3_5_2-1988417011434006362.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int8_3_5_40__scatterindices___1___1___updateshape__3_5_2-1988417011434006362.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int8_3_5_40__scatterindices___1___1___updateshape__3_5_27199336242141289053.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int8_3_5_40__scatterindices___1___1___updateshape__3_5_27199336242141289053.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int8_3_5_4__scatterindices___1___1___updateshape__3_2_4_-3231048872442668326.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int8_3_5_4__scatterindices___1___1___updateshape__3_2_4_-3231048872442668326.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int8_3_5_4__scatterindices___1___1___updateshape__3_2_4_-4160837117599691199.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int8_3_5_4__scatterindices___1___1___updateshape__3_2_4_-4160837117599691199.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int8_3__scatterindices___1___0___1___updateshape__3___up-7917886033026925853.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int8_3__scatterindices___1___0___1___updateshape__3___up-7917886033026925853.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int8_3__scatterindices___1___0___1___updateshape__3___up2271924756491171274.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_int8_3__scatterindices___1___0___1___updateshape__3___up2271924756491171274.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint16_1__scatterindices___0___0___updateshape__2___upda7888681396332677014.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint16_1__scatterindices___0___0___updateshape__2___upda7888681396332677014.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint16_1__scatterindices___0___0___updateshape__2___upda945060147471783225.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint16_1__scatterindices___0___0___updateshape__2___upda945060147471783225.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint16_2_3__scatterindices____2___2___2____updateshape__2510805737105385550.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint16_2_3__scatterindices____2___2___2____updateshape__2510805737105385550.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint16_2_3__scatterindices____2___2___2____updateshape__8091763406930871598.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint16_2_3__scatterindices____2___2___2____updateshape__8091763406930871598.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint16_3_5_40__scatterindices___1___1___updateshape__3_5-4926747791685884640.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint16_3_5_40__scatterindices___1___1___updateshape__3_5-4926747791685884640.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint16_3_5_40__scatterindices___1___1___updateshape__3_56146930483457941673.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint16_3_5_40__scatterindices___1___1___updateshape__3_56146930483457941673.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint16_3_5_4__scatterindices___1___1___updateshape__3_2_-4592846424164456833.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint16_3_5_4__scatterindices___1___1___updateshape__3_2_-4592846424164456833.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint16_3_5_4__scatterindices___1___1___updateshape__3_2_7666466305816482669.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint16_3_5_4__scatterindices___1___1___updateshape__3_2_7666466305816482669.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint16_3__scatterindices___1___0___1___updateshape__3___-3882386100438535526.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint16_3__scatterindices___1___0___1___updateshape__3___-3882386100438535526.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint16_3__scatterindices___1___0___1___updateshape__3___-5979552203502821981.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint16_3__scatterindices___1___0___1___updateshape__3___-5979552203502821981.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint32_1__scatterindices___0___0___updateshape__2___upda136913410679994980.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint32_1__scatterindices___0___0___updateshape__2___upda136913410679994980.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint32_1__scatterindices___0___0___updateshape__2___upda7842463203097941877.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint32_1__scatterindices___0___0___updateshape__2___upda7842463203097941877.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint32_2_3__scatterindices____2___2___2____updateshape__-1309214087076147471.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint32_2_3__scatterindices____2___2___2____updateshape__-1309214087076147471.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint32_2_3__scatterindices____2___2___2____updateshape__97537607199806852.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint32_2_3__scatterindices____2___2___2____updateshape__97537607199806852.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint32_3_5_40__scatterindices___1___1___updateshape__3_5-410985334763389823.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint32_3_5_40__scatterindices___1___1___updateshape__3_5-410985334763389823.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint32_3_5_40__scatterindices___1___1___updateshape__3_5-6577423887713838439.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint32_3_5_40__scatterindices___1___1___updateshape__3_5-6577423887713838439.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint32_3_5_4__scatterindices___1___1___updateshape__3_2_1623717598696775517.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint32_3_5_4__scatterindices___1___1___updateshape__3_2_1623717598696775517.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint32_3_5_4__scatterindices___1___1___updateshape__3_2_8309401109674874640.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint32_3_5_4__scatterindices___1___1___updateshape__3_2_8309401109674874640.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint32_3__scatterindices___1___0___1___updateshape__3___3455481995801809237.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint32_3__scatterindices___1___0___1___updateshape__3___3455481995801809237.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint32_3__scatterindices___1___0___1___updateshape__3___7498308269064318243.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint32_3__scatterindices___1___0___1___updateshape__3___7498308269064318243.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint8_1__scatterindices___0___0___updateshape__2___updat-9207802865953907581.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint8_1__scatterindices___0___0___updateshape__2___updat-9207802865953907581.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint8_1__scatterindices___0___0___updateshape__2___updat9140858870677867005.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint8_1__scatterindices___0___0___updateshape__2___updat9140858870677867005.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint8_2_3__scatterindices____2___2___2____updateshape__21352603121447941903.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint8_2_3__scatterindices____2___2___2____updateshape__21352603121447941903.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint8_2_3__scatterindices____2___2___2____updateshape__27480559985512445156.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint8_2_3__scatterindices____2___2___2____updateshape__27480559985512445156.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint8_3_5_40__scatterindices___1___1___updateshape__3_5_-6393488545608218666.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint8_3_5_40__scatterindices___1___1___updateshape__3_5_-6393488545608218666.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint8_3_5_40__scatterindices___1___1___updateshape__3_5_-92958002531278788.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint8_3_5_40__scatterindices___1___1___updateshape__3_5_-92958002531278788.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint8_3_5_4__scatterindices___1___1___updateshape__3_2_42856711317682290752.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint8_3_5_4__scatterindices___1___1___updateshape__3_2_42856711317682290752.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint8_3_5_4__scatterindices___1___1___updateshape__3_2_42902961225811021078.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint8_3_5_4__scatterindices___1___1___updateshape__3_2_42902961225811021078.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint8_3__scatterindices___1___0___1___updateshape__3___u4321644361351952093.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint8_3__scatterindices___1___0___1___updateshape__3___u4321644361351952093.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint8_3__scatterindices___1___0___1___updateshape__3___u5648339647004024495.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_non_unique_indices_shape_uint8_3__scatterindices___1___0___1___updateshape__3___u5648339647004024495.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_125__scatterindices__0__updateshape__1___updatewi-8617159013234137769.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_125__scatterindices__0__updateshape__1___updatewi-8617159013234137769.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_125__scatterindices__0__updateshape__1___updatewi6144652360058557977.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_125__scatterindices__0__updateshape__1___updatewi6144652360058557977.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_1_1__scatterindices__0__updateshape__1_1__updatew-1556558392001991646.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_1_1__scatterindices__0__updateshape__1_1__updatew-1556558392001991646.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_1_1__scatterindices__0__updateshape__1_1__updatew-5987512261321349511.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_1_1__scatterindices__0__updateshape__1_1__updatew-5987512261321349511.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_1__scatterindices__0__updateshape__1___updatewind-5581034558494065018.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_1__scatterindices__0__updateshape__1___updatewind-5581034558494065018.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_1__scatterindices__0__updateshape__1___updatewind8373448553845026835.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_1__scatterindices__0__updateshape__1___updatewind8373448553845026835.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__0__updateshape__2_3__updatew-6019789563017120555.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__0__updateshape__2_3__updatew-6019789563017120555.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__0__updateshape__2_3__updatew9202089644754291152.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__0__updateshape__2_3__updatew9202089644754291152.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1_2__updateshape__1___update-2741684093322986342.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1_2__updateshape__1___update-2741684093322986342.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1_2__updateshape__1___update7075641444893981314.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1_2__updateshape__1___update7075641444893981314.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1__updateshape__1_3__updatew425803056863035771.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1__updateshape__1_3__updatew425803056863035771.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1__updateshape__1_3__updatew9110202218978731330.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1__updateshape__1_3__updatew9110202218978731330.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_50_3__scatterindices__32__updateshape__1_3__updat-6062071545452394866.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_50_3__scatterindices__32__updateshape__1_3__updat-6062071545452394866.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_50_3__scatterindices__32__updateshape__1_3__updat-8004672162355768985.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1_50_3__scatterindices__32__updateshape__1_3__updat-8004672162355768985.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1__scatterindices__0__updateshape____updatewindowdi-828594468178229581.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1__scatterindices__0__updateshape____updatewindowdi-828594468178229581.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1__scatterindices__0__updateshape____updatewindowdi6429751923890686552.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_1__scatterindices__0__updateshape____updatewindowdi6429751923890686552.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upd-6848840407727231745.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upd-6848840407727231745.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upd1861388025332688117.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upd1861388025332688117.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_4_2_3__scatterindices__3_2__updateshape__2___update-1982638209236671047.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_4_2_3__scatterindices__3_2__updateshape__2___update-1982638209236671047.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_4_2_3__scatterindices__3_2__updateshape__2___update2088472121195190538.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_4_2_3__scatterindices__3_2__updateshape__2___update2088472121195190538.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices___0_1___2_3___updateshape__2_-1093032740725682184.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices___0_1___2_3___updateshape__2_-1093032740725682184.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices___0_1___2_3___updateshape__2_-4922945492660867696.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices___0_1___2_3___updateshape__2_-4922945492660867696.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2___-7603903374362641006.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2___-7603903374362641006.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2___3435585015422911912.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2___3435585015422911912.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0___1_____2___3____updates7547332501918920602.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0___1_____2___3____updates7547332501918920602.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0___1_____2___3____updates8050165712147161814.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0___1_____2___3____updates8050165712147161814.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_125__scatterindices__0__updateshape__1___updatewin-4752489888149503617.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_125__scatterindices__0__updateshape__1___updatewin-4752489888149503617.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_125__scatterindices__0__updateshape__1___updatewin2053556689837356458.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_125__scatterindices__0__updateshape__1___updatewin2053556689837356458.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_1_1__scatterindices__0__updateshape__1_1__updatewi-3781116865999811871.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_1_1__scatterindices__0__updateshape__1_1__updatewi-3781116865999811871.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_1_1__scatterindices__0__updateshape__1_1__updatewi7533314707669860824.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_1_1__scatterindices__0__updateshape__1_1__updatewi7533314707669860824.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_1__scatterindices__0__updateshape__1___updatewindo-8488847812238110952.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_1__scatterindices__0__updateshape__1___updatewindo-8488847812238110952.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_1__scatterindices__0__updateshape__1___updatewindo4277266865564877965.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_1__scatterindices__0__updateshape__1___updatewindo4277266865564877965.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__0__updateshape__2_3__updatewi-5697591077233325860.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__0__updateshape__2_3__updatewi-5697591077233325860.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__0__updateshape__2_3__updatewi5753373379559669218.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__0__updateshape__2_3__updatewi5753373379559669218.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1_2__updateshape__1___updatew-1222690156116202003.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1_2__updateshape__1___updatew-1222690156116202003.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1_2__updateshape__1___updatew-7525130878030551788.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1_2__updateshape__1___updatew-7525130878030551788.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1__updateshape__1_3__updatewi1334311401954125279.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1__updateshape__1_3__updatewi1334311401954125279.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1__updateshape__1_3__updatewi628492442243500081.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1__updateshape__1_3__updatewi628492442243500081.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_50_3__scatterindices__32__updateshape__1_3__update-435478597733378491.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_50_3__scatterindices__32__updateshape__1_3__update-435478597733378491.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_50_3__scatterindices__32__updateshape__1_3__update2986102359662279142.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1_50_3__scatterindices__32__updateshape__1_3__update2986102359662279142.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1__scatterindices__0__updateshape____updatewindowdim-4952504776566058822.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1__scatterindices__0__updateshape____updatewindowdim-4952504776566058822.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1__scatterindices__0__updateshape____updatewindowdim2796027074051456709.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_1__scatterindices__0__updateshape____updatewindowdim2796027074051456709.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda-6311750605783993279.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda-6311750605783993279.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda4265363395406675305.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda4265363395406675305.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_4_2_3__scatterindices__3_2__updateshape__2___updatew-3203912789197849558.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_4_2_3__scatterindices__3_2__updateshape__2___updatew-3203912789197849558.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_4_2_3__scatterindices__3_2__updateshape__2___updatew-3643129952740408905.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_4_2_3__scatterindices__3_2__updateshape__2___updatew-3643129952740408905.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7-8563111457028476801.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7-8563111457028476801.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_5_6_7__scatterindices___0_1___2_3___updateshape__2_74870609094287397096.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_5_6_7__scatterindices___0_1___2_3___updateshape__2_74870609094287397096.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____-759744508599333163.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____-759744508599333163.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____1245777998526320213.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____1245777998526320213.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0___1_____2___3____updatesh-4249322870906831285.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0___1_____2___3____updatesh-4249322870906831285.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0___1_____2___3____updatesh-6156631391951242845.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0___1_____2___3____updatesh-6156631391951242845.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewin-304007529601890135.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewin-304007529601890135.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewin455400941778422949.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewin455400941778422949.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__updatewi-8477777432015844399.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__updatewi-8477777432015844399.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__updatewi7074773785138082609.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__updatewi7074773785138082609.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___updatewindo-8612627503936106700.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___updatewindo-8612627503936106700.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___updatewindo-9153118378468889125.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___updatewindo-9153118378468889125.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatewi5782516177151935046.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatewi5782516177151935046.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatewi9041188103475055130.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatewi9041188103475055130.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___updatew1689752114083955572.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___updatew1689752114083955572.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___updatew8693638238679832728.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___updatew8693638238679832728.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatewi-4551395605147325529.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatewi-4551395605147325529.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatewi7730408894793448812.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatewi7730408894793448812.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__update4174760181820348577.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__update4174760181820348577.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__update7900894070573682987.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__update7900894070573682987.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdim1751609735067905465.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdim1751609735067905465.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdim5673305870149119583.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdim5673305870149119583.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda-2469456288279167158.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda-2469456288279167158.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda4342698834420844442.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda4342698834420844442.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___updatew4175976412957549642.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___updatew4175976412957549642.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___updatew5768555911120390580.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___updatew5768555911120390580.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7-1676888133310209796.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7-1676888133310209796.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7-4402240353080601551.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7-4402240353080601551.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____5697733633172945226.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____5697733633172945226.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____8934238829712448896.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____8934238829712448896.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____updatesh3554705983460704021.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____updatesh3554705983460704021.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____updatesh6790731219354090899.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____updatesh6790731219354090899.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_125__scatterindices__0__updateshape__1___updatewindo2839844844000946233.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_125__scatterindices__0__updateshape__1___updatewindo2839844844000946233.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_125__scatterindices__0__updateshape__1___updatewindo4691533306572779958.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_125__scatterindices__0__updateshape__1___updatewindo4691533306572779958.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_1_1__scatterindices__0__updateshape__1_1__updatewind-4922517182425747675.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_1_1__scatterindices__0__updateshape__1_1__updatewind-4922517182425747675.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_1_1__scatterindices__0__updateshape__1_1__updatewind1681211343400286627.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_1_1__scatterindices__0__updateshape__1_1__updatewind1681211343400286627.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_1__scatterindices__0__updateshape__1___updatewindowd-420922130789298176.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_1__scatterindices__0__updateshape__1___updatewindowd-420922130789298176.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_1__scatterindices__0__updateshape__1___updatewindowd-4663183835276024253.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_1__scatterindices__0__updateshape__1___updatewindowd-4663183835276024253.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__0__updateshape__2_3__updatewind-5816799921830533789.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__0__updateshape__2_3__updatewind-5816799921830533789.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__0__updateshape__2_3__updatewind-887253207283244392.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__0__updateshape__2_3__updatewind-887253207283244392.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1_2__updateshape__1___updatewin-6105746935257438539.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1_2__updateshape__1___updatewin-6105746935257438539.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1_2__updateshape__1___updatewin368283231402400784.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1_2__updateshape__1___updatewin368283231402400784.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1__updateshape__1_3__updatewind-4833649072894316135.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1__updateshape__1_3__updatewind-4833649072894316135.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1__updateshape__1_3__updatewind-7325755528902790593.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1__updateshape__1_3__updatewind-7325755528902790593.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_50_3__scatterindices__32__updateshape__1_3__updatewi-9172264402326490364.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_50_3__scatterindices__32__updateshape__1_3__updatewi-9172264402326490364.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_50_3__scatterindices__32__updateshape__1_3__updatewi5722805357516891196.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1_50_3__scatterindices__32__updateshape__1_3__updatewi5722805357516891196.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1__scatterindices__0__updateshape____updatewindowdims_3934064707146790949.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1__scatterindices__0__updateshape____updatewindowdims_3934064707146790949.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1__scatterindices__0__updateshape____updatewindowdims_8679781641694982610.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_1__scatterindices__0__updateshape____updatewindowdims_8679781641694982610.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-8619458148601629175.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-8619458148601629175.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_4_2_3_5__scatterindices__0_4__updateshape__4_3__update1072636734502228327.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_4_2_3_5__scatterindices__0_4__updateshape__4_3__update1072636734502228327.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_4_2_3__scatterindices__3_2__updateshape__2___updatewin-2373040689244975897.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_4_2_3__scatterindices__3_2__updateshape__2___updatewin-2373040689244975897.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_4_2_3__scatterindices__3_2__updateshape__2___updatewin-7039533867993701.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_4_2_3__scatterindices__3_2__updateshape__2___updatewin-7039533867993701.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-5273540091416886440.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-5273540091416886440.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__520632053864570090.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__520632053864570090.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-5623848772288331181.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-5623848772288331181.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up500212622559178017.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up500212622559178017.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0___1_____2___3____updateshap-340960696335901665.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0___1_____2___3____updateshap-340960696335901665.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0___1_____2___3____updateshap-7634999522019619612.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0___1_____2___3____updateshap-7634999522019619612.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_125__scatterindices__0__updateshape__1___updatewindo-7971939317121945253.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_125__scatterindices__0__updateshape__1___updatewindo-7971939317121945253.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_125__scatterindices__0__updateshape__1___updatewindo4095517369750484142.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_125__scatterindices__0__updateshape__1___updatewindo4095517369750484142.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_1_1__scatterindices__0__updateshape__1_1__updatewind-3312424635250872014.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_1_1__scatterindices__0__updateshape__1_1__updatewind-3312424635250872014.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_1_1__scatterindices__0__updateshape__1_1__updatewind139215505656195790.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_1_1__scatterindices__0__updateshape__1_1__updatewind139215505656195790.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_1__scatterindices__0__updateshape__1___updatewindowd7342322526435903367.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_1__scatterindices__0__updateshape__1___updatewindowd7342322526435903367.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_1__scatterindices__0__updateshape__1___updatewindowd7553302737739030242.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_1__scatterindices__0__updateshape__1___updatewindowd7553302737739030242.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__0__updateshape__2_3__updatewind-5394744753228806123.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__0__updateshape__2_3__updatewind-5394744753228806123.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__0__updateshape__2_3__updatewind3630342298095974182.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__0__updateshape__2_3__updatewind3630342298095974182.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1_2__updateshape__1___updatewin2110578568797174599.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1_2__updateshape__1___updatewin2110578568797174599.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1_2__updateshape__1___updatewin309107136629663177.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1_2__updateshape__1___updatewin309107136629663177.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1__updateshape__1_3__updatewind6204710529394502514.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1__updateshape__1_3__updatewind6204710529394502514.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1__updateshape__1_3__updatewind6271891592308477634.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1__updateshape__1_3__updatewind6271891592308477634.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_50_3__scatterindices__32__updateshape__1_3__updatewi-1127081133223858940.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_50_3__scatterindices__32__updateshape__1_3__updatewi-1127081133223858940.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_50_3__scatterindices__32__updateshape__1_3__updatewi1698984474341869219.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1_50_3__scatterindices__32__updateshape__1_3__updatewi1698984474341869219.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1__scatterindices__0__updateshape____updatewindowdims_-6540378403077330570.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1__scatterindices__0__updateshape____updatewindowdims_-6540378403077330570.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1__scatterindices__0__updateshape____updatewindowdims_-7397243544293713443.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_1__scatterindices__0__updateshape____updatewindowdims_-7397243544293713443.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-10712058622206155.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-10712058622206155.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_4_2_3_5__scatterindices__0_4__updateshape__4_3__update2550571537627097938.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_4_2_3_5__scatterindices__0_4__updateshape__4_3__update2550571537627097938.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_4_2_3__scatterindices__3_2__updateshape__2___updatewin1479578082839246648.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_4_2_3__scatterindices__3_2__updateshape__2___updatewin1479578082839246648.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_4_2_3__scatterindices__3_2__updateshape__2___updatewin8686567596578332985.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_4_2_3__scatterindices__3_2__updateshape__2___updatewin8686567596578332985.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-4663429453766771963.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-4663429453766771963.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-7181773669694201441.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-7181773669694201441.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-2238527862024472151.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-2238527862024472151.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-2970555778160149333.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-2970555778160149333.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0___1_____2___3____updateshap1715785822546040830.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0___1_____2___3____updateshap1715785822546040830.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0___1_____2___3____updateshap6710213962241311232.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0___1_____2___3____updateshap6710213962241311232.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_125__scatterindices__0__updateshape__1___updatewindow-5741837050715739462.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_125__scatterindices__0__updateshape__1___updatewindow-5741837050715739462.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_125__scatterindices__0__updateshape__1___updatewindow6124594656634777346.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_125__scatterindices__0__updateshape__1___updatewindow6124594656634777346.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_1_1__scatterindices__0__updateshape__1_1__updatewindo-8135371938509125618.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_1_1__scatterindices__0__updateshape__1_1__updatewindo-8135371938509125618.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_1_1__scatterindices__0__updateshape__1_1__updatewindo7417675200334150160.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_1_1__scatterindices__0__updateshape__1_1__updatewindo7417675200334150160.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_1__scatterindices__0__updateshape__1___updatewindowdi-4489868158232826085.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_1__scatterindices__0__updateshape__1___updatewindowdi-4489868158232826085.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_1__scatterindices__0__updateshape__1___updatewindowdi-5808469219638001439.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_1__scatterindices__0__updateshape__1___updatewindowdi-5808469219638001439.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__0__updateshape__2_3__updatewindo-5441909635197723241.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__0__updateshape__2_3__updatewindo-5441909635197723241.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__0__updateshape__2_3__updatewindo-6720695980401733509.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__0__updateshape__2_3__updatewindo-6720695980401733509.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1_2__updateshape__1___updatewind-2808008445529984142.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1_2__updateshape__1___updatewind-2808008445529984142.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1_2__updateshape__1___updatewind4987595175184550066.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1_2__updateshape__1___updatewind4987595175184550066.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1__updateshape__1_3__updatewindo-1784469910841869456.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1__updateshape__1_3__updatewindo-1784469910841869456.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1__updateshape__1_3__updatewindo7538936333147709933.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1__updateshape__1_3__updatewindo7538936333147709933.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_50_3__scatterindices__32__updateshape__1_3__updatewin1508955844563568818.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_50_3__scatterindices__32__updateshape__1_3__updatewin1508955844563568818.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_50_3__scatterindices__32__updateshape__1_3__updatewin6067048107147913826.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1_50_3__scatterindices__32__updateshape__1_3__updatewin6067048107147913826.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1__scatterindices__0__updateshape____updatewindowdims__-5061474144088218377.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1__scatterindices__0__updateshape____updatewindowdims__-5061474144088218377.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1__scatterindices__0__updateshape____updatewindowdims__7419933209394456505.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_1__scatterindices__0__updateshape____updatewindowdims__7419933209394456505.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatew-475177265581722258.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatew-475177265581722258.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatew5568489650471049080.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatew5568489650471049080.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_4_2_3__scatterindices__3_2__updateshape__2___updatewind-8611891650160216261.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_4_2_3__scatterindices__3_2__updateshape__2___updatewind-8611891650160216261.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_4_2_3__scatterindices__3_2__updateshape__2___updatewind6985804078066516697.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_4_2_3__scatterindices__3_2__updateshape__2___updatewind6985804078066516697.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__u3771363404680848958.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__u3771363404680848958.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__u808523439608182752.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__u808523439608182752.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upd6531262831845641784.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upd6531262831845641784.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upd7351713410321533699.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upd7351713410321533699.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0___1_____2___3____updateshape3968639201026952742.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0___1_____2___3____updateshape3968639201026952742.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0___1_____2___3____updateshape6792664875203398695.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0___1_____2___3____updateshape6792664875203398695.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_125__scatterindices__0__updateshape__1___updatewind-2355530058007938589.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_125__scatterindices__0__updateshape__1___updatewind-2355530058007938589.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_125__scatterindices__0__updateshape__1___updatewind5899607047074806462.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_125__scatterindices__0__updateshape__1___updatewind5899607047074806462.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_1_1__scatterindices__0__updateshape__1_1__updatewin4255143736696256140.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_1_1__scatterindices__0__updateshape__1_1__updatewin4255143736696256140.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_1_1__scatterindices__0__updateshape__1_1__updatewin5355292897265078190.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_1_1__scatterindices__0__updateshape__1_1__updatewin5355292897265078190.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_1__scatterindices__0__updateshape__1___updatewindow-1865959740833351532.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_1__scatterindices__0__updateshape__1___updatewindow-1865959740833351532.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_1__scatterindices__0__updateshape__1___updatewindow3224571850859326572.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_1__scatterindices__0__updateshape__1___updatewindow3224571850859326572.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__0__updateshape__2_3__updatewin1928081368629774964.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__0__updateshape__2_3__updatewin1928081368629774964.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__0__updateshape__2_3__updatewin6027022332699736532.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__0__updateshape__2_3__updatewin6027022332699736532.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1_2__updateshape__1___updatewi222960814350783234.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1_2__updateshape__1___updatewi222960814350783234.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1_2__updateshape__1___updatewi5126588181291957161.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1_2__updateshape__1___updatewi5126588181291957161.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1__updateshape__1_3__updatewin7804651276816942207.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1__updateshape__1_3__updatewin7804651276816942207.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1__updateshape__1_3__updatewin7981612942392985245.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1__updateshape__1_3__updatewin7981612942392985245.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_50_3__scatterindices__32__updateshape__1_3__updatew-4754160280417932241.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_50_3__scatterindices__32__updateshape__1_3__updatew-4754160280417932241.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_50_3__scatterindices__32__updateshape__1_3__updatew-8872713435005673417.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1_50_3__scatterindices__32__updateshape__1_3__updatew-8872713435005673417.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1__scatterindices__0__updateshape____updatewindowdims4804912606649857802.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1__scatterindices__0__updateshape____updatewindowdims4804912606649857802.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1__scatterindices__0__updateshape____updatewindowdims7558386364215168783.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_1__scatterindices__0__updateshape____updatewindowdims7558386364215168783.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat-8274419980979350893.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat-8274419980979350893.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat1709061966807053836.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat1709061966807053836.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_4_2_3__scatterindices__3_2__updateshape__2___updatewi-6073099928643051906.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_4_2_3__scatterindices__3_2__updateshape__2___updatewi-6073099928643051906.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_4_2_3__scatterindices__3_2__updateshape__2___updatewi8179654881998250566.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_4_2_3__scatterindices__3_2__updateshape__2___updatewi8179654881998250566.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_-4324625212547377416.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_-4324625212547377416.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_492152019281825947.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_492152019281825947.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u-5201943969373002426.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u-5201943969373002426.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u8141856249510461351.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u8141856249510461351.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0___1_____2___3____updatesha-5032991910029426792.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0___1_____2___3____updatesha-5032991910029426792.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0___1_____2___3____updatesha-7026742454312175741.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0___1_____2___3____updatesha-7026742454312175741.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_125__scatterindices__0__updateshape__1___updatewind-2493932993191221377.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_125__scatterindices__0__updateshape__1___updatewind-2493932993191221377.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_125__scatterindices__0__updateshape__1___updatewind-4727333056025903092.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_125__scatterindices__0__updateshape__1___updatewind-4727333056025903092.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_1_1__scatterindices__0__updateshape__1_1__updatewin-6232381483023765460.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_1_1__scatterindices__0__updateshape__1_1__updatewin-6232381483023765460.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_1_1__scatterindices__0__updateshape__1_1__updatewin8781756429572856750.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_1_1__scatterindices__0__updateshape__1_1__updatewin8781756429572856750.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_1__scatterindices__0__updateshape__1___updatewindow5934522417062545132.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_1__scatterindices__0__updateshape__1___updatewindow5934522417062545132.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_1__scatterindices__0__updateshape__1___updatewindow868296633592529009.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_1__scatterindices__0__updateshape__1___updatewindow868296633592529009.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__0__updateshape__2_3__updatewin-1641133002030508080.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__0__updateshape__2_3__updatewin-1641133002030508080.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__0__updateshape__2_3__updatewin3285453687476766879.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__0__updateshape__2_3__updatewin3285453687476766879.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1_2__updateshape__1___updatewi-2627349516123329495.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1_2__updateshape__1___updatewi-2627349516123329495.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1_2__updateshape__1___updatewi5639421007566031063.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1_2__updateshape__1___updatewi5639421007566031063.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1__updateshape__1_3__updatewin-4024738447497901356.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1__updateshape__1_3__updatewin-4024738447497901356.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1__updateshape__1_3__updatewin-4196632273973579364.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1__updateshape__1_3__updatewin-4196632273973579364.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_50_3__scatterindices__32__updateshape__1_3__updatew-740047246519077104.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_50_3__scatterindices__32__updateshape__1_3__updatew-740047246519077104.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_50_3__scatterindices__32__updateshape__1_3__updatew8128135906735836974.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1_50_3__scatterindices__32__updateshape__1_3__updatew8128135906735836974.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1__scatterindices__0__updateshape____updatewindowdims-8617825293348157163.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1__scatterindices__0__updateshape____updatewindowdims-8617825293348157163.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1__scatterindices__0__updateshape____updatewindowdims710391022991851600.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_1__scatterindices__0__updateshape____updatewindowdims710391022991851600.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat6791897860392195051.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat6791897860392195051.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat7462471797269110173.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat7462471797269110173.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_4_2_3__scatterindices__3_2__updateshape__2___updatewi1477502061111573603.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_4_2_3__scatterindices__3_2__updateshape__2___updatewi1477502061111573603.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_4_2_3__scatterindices__3_2__updateshape__2___updatewi58247371151849691.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_4_2_3__scatterindices__3_2__updateshape__2___updatewi58247371151849691.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_-2789322176808458196.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_-2789322176808458196.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_-4274140649884019517.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_-4274140649884019517.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u-6441999524429153529.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u-6441999524429153529.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u8666094006939621915.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u8666094006939621915.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0___1_____2___3____updatesha-1250379279784296323.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0___1_____2___3____updatesha-1250379279784296323.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0___1_____2___3____updatesha-2476939433263809573.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0___1_____2___3____updatesha-2476939433263809573.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_125__scatterindices__0__updateshape__1___updatewindo2641506595458680540.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_125__scatterindices__0__updateshape__1___updatewindo2641506595458680540.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_125__scatterindices__0__updateshape__1___updatewindo534641495725659400.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_125__scatterindices__0__updateshape__1___updatewindo534641495725659400.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_1_1__scatterindices__0__updateshape__1_1__updatewind1604574441012752035.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_1_1__scatterindices__0__updateshape__1_1__updatewind1604574441012752035.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_1_1__scatterindices__0__updateshape__1_1__updatewind2731002153338747654.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_1_1__scatterindices__0__updateshape__1_1__updatewind2731002153338747654.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_1__scatterindices__0__updateshape__1___updatewindowd2284374715751213946.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_1__scatterindices__0__updateshape__1___updatewindowd2284374715751213946.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_1__scatterindices__0__updateshape__1___updatewindowd2505509251588462368.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_1__scatterindices__0__updateshape__1___updatewindowd2505509251588462368.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__0__updateshape__2_3__updatewind-3487018839623291285.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__0__updateshape__2_3__updatewind-3487018839623291285.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__0__updateshape__2_3__updatewind-8604484497256600253.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__0__updateshape__2_3__updatewind-8604484497256600253.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1_2__updateshape__1___updatewin1380415797906781469.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1_2__updateshape__1___updatewin1380415797906781469.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1_2__updateshape__1___updatewin6374287187271323238.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1_2__updateshape__1___updatewin6374287187271323238.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1__updateshape__1_3__updatewind-1305194734761190035.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1__updateshape__1_3__updatewind-1305194734761190035.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1__updateshape__1_3__updatewind1678143756998009091.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1__updateshape__1_3__updatewind1678143756998009091.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_50_3__scatterindices__32__updateshape__1_3__updatewi-8078915839645359058.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_50_3__scatterindices__32__updateshape__1_3__updatewi-8078915839645359058.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_50_3__scatterindices__32__updateshape__1_3__updatewi-9185061050524067474.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1_50_3__scatterindices__32__updateshape__1_3__updatewi-9185061050524067474.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1__scatterindices__0__updateshape____updatewindowdims_-4251074730763850716.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1__scatterindices__0__updateshape____updatewindowdims_-4251074730763850716.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1__scatterindices__0__updateshape____updatewindowdims_-6837146777463778467.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_1__scatterindices__0__updateshape____updatewindowdims_-6837146777463778467.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-2442629959164459302.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-2442629959164459302.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_4_2_3_5__scatterindices__0_4__updateshape__4_3__update252259578072299482.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_4_2_3_5__scatterindices__0_4__updateshape__4_3__update252259578072299482.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_4_2_3__scatterindices__3_2__updateshape__2___updatewin5304681254417113664.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_4_2_3__scatterindices__3_2__updateshape__2___updatewin5304681254417113664.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_4_2_3__scatterindices__3_2__updateshape__2___updatewin8751159257015308632.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_4_2_3__scatterindices__3_2__updateshape__2___updatewin8751159257015308632.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__2224374599205381727.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__2224374599205381727.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__3481253470408735801.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__3481253470408735801.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-2206320351948067066.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-2206320351948067066.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up6159067232391152621.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up6159067232391152621.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0___1_____2___3____updateshap-7004792914768066328.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0___1_____2___3____updateshap-7004792914768066328.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0___1_____2___3____updateshap-8827782002690829532.mlir
+++ b/stablehlo/testdata/scatter_add_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0___1_____2___3____updateshap-8827782002690829532.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_dtypes_shape_bfloat16_5__scatterindices___0___2___updateshape__2___updatewindowdims____inser-2930277789604541476.mlir
+++ b/stablehlo/testdata/scatter_dtypes_shape_bfloat16_5__scatterindices___0___2___updateshape__2___updatewindowdims____inser-2930277789604541476.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_dtypes_shape_bool_5__scatterindices___0___2___updateshape__2___updatewindowdims____insertedw-7999209774018819546.mlir
+++ b/stablehlo/testdata/scatter_dtypes_shape_bool_5__scatterindices___0___2___updateshape__2___updatewindowdims____insertedw-7999209774018819546.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_dtypes_shape_complex64_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse360406677792545150.mlir
+++ b/stablehlo/testdata/scatter_dtypes_shape_complex64_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse360406677792545150.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_dtypes_shape_float16_5__scatterindices___0___2___updateshape__2___updatewindowdims____insert-6208401960821428700.mlir
+++ b/stablehlo/testdata/scatter_dtypes_shape_float16_5__scatterindices___0___2___updateshape__2___updatewindowdims____insert-6208401960821428700.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_dtypes_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowdims____insert-8815115321991225803.mlir
+++ b/stablehlo/testdata/scatter_dtypes_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowdims____insert-8815115321991225803.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_dtypes_shape_int16_5__scatterindices___0___2___updateshape__2___updatewindowdims____inserted-279814041569566222.mlir
+++ b/stablehlo/testdata/scatter_dtypes_shape_int16_5__scatterindices___0___2___updateshape__2___updatewindowdims____inserted-279814041569566222.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_dtypes_shape_int32_5__scatterindices___0___2___updateshape__2___updatewindowdims____inserted392539518372500492.mlir
+++ b/stablehlo/testdata/scatter_dtypes_shape_int32_5__scatterindices___0___2___updateshape__2___updatewindowdims____inserted392539518372500492.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_dtypes_shape_int8_5__scatterindices___0___2___updateshape__2___updatewindowdims____insertedw-8449960834207282352.mlir
+++ b/stablehlo/testdata/scatter_dtypes_shape_int8_5__scatterindices___0___2___updateshape__2___updatewindowdims____insertedw-8449960834207282352.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_dtypes_shape_uint16_5__scatterindices___0___2___updateshape__2___updatewindowdims____inserte2451184385895379567.mlir
+++ b/stablehlo/testdata/scatter_dtypes_shape_uint16_5__scatterindices___0___2___updateshape__2___updatewindowdims____inserte2451184385895379567.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_dtypes_shape_uint32_5__scatterindices___0___2___updateshape__2___updatewindowdims____inserte-2961744518792924699.mlir
+++ b/stablehlo/testdata/scatter_dtypes_shape_uint32_5__scatterindices___0___2___updateshape__2___updatewindowdims____inserte-2961744518792924699.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_dtypes_shape_uint8_5__scatterindices___0___2___updateshape__2___updatewindowdims____inserted1788240898021135728.mlir
+++ b/stablehlo/testdata/scatter_dtypes_shape_uint8_5__scatterindices___0___2___updateshape__2___updatewindowdims____inserted1788240898021135728.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_dtypes_shape_bfloat16_5__scatterindices___0___2___updateshape__2___updatewindowdims____i-392861041873938592.mlir
+++ b/stablehlo/testdata/scatter_max_dtypes_shape_bfloat16_5__scatterindices___0___2___updateshape__2___updatewindowdims____i-392861041873938592.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_dtypes_shape_bool_5__scatterindices___0___2___updateshape__2___updatewindowdims____inser5683702453722149665.mlir
+++ b/stablehlo/testdata/scatter_max_dtypes_shape_bool_5__scatterindices___0___2___updateshape__2___updatewindowdims____inser5683702453722149665.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_dtypes_shape_complex64_5__scatterindices___0___2___updateshape__2___updatewindowdims____-6396961326923825596.mlir
+++ b/stablehlo/testdata/scatter_max_dtypes_shape_complex64_5__scatterindices___0___2___updateshape__2___updatewindowdims____-6396961326923825596.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_dtypes_shape_float16_5__scatterindices___0___2___updateshape__2___updatewindowdims____in1336689541491778229.mlir
+++ b/stablehlo/testdata/scatter_max_dtypes_shape_float16_5__scatterindices___0___2___updateshape__2___updatewindowdims____in1336689541491778229.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_dtypes_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowdims____in5989306877217321302.mlir
+++ b/stablehlo/testdata/scatter_max_dtypes_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowdims____in5989306877217321302.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_dtypes_shape_int16_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse-5829043612105941797.mlir
+++ b/stablehlo/testdata/scatter_max_dtypes_shape_int16_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse-5829043612105941797.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_dtypes_shape_int32_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse2177675569692235609.mlir
+++ b/stablehlo/testdata/scatter_max_dtypes_shape_int32_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse2177675569692235609.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_dtypes_shape_int8_5__scatterindices___0___2___updateshape__2___updatewindowdims____inser2469995342507633075.mlir
+++ b/stablehlo/testdata/scatter_max_dtypes_shape_int8_5__scatterindices___0___2___updateshape__2___updatewindowdims____inser2469995342507633075.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_dtypes_shape_uint16_5__scatterindices___0___2___updateshape__2___updatewindowdims____ins8815963655942062891.mlir
+++ b/stablehlo/testdata/scatter_max_dtypes_shape_uint16_5__scatterindices___0___2___updateshape__2___updatewindowdims____ins8815963655942062891.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_dtypes_shape_uint32_5__scatterindices___0___2___updateshape__2___updatewindowdims____ins5453280543548493478.mlir
+++ b/stablehlo/testdata/scatter_max_dtypes_shape_uint32_5__scatterindices___0___2___updateshape__2___updatewindowdims____ins5453280543548493478.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_dtypes_shape_uint8_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse-8556092368691638686.mlir
+++ b/stablehlo/testdata/scatter_max_dtypes_shape_uint8_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse-8556092368691638686.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowd-4390078863631050283.mlir
+++ b/stablehlo/testdata/scatter_max_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowd-4390078863631050283.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowd3210884206065312593.mlir
+++ b/stablehlo/testdata/scatter_max_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowd3210884206065312593.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatewindow1025456038908883704.mlir
+++ b/stablehlo/testdata/scatter_max_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatewindow1025456038908883704.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatewindow3237573494961686018.mlir
+++ b/stablehlo/testdata/scatter_max_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatewindow3237573494961686018.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_bfloat16_1__scatterindices___0___0___updateshape__2___up-7839859950408934269.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_bfloat16_1__scatterindices___0___0___updateshape__2___up-7839859950408934269.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_bfloat16_1__scatterindices___0___0___updateshape__2___up6942369263525378132.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_bfloat16_1__scatterindices___0___0___updateshape__2___up6942369263525378132.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_bfloat16_2_3__scatterindices____2___2___2____updateshape-7756467163902878913.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_bfloat16_2_3__scatterindices____2___2___2____updateshape-7756467163902878913.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_bfloat16_2_3__scatterindices____2___2___2____updateshape2214961252790317124.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_bfloat16_2_3__scatterindices____2___2___2____updateshape2214961252790317124.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_bfloat16_3_5_40__scatterindices___1___1___updateshape__3-8026909858088384599.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_bfloat16_3_5_40__scatterindices___1___1___updateshape__3-8026909858088384599.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_bfloat16_3_5_40__scatterindices___1___1___updateshape__3807314941237875241.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_bfloat16_3_5_40__scatterindices___1___1___updateshape__3807314941237875241.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_bfloat16_3_5_4__scatterindices___1___1___updateshape__3_-488454440685315220.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_bfloat16_3_5_4__scatterindices___1___1___updateshape__3_-488454440685315220.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_bfloat16_3_5_4__scatterindices___1___1___updateshape__3_-6003342809812860302.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_bfloat16_3_5_4__scatterindices___1___1___updateshape__3_-6003342809812860302.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_bfloat16_3__scatterindices___1___0___1___updateshape__3_-3973973289357598622.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_bfloat16_3__scatterindices___1___0___1___updateshape__3_-3973973289357598622.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_bfloat16_3__scatterindices___1___0___1___updateshape__3_4256773944042201098.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_bfloat16_3__scatterindices___1___0___1___updateshape__3_4256773944042201098.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float16_1__scatterindices___0___0___updateshape__2___upd3204989355605098687.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float16_1__scatterindices___0___0___updateshape__2___upd3204989355605098687.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float16_1__scatterindices___0___0___updateshape__2___upd8022799176354603242.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float16_1__scatterindices___0___0___updateshape__2___upd8022799176354603242.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float16_2_3__scatterindices____2___2___2____updateshape_3719304099671093957.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float16_2_3__scatterindices____2___2___2____updateshape_3719304099671093957.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float16_2_3__scatterindices____2___2___2____updateshape_7082877253723391854.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float16_2_3__scatterindices____2___2___2____updateshape_7082877253723391854.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float16_3_5_40__scatterindices___1___1___updateshape__3_-7938565271035863995.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float16_3_5_40__scatterindices___1___1___updateshape__3_-7938565271035863995.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float16_3_5_40__scatterindices___1___1___updateshape__3_6570978612883412575.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float16_3_5_40__scatterindices___1___1___updateshape__3_6570978612883412575.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float16_3_5_4__scatterindices___1___1___updateshape__3_2-7773190694039022277.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float16_3_5_4__scatterindices___1___1___updateshape__3_2-7773190694039022277.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float16_3_5_4__scatterindices___1___1___updateshape__3_27849137539433517548.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float16_3_5_4__scatterindices___1___1___updateshape__3_27849137539433517548.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float16_3__scatterindices___1___0___1___updateshape__3__-4810395954883699510.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float16_3__scatterindices___1___0___1___updateshape__3__-4810395954883699510.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float16_3__scatterindices___1___0___1___updateshape__3__6571579309048280685.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float16_3__scatterindices___1___0___1___updateshape__3__6571579309048280685.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float32_1__scatterindices___0___0___updateshape__2___upd-1844039835433546582.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float32_1__scatterindices___0___0___updateshape__2___upd-1844039835433546582.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float32_1__scatterindices___0___0___updateshape__2___upd4721539826240850833.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float32_1__scatterindices___0___0___updateshape__2___upd4721539826240850833.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float32_2_3__scatterindices____2___2___2____updateshape_-6493859547791056291.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float32_2_3__scatterindices____2___2___2____updateshape_-6493859547791056291.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float32_2_3__scatterindices____2___2___2____updateshape_-9093868482978590861.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float32_2_3__scatterindices____2___2___2____updateshape_-9093868482978590861.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float32_3_5_40__scatterindices___1___1___updateshape__3_3101807958862616076.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float32_3_5_40__scatterindices___1___1___updateshape__3_3101807958862616076.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float32_3_5_40__scatterindices___1___1___updateshape__3_7771598417814736050.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float32_3_5_40__scatterindices___1___1___updateshape__3_7771598417814736050.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float32_3_5_4__scatterindices___1___1___updateshape__3_2-4088478221285117728.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float32_3_5_4__scatterindices___1___1___updateshape__3_2-4088478221285117728.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float32_3_5_4__scatterindices___1___1___updateshape__3_25732955927815578406.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float32_3_5_4__scatterindices___1___1___updateshape__3_25732955927815578406.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float32_3__scatterindices___1___0___1___updateshape__3__-6639842389483865163.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float32_3__scatterindices___1___0___1___updateshape__3__-6639842389483865163.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float32_3__scatterindices___1___0___1___updateshape__3__7830488357588033204.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_float32_3__scatterindices___1___0___1___updateshape__3__7830488357588033204.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int16_1__scatterindices___0___0___updateshape__2___updat6963600156708085907.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int16_1__scatterindices___0___0___updateshape__2___updat6963600156708085907.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int16_1__scatterindices___0___0___updateshape__2___updat8878416149102138078.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int16_1__scatterindices___0___0___updateshape__2___updat8878416149102138078.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int16_2_3__scatterindices____2___2___2____updateshape__2-7314731004182888952.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int16_2_3__scatterindices____2___2___2____updateshape__2-7314731004182888952.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int16_2_3__scatterindices____2___2___2____updateshape__21821906852332500498.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int16_2_3__scatterindices____2___2___2____updateshape__21821906852332500498.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int16_3_5_40__scatterindices___1___1___updateshape__3_5_4499147356245180063.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int16_3_5_40__scatterindices___1___1___updateshape__3_5_4499147356245180063.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int16_3_5_40__scatterindices___1___1___updateshape__3_5_9025587788653182690.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int16_3_5_40__scatterindices___1___1___updateshape__3_5_9025587788653182690.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int16_3_5_4__scatterindices___1___1___updateshape__3_2_4-583937543846099786.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int16_3_5_4__scatterindices___1___1___updateshape__3_2_4-583937543846099786.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int16_3_5_4__scatterindices___1___1___updateshape__3_2_4-7084715015461268786.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int16_3_5_4__scatterindices___1___1___updateshape__3_2_4-7084715015461268786.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int16_3__scatterindices___1___0___1___updateshape__3___u-7412834368070813317.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int16_3__scatterindices___1___0___1___updateshape__3___u-7412834368070813317.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int16_3__scatterindices___1___0___1___updateshape__3___u-7485079511943524453.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int16_3__scatterindices___1___0___1___updateshape__3___u-7485079511943524453.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int32_1__scatterindices___0___0___updateshape__2___updat-2821015016578538976.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int32_1__scatterindices___0___0___updateshape__2___updat-2821015016578538976.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int32_1__scatterindices___0___0___updateshape__2___updat-4363515628628173317.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int32_1__scatterindices___0___0___updateshape__2___updat-4363515628628173317.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int32_2_3__scatterindices____2___2___2____updateshape__2-8552418276306640556.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int32_2_3__scatterindices____2___2___2____updateshape__2-8552418276306640556.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int32_2_3__scatterindices____2___2___2____updateshape__26232119252440644995.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int32_2_3__scatterindices____2___2___2____updateshape__26232119252440644995.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int32_3_5_40__scatterindices___1___1___updateshape__3_5_1762756447761634290.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int32_3_5_40__scatterindices___1___1___updateshape__3_5_1762756447761634290.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int32_3_5_40__scatterindices___1___1___updateshape__3_5_370064940315831604.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int32_3_5_40__scatterindices___1___1___updateshape__3_5_370064940315831604.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int32_3_5_4__scatterindices___1___1___updateshape__3_2_4-5091538715183112685.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int32_3_5_4__scatterindices___1___1___updateshape__3_2_4-5091538715183112685.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int32_3_5_4__scatterindices___1___1___updateshape__3_2_4-5230031465544313104.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int32_3_5_4__scatterindices___1___1___updateshape__3_2_4-5230031465544313104.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int32_3__scatterindices___1___0___1___updateshape__3___u745960711584405074.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int32_3__scatterindices___1___0___1___updateshape__3___u745960711584405074.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int32_3__scatterindices___1___0___1___updateshape__3___u7474826191716339973.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int32_3__scatterindices___1___0___1___updateshape__3___u7474826191716339973.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int8_1__scatterindices___0___0___updateshape__2___update-5394974141977995339.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int8_1__scatterindices___0___0___updateshape__2___update-5394974141977995339.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int8_1__scatterindices___0___0___updateshape__2___update3840665188349095112.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int8_1__scatterindices___0___0___updateshape__2___update3840665188349095112.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int8_2_3__scatterindices____2___2___2____updateshape__2_6576008549206823569.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int8_2_3__scatterindices____2___2___2____updateshape__2_6576008549206823569.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int8_2_3__scatterindices____2___2___2____updateshape__2_8145936191260086532.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int8_2_3__scatterindices____2___2___2____updateshape__2_8145936191260086532.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int8_3_5_40__scatterindices___1___1___updateshape__3_5_2-3817844005059537029.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int8_3_5_40__scatterindices___1___1___updateshape__3_5_2-3817844005059537029.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int8_3_5_40__scatterindices___1___1___updateshape__3_5_2454799236677986965.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int8_3_5_40__scatterindices___1___1___updateshape__3_5_2454799236677986965.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int8_3_5_4__scatterindices___1___1___updateshape__3_2_4_-704981458838703190.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int8_3_5_4__scatterindices___1___1___updateshape__3_2_4_-704981458838703190.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int8_3_5_4__scatterindices___1___1___updateshape__3_2_4_6593676401126510993.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int8_3_5_4__scatterindices___1___1___updateshape__3_2_4_6593676401126510993.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int8_3__scatterindices___1___0___1___updateshape__3___up-1167360532793909946.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int8_3__scatterindices___1___0___1___updateshape__3___up-1167360532793909946.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int8_3__scatterindices___1___0___1___updateshape__3___up-8298869919665076145.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_int8_3__scatterindices___1___0___1___updateshape__3___up-8298869919665076145.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint16_1__scatterindices___0___0___updateshape__2___upda161921840649824051.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint16_1__scatterindices___0___0___updateshape__2___upda161921840649824051.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint16_1__scatterindices___0___0___updateshape__2___upda3735630494581482059.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint16_1__scatterindices___0___0___updateshape__2___upda3735630494581482059.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint16_2_3__scatterindices____2___2___2____updateshape__2688714887801807388.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint16_2_3__scatterindices____2___2___2____updateshape__2688714887801807388.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint16_2_3__scatterindices____2___2___2____updateshape__8361960485238181174.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint16_2_3__scatterindices____2___2___2____updateshape__8361960485238181174.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint16_3_5_40__scatterindices___1___1___updateshape__3_5-5809831560180248311.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint16_3_5_40__scatterindices___1___1___updateshape__3_5-5809831560180248311.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint16_3_5_40__scatterindices___1___1___updateshape__3_56857962009318709386.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint16_3_5_40__scatterindices___1___1___updateshape__3_56857962009318709386.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint16_3_5_4__scatterindices___1___1___updateshape__3_2_-2304007480951039088.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint16_3_5_4__scatterindices___1___1___updateshape__3_2_-2304007480951039088.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint16_3_5_4__scatterindices___1___1___updateshape__3_2_5459370073862717448.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint16_3_5_4__scatterindices___1___1___updateshape__3_2_5459370073862717448.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint16_3__scatterindices___1___0___1___updateshape__3___-4638989347349221305.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint16_3__scatterindices___1___0___1___updateshape__3___-4638989347349221305.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint16_3__scatterindices___1___0___1___updateshape__3___5197437071204231332.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint16_3__scatterindices___1___0___1___updateshape__3___5197437071204231332.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint32_1__scatterindices___0___0___updateshape__2___upda-5033170067209841298.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint32_1__scatterindices___0___0___updateshape__2___upda-5033170067209841298.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint32_1__scatterindices___0___0___updateshape__2___upda3405531792482433818.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint32_1__scatterindices___0___0___updateshape__2___upda3405531792482433818.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint32_2_3__scatterindices____2___2___2____updateshape__-3874832709047427655.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint32_2_3__scatterindices____2___2___2____updateshape__-3874832709047427655.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint32_2_3__scatterindices____2___2___2____updateshape__-6809006410571346051.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint32_2_3__scatterindices____2___2___2____updateshape__-6809006410571346051.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint32_3_5_40__scatterindices___1___1___updateshape__3_5-8087282932593150333.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint32_3_5_40__scatterindices___1___1___updateshape__3_5-8087282932593150333.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint32_3_5_40__scatterindices___1___1___updateshape__3_53752717208774607143.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint32_3_5_40__scatterindices___1___1___updateshape__3_53752717208774607143.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint32_3_5_4__scatterindices___1___1___updateshape__3_2_-9119104572226652429.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint32_3_5_4__scatterindices___1___1___updateshape__3_2_-9119104572226652429.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint32_3_5_4__scatterindices___1___1___updateshape__3_2_9027081709691489580.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint32_3_5_4__scatterindices___1___1___updateshape__3_2_9027081709691489580.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint32_3__scatterindices___1___0___1___updateshape__3___-2824440249156885329.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint32_3__scatterindices___1___0___1___updateshape__3___-2824440249156885329.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint32_3__scatterindices___1___0___1___updateshape__3___4204330477043591502.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint32_3__scatterindices___1___0___1___updateshape__3___4204330477043591502.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint8_1__scatterindices___0___0___updateshape__2___updat-1928048275487284072.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint8_1__scatterindices___0___0___updateshape__2___updat-1928048275487284072.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint8_1__scatterindices___0___0___updateshape__2___updat-5645493756063806586.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint8_1__scatterindices___0___0___updateshape__2___updat-5645493756063806586.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint8_2_3__scatterindices____2___2___2____updateshape__2-4849279551096494062.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint8_2_3__scatterindices____2___2___2____updateshape__2-4849279551096494062.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint8_2_3__scatterindices____2___2___2____updateshape__2-5015570983650787750.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint8_2_3__scatterindices____2___2___2____updateshape__2-5015570983650787750.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint8_3_5_40__scatterindices___1___1___updateshape__3_5_-6488793373393055668.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint8_3_5_40__scatterindices___1___1___updateshape__3_5_-6488793373393055668.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint8_3_5_40__scatterindices___1___1___updateshape__3_5_2876137255340148048.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint8_3_5_40__scatterindices___1___1___updateshape__3_5_2876137255340148048.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint8_3_5_4__scatterindices___1___1___updateshape__3_2_4-5468250991339657190.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint8_3_5_4__scatterindices___1___1___updateshape__3_2_4-5468250991339657190.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint8_3_5_4__scatterindices___1___1___updateshape__3_2_46597706213966163723.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint8_3_5_4__scatterindices___1___1___updateshape__3_2_46597706213966163723.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint8_3__scatterindices___1___0___1___updateshape__3___u8008517684702321245.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint8_3__scatterindices___1___0___1___updateshape__3___u8008517684702321245.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint8_3__scatterindices___1___0___1___updateshape__3___u8952013310211685863.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_non_unique_indices_shape_uint8_3__scatterindices___1___0___1___updateshape__3___u8952013310211685863.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_125__scatterindices__0__updateshape__1___updatewi-7951316018913039515.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_125__scatterindices__0__updateshape__1___updatewi-7951316018913039515.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_125__scatterindices__0__updateshape__1___updatewi6702824425361821392.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_125__scatterindices__0__updateshape__1___updatewi6702824425361821392.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_1_1__scatterindices__0__updateshape__1_1__updatew-5972702966998148248.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_1_1__scatterindices__0__updateshape__1_1__updatew-5972702966998148248.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_1_1__scatterindices__0__updateshape__1_1__updatew1407841965061306462.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_1_1__scatterindices__0__updateshape__1_1__updatew1407841965061306462.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_1__scatterindices__0__updateshape__1___updatewind-3943852519473722017.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_1__scatterindices__0__updateshape__1___updatewind-3943852519473722017.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_1__scatterindices__0__updateshape__1___updatewind127580504216186793.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_1__scatterindices__0__updateshape__1___updatewind127580504216186793.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__0__updateshape__2_3__updatew-7506540865680037479.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__0__updateshape__2_3__updatew-7506540865680037479.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__0__updateshape__2_3__updatew5584184258335034500.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__0__updateshape__2_3__updatew5584184258335034500.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1_2__updateshape__1___update-4251555005392764840.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1_2__updateshape__1___update-4251555005392764840.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1_2__updateshape__1___update-5229134625950574353.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1_2__updateshape__1___update-5229134625950574353.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1__updateshape__1_3__updatew-3961914136394634324.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1__updateshape__1_3__updatew-3961914136394634324.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1__updateshape__1_3__updatew3401137719720140593.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1__updateshape__1_3__updatew3401137719720140593.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_50_3__scatterindices__32__updateshape__1_3__updat2982281935440931080.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_50_3__scatterindices__32__updateshape__1_3__updat2982281935440931080.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_50_3__scatterindices__32__updateshape__1_3__updat3084121004419047144.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1_50_3__scatterindices__32__updateshape__1_3__updat3084121004419047144.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1__scatterindices__0__updateshape____updatewindowdi2750489734415423653.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1__scatterindices__0__updateshape____updatewindowdi2750489734415423653.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1__scatterindices__0__updateshape____updatewindowdi5124668511842850918.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_1__scatterindices__0__updateshape____updatewindowdi5124668511842850918.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upd-6081757470381034206.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upd-6081757470381034206.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upd3885288221741258848.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upd3885288221741258848.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_4_2_3__scatterindices__3_2__updateshape__2___update7364310318843531288.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_4_2_3__scatterindices__3_2__updateshape__2___update7364310318843531288.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_4_2_3__scatterindices__3_2__updateshape__2___update8372352202104151718.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_4_2_3__scatterindices__3_2__updateshape__2___update8372352202104151718.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices___0_1___2_3___updateshape__2_-6857933840613967855.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices___0_1___2_3___updateshape__2_-6857933840613967855.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices___0_1___2_3___updateshape__2_1854402682370088797.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices___0_1___2_3___updateshape__2_1854402682370088797.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2___-4664842944644532288.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2___-4664842944644532288.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2___-4912124039036857606.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2___-4912124039036857606.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0___1_____2___3____updates8425066511028864359.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0___1_____2___3____updates8425066511028864359.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0___1_____2___3____updates9039479434269282771.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0___1_____2___3____updates9039479434269282771.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_125__scatterindices__0__updateshape__1___updatewin-8731115509034630074.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_125__scatterindices__0__updateshape__1___updatewin-8731115509034630074.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_125__scatterindices__0__updateshape__1___updatewin5456048288023940070.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_125__scatterindices__0__updateshape__1___updatewin5456048288023940070.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_1_1__scatterindices__0__updateshape__1_1__updatewi-7461026489300552530.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_1_1__scatterindices__0__updateshape__1_1__updatewi-7461026489300552530.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_1_1__scatterindices__0__updateshape__1_1__updatewi7584067801932672436.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_1_1__scatterindices__0__updateshape__1_1__updatewi7584067801932672436.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_1__scatterindices__0__updateshape__1___updatewindo6262511284222583383.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_1__scatterindices__0__updateshape__1___updatewindo6262511284222583383.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_1__scatterindices__0__updateshape__1___updatewindo826934003937973373.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_1__scatterindices__0__updateshape__1___updatewindo826934003937973373.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__0__updateshape__2_3__updatewi-413052865564151320.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__0__updateshape__2_3__updatewi-413052865564151320.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__0__updateshape__2_3__updatewi4461960695973448237.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__0__updateshape__2_3__updatewi4461960695973448237.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1_2__updateshape__1___updatew-5801480997889705312.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1_2__updateshape__1___updatew-5801480997889705312.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1_2__updateshape__1___updatew8160063217424680651.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1_2__updateshape__1___updatew8160063217424680651.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1__updateshape__1_3__updatewi-2327934312904943306.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1__updateshape__1_3__updatewi-2327934312904943306.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1__updateshape__1_3__updatewi-5939485743090244293.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1__updateshape__1_3__updatewi-5939485743090244293.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_50_3__scatterindices__32__updateshape__1_3__update-6025244686982047499.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_50_3__scatterindices__32__updateshape__1_3__update-6025244686982047499.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_50_3__scatterindices__32__updateshape__1_3__update3446534180989259789.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1_50_3__scatterindices__32__updateshape__1_3__update3446534180989259789.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1__scatterindices__0__updateshape____updatewindowdim-5250745436348551263.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1__scatterindices__0__updateshape____updatewindowdim-5250745436348551263.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1__scatterindices__0__updateshape____updatewindowdim7739733770160348375.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_1__scatterindices__0__updateshape____updatewindowdim7739733770160348375.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda-3538272321874794861.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda-3538272321874794861.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda-392663043202175784.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda-392663043202175784.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_4_2_3__scatterindices__3_2__updateshape__2___updatew-2440309485513542178.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_4_2_3__scatterindices__3_2__updateshape__2___updatew-2440309485513542178.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_4_2_3__scatterindices__3_2__updateshape__2___updatew7426129206573115753.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_4_2_3__scatterindices__3_2__updateshape__2___updatew7426129206573115753.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7-159451342797418259.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7-159451342797418259.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7-5578923499037233624.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7-5578923499037233624.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____-2444622237702936986.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____-2444622237702936986.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____-7757199019071415531.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____-7757199019071415531.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0___1_____2___3____updatesh-3136091413228841764.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0___1_____2___3____updatesh-3136091413228841764.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0___1_____2___3____updatesh-6758286671672048533.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0___1_____2___3____updatesh-6758286671672048533.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewin6630480169388456900.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewin6630480169388456900.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewin8572492367628107196.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewin8572492367628107196.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__updatewi-7371943639734852459.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__updatewi-7371943639734852459.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__updatewi4068384492096779511.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__updatewi4068384492096779511.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___updatewindo-2154616836031129399.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___updatewindo-2154616836031129399.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___updatewindo8211732968977781634.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___updatewindo8211732968977781634.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatewi1964705741470670687.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatewi1964705741470670687.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatewi8565875730962467804.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatewi8565875730962467804.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___updatew-404205633388340906.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___updatew-404205633388340906.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___updatew3237864401487247669.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___updatew3237864401487247669.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatewi-2067769420489394878.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatewi-2067769420489394878.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatewi-6579002509224460796.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatewi-6579002509224460796.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__update-2859679405862166530.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__update-2859679405862166530.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__update-7634215713295217725.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__update-7634215713295217725.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdim-8284545332321621723.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdim-8284545332321621723.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdim2552856992181958030.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdim2552856992181958030.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda-2412234970495546907.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda-2412234970495546907.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda453838035690433383.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda453838035690433383.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___updatew-7533059538631912228.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___updatew-7533059538631912228.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___updatew3375484086611496655.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___updatew3375484086611496655.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7-3920948015976371115.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7-3920948015976371115.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7-7515156318392282609.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7-7515156318392282609.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____-1170955320691764183.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____-1170955320691764183.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____2313902312206829190.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____2313902312206829190.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____updatesh-7684033199204675714.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____updatesh-7684033199204675714.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____updatesh3178105627475464119.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____updatesh3178105627475464119.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_125__scatterindices__0__updateshape__1___updatewindo-3654291814679525556.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_125__scatterindices__0__updateshape__1___updatewindo-3654291814679525556.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_125__scatterindices__0__updateshape__1___updatewindo-871221408395309914.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_125__scatterindices__0__updateshape__1___updatewindo-871221408395309914.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_1_1__scatterindices__0__updateshape__1_1__updatewind-1266270276664743071.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_1_1__scatterindices__0__updateshape__1_1__updatewind-1266270276664743071.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_1_1__scatterindices__0__updateshape__1_1__updatewind7510692379337228912.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_1_1__scatterindices__0__updateshape__1_1__updatewind7510692379337228912.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_1__scatterindices__0__updateshape__1___updatewindowd-5539344497814516958.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_1__scatterindices__0__updateshape__1___updatewindowd-5539344497814516958.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_1__scatterindices__0__updateshape__1___updatewindowd628686664965122633.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_1__scatterindices__0__updateshape__1___updatewindowd628686664965122633.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__0__updateshape__2_3__updatewind-7281596825748537654.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__0__updateshape__2_3__updatewind-7281596825748537654.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__0__updateshape__2_3__updatewind343624490879144246.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__0__updateshape__2_3__updatewind343624490879144246.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1_2__updateshape__1___updatewin-9130298215407344948.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1_2__updateshape__1___updatewin-9130298215407344948.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1_2__updateshape__1___updatewin29170760427750106.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1_2__updateshape__1___updatewin29170760427750106.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1__updateshape__1_3__updatewind6199941392158014970.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1__updateshape__1_3__updatewind6199941392158014970.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1__updateshape__1_3__updatewind7584387903479037346.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1__updateshape__1_3__updatewind7584387903479037346.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_50_3__scatterindices__32__updateshape__1_3__updatewi645749440987017403.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_50_3__scatterindices__32__updateshape__1_3__updatewi645749440987017403.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_50_3__scatterindices__32__updateshape__1_3__updatewi7756715673163114539.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1_50_3__scatterindices__32__updateshape__1_3__updatewi7756715673163114539.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1__scatterindices__0__updateshape____updatewindowdims_-3679121800625812234.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1__scatterindices__0__updateshape____updatewindowdims_-3679121800625812234.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1__scatterindices__0__updateshape____updatewindowdims_-8475013276026304217.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_1__scatterindices__0__updateshape____updatewindowdims_-8475013276026304217.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_4_2_3_5__scatterindices__0_4__updateshape__4_3__update5145103864147144487.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_4_2_3_5__scatterindices__0_4__updateshape__4_3__update5145103864147144487.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_4_2_3_5__scatterindices__0_4__updateshape__4_3__update5305151552116457906.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_4_2_3_5__scatterindices__0_4__updateshape__4_3__update5305151552116457906.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_4_2_3__scatterindices__3_2__updateshape__2___updatewin6273731547009376844.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_4_2_3__scatterindices__3_2__updateshape__2___updatewin6273731547009376844.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_4_2_3__scatterindices__3_2__updateshape__2___updatewin942858064976496756.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_4_2_3__scatterindices__3_2__updateshape__2___updatewin942858064976496756.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-3444864293038376401.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-3444864293038376401.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-7188394306654795863.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-7188394306654795863.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up7107157064561570510.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up7107157064561570510.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up7387677201127024645.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up7387677201127024645.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0___1_____2___3____updateshap-8046792862695677092.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0___1_____2___3____updateshap-8046792862695677092.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0___1_____2___3____updateshap6673711492997861910.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0___1_____2___3____updateshap6673711492997861910.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_125__scatterindices__0__updateshape__1___updatewindo4656103149856539072.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_125__scatterindices__0__updateshape__1___updatewindo4656103149856539072.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_125__scatterindices__0__updateshape__1___updatewindo6174606093632257094.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_125__scatterindices__0__updateshape__1___updatewindo6174606093632257094.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_1_1__scatterindices__0__updateshape__1_1__updatewind7605846626881629019.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_1_1__scatterindices__0__updateshape__1_1__updatewind7605846626881629019.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_1_1__scatterindices__0__updateshape__1_1__updatewind8480432924465288348.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_1_1__scatterindices__0__updateshape__1_1__updatewind8480432924465288348.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_1__scatterindices__0__updateshape__1___updatewindowd-1521835621444368318.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_1__scatterindices__0__updateshape__1___updatewindowd-1521835621444368318.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_1__scatterindices__0__updateshape__1___updatewindowd-169679448021614044.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_1__scatterindices__0__updateshape__1___updatewindowd-169679448021614044.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__0__updateshape__2_3__updatewind8659525051222717199.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__0__updateshape__2_3__updatewind8659525051222717199.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__0__updateshape__2_3__updatewind9221825623425246191.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__0__updateshape__2_3__updatewind9221825623425246191.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1_2__updateshape__1___updatewin-1243305172105270209.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1_2__updateshape__1___updatewin-1243305172105270209.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1_2__updateshape__1___updatewin2903989190550323920.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1_2__updateshape__1___updatewin2903989190550323920.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1__updateshape__1_3__updatewind8114183208411738953.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1__updateshape__1_3__updatewind8114183208411738953.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1__updateshape__1_3__updatewind9011474719121171092.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1__updateshape__1_3__updatewind9011474719121171092.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_50_3__scatterindices__32__updateshape__1_3__updatewi-1609030670137173878.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_50_3__scatterindices__32__updateshape__1_3__updatewi-1609030670137173878.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_50_3__scatterindices__32__updateshape__1_3__updatewi3133214799466578856.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1_50_3__scatterindices__32__updateshape__1_3__updatewi3133214799466578856.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1__scatterindices__0__updateshape____updatewindowdims_-1135572076354273511.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1__scatterindices__0__updateshape____updatewindowdims_-1135572076354273511.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1__scatterindices__0__updateshape____updatewindowdims_-3604859808534884877.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_1__scatterindices__0__updateshape____updatewindowdims_-3604859808534884877.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_4_2_3_5__scatterindices__0_4__updateshape__4_3__update4471163082483622438.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_4_2_3_5__scatterindices__0_4__updateshape__4_3__update4471163082483622438.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_4_2_3_5__scatterindices__0_4__updateshape__4_3__update6384155601706297380.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_4_2_3_5__scatterindices__0_4__updateshape__4_3__update6384155601706297380.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_4_2_3__scatterindices__3_2__updateshape__2___updatewin-4610183090425207438.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_4_2_3__scatterindices__3_2__updateshape__2___updatewin-4610183090425207438.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_4_2_3__scatterindices__3_2__updateshape__2___updatewin-8061986652111493245.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_4_2_3__scatterindices__3_2__updateshape__2___updatewin-8061986652111493245.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-163470273381609128.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-163470273381609128.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-18573880227059666.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-18573880227059666.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-3276982532932579518.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-3276982532932579518.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-4337912569205295127.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-4337912569205295127.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0___1_____2___3____updateshap-464904247894401737.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0___1_____2___3____updateshap-464904247894401737.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0___1_____2___3____updateshap164430147412181105.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0___1_____2___3____updateshap164430147412181105.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_125__scatterindices__0__updateshape__1___updatewindow-8386886293990609168.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_125__scatterindices__0__updateshape__1___updatewindow-8386886293990609168.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_125__scatterindices__0__updateshape__1___updatewindow6998811498039155782.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_125__scatterindices__0__updateshape__1___updatewindow6998811498039155782.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_1_1__scatterindices__0__updateshape__1_1__updatewindo-166998336338534843.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_1_1__scatterindices__0__updateshape__1_1__updatewindo-166998336338534843.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_1_1__scatterindices__0__updateshape__1_1__updatewindo4171420055510686488.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_1_1__scatterindices__0__updateshape__1_1__updatewindo4171420055510686488.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_1__scatterindices__0__updateshape__1___updatewindowdi2814190485852129409.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_1__scatterindices__0__updateshape__1___updatewindowdi2814190485852129409.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_1__scatterindices__0__updateshape__1___updatewindowdi3666386104836301017.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_1__scatterindices__0__updateshape__1___updatewindowdi3666386104836301017.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__0__updateshape__2_3__updatewindo-4820753800701744168.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__0__updateshape__2_3__updatewindo-4820753800701744168.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__0__updateshape__2_3__updatewindo6247082404024764138.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__0__updateshape__2_3__updatewindo6247082404024764138.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1_2__updateshape__1___updatewind-4394756924061263821.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1_2__updateshape__1___updatewind-4394756924061263821.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1_2__updateshape__1___updatewind8730101061849356499.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1_2__updateshape__1___updatewind8730101061849356499.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1__updateshape__1_3__updatewindo-229339135565173539.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1__updateshape__1_3__updatewindo-229339135565173539.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1__updateshape__1_3__updatewindo1356973389398030785.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1__updateshape__1_3__updatewindo1356973389398030785.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_50_3__scatterindices__32__updateshape__1_3__updatewin-2721867853299623403.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_50_3__scatterindices__32__updateshape__1_3__updatewin-2721867853299623403.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_50_3__scatterindices__32__updateshape__1_3__updatewin-8208861813110223290.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1_50_3__scatterindices__32__updateshape__1_3__updatewin-8208861813110223290.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1__scatterindices__0__updateshape____updatewindowdims__-6373449430230855376.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1__scatterindices__0__updateshape____updatewindowdims__-6373449430230855376.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1__scatterindices__0__updateshape____updatewindowdims__7302486127658143934.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_1__scatterindices__0__updateshape____updatewindowdims__7302486127658143934.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatew360761962830156288.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatew360761962830156288.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatew8812456315477330015.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatew8812456315477330015.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_4_2_3__scatterindices__3_2__updateshape__2___updatewind-78009980723520832.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_4_2_3__scatterindices__3_2__updateshape__2___updatewind-78009980723520832.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_4_2_3__scatterindices__3_2__updateshape__2___updatewind231526804584745672.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_4_2_3__scatterindices__3_2__updateshape__2___updatewind231526804584745672.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__u3069527597941492880.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__u3069527597941492880.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__u6138003060915204942.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__u6138003060915204942.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upd-3453535066437865765.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upd-3453535066437865765.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upd7484757335449695351.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upd7484757335449695351.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0___1_____2___3____updateshape2008502797251229853.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0___1_____2___3____updateshape2008502797251229853.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0___1_____2___3____updateshape9059928969943241058.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0___1_____2___3____updateshape9059928969943241058.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_125__scatterindices__0__updateshape__1___updatewind-6752944464245862548.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_125__scatterindices__0__updateshape__1___updatewind-6752944464245862548.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_125__scatterindices__0__updateshape__1___updatewind-6808379694680963614.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_125__scatterindices__0__updateshape__1___updatewind-6808379694680963614.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_1_1__scatterindices__0__updateshape__1_1__updatewin1465340387020024301.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_1_1__scatterindices__0__updateshape__1_1__updatewin1465340387020024301.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_1_1__scatterindices__0__updateshape__1_1__updatewin5254831785028503037.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_1_1__scatterindices__0__updateshape__1_1__updatewin5254831785028503037.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_1__scatterindices__0__updateshape__1___updatewindow-6162849774345350374.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_1__scatterindices__0__updateshape__1___updatewindow-6162849774345350374.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_1__scatterindices__0__updateshape__1___updatewindow2124728795437520929.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_1__scatterindices__0__updateshape__1___updatewindow2124728795437520929.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__0__updateshape__2_3__updatewin2617421260401081730.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__0__updateshape__2_3__updatewin2617421260401081730.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__0__updateshape__2_3__updatewin8448822445776111624.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__0__updateshape__2_3__updatewin8448822445776111624.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1_2__updateshape__1___updatewi-4016152869797095665.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1_2__updateshape__1___updatewi-4016152869797095665.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1_2__updateshape__1___updatewi2385945470013585710.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1_2__updateshape__1___updatewi2385945470013585710.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1__updateshape__1_3__updatewin2679635985562700073.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1__updateshape__1_3__updatewin2679635985562700073.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1__updateshape__1_3__updatewin7808601965039850272.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1__updateshape__1_3__updatewin7808601965039850272.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_50_3__scatterindices__32__updateshape__1_3__updatew-1160369651841163817.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_50_3__scatterindices__32__updateshape__1_3__updatew-1160369651841163817.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_50_3__scatterindices__32__updateshape__1_3__updatew2441965319563582007.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1_50_3__scatterindices__32__updateshape__1_3__updatew2441965319563582007.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1__scatterindices__0__updateshape____updatewindowdims-4284546542326456679.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1__scatterindices__0__updateshape____updatewindowdims-4284546542326456679.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1__scatterindices__0__updateshape____updatewindowdims-4941197402186890645.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_1__scatterindices__0__updateshape____updatewindowdims-4941197402186890645.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat5717897549646019228.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat5717897549646019228.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat8983247923438467165.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat8983247923438467165.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_4_2_3__scatterindices__3_2__updateshape__2___updatewi-1489473092002645628.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_4_2_3__scatterindices__3_2__updateshape__2___updatewi-1489473092002645628.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_4_2_3__scatterindices__3_2__updateshape__2___updatewi4907939457090036648.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_4_2_3__scatterindices__3_2__updateshape__2___updatewi4907939457090036648.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_-231979961555022713.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_-231979961555022713.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_8754120654496972949.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_8754120654496972949.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u6156571203190694208.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u6156571203190694208.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u7653219651823671808.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u7653219651823671808.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0___1_____2___3____updatesha3560960001983197772.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0___1_____2___3____updatesha3560960001983197772.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0___1_____2___3____updatesha6359168246041175228.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0___1_____2___3____updatesha6359168246041175228.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_125__scatterindices__0__updateshape__1___updatewind-3688988568462201922.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_125__scatterindices__0__updateshape__1___updatewind-3688988568462201922.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_125__scatterindices__0__updateshape__1___updatewind2534325557785002654.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_125__scatterindices__0__updateshape__1___updatewind2534325557785002654.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_1_1__scatterindices__0__updateshape__1_1__updatewin-8530351583768892932.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_1_1__scatterindices__0__updateshape__1_1__updatewin-8530351583768892932.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_1_1__scatterindices__0__updateshape__1_1__updatewin2336848997200141272.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_1_1__scatterindices__0__updateshape__1_1__updatewin2336848997200141272.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_1__scatterindices__0__updateshape__1___updatewindow-1949369266602443161.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_1__scatterindices__0__updateshape__1___updatewindow-1949369266602443161.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_1__scatterindices__0__updateshape__1___updatewindow1516144548387135784.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_1__scatterindices__0__updateshape__1___updatewindow1516144548387135784.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__0__updateshape__2_3__updatewin-312996440089190260.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__0__updateshape__2_3__updatewin-312996440089190260.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__0__updateshape__2_3__updatewin-3855556489712161194.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__0__updateshape__2_3__updatewin-3855556489712161194.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1_2__updateshape__1___updatewi1703169112067469677.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1_2__updateshape__1___updatewi1703169112067469677.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1_2__updateshape__1___updatewi618583376894179380.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1_2__updateshape__1___updatewi618583376894179380.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1__updateshape__1_3__updatewin-5501066061188023133.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1__updateshape__1_3__updatewin-5501066061188023133.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1__updateshape__1_3__updatewin8255429920127766752.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1__updateshape__1_3__updatewin8255429920127766752.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_50_3__scatterindices__32__updateshape__1_3__updatew-3145522822460544824.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_50_3__scatterindices__32__updateshape__1_3__updatew-3145522822460544824.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_50_3__scatterindices__32__updateshape__1_3__updatew8234721788552425508.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1_50_3__scatterindices__32__updateshape__1_3__updatew8234721788552425508.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1__scatterindices__0__updateshape____updatewindowdims-7729688490175977200.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1__scatterindices__0__updateshape____updatewindowdims-7729688490175977200.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1__scatterindices__0__updateshape____updatewindowdims4711489216670640103.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_1__scatterindices__0__updateshape____updatewindowdims4711489216670640103.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat6275639048557222837.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat6275639048557222837.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat6576522988704498337.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat6576522988704498337.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_4_2_3__scatterindices__3_2__updateshape__2___updatewi2066102519051268717.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_4_2_3__scatterindices__3_2__updateshape__2___updatewi2066102519051268717.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_4_2_3__scatterindices__3_2__updateshape__2___updatewi6905061648456258990.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_4_2_3__scatterindices__3_2__updateshape__2___updatewi6905061648456258990.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_-4268300808812953018.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_-4268300808812953018.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_-9153478667077725183.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_-9153478667077725183.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u-6157939275883288533.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u-6157939275883288533.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u8511265051077457043.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u8511265051077457043.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0___1_____2___3____updatesha-2091136672711357126.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0___1_____2___3____updatesha-2091136672711357126.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0___1_____2___3____updatesha796353546737293148.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0___1_____2___3____updatesha796353546737293148.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_125__scatterindices__0__updateshape__1___updatewindo2689091551362511366.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_125__scatterindices__0__updateshape__1___updatewindo2689091551362511366.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_125__scatterindices__0__updateshape__1___updatewindo3624303292444803106.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_125__scatterindices__0__updateshape__1___updatewindo3624303292444803106.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_1_1__scatterindices__0__updateshape__1_1__updatewind-8504773445311031845.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_1_1__scatterindices__0__updateshape__1_1__updatewind-8504773445311031845.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_1_1__scatterindices__0__updateshape__1_1__updatewind8076236772147644448.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_1_1__scatterindices__0__updateshape__1_1__updatewind8076236772147644448.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_1__scatterindices__0__updateshape__1___updatewindowd-1579650891753513969.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_1__scatterindices__0__updateshape__1___updatewindowd-1579650891753513969.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_1__scatterindices__0__updateshape__1___updatewindowd6935007064526363979.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_1__scatterindices__0__updateshape__1___updatewindowd6935007064526363979.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__0__updateshape__2_3__updatewind-2961218062536580227.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__0__updateshape__2_3__updatewind-2961218062536580227.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__0__updateshape__2_3__updatewind2771680170207766950.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__0__updateshape__2_3__updatewind2771680170207766950.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1_2__updateshape__1___updatewin1983890828044820225.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1_2__updateshape__1___updatewin1983890828044820225.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1_2__updateshape__1___updatewin62016766260514297.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1_2__updateshape__1___updatewin62016766260514297.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1__updateshape__1_3__updatewind-692020949637620008.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1__updateshape__1_3__updatewind-692020949637620008.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1__updateshape__1_3__updatewind7583448234884642512.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1__updateshape__1_3__updatewind7583448234884642512.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_50_3__scatterindices__32__updateshape__1_3__updatewi373097052078385741.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_50_3__scatterindices__32__updateshape__1_3__updatewi373097052078385741.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_50_3__scatterindices__32__updateshape__1_3__updatewi5387246296885867613.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1_50_3__scatterindices__32__updateshape__1_3__updatewi5387246296885867613.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1__scatterindices__0__updateshape____updatewindowdims_-6261381946082163628.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1__scatterindices__0__updateshape____updatewindowdims_-6261381946082163628.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1__scatterindices__0__updateshape____updatewindowdims_8998606905763508495.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_1__scatterindices__0__updateshape____updatewindowdims_8998606905763508495.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_4_2_3_5__scatterindices__0_4__updateshape__4_3__update37168508320117536.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_4_2_3_5__scatterindices__0_4__updateshape__4_3__update37168508320117536.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_4_2_3_5__scatterindices__0_4__updateshape__4_3__update4396915468484087491.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_4_2_3_5__scatterindices__0_4__updateshape__4_3__update4396915468484087491.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_4_2_3__scatterindices__3_2__updateshape__2___updatewin-3224467062420307614.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_4_2_3__scatterindices__3_2__updateshape__2___updatewin-3224467062420307614.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_4_2_3__scatterindices__3_2__updateshape__2___updatewin3891239180403390738.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_4_2_3__scatterindices__3_2__updateshape__2___updatewin3891239180403390738.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-2151910845188751696.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-2151910845188751696.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-2404637618845325000.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-2404637618845325000.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-572190243029509453.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-572190243029509453.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up7668301934060675915.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up7668301934060675915.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0___1_____2___3____updateshap-115477283981442116.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0___1_____2___3____updateshap-115477283981442116.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0___1_____2___3____updateshap-3395923389630413235.mlir
+++ b/stablehlo/testdata/scatter_max_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0___1_____2___3____updateshap-3395923389630413235.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_dtypes_shape_bfloat16_5__scatterindices___0___2___updateshape__2___updatewindowdims____i1719900046009157333.mlir
+++ b/stablehlo/testdata/scatter_min_dtypes_shape_bfloat16_5__scatterindices___0___2___updateshape__2___updatewindowdims____i1719900046009157333.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_dtypes_shape_bool_5__scatterindices___0___2___updateshape__2___updatewindowdims____inser1719862287393275076.mlir
+++ b/stablehlo/testdata/scatter_min_dtypes_shape_bool_5__scatterindices___0___2___updateshape__2___updatewindowdims____inser1719862287393275076.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_dtypes_shape_complex64_5__scatterindices___0___2___updateshape__2___updatewindowdims____4352046343394697159.mlir
+++ b/stablehlo/testdata/scatter_min_dtypes_shape_complex64_5__scatterindices___0___2___updateshape__2___updatewindowdims____4352046343394697159.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_dtypes_shape_float16_5__scatterindices___0___2___updateshape__2___updatewindowdims____in3400391015131318119.mlir
+++ b/stablehlo/testdata/scatter_min_dtypes_shape_float16_5__scatterindices___0___2___updateshape__2___updatewindowdims____in3400391015131318119.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_dtypes_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowdims____in-3152158342664535743.mlir
+++ b/stablehlo/testdata/scatter_min_dtypes_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowdims____in-3152158342664535743.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_dtypes_shape_int16_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse7721631736843667759.mlir
+++ b/stablehlo/testdata/scatter_min_dtypes_shape_int16_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse7721631736843667759.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_dtypes_shape_int32_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse4043667791730656744.mlir
+++ b/stablehlo/testdata/scatter_min_dtypes_shape_int32_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse4043667791730656744.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_dtypes_shape_int8_5__scatterindices___0___2___updateshape__2___updatewindowdims____inser7141706196654897674.mlir
+++ b/stablehlo/testdata/scatter_min_dtypes_shape_int8_5__scatterindices___0___2___updateshape__2___updatewindowdims____inser7141706196654897674.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_dtypes_shape_uint16_5__scatterindices___0___2___updateshape__2___updatewindowdims____ins9124514689364773013.mlir
+++ b/stablehlo/testdata/scatter_min_dtypes_shape_uint16_5__scatterindices___0___2___updateshape__2___updatewindowdims____ins9124514689364773013.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_dtypes_shape_uint32_5__scatterindices___0___2___updateshape__2___updatewindowdims____ins-4863845320241037762.mlir
+++ b/stablehlo/testdata/scatter_min_dtypes_shape_uint32_5__scatterindices___0___2___updateshape__2___updatewindowdims____ins-4863845320241037762.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_dtypes_shape_uint8_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse534852232021846945.mlir
+++ b/stablehlo/testdata/scatter_min_dtypes_shape_uint8_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse534852232021846945.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_indices_are_sorted_shape_float32_5__scatterindices___0___2___updateshape__2___updatewind5825509085618127810.mlir
+++ b/stablehlo/testdata/scatter_min_indices_are_sorted_shape_float32_5__scatterindices___0___2___updateshape__2___updatewind5825509085618127810.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowd-4280126132222170601.mlir
+++ b/stablehlo/testdata/scatter_min_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowd-4280126132222170601.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowd-7030084515635948913.mlir
+++ b/stablehlo/testdata/scatter_min_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowd-7030084515635948913.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatewindow-6977587035204418846.mlir
+++ b/stablehlo/testdata/scatter_min_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatewindow-6977587035204418846.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatewindow794294539857980968.mlir
+++ b/stablehlo/testdata/scatter_min_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatewindow794294539857980968.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_bfloat16_1__scatterindices___0___0___updateshape__2___up-6655058111581649220.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_bfloat16_1__scatterindices___0___0___updateshape__2___up-6655058111581649220.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_bfloat16_1__scatterindices___0___0___updateshape__2___up257011455004234925.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_bfloat16_1__scatterindices___0___0___updateshape__2___up257011455004234925.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_bfloat16_2_3__scatterindices____2___2___2____updateshape-2249289855259825998.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_bfloat16_2_3__scatterindices____2___2___2____updateshape-2249289855259825998.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_bfloat16_2_3__scatterindices____2___2___2____updateshape3597514414725498598.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_bfloat16_2_3__scatterindices____2___2___2____updateshape3597514414725498598.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_bfloat16_3_5_40__scatterindices___1___1___updateshape__3-5074117366129902401.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_bfloat16_3_5_40__scatterindices___1___1___updateshape__3-5074117366129902401.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_bfloat16_3_5_40__scatterindices___1___1___updateshape__34933250815520880524.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_bfloat16_3_5_40__scatterindices___1___1___updateshape__34933250815520880524.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_bfloat16_3_5_4__scatterindices___1___1___updateshape__3_6244259100277537568.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_bfloat16_3_5_4__scatterindices___1___1___updateshape__3_6244259100277537568.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_bfloat16_3_5_4__scatterindices___1___1___updateshape__3_7096135450420072774.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_bfloat16_3_5_4__scatterindices___1___1___updateshape__3_7096135450420072774.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_bfloat16_3__scatterindices___1___0___1___updateshape__3_-2390111683147858631.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_bfloat16_3__scatterindices___1___0___1___updateshape__3_-2390111683147858631.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_bfloat16_3__scatterindices___1___0___1___updateshape__3_6371101921313517982.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_bfloat16_3__scatterindices___1___0___1___updateshape__3_6371101921313517982.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float16_1__scatterindices___0___0___updateshape__2___upd-6220627124317296940.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float16_1__scatterindices___0___0___updateshape__2___upd-6220627124317296940.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float16_1__scatterindices___0___0___updateshape__2___upd4569219469464053131.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float16_1__scatterindices___0___0___updateshape__2___upd4569219469464053131.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float16_2_3__scatterindices____2___2___2____updateshape_4356686229420019100.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float16_2_3__scatterindices____2___2___2____updateshape_4356686229420019100.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float16_2_3__scatterindices____2___2___2____updateshape_8694718717423353139.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float16_2_3__scatterindices____2___2___2____updateshape_8694718717423353139.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float16_3_5_40__scatterindices___1___1___updateshape__3_-8316221048643743799.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float16_3_5_40__scatterindices___1___1___updateshape__3_-8316221048643743799.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float16_3_5_40__scatterindices___1___1___updateshape__3_-857194216228152443.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float16_3_5_40__scatterindices___1___1___updateshape__3_-857194216228152443.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float16_3_5_4__scatterindices___1___1___updateshape__3_2-714900388043421455.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float16_3_5_4__scatterindices___1___1___updateshape__3_2-714900388043421455.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float16_3_5_4__scatterindices___1___1___updateshape__3_294168853516180589.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float16_3_5_4__scatterindices___1___1___updateshape__3_294168853516180589.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float16_3__scatterindices___1___0___1___updateshape__3__-1592233629693916822.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float16_3__scatterindices___1___0___1___updateshape__3__-1592233629693916822.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float16_3__scatterindices___1___0___1___updateshape__3__-4570510485399197673.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float16_3__scatterindices___1___0___1___updateshape__3__-4570510485399197673.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float32_1__scatterindices___0___0___updateshape__2___upd-8091195660655238031.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float32_1__scatterindices___0___0___updateshape__2___upd-8091195660655238031.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float32_1__scatterindices___0___0___updateshape__2___upd3680312855999364491.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float32_1__scatterindices___0___0___updateshape__2___upd3680312855999364491.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float32_2_3__scatterindices____2___2___2____updateshape_-3099664615390500206.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float32_2_3__scatterindices____2___2___2____updateshape_-3099664615390500206.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float32_2_3__scatterindices____2___2___2____updateshape_4115365008761471583.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float32_2_3__scatterindices____2___2___2____updateshape_4115365008761471583.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float32_3_5_40__scatterindices___1___1___updateshape__3_-2626246477929477630.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float32_3_5_40__scatterindices___1___1___updateshape__3_-2626246477929477630.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float32_3_5_40__scatterindices___1___1___updateshape__3_5421303431107764636.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float32_3_5_40__scatterindices___1___1___updateshape__3_5421303431107764636.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float32_3_5_4__scatterindices___1___1___updateshape__3_2-4098451780701630155.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float32_3_5_4__scatterindices___1___1___updateshape__3_2-4098451780701630155.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float32_3_5_4__scatterindices___1___1___updateshape__3_2-4943527707746498712.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float32_3_5_4__scatterindices___1___1___updateshape__3_2-4943527707746498712.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float32_3__scatterindices___1___0___1___updateshape__3__-3971564147856755499.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float32_3__scatterindices___1___0___1___updateshape__3__-3971564147856755499.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float32_3__scatterindices___1___0___1___updateshape__3__7215406999342465565.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_float32_3__scatterindices___1___0___1___updateshape__3__7215406999342465565.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int16_1__scatterindices___0___0___updateshape__2___updat-2407133498544979633.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int16_1__scatterindices___0___0___updateshape__2___updat-2407133498544979633.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int16_1__scatterindices___0___0___updateshape__2___updat707246471925448235.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int16_1__scatterindices___0___0___updateshape__2___updat707246471925448235.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int16_2_3__scatterindices____2___2___2____updateshape__2-3082733421359615550.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int16_2_3__scatterindices____2___2___2____updateshape__2-3082733421359615550.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int16_2_3__scatterindices____2___2___2____updateshape__21853808655309087749.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int16_2_3__scatterindices____2___2___2____updateshape__21853808655309087749.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int16_3_5_40__scatterindices___1___1___updateshape__3_5_-3168049263500542045.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int16_3_5_40__scatterindices___1___1___updateshape__3_5_-3168049263500542045.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int16_3_5_40__scatterindices___1___1___updateshape__3_5_-4612044676003355777.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int16_3_5_40__scatterindices___1___1___updateshape__3_5_-4612044676003355777.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int16_3_5_4__scatterindices___1___1___updateshape__3_2_44884154015831063889.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int16_3_5_4__scatterindices___1___1___updateshape__3_2_44884154015831063889.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int16_3_5_4__scatterindices___1___1___updateshape__3_2_46191447577027647775.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int16_3_5_4__scatterindices___1___1___updateshape__3_2_46191447577027647775.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int16_3__scatterindices___1___0___1___updateshape__3___u6262865648268185343.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int16_3__scatterindices___1___0___1___updateshape__3___u6262865648268185343.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int16_3__scatterindices___1___0___1___updateshape__3___u8732534266313544978.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int16_3__scatterindices___1___0___1___updateshape__3___u8732534266313544978.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int32_1__scatterindices___0___0___updateshape__2___updat-7343798520741133620.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int32_1__scatterindices___0___0___updateshape__2___updat-7343798520741133620.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int32_1__scatterindices___0___0___updateshape__2___updat8346955452553751621.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int32_1__scatterindices___0___0___updateshape__2___updat8346955452553751621.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int32_2_3__scatterindices____2___2___2____updateshape__21575384273124453539.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int32_2_3__scatterindices____2___2___2____updateshape__21575384273124453539.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int32_2_3__scatterindices____2___2___2____updateshape__29049572619063429077.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int32_2_3__scatterindices____2___2___2____updateshape__29049572619063429077.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int32_3_5_40__scatterindices___1___1___updateshape__3_5_-4492180260379123575.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int32_3_5_40__scatterindices___1___1___updateshape__3_5_-4492180260379123575.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int32_3_5_40__scatterindices___1___1___updateshape__3_5_-6804281654964710260.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int32_3_5_40__scatterindices___1___1___updateshape__3_5_-6804281654964710260.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int32_3_5_4__scatterindices___1___1___updateshape__3_2_4-8085552538497462086.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int32_3_5_4__scatterindices___1___1___updateshape__3_2_4-8085552538497462086.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int32_3_5_4__scatterindices___1___1___updateshape__3_2_48915394162869716664.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int32_3_5_4__scatterindices___1___1___updateshape__3_2_48915394162869716664.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int32_3__scatterindices___1___0___1___updateshape__3___u-4091295550652669529.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int32_3__scatterindices___1___0___1___updateshape__3___u-4091295550652669529.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int32_3__scatterindices___1___0___1___updateshape__3___u549801763074919359.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int32_3__scatterindices___1___0___1___updateshape__3___u549801763074919359.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int8_1__scatterindices___0___0___updateshape__2___update-1360754318140092109.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int8_1__scatterindices___0___0___updateshape__2___update-1360754318140092109.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int8_1__scatterindices___0___0___updateshape__2___update-6651041623792386111.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int8_1__scatterindices___0___0___updateshape__2___update-6651041623792386111.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int8_2_3__scatterindices____2___2___2____updateshape__2_-2225969877503185882.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int8_2_3__scatterindices____2___2___2____updateshape__2_-2225969877503185882.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int8_2_3__scatterindices____2___2___2____updateshape__2_-3742461097496387086.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int8_2_3__scatterindices____2___2___2____updateshape__2_-3742461097496387086.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int8_3_5_40__scatterindices___1___1___updateshape__3_5_2-7764254308842032551.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int8_3_5_40__scatterindices___1___1___updateshape__3_5_2-7764254308842032551.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int8_3_5_40__scatterindices___1___1___updateshape__3_5_23450775816481210993.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int8_3_5_40__scatterindices___1___1___updateshape__3_5_23450775816481210993.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int8_3_5_4__scatterindices___1___1___updateshape__3_2_4_-6591631366574437153.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int8_3_5_4__scatterindices___1___1___updateshape__3_2_4_-6591631366574437153.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int8_3_5_4__scatterindices___1___1___updateshape__3_2_4_-8706909794187844482.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int8_3_5_4__scatterindices___1___1___updateshape__3_2_4_-8706909794187844482.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int8_3__scatterindices___1___0___1___updateshape__3___up-1297660150798520786.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int8_3__scatterindices___1___0___1___updateshape__3___up-1297660150798520786.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int8_3__scatterindices___1___0___1___updateshape__3___up6318457899351731724.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_int8_3__scatterindices___1___0___1___updateshape__3___up6318457899351731724.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint16_1__scatterindices___0___0___updateshape__2___upda5207510223195637833.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint16_1__scatterindices___0___0___updateshape__2___upda5207510223195637833.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint16_1__scatterindices___0___0___updateshape__2___upda6262798125151336282.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint16_1__scatterindices___0___0___updateshape__2___upda6262798125151336282.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint16_2_3__scatterindices____2___2___2____updateshape__-8656143665335338128.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint16_2_3__scatterindices____2___2___2____updateshape__-8656143665335338128.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint16_2_3__scatterindices____2___2___2____updateshape__8667165760414880574.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint16_2_3__scatterindices____2___2___2____updateshape__8667165760414880574.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint16_3_5_40__scatterindices___1___1___updateshape__3_5-4608489474011168533.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint16_3_5_40__scatterindices___1___1___updateshape__3_5-4608489474011168533.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint16_3_5_40__scatterindices___1___1___updateshape__3_54655453964880485515.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint16_3_5_40__scatterindices___1___1___updateshape__3_54655453964880485515.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint16_3_5_4__scatterindices___1___1___updateshape__3_2_-8520820431443740876.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint16_3_5_4__scatterindices___1___1___updateshape__3_2_-8520820431443740876.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint16_3_5_4__scatterindices___1___1___updateshape__3_2_3572500993044654711.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint16_3_5_4__scatterindices___1___1___updateshape__3_2_3572500993044654711.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint16_3__scatterindices___1___0___1___updateshape__3___-7867920288811157954.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint16_3__scatterindices___1___0___1___updateshape__3___-7867920288811157954.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint16_3__scatterindices___1___0___1___updateshape__3___8720268492036459268.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint16_3__scatterindices___1___0___1___updateshape__3___8720268492036459268.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint32_1__scatterindices___0___0___updateshape__2___upda-2091068717007306664.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint32_1__scatterindices___0___0___updateshape__2___upda-2091068717007306664.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint32_1__scatterindices___0___0___updateshape__2___upda8120988465709075289.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint32_1__scatterindices___0___0___updateshape__2___upda8120988465709075289.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint32_2_3__scatterindices____2___2___2____updateshape__-8786096591665500031.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint32_2_3__scatterindices____2___2___2____updateshape__-8786096591665500031.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint32_2_3__scatterindices____2___2___2____updateshape__1436396732987470658.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint32_2_3__scatterindices____2___2___2____updateshape__1436396732987470658.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint32_3_5_40__scatterindices___1___1___updateshape__3_5-138328594848753004.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint32_3_5_40__scatterindices___1___1___updateshape__3_5-138328594848753004.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint32_3_5_40__scatterindices___1___1___updateshape__3_5-823404253934322853.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint32_3_5_40__scatterindices___1___1___updateshape__3_5-823404253934322853.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint32_3_5_4__scatterindices___1___1___updateshape__3_2_-7530330949824434259.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint32_3_5_4__scatterindices___1___1___updateshape__3_2_-7530330949824434259.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint32_3_5_4__scatterindices___1___1___updateshape__3_2_5820078437345868748.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint32_3_5_4__scatterindices___1___1___updateshape__3_2_5820078437345868748.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint32_3__scatterindices___1___0___1___updateshape__3___-129985155865775457.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint32_3__scatterindices___1___0___1___updateshape__3___-129985155865775457.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint32_3__scatterindices___1___0___1___updateshape__3___2343539028412553554.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint32_3__scatterindices___1___0___1___updateshape__3___2343539028412553554.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint8_1__scatterindices___0___0___updateshape__2___updat-1272592393935837253.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint8_1__scatterindices___0___0___updateshape__2___updat-1272592393935837253.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint8_1__scatterindices___0___0___updateshape__2___updat4425389787711593969.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint8_1__scatterindices___0___0___updateshape__2___updat4425389787711593969.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint8_2_3__scatterindices____2___2___2____updateshape__2-3410694954850677544.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint8_2_3__scatterindices____2___2___2____updateshape__2-3410694954850677544.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint8_2_3__scatterindices____2___2___2____updateshape__29203764322210362910.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint8_2_3__scatterindices____2___2___2____updateshape__29203764322210362910.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint8_3_5_40__scatterindices___1___1___updateshape__3_5_-7295488856326444060.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint8_3_5_40__scatterindices___1___1___updateshape__3_5_-7295488856326444060.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint8_3_5_40__scatterindices___1___1___updateshape__3_5_3070699946697361877.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint8_3_5_40__scatterindices___1___1___updateshape__3_5_3070699946697361877.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint8_3_5_4__scatterindices___1___1___updateshape__3_2_4-5549751385104158980.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint8_3_5_4__scatterindices___1___1___updateshape__3_2_4-5549751385104158980.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint8_3_5_4__scatterindices___1___1___updateshape__3_2_4-5718248314471681435.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint8_3_5_4__scatterindices___1___1___updateshape__3_2_4-5718248314471681435.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint8_3__scatterindices___1___0___1___updateshape__3___u-5425130638233748095.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint8_3__scatterindices___1___0___1___updateshape__3___u-5425130638233748095.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint8_3__scatterindices___1___0___1___updateshape__3___u-6732484422315882264.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_non_unique_indices_shape_uint8_3__scatterindices___1___0___1___updateshape__3___u-6732484422315882264.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_125__scatterindices__0__updateshape__1___updatewi-8455060674813840089.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_125__scatterindices__0__updateshape__1___updatewi-8455060674813840089.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_125__scatterindices__0__updateshape__1___updatewi6988113685815211566.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_125__scatterindices__0__updateshape__1___updatewi6988113685815211566.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_1_1__scatterindices__0__updateshape__1_1__updatew6079948891887161857.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_1_1__scatterindices__0__updateshape__1_1__updatew6079948891887161857.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_1_1__scatterindices__0__updateshape__1_1__updatew6549659875295259688.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_1_1__scatterindices__0__updateshape__1_1__updatew6549659875295259688.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_1__scatterindices__0__updateshape__1___updatewind3824046247028131474.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_1__scatterindices__0__updateshape__1___updatewind3824046247028131474.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_1__scatterindices__0__updateshape__1___updatewind7836302535510859558.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_1__scatterindices__0__updateshape__1___updatewind7836302535510859558.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__0__updateshape__2_3__updatew-2507891561465170673.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__0__updateshape__2_3__updatew-2507891561465170673.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__0__updateshape__2_3__updatew-4606238653677723928.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__0__updateshape__2_3__updatew-4606238653677723928.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1_2__updateshape__1___update3838801698297708086.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1_2__updateshape__1___update3838801698297708086.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1_2__updateshape__1___update8582144022432454162.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1_2__updateshape__1___update8582144022432454162.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1__updateshape__1_3__updatew-3499019506028152780.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1__updateshape__1_3__updatew-3499019506028152780.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1__updateshape__1_3__updatew-5731561847796673736.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1__updateshape__1_3__updatew-5731561847796673736.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_50_3__scatterindices__32__updateshape__1_3__updat9063298096984913623.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_50_3__scatterindices__32__updateshape__1_3__updat9063298096984913623.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_50_3__scatterindices__32__updateshape__1_3__updat9081076048855731653.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1_50_3__scatterindices__32__updateshape__1_3__updat9081076048855731653.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1__scatterindices__0__updateshape____updatewindowdi4014730839607642488.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1__scatterindices__0__updateshape____updatewindowdi4014730839607642488.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1__scatterindices__0__updateshape____updatewindowdi6405466108572526127.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_1__scatterindices__0__updateshape____updatewindowdi6405466108572526127.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upd3563814370155075944.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upd3563814370155075944.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upd8749611313497629157.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upd8749611313497629157.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_4_2_3__scatterindices__3_2__updateshape__2___update3767757828594658078.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_4_2_3__scatterindices__3_2__updateshape__2___update3767757828594658078.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_4_2_3__scatterindices__3_2__updateshape__2___update3837990416671658082.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_4_2_3__scatterindices__3_2__updateshape__2___update3837990416671658082.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices___0_1___2_3___updateshape__2_-7532755016762737811.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices___0_1___2_3___updateshape__2_-7532755016762737811.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices___0_1___2_3___updateshape__2_8460571233850253931.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices___0_1___2_3___updateshape__2_8460571233850253931.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2___-3281381171658143616.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2___-3281381171658143616.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2___7895186756503018450.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2___7895186756503018450.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0___1_____2___3____updates-7133135434776847571.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0___1_____2___3____updates-7133135434776847571.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0___1_____2___3____updates1992556058291306227.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0___1_____2___3____updates1992556058291306227.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_125__scatterindices__0__updateshape__1___updatewin-7219620919170275402.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_125__scatterindices__0__updateshape__1___updatewin-7219620919170275402.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_125__scatterindices__0__updateshape__1___updatewin2019808635615422103.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_125__scatterindices__0__updateshape__1___updatewin2019808635615422103.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_1_1__scatterindices__0__updateshape__1_1__updatewi-1154839571289251294.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_1_1__scatterindices__0__updateshape__1_1__updatewi-1154839571289251294.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_1_1__scatterindices__0__updateshape__1_1__updatewi5444842911984533710.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_1_1__scatterindices__0__updateshape__1_1__updatewi5444842911984533710.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_1__scatterindices__0__updateshape__1___updatewindo-2950411685828876999.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_1__scatterindices__0__updateshape__1___updatewindo-2950411685828876999.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_1__scatterindices__0__updateshape__1___updatewindo1094744759700233541.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_1__scatterindices__0__updateshape__1___updatewindo1094744759700233541.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__0__updateshape__2_3__updatewi3333288523443268181.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__0__updateshape__2_3__updatewi3333288523443268181.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__0__updateshape__2_3__updatewi422102818376078865.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__0__updateshape__2_3__updatewi422102818376078865.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1_2__updateshape__1___updatew-6181263443370822618.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1_2__updateshape__1___updatew-6181263443370822618.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1_2__updateshape__1___updatew-6433087509074096220.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1_2__updateshape__1___updatew-6433087509074096220.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1__updateshape__1_3__updatewi-2252964348354275925.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1__updateshape__1_3__updatewi-2252964348354275925.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1__updateshape__1_3__updatewi7411317443831486478.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1__updateshape__1_3__updatewi7411317443831486478.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_50_3__scatterindices__32__updateshape__1_3__update-5100689976626851558.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_50_3__scatterindices__32__updateshape__1_3__update-5100689976626851558.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_50_3__scatterindices__32__updateshape__1_3__update9033995531765975800.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1_50_3__scatterindices__32__updateshape__1_3__update9033995531765975800.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1__scatterindices__0__updateshape____updatewindowdim-7066819620180239285.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1__scatterindices__0__updateshape____updatewindowdim-7066819620180239285.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1__scatterindices__0__updateshape____updatewindowdim-7801774742063109687.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_1__scatterindices__0__updateshape____updatewindowdim-7801774742063109687.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda630720772185460788.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda630720772185460788.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda678556358992363704.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda678556358992363704.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_4_2_3__scatterindices__3_2__updateshape__2___updatew6849606337113289247.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_4_2_3__scatterindices__3_2__updateshape__2___updatew6849606337113289247.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_4_2_3__scatterindices__3_2__updateshape__2___updatew7952926376746779189.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_4_2_3__scatterindices__3_2__updateshape__2___updatew7952926376746779189.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7-1846790892893359733.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7-1846790892893359733.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_5_6_7__scatterindices___0_1___2_3___updateshape__2_77771727832633254392.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_5_6_7__scatterindices___0_1___2_3___updateshape__2_77771727832633254392.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____3311700604022838238.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____3311700604022838238.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____6631360807004031578.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____6631360807004031578.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0___1_____2___3____updatesh-2441375675325881794.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0___1_____2___3____updatesh-2441375675325881794.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0___1_____2___3____updatesh4339301259731857950.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0___1_____2___3____updatesh4339301259731857950.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewin3434837777651772019.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewin3434837777651772019.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewin6626096260784457491.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewin6626096260784457491.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__updatewi4187542989145136011.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__updatewi4187542989145136011.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__updatewi7379173832243563380.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__updatewi7379173832243563380.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___updatewindo-6873417748702292701.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___updatewindo-6873417748702292701.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___updatewindo6832112543129542117.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___updatewindo6832112543129542117.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatewi-1913261295690793592.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatewi-1913261295690793592.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatewi2385003291164847436.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatewi2385003291164847436.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___updatew2151281305958059125.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___updatew2151281305958059125.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___updatew3832905097368469483.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___updatew3832905097368469483.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatewi-3362430168774037732.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatewi-3362430168774037732.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatewi106994944400262570.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatewi106994944400262570.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__update-577545178140062831.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__update-577545178140062831.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__update-6011850232913338927.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__update-6011850232913338927.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdim-3256607664589015350.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdim-3256607664589015350.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdim-7327087540068455882.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdim-7327087540068455882.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda-6616585842710565767.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda-6616585842710565767.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda-7864195232735747393.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda-7864195232735747393.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___updatew-7199475041378945992.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___updatew-7199475041378945992.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___updatew-8839460156077137232.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___updatew-8839460156077137232.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape__2_71141133607715404040.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape__2_71141133607715404040.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape__2_74444378811213684451.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape__2_74444378811213684451.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____-1929229371068995825.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____-1929229371068995825.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____7796631715486587555.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____7796631715486587555.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____updatesh-4864067830661700007.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____updatesh-4864067830661700007.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____updatesh-8078869473627428624.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____updatesh-8078869473627428624.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_125__scatterindices__0__updateshape__1___updatewindo-4048898580210518923.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_125__scatterindices__0__updateshape__1___updatewindo-4048898580210518923.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_125__scatterindices__0__updateshape__1___updatewindo2663632515478957534.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_125__scatterindices__0__updateshape__1___updatewindo2663632515478957534.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_1_1__scatterindices__0__updateshape__1_1__updatewind-4872233943325429746.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_1_1__scatterindices__0__updateshape__1_1__updatewind-4872233943325429746.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_1_1__scatterindices__0__updateshape__1_1__updatewind-5131798970918347525.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_1_1__scatterindices__0__updateshape__1_1__updatewind-5131798970918347525.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_1__scatterindices__0__updateshape__1___updatewindowd-5817743396570967462.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_1__scatterindices__0__updateshape__1___updatewindowd-5817743396570967462.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_1__scatterindices__0__updateshape__1___updatewindowd-9101122120036262009.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_1__scatterindices__0__updateshape__1___updatewindowd-9101122120036262009.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__0__updateshape__2_3__updatewind4956717948692458560.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__0__updateshape__2_3__updatewind4956717948692458560.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__0__updateshape__2_3__updatewind6488415553946838757.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__0__updateshape__2_3__updatewind6488415553946838757.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1_2__updateshape__1___updatewin-2311893409916309480.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1_2__updateshape__1___updatewin-2311893409916309480.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1_2__updateshape__1___updatewin5443007369435740914.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1_2__updateshape__1___updatewin5443007369435740914.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1__updateshape__1_3__updatewind139047943743357621.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1__updateshape__1_3__updatewind139047943743357621.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1__updateshape__1_3__updatewind2569505830733396853.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1__updateshape__1_3__updatewind2569505830733396853.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_50_3__scatterindices__32__updateshape__1_3__updatewi-4522415576264482421.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_50_3__scatterindices__32__updateshape__1_3__updatewi-4522415576264482421.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_50_3__scatterindices__32__updateshape__1_3__updatewi-6751549191563984126.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1_50_3__scatterindices__32__updateshape__1_3__updatewi-6751549191563984126.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1__scatterindices__0__updateshape____updatewindowdims_-4184954724394605776.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1__scatterindices__0__updateshape____updatewindowdims_-4184954724394605776.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1__scatterindices__0__updateshape____updatewindowdims_2909575980966412820.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_1__scatterindices__0__updateshape____updatewindowdims_2909575980966412820.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-6850199035370975979.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-6850199035370975979.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_4_2_3_5__scatterindices__0_4__updateshape__4_3__update2307656599037197652.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_4_2_3_5__scatterindices__0_4__updateshape__4_3__update2307656599037197652.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_4_2_3__scatterindices__3_2__updateshape__2___updatewin3937406258051021731.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_4_2_3__scatterindices__3_2__updateshape__2___updatewin3937406258051021731.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_4_2_3__scatterindices__3_2__updateshape__2___updatewin4671330445293080617.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_4_2_3__scatterindices__3_2__updateshape__2___updatewin4671330445293080617.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-6823698740828894740.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-6823698740828894740.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__8116338334848718103.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__8116338334848718103.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up1897490814391211893.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up1897490814391211893.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up3955050749775670123.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up3955050749775670123.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0___1_____2___3____updateshap-2669360800802260213.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0___1_____2___3____updateshap-2669360800802260213.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0___1_____2___3____updateshap-5300422118746435442.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0___1_____2___3____updateshap-5300422118746435442.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_125__scatterindices__0__updateshape__1___updatewindo-5773493145779110529.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_125__scatterindices__0__updateshape__1___updatewindo-5773493145779110529.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_125__scatterindices__0__updateshape__1___updatewindo-6306854691638577587.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_125__scatterindices__0__updateshape__1___updatewindo-6306854691638577587.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_1_1__scatterindices__0__updateshape__1_1__updatewind4521601090946723752.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_1_1__scatterindices__0__updateshape__1_1__updatewind4521601090946723752.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_1_1__scatterindices__0__updateshape__1_1__updatewind8113619835508400365.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_1_1__scatterindices__0__updateshape__1_1__updatewind8113619835508400365.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_1__scatterindices__0__updateshape__1___updatewindowd-3469160267547152989.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_1__scatterindices__0__updateshape__1___updatewindowd-3469160267547152989.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_1__scatterindices__0__updateshape__1___updatewindowd-4485215942239891048.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_1__scatterindices__0__updateshape__1___updatewindowd-4485215942239891048.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__0__updateshape__2_3__updatewind-4157173160933560839.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__0__updateshape__2_3__updatewind-4157173160933560839.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__0__updateshape__2_3__updatewind-8276893021528647212.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__0__updateshape__2_3__updatewind-8276893021528647212.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1_2__updateshape__1___updatewin-3907920868952273498.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1_2__updateshape__1___updatewin-3907920868952273498.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1_2__updateshape__1___updatewin-5829009328670546117.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1_2__updateshape__1___updatewin-5829009328670546117.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1__updateshape__1_3__updatewind-1880838265011712149.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1__updateshape__1_3__updatewind-1880838265011712149.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1__updateshape__1_3__updatewind-711642015244088147.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1__updateshape__1_3__updatewind-711642015244088147.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_50_3__scatterindices__32__updateshape__1_3__updatewi-1976704082280904433.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_50_3__scatterindices__32__updateshape__1_3__updatewi-1976704082280904433.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_50_3__scatterindices__32__updateshape__1_3__updatewi1744785575307162204.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1_50_3__scatterindices__32__updateshape__1_3__updatewi1744785575307162204.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1__scatterindices__0__updateshape____updatewindowdims_3989505911331951517.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1__scatterindices__0__updateshape____updatewindowdims_3989505911331951517.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1__scatterindices__0__updateshape____updatewindowdims_5832033282227399517.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_1__scatterindices__0__updateshape____updatewindowdims_5832033282227399517.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-300910068295299136.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-300910068295299136.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-4635129519501855715.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-4635129519501855715.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_4_2_3__scatterindices__3_2__updateshape__2___updatewin-4972159876752712758.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_4_2_3__scatterindices__3_2__updateshape__2___updatewin-4972159876752712758.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_4_2_3__scatterindices__3_2__updateshape__2___updatewin-5028247379765118510.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_4_2_3__scatterindices__3_2__updateshape__2___updatewin-5028247379765118510.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__3328729301052536943.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__3328729301052536943.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__4304361855510301002.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__4304361855510301002.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-618963719957585263.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-618963719957585263.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up9163082647035002694.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up9163082647035002694.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0___1_____2___3____updateshap-2358744188387002594.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0___1_____2___3____updateshap-2358744188387002594.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0___1_____2___3____updateshap1996461387154660185.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0___1_____2___3____updateshap1996461387154660185.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_125__scatterindices__0__updateshape__1___updatewindow-2164897151381856441.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_125__scatterindices__0__updateshape__1___updatewindow-2164897151381856441.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_125__scatterindices__0__updateshape__1___updatewindow-2961561519251948998.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_125__scatterindices__0__updateshape__1___updatewindow-2961561519251948998.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_1_1__scatterindices__0__updateshape__1_1__updatewindo-8020988861111988180.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_1_1__scatterindices__0__updateshape__1_1__updatewindo-8020988861111988180.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_1_1__scatterindices__0__updateshape__1_1__updatewindo4881717839749137459.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_1_1__scatterindices__0__updateshape__1_1__updatewindo4881717839749137459.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_1__scatterindices__0__updateshape__1___updatewindowdi-1401586037954451478.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_1__scatterindices__0__updateshape__1___updatewindowdi-1401586037954451478.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_1__scatterindices__0__updateshape__1___updatewindowdi-3299551669044129890.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_1__scatterindices__0__updateshape__1___updatewindowdi-3299551669044129890.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__0__updateshape__2_3__updatewindo-482045768683493515.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__0__updateshape__2_3__updatewindo-482045768683493515.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__0__updateshape__2_3__updatewindo3010445502852181464.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__0__updateshape__2_3__updatewindo3010445502852181464.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1_2__updateshape__1___updatewind1932062239427915429.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1_2__updateshape__1___updatewind1932062239427915429.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1_2__updateshape__1___updatewind6959809007312719819.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1_2__updateshape__1___updatewind6959809007312719819.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1__updateshape__1_3__updatewindo6234545826659136216.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1__updateshape__1_3__updatewindo6234545826659136216.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1__updateshape__1_3__updatewindo6651601235066092967.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1__updateshape__1_3__updatewindo6651601235066092967.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_50_3__scatterindices__32__updateshape__1_3__updatewin-8494262652049039261.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_50_3__scatterindices__32__updateshape__1_3__updatewin-8494262652049039261.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_50_3__scatterindices__32__updateshape__1_3__updatewin-9177737518976100433.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1_50_3__scatterindices__32__updateshape__1_3__updatewin-9177737518976100433.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1__scatterindices__0__updateshape____updatewindowdims__-1308981154281318723.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1__scatterindices__0__updateshape____updatewindowdims__-1308981154281318723.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1__scatterindices__0__updateshape____updatewindowdims__-6584724419750600150.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_1__scatterindices__0__updateshape____updatewindowdims__-6584724419750600150.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatew-8355771186641774244.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatew-8355771186641774244.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatew8744947161230796126.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatew8744947161230796126.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_4_2_3__scatterindices__3_2__updateshape__2___updatewind-3464400292317216201.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_4_2_3__scatterindices__3_2__updateshape__2___updatewind-3464400292317216201.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_4_2_3__scatterindices__3_2__updateshape__2___updatewind8789432491710657866.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_4_2_3__scatterindices__3_2__updateshape__2___updatewind8789432491710657866.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__u-4379412217277116514.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__u-4379412217277116514.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__u-4620022713790399524.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__u-4620022713790399524.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upd-528608027875306388.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upd-528608027875306388.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upd2543776539875068957.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upd2543776539875068957.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0___1_____2___3____updateshape-6662304895221129059.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0___1_____2___3____updateshape-6662304895221129059.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0___1_____2___3____updateshape1379091125016347204.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0___1_____2___3____updateshape1379091125016347204.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_125__scatterindices__0__updateshape__1___updatewind6104678372056570904.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_125__scatterindices__0__updateshape__1___updatewind6104678372056570904.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_125__scatterindices__0__updateshape__1___updatewind8951713881198357282.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_125__scatterindices__0__updateshape__1___updatewind8951713881198357282.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_1_1__scatterindices__0__updateshape__1_1__updatewin-2293786845320776475.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_1_1__scatterindices__0__updateshape__1_1__updatewin-2293786845320776475.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_1_1__scatterindices__0__updateshape__1_1__updatewin-825491026465492200.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_1_1__scatterindices__0__updateshape__1_1__updatewin-825491026465492200.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_1__scatterindices__0__updateshape__1___updatewindow-3748161403226128671.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_1__scatterindices__0__updateshape__1___updatewindow-3748161403226128671.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_1__scatterindices__0__updateshape__1___updatewindow-5452883222867681143.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_1__scatterindices__0__updateshape__1___updatewindow-5452883222867681143.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__0__updateshape__2_3__updatewin-4983694071830808263.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__0__updateshape__2_3__updatewin-4983694071830808263.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__0__updateshape__2_3__updatewin-922800980968193647.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__0__updateshape__2_3__updatewin-922800980968193647.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1_2__updateshape__1___updatewi-7628752331345613625.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1_2__updateshape__1___updatewi-7628752331345613625.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1_2__updateshape__1___updatewi7087372310607227699.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1_2__updateshape__1___updatewi7087372310607227699.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1__updateshape__1_3__updatewin-4238276651709682367.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1__updateshape__1_3__updatewin-4238276651709682367.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1__updateshape__1_3__updatewin2574239198136190332.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1__updateshape__1_3__updatewin2574239198136190332.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_50_3__scatterindices__32__updateshape__1_3__updatew-7448424536125729420.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_50_3__scatterindices__32__updateshape__1_3__updatew-7448424536125729420.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_50_3__scatterindices__32__updateshape__1_3__updatew1534887604859550305.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1_50_3__scatterindices__32__updateshape__1_3__updatew1534887604859550305.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1__scatterindices__0__updateshape____updatewindowdims-7120094586284358384.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1__scatterindices__0__updateshape____updatewindowdims-7120094586284358384.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1__scatterindices__0__updateshape____updatewindowdims-8557503002565537042.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_1__scatterindices__0__updateshape____updatewindowdims-8557503002565537042.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat-2855550188487489879.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat-2855550188487489879.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat-6858799924904399445.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat-6858799924904399445.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_4_2_3__scatterindices__3_2__updateshape__2___updatewi3842920200244835884.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_4_2_3__scatterindices__3_2__updateshape__2___updatewi3842920200244835884.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_4_2_3__scatterindices__3_2__updateshape__2___updatewi531814443214012646.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_4_2_3__scatterindices__3_2__updateshape__2___updatewi531814443214012646.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_-2203453677154150371.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_-2203453677154150371.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_1680898793278744290.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_1680898793278744290.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u-5568333888604383669.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u-5568333888604383669.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u-7686200927978297073.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u-7686200927978297073.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0___1_____2___3____updatesha-8261153333685108720.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0___1_____2___3____updatesha-8261153333685108720.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0___1_____2___3____updatesha8897516788227473093.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0___1_____2___3____updatesha8897516788227473093.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_125__scatterindices__0__updateshape__1___updatewind5324299034178680984.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_125__scatterindices__0__updateshape__1___updatewind5324299034178680984.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_125__scatterindices__0__updateshape__1___updatewind8053525223274197913.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_125__scatterindices__0__updateshape__1___updatewind8053525223274197913.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_1_1__scatterindices__0__updateshape__1_1__updatewin-3919347360338486161.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_1_1__scatterindices__0__updateshape__1_1__updatewin-3919347360338486161.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_1_1__scatterindices__0__updateshape__1_1__updatewin557265926019113997.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_1_1__scatterindices__0__updateshape__1_1__updatewin557265926019113997.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_1__scatterindices__0__updateshape__1___updatewindow-530097313420603595.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_1__scatterindices__0__updateshape__1___updatewindow-530097313420603595.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_1__scatterindices__0__updateshape__1___updatewindow5540511942877021843.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_1__scatterindices__0__updateshape__1___updatewindow5540511942877021843.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__0__updateshape__2_3__updatewin-7921085769571620715.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__0__updateshape__2_3__updatewin-7921085769571620715.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__0__updateshape__2_3__updatewin5516599741785648027.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__0__updateshape__2_3__updatewin5516599741785648027.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1_2__updateshape__1___updatewi-3890715224454106690.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1_2__updateshape__1___updatewi-3890715224454106690.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1_2__updateshape__1___updatewi2451467265301592276.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1_2__updateshape__1___updatewi2451467265301592276.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1__updateshape__1_3__updatewin-6835298325160753158.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1__updateshape__1_3__updatewin-6835298325160753158.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1__updateshape__1_3__updatewin5907199364789461624.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1__updateshape__1_3__updatewin5907199364789461624.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_50_3__scatterindices__32__updateshape__1_3__updatew3599289276786300260.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_50_3__scatterindices__32__updateshape__1_3__updatew3599289276786300260.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_50_3__scatterindices__32__updateshape__1_3__updatew5573174805555653228.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1_50_3__scatterindices__32__updateshape__1_3__updatew5573174805555653228.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1__scatterindices__0__updateshape____updatewindowdims3891969193358125108.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1__scatterindices__0__updateshape____updatewindowdims3891969193358125108.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1__scatterindices__0__updateshape____updatewindowdims6728519843519579187.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_1__scatterindices__0__updateshape____updatewindowdims6728519843519579187.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat1875016188276619820.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat1875016188276619820.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat2832033142102107345.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat2832033142102107345.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_4_2_3__scatterindices__3_2__updateshape__2___updatewi4541439119239315328.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_4_2_3__scatterindices__3_2__updateshape__2___updatewi4541439119239315328.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_4_2_3__scatterindices__3_2__updateshape__2___updatewi6249915064913725474.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_4_2_3__scatterindices__3_2__updateshape__2___updatewi6249915064913725474.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_4998849318336846036.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_4998849318336846036.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_8808245818971476835.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_8808245818971476835.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u-1847282675845561838.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u-1847282675845561838.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u-7307692730245064305.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u-7307692730245064305.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0___1_____2___3____updatesha-8377372164247774274.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0___1_____2___3____updatesha-8377372164247774274.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0___1_____2___3____updatesha101657976520010788.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0___1_____2___3____updatesha101657976520010788.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_125__scatterindices__0__updateshape__1___updatewindo-7267870577026374491.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_125__scatterindices__0__updateshape__1___updatewindo-7267870577026374491.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_125__scatterindices__0__updateshape__1___updatewindo-7831274120441572214.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_125__scatterindices__0__updateshape__1___updatewindo-7831274120441572214.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_1_1__scatterindices__0__updateshape__1_1__updatewind-4364353834884633969.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_1_1__scatterindices__0__updateshape__1_1__updatewind-4364353834884633969.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_1_1__scatterindices__0__updateshape__1_1__updatewind95337174995502651.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_1_1__scatterindices__0__updateshape__1_1__updatewind95337174995502651.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_1__scatterindices__0__updateshape__1___updatewindowd-4401939044538948194.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_1__scatterindices__0__updateshape__1___updatewindowd-4401939044538948194.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_1__scatterindices__0__updateshape__1___updatewindowd7374118277642078703.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_1__scatterindices__0__updateshape__1___updatewindowd7374118277642078703.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__0__updateshape__2_3__updatewind-4320742272598554972.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__0__updateshape__2_3__updatewind-4320742272598554972.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__0__updateshape__2_3__updatewind-5647768797625277636.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__0__updateshape__2_3__updatewind-5647768797625277636.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1_2__updateshape__1___updatewin-2598259718380766207.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1_2__updateshape__1___updatewin-2598259718380766207.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1_2__updateshape__1___updatewin-4507202267474985982.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1_2__updateshape__1___updatewin-4507202267474985982.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1__updateshape__1_3__updatewind-282272057526996412.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1__updateshape__1_3__updatewind-282272057526996412.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1__updateshape__1_3__updatewind5289939932728021031.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1__updateshape__1_3__updatewind5289939932728021031.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_50_3__scatterindices__32__updateshape__1_3__updatewi-1911855998223034084.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_50_3__scatterindices__32__updateshape__1_3__updatewi-1911855998223034084.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_50_3__scatterindices__32__updateshape__1_3__updatewi-8788238066019617104.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1_50_3__scatterindices__32__updateshape__1_3__updatewi-8788238066019617104.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1__scatterindices__0__updateshape____updatewindowdims_1435654138527556962.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1__scatterindices__0__updateshape____updatewindowdims_1435654138527556962.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1__scatterindices__0__updateshape____updatewindowdims_4791307863228181924.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_1__scatterindices__0__updateshape____updatewindowdims_4791307863228181924.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-3631479775757131866.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-3631479775757131866.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_4_2_3_5__scatterindices__0_4__updateshape__4_3__update8304920547383840732.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_4_2_3_5__scatterindices__0_4__updateshape__4_3__update8304920547383840732.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_4_2_3__scatterindices__3_2__updateshape__2___updatewin-4726102016836464664.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_4_2_3__scatterindices__3_2__updateshape__2___updatewin-4726102016836464664.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_4_2_3__scatterindices__3_2__updateshape__2___updatewin6504664932451562272.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_4_2_3__scatterindices__3_2__updateshape__2___updatewin6504664932451562272.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-1521424101927027807.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-1521424101927027807.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-7210161950186348637.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-7210161950186348637.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-1488261666750715563.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-1488261666750715563.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-347543453836881210.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-347543453836881210.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0___1_____2___3____updateshap-5935271915580022048.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0___1_____2___3____updateshap-5935271915580022048.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0___1_____2___3____updateshap8601300616414390880.mlir
+++ b/stablehlo/testdata/scatter_min_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0___1_____2___3____updateshap8601300616414390880.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_shapes_and_dimension_numbers_shape_float32_10_5__scatterindices___0___2___1___updateshap2046588017570464208.mlir
+++ b/stablehlo/testdata/scatter_min_shapes_and_dimension_numbers_shape_float32_10_5__scatterindices___0___2___1___updateshap2046588017570464208.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_min_shapes_and_dimension_numbers_shape_float32_10__scatterindices___0___0___0___updateshape_7540184139313307643.mlir
+++ b/stablehlo/testdata/scatter_min_shapes_and_dimension_numbers_shape_float32_10__scatterindices___0___0___0___updateshape_7540184139313307643.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowdims_-8447536616241837701.mlir
+++ b/stablehlo/testdata/scatter_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowdims_-8447536616241837701.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowdims_-9193453681395924655.mlir
+++ b/stablehlo/testdata/scatter_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowdims_-9193453681395924655.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatewindowdims-8163468306341242010.mlir
+++ b/stablehlo/testdata/scatter_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatewindowdims-8163468306341242010.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatewindowdims1979005098091914037.mlir
+++ b/stablehlo/testdata/scatter_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatewindowdims1979005098091914037.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_dtypes_shape_bfloat16_5__scatterindices___0___2___updateshape__2___updatewindowdims____i-8818140716242942777.mlir
+++ b/stablehlo/testdata/scatter_mul_dtypes_shape_bfloat16_5__scatterindices___0___2___updateshape__2___updatewindowdims____i-8818140716242942777.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_dtypes_shape_complex64_5__scatterindices___0___2___updateshape__2___updatewindowdims____2849053335900351376.mlir
+++ b/stablehlo/testdata/scatter_mul_dtypes_shape_complex64_5__scatterindices___0___2___updateshape__2___updatewindowdims____2849053335900351376.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_dtypes_shape_float16_5__scatterindices___0___2___updateshape__2___updatewindowdims____in6295346331202233422.mlir
+++ b/stablehlo/testdata/scatter_mul_dtypes_shape_float16_5__scatterindices___0___2___updateshape__2___updatewindowdims____in6295346331202233422.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_dtypes_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowdims____in3461545776928786403.mlir
+++ b/stablehlo/testdata/scatter_mul_dtypes_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowdims____in3461545776928786403.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_dtypes_shape_int16_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse-946010944284495501.mlir
+++ b/stablehlo/testdata/scatter_mul_dtypes_shape_int16_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse-946010944284495501.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_dtypes_shape_int32_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse7107969741003160690.mlir
+++ b/stablehlo/testdata/scatter_mul_dtypes_shape_int32_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse7107969741003160690.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_dtypes_shape_int8_5__scatterindices___0___2___updateshape__2___updatewindowdims____inser5257149825007736758.mlir
+++ b/stablehlo/testdata/scatter_mul_dtypes_shape_int8_5__scatterindices___0___2___updateshape__2___updatewindowdims____inser5257149825007736758.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_dtypes_shape_uint16_5__scatterindices___0___2___updateshape__2___updatewindowdims____ins-6272450472772319521.mlir
+++ b/stablehlo/testdata/scatter_mul_dtypes_shape_uint16_5__scatterindices___0___2___updateshape__2___updatewindowdims____ins-6272450472772319521.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_dtypes_shape_uint32_5__scatterindices___0___2___updateshape__2___updatewindowdims____ins2853409422886604297.mlir
+++ b/stablehlo/testdata/scatter_mul_dtypes_shape_uint32_5__scatterindices___0___2___updateshape__2___updatewindowdims____ins2853409422886604297.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_dtypes_shape_uint8_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse-6082089585072626272.mlir
+++ b/stablehlo/testdata/scatter_mul_dtypes_shape_uint8_5__scatterindices___0___2___updateshape__2___updatewindowdims____inse-6082089585072626272.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowd-5874148103768417641.mlir
+++ b/stablehlo/testdata/scatter_mul_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowd-5874148103768417641.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowd6195566175507190160.mlir
+++ b/stablehlo/testdata/scatter_mul_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowd6195566175507190160.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatewindow-3409624153632020317.mlir
+++ b/stablehlo/testdata/scatter_mul_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatewindow-3409624153632020317.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatewindow-8783135513137066974.mlir
+++ b/stablehlo/testdata/scatter_mul_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatewindow-8783135513137066974.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_bfloat16_1__scatterindices___0___0___updateshape__2___up-5884834123805549505.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_bfloat16_1__scatterindices___0___0___updateshape__2___up-5884834123805549505.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_bfloat16_1__scatterindices___0___0___updateshape__2___up8705143908452656300.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_bfloat16_1__scatterindices___0___0___updateshape__2___up8705143908452656300.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_bfloat16_2_3__scatterindices____2___2___2____updateshape-7803826843619021591.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_bfloat16_2_3__scatterindices____2___2___2____updateshape-7803826843619021591.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_bfloat16_2_3__scatterindices____2___2___2____updateshape6701127154102155436.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_bfloat16_2_3__scatterindices____2___2___2____updateshape6701127154102155436.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_bfloat16_3_5_40__scatterindices___1___1___updateshape__35129282179707517658.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_bfloat16_3_5_40__scatterindices___1___1___updateshape__35129282179707517658.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_bfloat16_3_5_40__scatterindices___1___1___updateshape__35867807482160217870.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_bfloat16_3_5_40__scatterindices___1___1___updateshape__35867807482160217870.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_bfloat16_3_5_4__scatterindices___1___1___updateshape__3_-6622735777596271264.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_bfloat16_3_5_4__scatterindices___1___1___updateshape__3_-6622735777596271264.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_bfloat16_3_5_4__scatterindices___1___1___updateshape__3_4553474462917028659.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_bfloat16_3_5_4__scatterindices___1___1___updateshape__3_4553474462917028659.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_bfloat16_3__scatterindices___1___0___1___updateshape__3_-145760181962938805.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_bfloat16_3__scatterindices___1___0___1___updateshape__3_-145760181962938805.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_bfloat16_3__scatterindices___1___0___1___updateshape__3_-8371739205776775064.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_bfloat16_3__scatterindices___1___0___1___updateshape__3_-8371739205776775064.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float16_1__scatterindices___0___0___updateshape__2___upd322742675240437040.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float16_1__scatterindices___0___0___updateshape__2___upd322742675240437040.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float16_1__scatterindices___0___0___updateshape__2___upd733684278547254401.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float16_1__scatterindices___0___0___updateshape__2___upd733684278547254401.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float16_2_3__scatterindices____2___2___2____updateshape_-6140700220738729259.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float16_2_3__scatterindices____2___2___2____updateshape_-6140700220738729259.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float16_2_3__scatterindices____2___2___2____updateshape_-8345408382580861067.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float16_2_3__scatterindices____2___2___2____updateshape_-8345408382580861067.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float16_3_5_40__scatterindices___1___1___updateshape__3_-7757659907667194445.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float16_3_5_40__scatterindices___1___1___updateshape__3_-7757659907667194445.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float16_3_5_40__scatterindices___1___1___updateshape__3_197919947003228826.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float16_3_5_40__scatterindices___1___1___updateshape__3_197919947003228826.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float16_3_5_4__scatterindices___1___1___updateshape__3_2-7947552070747803171.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float16_3_5_4__scatterindices___1___1___updateshape__3_2-7947552070747803171.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float16_3_5_4__scatterindices___1___1___updateshape__3_25570052255445993142.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float16_3_5_4__scatterindices___1___1___updateshape__3_25570052255445993142.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float16_3__scatterindices___1___0___1___updateshape__3__-3382522699924592203.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float16_3__scatterindices___1___0___1___updateshape__3__-3382522699924592203.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float16_3__scatterindices___1___0___1___updateshape__3__-4211286303940773681.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float16_3__scatterindices___1___0___1___updateshape__3__-4211286303940773681.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float32_1__scatterindices___0___0___updateshape__2___upd-4240085725628378496.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float32_1__scatterindices___0___0___updateshape__2___upd-4240085725628378496.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float32_1__scatterindices___0___0___updateshape__2___upd8296829068770047821.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float32_1__scatterindices___0___0___updateshape__2___upd8296829068770047821.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float32_2_3__scatterindices____2___2___2____updateshape_-1153956390855415424.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float32_2_3__scatterindices____2___2___2____updateshape_-1153956390855415424.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float32_2_3__scatterindices____2___2___2____updateshape_-5918800170200989140.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float32_2_3__scatterindices____2___2___2____updateshape_-5918800170200989140.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float32_3_5_40__scatterindices___1___1___updateshape__3_-7580188922100577254.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float32_3_5_40__scatterindices___1___1___updateshape__3_-7580188922100577254.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float32_3_5_40__scatterindices___1___1___updateshape__3_5775500666699308696.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float32_3_5_40__scatterindices___1___1___updateshape__3_5775500666699308696.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float32_3_5_4__scatterindices___1___1___updateshape__3_2-7239115346209951984.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float32_3_5_4__scatterindices___1___1___updateshape__3_2-7239115346209951984.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float32_3_5_4__scatterindices___1___1___updateshape__3_2-7654327717305556714.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float32_3_5_4__scatterindices___1___1___updateshape__3_2-7654327717305556714.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float32_3__scatterindices___1___0___1___updateshape__3__-2072492453741906856.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float32_3__scatterindices___1___0___1___updateshape__3__-2072492453741906856.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float32_3__scatterindices___1___0___1___updateshape__3__-689434329673296.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_float32_3__scatterindices___1___0___1___updateshape__3__-689434329673296.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int16_1__scatterindices___0___0___updateshape__2___updat-3529340748184752289.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int16_1__scatterindices___0___0___updateshape__2___updat-3529340748184752289.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int16_1__scatterindices___0___0___updateshape__2___updat561594413493909078.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int16_1__scatterindices___0___0___updateshape__2___updat561594413493909078.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int16_2_3__scatterindices____2___2___2____updateshape__2-2688753720662318550.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int16_2_3__scatterindices____2___2___2____updateshape__2-2688753720662318550.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int16_2_3__scatterindices____2___2___2____updateshape__2-377529509809056652.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int16_2_3__scatterindices____2___2___2____updateshape__2-377529509809056652.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int16_3_5_40__scatterindices___1___1___updateshape__3_5_-7710644996687728757.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int16_3_5_40__scatterindices___1___1___updateshape__3_5_-7710644996687728757.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int16_3_5_40__scatterindices___1___1___updateshape__3_5_2970487491126707417.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int16_3_5_40__scatterindices___1___1___updateshape__3_5_2970487491126707417.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int16_3_5_4__scatterindices___1___1___updateshape__3_2_4-6292020326763356426.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int16_3_5_4__scatterindices___1___1___updateshape__3_2_4-6292020326763356426.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int16_3_5_4__scatterindices___1___1___updateshape__3_2_46232449216193599633.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int16_3_5_4__scatterindices___1___1___updateshape__3_2_46232449216193599633.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int16_3__scatterindices___1___0___1___updateshape__3___u-5457944352225901292.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int16_3__scatterindices___1___0___1___updateshape__3___u-5457944352225901292.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int16_3__scatterindices___1___0___1___updateshape__3___u-6947452231428007930.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int16_3__scatterindices___1___0___1___updateshape__3___u-6947452231428007930.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int32_1__scatterindices___0___0___updateshape__2___updat-7831187107835337863.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int32_1__scatterindices___0___0___updateshape__2___updat-7831187107835337863.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int32_1__scatterindices___0___0___updateshape__2___updat3013699399251572191.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int32_1__scatterindices___0___0___updateshape__2___updat3013699399251572191.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int32_2_3__scatterindices____2___2___2____updateshape__2-2568914706362044844.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int32_2_3__scatterindices____2___2___2____updateshape__2-2568914706362044844.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int32_2_3__scatterindices____2___2___2____updateshape__21379637257835652405.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int32_2_3__scatterindices____2___2___2____updateshape__21379637257835652405.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int32_3_5_40__scatterindices___1___1___updateshape__3_5_-6397860387266378208.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int32_3_5_40__scatterindices___1___1___updateshape__3_5_-6397860387266378208.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int32_3_5_40__scatterindices___1___1___updateshape__3_5_-8425013369710626776.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int32_3_5_40__scatterindices___1___1___updateshape__3_5_-8425013369710626776.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int32_3_5_4__scatterindices___1___1___updateshape__3_2_4-1354491335324461437.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int32_3_5_4__scatterindices___1___1___updateshape__3_2_4-1354491335324461437.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int32_3_5_4__scatterindices___1___1___updateshape__3_2_44517803174587004329.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int32_3_5_4__scatterindices___1___1___updateshape__3_2_44517803174587004329.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int32_3__scatterindices___1___0___1___updateshape__3___u-8298357739460833153.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int32_3__scatterindices___1___0___1___updateshape__3___u-8298357739460833153.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int32_3__scatterindices___1___0___1___updateshape__3___u2992424440995594389.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int32_3__scatterindices___1___0___1___updateshape__3___u2992424440995594389.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int8_1__scatterindices___0___0___updateshape__2___update-6155816636504228609.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int8_1__scatterindices___0___0___updateshape__2___update-6155816636504228609.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int8_1__scatterindices___0___0___updateshape__2___update5958272776881116115.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int8_1__scatterindices___0___0___updateshape__2___update5958272776881116115.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int8_2_3__scatterindices____2___2___2____updateshape__2_-273914920177501008.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int8_2_3__scatterindices____2___2___2____updateshape__2_-273914920177501008.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int8_2_3__scatterindices____2___2___2____updateshape__2_-6476029564649474413.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int8_2_3__scatterindices____2___2___2____updateshape__2_-6476029564649474413.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int8_3_5_40__scatterindices___1___1___updateshape__3_5_2-1853547627817211597.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int8_3_5_40__scatterindices___1___1___updateshape__3_5_2-1853547627817211597.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int8_3_5_40__scatterindices___1___1___updateshape__3_5_22695725104585857772.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int8_3_5_40__scatterindices___1___1___updateshape__3_5_22695725104585857772.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int8_3_5_4__scatterindices___1___1___updateshape__3_2_4_-2838624526001024835.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int8_3_5_4__scatterindices___1___1___updateshape__3_2_4_-2838624526001024835.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int8_3_5_4__scatterindices___1___1___updateshape__3_2_4_7685550097225305461.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int8_3_5_4__scatterindices___1___1___updateshape__3_2_4_7685550097225305461.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int8_3__scatterindices___1___0___1___updateshape__3___up-1361580417478478018.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int8_3__scatterindices___1___0___1___updateshape__3___up-1361580417478478018.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int8_3__scatterindices___1___0___1___updateshape__3___up-6118132633872574782.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_int8_3__scatterindices___1___0___1___updateshape__3___up-6118132633872574782.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint16_1__scatterindices___0___0___updateshape__2___upda2503261450963630172.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint16_1__scatterindices___0___0___updateshape__2___upda2503261450963630172.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint16_1__scatterindices___0___0___updateshape__2___upda5093204510233506868.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint16_1__scatterindices___0___0___updateshape__2___upda5093204510233506868.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint16_2_3__scatterindices____2___2___2____updateshape__-1750143131007774592.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint16_2_3__scatterindices____2___2___2____updateshape__-1750143131007774592.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint16_2_3__scatterindices____2___2___2____updateshape__-5500787063730751651.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint16_2_3__scatterindices____2___2___2____updateshape__-5500787063730751651.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint16_3_5_40__scatterindices___1___1___updateshape__3_5-5919758369527735070.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint16_3_5_40__scatterindices___1___1___updateshape__3_5-5919758369527735070.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint16_3_5_40__scatterindices___1___1___updateshape__3_57458529555874971234.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint16_3_5_40__scatterindices___1___1___updateshape__3_57458529555874971234.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint16_3_5_4__scatterindices___1___1___updateshape__3_2_-636077671172413854.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint16_3_5_4__scatterindices___1___1___updateshape__3_2_-636077671172413854.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint16_3_5_4__scatterindices___1___1___updateshape__3_2_8211125442785068895.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint16_3_5_4__scatterindices___1___1___updateshape__3_2_8211125442785068895.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint16_3__scatterindices___1___0___1___updateshape__3___-2867485987227787074.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint16_3__scatterindices___1___0___1___updateshape__3___-2867485987227787074.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint16_3__scatterindices___1___0___1___updateshape__3___381164792639576333.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint16_3__scatterindices___1___0___1___updateshape__3___381164792639576333.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint32_1__scatterindices___0___0___updateshape__2___upda-2795949964342122630.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint32_1__scatterindices___0___0___updateshape__2___upda-2795949964342122630.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint32_1__scatterindices___0___0___updateshape__2___upda2250736341764409016.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint32_1__scatterindices___0___0___updateshape__2___upda2250736341764409016.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint32_2_3__scatterindices____2___2___2____updateshape__-1690059249365063935.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint32_2_3__scatterindices____2___2___2____updateshape__-1690059249365063935.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint32_2_3__scatterindices____2___2___2____updateshape__-7198034765269814555.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint32_2_3__scatterindices____2___2___2____updateshape__-7198034765269814555.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint32_3_5_40__scatterindices___1___1___updateshape__3_5-5318382943476393861.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint32_3_5_40__scatterindices___1___1___updateshape__3_5-5318382943476393861.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint32_3_5_40__scatterindices___1___1___updateshape__3_57035426037223572327.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint32_3_5_40__scatterindices___1___1___updateshape__3_57035426037223572327.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint32_3_5_4__scatterindices___1___1___updateshape__3_2_-4101621119111344638.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint32_3_5_4__scatterindices___1___1___updateshape__3_2_-4101621119111344638.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint32_3_5_4__scatterindices___1___1___updateshape__3_2_-6343906009227681817.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint32_3_5_4__scatterindices___1___1___updateshape__3_2_-6343906009227681817.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint32_3__scatterindices___1___0___1___updateshape__3___-3922149894643362258.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint32_3__scatterindices___1___0___1___updateshape__3___-3922149894643362258.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint32_3__scatterindices___1___0___1___updateshape__3___-6180249292673263141.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint32_3__scatterindices___1___0___1___updateshape__3___-6180249292673263141.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint8_1__scatterindices___0___0___updateshape__2___updat4024776412691488168.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint8_1__scatterindices___0___0___updateshape__2___updat4024776412691488168.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint8_1__scatterindices___0___0___updateshape__2___updat5272633470443816471.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint8_1__scatterindices___0___0___updateshape__2___updat5272633470443816471.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint8_2_3__scatterindices____2___2___2____updateshape__24766134113834505929.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint8_2_3__scatterindices____2___2___2____updateshape__24766134113834505929.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint8_2_3__scatterindices____2___2___2____updateshape__25513192764788487323.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint8_2_3__scatterindices____2___2___2____updateshape__25513192764788487323.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint8_3_5_40__scatterindices___1___1___updateshape__3_5_-8174486124717837339.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint8_3_5_40__scatterindices___1___1___updateshape__3_5_-8174486124717837339.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint8_3_5_40__scatterindices___1___1___updateshape__3_5_1143847998952290388.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint8_3_5_40__scatterindices___1___1___updateshape__3_5_1143847998952290388.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint8_3_5_4__scatterindices___1___1___updateshape__3_2_41873808453015829452.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint8_3_5_4__scatterindices___1___1___updateshape__3_2_41873808453015829452.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint8_3_5_4__scatterindices___1___1___updateshape__3_2_4746412150290416873.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint8_3_5_4__scatterindices___1___1___updateshape__3_2_4746412150290416873.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint8_3__scatterindices___1___0___1___updateshape__3___u-5426271295044320436.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint8_3__scatterindices___1___0___1___updateshape__3___u-5426271295044320436.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint8_3__scatterindices___1___0___1___updateshape__3___u-6108961382462025285.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_non_unique_indices_shape_uint8_3__scatterindices___1___0___1___updateshape__3___u-6108961382462025285.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_125__scatterindices__0__updateshape__1___updatewi-3360477254955707104.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_125__scatterindices__0__updateshape__1___updatewi-3360477254955707104.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_125__scatterindices__0__updateshape__1___updatewi-7946346305990918934.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_125__scatterindices__0__updateshape__1___updatewi-7946346305990918934.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_1_1__scatterindices__0__updateshape__1_1__updatew-4215525067889211598.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_1_1__scatterindices__0__updateshape__1_1__updatew-4215525067889211598.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_1_1__scatterindices__0__updateshape__1_1__updatew6431305253276105236.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_1_1__scatterindices__0__updateshape__1_1__updatew6431305253276105236.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_1__scatterindices__0__updateshape__1___updatewind-2780272603278834227.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_1__scatterindices__0__updateshape__1___updatewind-2780272603278834227.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_1__scatterindices__0__updateshape__1___updatewind4104176976515763082.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_1__scatterindices__0__updateshape__1___updatewind4104176976515763082.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__0__updateshape__2_3__updatew2559860308944517111.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__0__updateshape__2_3__updatew2559860308944517111.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__0__updateshape__2_3__updatew8742465151666686826.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__0__updateshape__2_3__updatew8742465151666686826.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1_2__updateshape__1___update-1881389378983648424.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1_2__updateshape__1___update-1881389378983648424.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1_2__updateshape__1___update-6387272614647063159.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1_2__updateshape__1___update-6387272614647063159.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1__updateshape__1_3__updatew-335502595080908761.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1__updateshape__1_3__updatew-335502595080908761.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1__updateshape__1_3__updatew5647609707928580429.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1__updateshape__1_3__updatew5647609707928580429.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_50_3__scatterindices__32__updateshape__1_3__updat-5889877709785329052.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_50_3__scatterindices__32__updateshape__1_3__updat-5889877709785329052.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_50_3__scatterindices__32__updateshape__1_3__updat3688725826103030188.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1_50_3__scatterindices__32__updateshape__1_3__updat3688725826103030188.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1__scatterindices__0__updateshape____updatewindowdi8099031119810233793.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1__scatterindices__0__updateshape____updatewindowdi8099031119810233793.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1__scatterindices__0__updateshape____updatewindowdi8325755295697371291.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_1__scatterindices__0__updateshape____updatewindowdi8325755295697371291.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upd3417738498369290757.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upd3417738498369290757.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upd9109906871151307668.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upd9109906871151307668.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_4_2_3__scatterindices__3_2__updateshape__2___update-4702680586383969660.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_4_2_3__scatterindices__3_2__updateshape__2___update-4702680586383969660.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_4_2_3__scatterindices__3_2__updateshape__2___update-8795005146239087129.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_4_2_3__scatterindices__3_2__updateshape__2___update-8795005146239087129.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices___0_1___2_3___updateshape__2_-6656881674249389345.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices___0_1___2_3___updateshape__2_-6656881674249389345.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices___0_1___2_3___updateshape__2_2316509734154499027.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices___0_1___2_3___updateshape__2_2316509734154499027.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2___-7981361882450982124.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2___-7981361882450982124.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2___1647529870284745307.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2___1647529870284745307.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0___1_____2___3____updates1467080413083166032.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0___1_____2___3____updates1467080413083166032.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0___1_____2___3____updates3651937655910732508.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0___1_____2___3____updates3651937655910732508.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_125__scatterindices__0__updateshape__1___updatewin-1705989900307999079.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_125__scatterindices__0__updateshape__1___updatewin-1705989900307999079.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_125__scatterindices__0__updateshape__1___updatewin-246492594110861908.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_125__scatterindices__0__updateshape__1___updatewin-246492594110861908.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_1_1__scatterindices__0__updateshape__1_1__updatewi-4346732979607199533.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_1_1__scatterindices__0__updateshape__1_1__updatewi-4346732979607199533.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_1_1__scatterindices__0__updateshape__1_1__updatewi-5946980796241614660.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_1_1__scatterindices__0__updateshape__1_1__updatewi-5946980796241614660.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_1__scatterindices__0__updateshape__1___updatewindo-306016717615730660.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_1__scatterindices__0__updateshape__1___updatewindo-306016717615730660.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_1__scatterindices__0__updateshape__1___updatewindo3890941391873863717.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_1__scatterindices__0__updateshape__1___updatewindo3890941391873863717.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__0__updateshape__2_3__updatewi1839078693190890993.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__0__updateshape__2_3__updatewi1839078693190890993.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__0__updateshape__2_3__updatewi5761561957537694476.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__0__updateshape__2_3__updatewi5761561957537694476.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1_2__updateshape__1___updatew6252979626325873169.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1_2__updateshape__1___updatew6252979626325873169.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1_2__updateshape__1___updatew7494928465242488531.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1_2__updateshape__1___updatew7494928465242488531.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1__updateshape__1_3__updatewi-3584544566206542049.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1__updateshape__1_3__updatewi-3584544566206542049.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1__updateshape__1_3__updatewi-7572000476884458861.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1__updateshape__1_3__updatewi-7572000476884458861.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_50_3__scatterindices__32__updateshape__1_3__update-598301403947229232.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_50_3__scatterindices__32__updateshape__1_3__update-598301403947229232.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_50_3__scatterindices__32__updateshape__1_3__update8652299584681040983.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1_50_3__scatterindices__32__updateshape__1_3__update8652299584681040983.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1__scatterindices__0__updateshape____updatewindowdim-7668310686109821516.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1__scatterindices__0__updateshape____updatewindowdim-7668310686109821516.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1__scatterindices__0__updateshape____updatewindowdim439772284860314777.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_1__scatterindices__0__updateshape____updatewindowdim439772284860314777.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda-8229569663899407117.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda-8229569663899407117.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda1985329647950112572.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda1985329647950112572.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_4_2_3__scatterindices__3_2__updateshape__2___updatew-8523218113249752123.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_4_2_3__scatterindices__3_2__updateshape__2___updatew-8523218113249752123.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_4_2_3__scatterindices__3_2__updateshape__2___updatew6735558503942351692.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_4_2_3__scatterindices__3_2__updateshape__2___updatew6735558503942351692.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7-4258334668196109132.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7-4258334668196109132.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_5_6_7__scatterindices___0_1___2_3___updateshape__2_76621240554816602630.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_5_6_7__scatterindices___0_1___2_3___updateshape__2_76621240554816602630.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____-2362187331049583053.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____-2362187331049583053.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____-5820826746249069089.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____-5820826746249069089.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0___1_____2___3____updatesh-8865046078508563898.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0___1_____2___3____updatesh-8865046078508563898.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0___1_____2___3____updatesh3362558007660062089.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0___1_____2___3____updatesh3362558007660062089.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewin-6464005931074999144.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewin-6464005931074999144.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewin1632551694578966009.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewin1632551694578966009.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__updatewi-4057511293439628981.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__updatewi-4057511293439628981.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__updatewi465178004043834746.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__updatewi465178004043834746.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___updatewindo3601856020145074869.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___updatewindo3601856020145074869.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___updatewindo4848867162453427424.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___updatewindo4848867162453427424.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatewi5803760535453716447.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatewi5803760535453716447.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatewi676591662531539119.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatewi676591662531539119.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___updatew-6954106673892958067.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___updatew-6954106673892958067.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___updatew6445319413769660340.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___updatew6445319413769660340.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatewi7109546237705646979.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatewi7109546237705646979.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatewi8953743155862854282.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatewi8953743155862854282.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__update2709164478077877077.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__update2709164478077877077.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__update6879970989976731825.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__update6879970989976731825.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdim-2705209602339395263.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdim-2705209602339395263.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdim-4975626822862635303.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdim-4975626822862635303.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda-8979056223101967933.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda-8979056223101967933.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda7605760556573737631.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3__upda7605760556573737631.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___updatew-7612717851277605180.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___updatew-7612717851277605180.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___updatew3278581319799892390.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___updatew3278581319799892390.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7-2031264665322592657.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7-2031264665322592657.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape__2_76375060216127585701.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape__2_76375060216127585701.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____-5359808417426891675.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____-5359808417426891675.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____2501261658899671469.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____2501261658899671469.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____updatesh4730208024092888126.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____updatesh4730208024092888126.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____updatesh979978458744744089.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____updatesh979978458744744089.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_125__scatterindices__0__updateshape__1___updatewindo-894643363405551362.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_125__scatterindices__0__updateshape__1___updatewindo-894643363405551362.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_125__scatterindices__0__updateshape__1___updatewindo2210039802490704290.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_125__scatterindices__0__updateshape__1___updatewindo2210039802490704290.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_1_1__scatterindices__0__updateshape__1_1__updatewind4564339569477160634.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_1_1__scatterindices__0__updateshape__1_1__updatewind4564339569477160634.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_1_1__scatterindices__0__updateshape__1_1__updatewind7066681658393563090.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_1_1__scatterindices__0__updateshape__1_1__updatewind7066681658393563090.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_1__scatterindices__0__updateshape__1___updatewindowd1131523970815717172.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_1__scatterindices__0__updateshape__1___updatewindowd1131523970815717172.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_1__scatterindices__0__updateshape__1___updatewindowd7341461832802061798.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_1__scatterindices__0__updateshape__1___updatewindowd7341461832802061798.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__0__updateshape__2_3__updatewind5115612453657169070.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__0__updateshape__2_3__updatewind5115612453657169070.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__0__updateshape__2_3__updatewind8686182913507257521.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__0__updateshape__2_3__updatewind8686182913507257521.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1_2__updateshape__1___updatewin3357486422049699870.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1_2__updateshape__1___updatewin3357486422049699870.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1_2__updateshape__1___updatewin5579100838365427816.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1_2__updateshape__1___updatewin5579100838365427816.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1__updateshape__1_3__updatewind-5330481510598916239.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1__updateshape__1_3__updatewind-5330481510598916239.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1__updateshape__1_3__updatewind6212760972741628489.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1__updateshape__1_3__updatewind6212760972741628489.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_50_3__scatterindices__32__updateshape__1_3__updatewi-4661087241743951708.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_50_3__scatterindices__32__updateshape__1_3__updatewi-4661087241743951708.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_50_3__scatterindices__32__updateshape__1_3__updatewi2227239171340197214.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1_50_3__scatterindices__32__updateshape__1_3__updatewi2227239171340197214.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1__scatterindices__0__updateshape____updatewindowdims_-3022424246807224585.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1__scatterindices__0__updateshape____updatewindowdims_-3022424246807224585.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1__scatterindices__0__updateshape____updatewindowdims_6495970254371841842.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_1__scatterindices__0__updateshape____updatewindowdims_6495970254371841842.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-4024893389875354515.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-4024893389875354515.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-5668681648500657011.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-5668681648500657011.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_4_2_3__scatterindices__3_2__updateshape__2___updatewin-9105649694610227047.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_4_2_3__scatterindices__3_2__updateshape__2___updatewin-9105649694610227047.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_4_2_3__scatterindices__3_2__updateshape__2___updatewin6073515528611323777.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_4_2_3__scatterindices__3_2__updateshape__2___updatewin6073515528611323777.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-3882476055472377626.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-3882476055472377626.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-513754655167866318.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-513754655167866318.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-8966013931511561723.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up-8966013931511561723.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up391128158965102141.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up391128158965102141.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0___1_____2___3____updateshap-9078196501509989682.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0___1_____2___3____updateshap-9078196501509989682.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0___1_____2___3____updateshap5700558581733748335.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0___1_____2___3____updateshap5700558581733748335.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_125__scatterindices__0__updateshape__1___updatewindo-6562225039484538740.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_125__scatterindices__0__updateshape__1___updatewindo-6562225039484538740.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_125__scatterindices__0__updateshape__1___updatewindo8232220520292271211.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_125__scatterindices__0__updateshape__1___updatewindo8232220520292271211.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_1_1__scatterindices__0__updateshape__1_1__updatewind-7916337849519059432.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_1_1__scatterindices__0__updateshape__1_1__updatewind-7916337849519059432.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_1_1__scatterindices__0__updateshape__1_1__updatewind761967631948328949.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_1_1__scatterindices__0__updateshape__1_1__updatewind761967631948328949.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_1__scatterindices__0__updateshape__1___updatewindowd-5359430482089778863.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_1__scatterindices__0__updateshape__1___updatewindowd-5359430482089778863.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_1__scatterindices__0__updateshape__1___updatewindowd5240083812117045369.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_1__scatterindices__0__updateshape__1___updatewindowd5240083812117045369.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__0__updateshape__2_3__updatewind-3880842726960184803.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__0__updateshape__2_3__updatewind-3880842726960184803.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__0__updateshape__2_3__updatewind-849743020913739099.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__0__updateshape__2_3__updatewind-849743020913739099.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1_2__updateshape__1___updatewin-1988034303685772822.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1_2__updateshape__1___updatewin-1988034303685772822.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1_2__updateshape__1___updatewin217957902070723668.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1_2__updateshape__1___updatewin217957902070723668.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1__updateshape__1_3__updatewind-1045259206755100465.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1__updateshape__1_3__updatewind-1045259206755100465.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1__updateshape__1_3__updatewind-2163171530325055090.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1__updateshape__1_3__updatewind-2163171530325055090.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_50_3__scatterindices__32__updateshape__1_3__updatewi-6750428638558261011.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_50_3__scatterindices__32__updateshape__1_3__updatewi-6750428638558261011.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_50_3__scatterindices__32__updateshape__1_3__updatewi3312930273958637148.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1_50_3__scatterindices__32__updateshape__1_3__updatewi3312930273958637148.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1__scatterindices__0__updateshape____updatewindowdims_-2160631094585953130.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1__scatterindices__0__updateshape____updatewindowdims_-2160631094585953130.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1__scatterindices__0__updateshape____updatewindowdims_5211705405518386156.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_1__scatterindices__0__updateshape____updatewindowdims_5211705405518386156.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-8648264117507005007.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-8648264117507005007.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_4_2_3_5__scatterindices__0_4__updateshape__4_3__update6159597994996988558.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_4_2_3_5__scatterindices__0_4__updateshape__4_3__update6159597994996988558.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_4_2_3__scatterindices__3_2__updateshape__2___updatewin3292662860220954186.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_4_2_3__scatterindices__3_2__updateshape__2___updatewin3292662860220954186.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_4_2_3__scatterindices__3_2__updateshape__2___updatewin8363876055077466091.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_4_2_3__scatterindices__3_2__updateshape__2___updatewin8363876055077466091.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__1300960516346061501.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__1300960516346061501.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__8366371928875377100.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__8366371928875377100.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up1636569897511669512.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up1636569897511669512.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up3340198020277021599.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up3340198020277021599.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0___1_____2___3____updateshap-8225746493159059601.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0___1_____2___3____updateshap-8225746493159059601.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0___1_____2___3____updateshap4011951321233696206.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0___1_____2___3____updateshap4011951321233696206.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_125__scatterindices__0__updateshape__1___updatewindow-111981570719861577.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_125__scatterindices__0__updateshape__1___updatewindow-111981570719861577.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_125__scatterindices__0__updateshape__1___updatewindow3372628312255323136.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_125__scatterindices__0__updateshape__1___updatewindow3372628312255323136.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_1_1__scatterindices__0__updateshape__1_1__updatewindo3534973217554270585.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_1_1__scatterindices__0__updateshape__1_1__updatewindo3534973217554270585.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_1_1__scatterindices__0__updateshape__1_1__updatewindo4155173732612390224.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_1_1__scatterindices__0__updateshape__1_1__updatewindo4155173732612390224.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_1__scatterindices__0__updateshape__1___updatewindowdi2887914144604862218.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_1__scatterindices__0__updateshape__1___updatewindowdi2887914144604862218.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_1__scatterindices__0__updateshape__1___updatewindowdi4469707123732510219.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_1__scatterindices__0__updateshape__1___updatewindowdi4469707123732510219.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__0__updateshape__2_3__updatewindo-1464735832931959797.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__0__updateshape__2_3__updatewindo-1464735832931959797.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__0__updateshape__2_3__updatewindo991080895202624293.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__0__updateshape__2_3__updatewindo991080895202624293.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1_2__updateshape__1___updatewind-5869849077510288141.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1_2__updateshape__1___updatewind-5869849077510288141.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1_2__updateshape__1___updatewind4714892237262590743.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1_2__updateshape__1___updatewind4714892237262590743.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1__updateshape__1_3__updatewindo-2821247655828279221.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1__updateshape__1_3__updatewindo-2821247655828279221.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1__updateshape__1_3__updatewindo5883765822750344543.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1__updateshape__1_3__updatewindo5883765822750344543.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_50_3__scatterindices__32__updateshape__1_3__updatewin3890704783693838053.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_50_3__scatterindices__32__updateshape__1_3__updatewin3890704783693838053.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_50_3__scatterindices__32__updateshape__1_3__updatewin5926764019743641747.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1_50_3__scatterindices__32__updateshape__1_3__updatewin5926764019743641747.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1__scatterindices__0__updateshape____updatewindowdims__1254005676560697655.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1__scatterindices__0__updateshape____updatewindowdims__1254005676560697655.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1__scatterindices__0__updateshape____updatewindowdims__2042027638374529727.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_1__scatterindices__0__updateshape____updatewindowdims__2042027638374529727.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatew-3294582951459358199.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatew-3294582951459358199.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatew8954133149842640533.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatew8954133149842640533.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_4_2_3__scatterindices__3_2__updateshape__2___updatewind-2950263105139370261.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_4_2_3__scatterindices__3_2__updateshape__2___updatewind-2950263105139370261.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_4_2_3__scatterindices__3_2__updateshape__2___updatewind-4707753359265092675.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_4_2_3__scatterindices__3_2__updateshape__2___updatewind-4707753359265092675.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__u-5932100710693672352.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__u-5932100710693672352.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__u533406235125782564.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__u533406235125782564.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upd-345864373339151471.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upd-345864373339151471.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upd1553916274230136318.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upd1553916274230136318.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0___1_____2___3____updateshape4285133721288375655.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0___1_____2___3____updateshape4285133721288375655.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0___1_____2___3____updateshape4507876843873845780.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0___1_____2___3____updateshape4507876843873845780.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_125__scatterindices__0__updateshape__1___updatewind-1667807402137901181.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_125__scatterindices__0__updateshape__1___updatewind-1667807402137901181.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_125__scatterindices__0__updateshape__1___updatewind821217668492272078.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_125__scatterindices__0__updateshape__1___updatewind821217668492272078.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_1_1__scatterindices__0__updateshape__1_1__updatewin3418850834955662541.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_1_1__scatterindices__0__updateshape__1_1__updatewin3418850834955662541.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_1_1__scatterindices__0__updateshape__1_1__updatewin4201243891161652134.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_1_1__scatterindices__0__updateshape__1_1__updatewin4201243891161652134.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_1__scatterindices__0__updateshape__1___updatewindow3680904523812281099.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_1__scatterindices__0__updateshape__1___updatewindow3680904523812281099.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_1__scatterindices__0__updateshape__1___updatewindow4781847233955898769.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_1__scatterindices__0__updateshape__1___updatewindow4781847233955898769.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__0__updateshape__2_3__updatewin-322681613942851425.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__0__updateshape__2_3__updatewin-322681613942851425.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__0__updateshape__2_3__updatewin2126778553061836798.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__0__updateshape__2_3__updatewin2126778553061836798.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1_2__updateshape__1___updatewi-6766913623160416458.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1_2__updateshape__1___updatewi-6766913623160416458.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1_2__updateshape__1___updatewi1162864048077847697.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1_2__updateshape__1___updatewi1162864048077847697.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1__updateshape__1_3__updatewin-113788717369935348.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1__updateshape__1_3__updatewin-113788717369935348.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1__updateshape__1_3__updatewin8975737341944237165.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1__updateshape__1_3__updatewin8975737341944237165.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_50_3__scatterindices__32__updateshape__1_3__updatew-8407979194831241665.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_50_3__scatterindices__32__updateshape__1_3__updatew-8407979194831241665.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_50_3__scatterindices__32__updateshape__1_3__updatew1896497151505034933.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1_50_3__scatterindices__32__updateshape__1_3__updatew1896497151505034933.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1__scatterindices__0__updateshape____updatewindowdims-6732567000122109466.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1__scatterindices__0__updateshape____updatewindowdims-6732567000122109466.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1__scatterindices__0__updateshape____updatewindowdims8369315150788296177.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_1__scatterindices__0__updateshape____updatewindowdims8369315150788296177.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat1872239608779336173.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat1872239608779336173.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat7331007253302672627.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat7331007253302672627.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_4_2_3__scatterindices__3_2__updateshape__2___updatewi-6289641638059328425.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_4_2_3__scatterindices__3_2__updateshape__2___updatewi-6289641638059328425.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_4_2_3__scatterindices__3_2__updateshape__2___updatewi6894674836177418052.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_4_2_3__scatterindices__3_2__updateshape__2___updatewi6894674836177418052.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_-4801225886434282536.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_-4801225886434282536.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_3972516982325290392.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_3972516982325290392.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u-377631690596425522.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u-377631690596425522.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u6860646687466945699.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u6860646687466945699.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0___1_____2___3____updatesha-4251669814050383889.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0___1_____2___3____updatesha-4251669814050383889.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0___1_____2___3____updatesha-8858309163784542992.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0___1_____2___3____updatesha-8858309163784542992.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_125__scatterindices__0__updateshape__1___updatewind-1704453188135452065.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_125__scatterindices__0__updateshape__1___updatewind-1704453188135452065.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_125__scatterindices__0__updateshape__1___updatewind3660954273200353020.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_125__scatterindices__0__updateshape__1___updatewind3660954273200353020.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_1_1__scatterindices__0__updateshape__1_1__updatewin-4234295038244077699.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_1_1__scatterindices__0__updateshape__1_1__updatewin-4234295038244077699.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_1_1__scatterindices__0__updateshape__1_1__updatewin7679086674395570535.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_1_1__scatterindices__0__updateshape__1_1__updatewin7679086674395570535.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_1__scatterindices__0__updateshape__1___updatewindow-110325613177501848.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_1__scatterindices__0__updateshape__1___updatewindow-110325613177501848.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_1__scatterindices__0__updateshape__1___updatewindow8551599803177390565.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_1__scatterindices__0__updateshape__1___updatewindow8551599803177390565.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__0__updateshape__2_3__updatewin-1859429760712290799.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__0__updateshape__2_3__updatewin-1859429760712290799.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__0__updateshape__2_3__updatewin3387081657127263646.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__0__updateshape__2_3__updatewin3387081657127263646.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1_2__updateshape__1___updatewi-2449112500337245365.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1_2__updateshape__1___updatewi-2449112500337245365.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1_2__updateshape__1___updatewi4744761297352104237.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1_2__updateshape__1___updatewi4744761297352104237.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1__updateshape__1_3__updatewin1307550907639424494.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1__updateshape__1_3__updatewin1307550907639424494.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1__updateshape__1_3__updatewin6567349431661793525.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1__updateshape__1_3__updatewin6567349431661793525.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_50_3__scatterindices__32__updateshape__1_3__updatew-8119964461084363759.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_50_3__scatterindices__32__updateshape__1_3__updatew-8119964461084363759.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_50_3__scatterindices__32__updateshape__1_3__updatew3673094684779122943.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1_50_3__scatterindices__32__updateshape__1_3__updatew3673094684779122943.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1__scatterindices__0__updateshape____updatewindowdims1969687651635792397.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1__scatterindices__0__updateshape____updatewindowdims1969687651635792397.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1__scatterindices__0__updateshape____updatewindowdims2696056147646221299.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_1__scatterindices__0__updateshape____updatewindowdims2696056147646221299.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat-542804495611746280.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat-542804495611746280.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat9217932344131399686.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updat9217932344131399686.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_4_2_3__scatterindices__3_2__updateshape__2___updatewi-5713978486446818932.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_4_2_3__scatterindices__3_2__updateshape__2___updatewi-5713978486446818932.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_4_2_3__scatterindices__3_2__updateshape__2___updatewi5259753196347630593.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_4_2_3__scatterindices__3_2__updateshape__2___updatewi5259753196347630593.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_-7053757109840106619.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_-7053757109840106619.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_4871342495677478541.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7_4871342495677478541.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u2457362189692860874.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u2457362189692860874.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u6188014052084615117.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____u6188014052084615117.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0___1_____2___3____updatesha4248940963503671441.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0___1_____2___3____updatesha4248940963503671441.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0___1_____2___3____updatesha6868272512651083334.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0___1_____2___3____updatesha6868272512651083334.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_125__scatterindices__0__updateshape__1___updatewindo-1910154477968116386.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_125__scatterindices__0__updateshape__1___updatewindo-1910154477968116386.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_125__scatterindices__0__updateshape__1___updatewindo8260422791672786393.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_125__scatterindices__0__updateshape__1___updatewindo8260422791672786393.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_1_1__scatterindices__0__updateshape__1_1__updatewind-5161385092992564727.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_1_1__scatterindices__0__updateshape__1_1__updatewind-5161385092992564727.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_1_1__scatterindices__0__updateshape__1_1__updatewind7864482691090263849.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_1_1__scatterindices__0__updateshape__1_1__updatewind7864482691090263849.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_1__scatterindices__0__updateshape__1___updatewindowd-3673649132944055118.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_1__scatterindices__0__updateshape__1___updatewindowd-3673649132944055118.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_1__scatterindices__0__updateshape__1___updatewindowd7995333100578489040.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_1__scatterindices__0__updateshape__1___updatewindowd7995333100578489040.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__0__updateshape__2_3__updatewind-3849831729354064929.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__0__updateshape__2_3__updatewind-3849831729354064929.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__0__updateshape__2_3__updatewind-3919994019662167690.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__0__updateshape__2_3__updatewind-3919994019662167690.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1_2__updateshape__1___updatewin-8230579987754338924.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1_2__updateshape__1___updatewin-8230579987754338924.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1_2__updateshape__1___updatewin6410318316600411775.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1_2__updateshape__1___updatewin6410318316600411775.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1__updateshape__1_3__updatewind-18644883834479203.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1__updateshape__1_3__updatewind-18644883834479203.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1__updateshape__1_3__updatewind1471471209202151261.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1__updateshape__1_3__updatewind1471471209202151261.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_50_3__scatterindices__32__updateshape__1_3__updatewi-3494775986942929214.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_50_3__scatterindices__32__updateshape__1_3__updatewi-3494775986942929214.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_50_3__scatterindices__32__updateshape__1_3__updatewi4960596588736335712.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1_50_3__scatterindices__32__updateshape__1_3__updatewi4960596588736335712.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1__scatterindices__0__updateshape____updatewindowdims_7030611960189158297.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1__scatterindices__0__updateshape____updatewindowdims_7030611960189158297.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1__scatterindices__0__updateshape____updatewindowdims_987589972778068218.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_1__scatterindices__0__updateshape____updatewindowdims_987589972778068218.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-6688911708365296131.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_4_2_3_5__scatterindices__0_4__updateshape__4_3__update-6688911708365296131.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_4_2_3_5__scatterindices__0_4__updateshape__4_3__update8221209685807053597.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_4_2_3_5__scatterindices__0_4__updateshape__4_3__update8221209685807053597.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_4_2_3__scatterindices__3_2__updateshape__2___updatewin-1390584555678624339.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_4_2_3__scatterindices__3_2__updateshape__2___updatewin-1390584555678624339.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_4_2_3__scatterindices__3_2__updateshape__2___updatewin-4833110851173867022.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_4_2_3__scatterindices__3_2__updateshape__2___updatewin-4833110851173867022.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-3139063086521215457.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-3139063086521215457.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-4201352065835320077.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__-4201352065835320077.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up1751444907009857893.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up1751444907009857893.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up7676739352108892783.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____up7676739352108892783.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0___1_____2___3____updateshap-2761376882161010530.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0___1_____2___3____updateshap-2761376882161010530.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0___1_____2___3____updateshap-3709788139329733973.mlir
+++ b/stablehlo/testdata/scatter_mul_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0___1_____2___3____updateshap-3709788139329733973.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_125__scatterindices__0__updateshape__1___updatewindow1533954122127809733.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_125__scatterindices__0__updateshape__1___updatewindow1533954122127809733.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_125__scatterindices__0__updateshape__1___updatewindow2212334345328524560.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_125__scatterindices__0__updateshape__1___updatewindow2212334345328524560.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_1_1__scatterindices__0__updateshape__1_1__updatewindo-5515472226926612209.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_1_1__scatterindices__0__updateshape__1_1__updatewindo-5515472226926612209.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_1_1__scatterindices__0__updateshape__1_1__updatewindo-5746832321951146741.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_1_1__scatterindices__0__updateshape__1_1__updatewindo-5746832321951146741.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_1__scatterindices__0__updateshape__1___updatewindowdi-4275631455928422701.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_1__scatterindices__0__updateshape__1___updatewindowdi-4275631455928422701.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_1__scatterindices__0__updateshape__1___updatewindowdi880223842074782525.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_1__scatterindices__0__updateshape__1___updatewindowdi880223842074782525.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__0__updateshape__2_3__updatewindo-6921631478747710153.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__0__updateshape__2_3__updatewindo-6921631478747710153.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__0__updateshape__2_3__updatewindo7169358858965434835.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__0__updateshape__2_3__updatewindo7169358858965434835.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1_2__updateshape__1___updatewind-8327222120113615417.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1_2__updateshape__1___updatewind-8327222120113615417.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1_2__updateshape__1___updatewind3214235195966616342.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1_2__updateshape__1___updatewind3214235195966616342.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1__updateshape__1_3__updatewindo-748528918597234818.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1__updateshape__1_3__updatewindo-748528918597234818.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1__updateshape__1_3__updatewindo4827717327284223529.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_2_3__scatterindices__1__updateshape__1_3__updatewindo4827717327284223529.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_50_3__scatterindices__32__updateshape__1_3__updatewin-811004303319833014.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_50_3__scatterindices__32__updateshape__1_3__updatewin-811004303319833014.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_50_3__scatterindices__32__updateshape__1_3__updatewin-8968797547817646506.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1_50_3__scatterindices__32__updateshape__1_3__updatewin-8968797547817646506.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1__scatterindices__0__updateshape____updatewindowdims__803457496356836485.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1__scatterindices__0__updateshape____updatewindowdims__803457496356836485.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1__scatterindices__0__updateshape____updatewindowdims__8767377410188178831.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_1__scatterindices__0__updateshape____updatewindowdims__8767377410188178831.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatew2557353525546824738.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatew2557353525546824738.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatew4970676801450038327.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatew4970676801450038327.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_4_2_3__scatterindices__3_2__updateshape__2___updatewind-4730266098010714399.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_4_2_3__scatterindices__3_2__updateshape__2___updatewind-4730266098010714399.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_4_2_3__scatterindices__3_2__updateshape__2___updatewind4163324590869984089.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_4_2_3__scatterindices__3_2__updateshape__2___updatewind4163324590869984089.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__u6903743958365226192.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__u6903743958365226192.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__u851653131651182203.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__u851653131651182203.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upd-4211788900756011514.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upd-4211788900756011514.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upd-567013946010987568.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upd-567013946010987568.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0___1_____2___3____updateshape-2470723896364236739.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0___1_____2___3____updateshape-2470723896364236739.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0___1_____2___3____updateshape-2777750282793909638.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_bfloat16_5_6_7__scatterindices____0___1_____2___3____updateshape-2777750282793909638.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_125__scatterindices__0__updateshape__1___updatewindowd-7931172523670735374.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_125__scatterindices__0__updateshape__1___updatewindowd-7931172523670735374.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_125__scatterindices__0__updateshape__1___updatewindowd-7993092849982844884.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_125__scatterindices__0__updateshape__1___updatewindowd-7993092849982844884.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_1_1__scatterindices__0__updateshape__1_1__updatewindow-5898398544245547889.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_1_1__scatterindices__0__updateshape__1_1__updatewindow-5898398544245547889.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_1_1__scatterindices__0__updateshape__1_1__updatewindow9167193204831340500.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_1_1__scatterindices__0__updateshape__1_1__updatewindow9167193204831340500.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_1__scatterindices__0__updateshape__1___updatewindowdim-6697600837644775619.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_1__scatterindices__0__updateshape__1___updatewindowdim-6697600837644775619.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_1__scatterindices__0__updateshape__1___updatewindowdim-8696271625363789640.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_1__scatterindices__0__updateshape__1___updatewindowdim-8696271625363789640.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__0__updateshape__2_3__updatewindow-4892701647612422962.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__0__updateshape__2_3__updatewindow-4892701647612422962.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__0__updateshape__2_3__updatewindow2596278087494014499.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__0__updateshape__2_3__updatewindow2596278087494014499.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1_2__updateshape__1___updatewindo-8075241794635431733.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1_2__updateshape__1___updatewindo-8075241794635431733.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1_2__updateshape__1___updatewindo1273402148187748210.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1_2__updateshape__1___updatewindo1273402148187748210.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1__updateshape__1_3__updatewindow2449512720322872831.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1__updateshape__1_3__updatewindow2449512720322872831.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1__updateshape__1_3__updatewindow5376840236682189212.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_2_3__scatterindices__1__updateshape__1_3__updatewindow5376840236682189212.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_50_3__scatterindices__32__updateshape__1_3__updatewind-4988232798612003322.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_50_3__scatterindices__32__updateshape__1_3__updatewind-4988232798612003322.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_50_3__scatterindices__32__updateshape__1_3__updatewind-5971616284794195597.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1_50_3__scatterindices__32__updateshape__1_3__updatewind-5971616284794195597.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1__scatterindices__0__updateshape____updatewindowdims___-1581882056067495630.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1__scatterindices__0__updateshape____updatewindowdims___-1581882056067495630.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1__scatterindices__0__updateshape____updatewindowdims___6931141976005902227.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_1__scatterindices__0__updateshape____updatewindowdims___6931141976005902227.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewi-4440686757305113217.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewi-4440686757305113217.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewi6177149507061095935.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewi6177149507061095935.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_4_2_3__scatterindices__3_2__updateshape__2___updatewindo-6702992408726250105.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_4_2_3__scatterindices__3_2__updateshape__2___updatewindo-6702992408726250105.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_4_2_3__scatterindices__3_2__updateshape__2___updatewindo9003353866223854776.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_4_2_3__scatterindices__3_2__updateshape__2___updatewindo9003353866223854776.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__up-3915391758544634424.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__up-3915391758544634424.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__up5091440795627112933.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__up5091440795627112933.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upda-3895422969289538715.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upda-3895422969289538715.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upda-8607484419178884934.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upda-8607484419178884934.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0___1_____2___3____updateshape_-3264758681388995130.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0___1_____2___3____updateshape_-3264758681388995130.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0___1_____2___3____updateshape_-4145200395049429998.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float16_5_6_7__scatterindices____0___1_____2___3____updateshape_-4145200395049429998.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewindowd-5032394219303006330.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewindowd-5032394219303006330.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewindowd-6124250000237564558.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewindowd-6124250000237564558.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__updatewindow-1166308964052795389.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__updatewindow-1166308964052795389.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__updatewindow6146376150855278773.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__updatewindow6146376150855278773.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___updatewindowdim-5224563014099850559.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___updatewindowdim-5224563014099850559.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___updatewindowdim5902876704179291364.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___updatewindowdim5902876704179291364.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatewindow-1359298270164992119.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatewindow-1359298270164992119.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatewindow4638245368204258251.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatewindow4638245368204258251.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___updatewindo-6952903215068308375.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___updatewindo-6952903215068308375.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___updatewindo8098655806184711956.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___updatewindo8098655806184711956.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatewindow-3166175301749478603.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatewindow-3166175301749478603.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatewindow-8091553558886532801.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatewindow-8091553558886532801.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__updatewind-4592039499336222183.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__updatewind-4592039499336222183.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__updatewind551072783988540586.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__updatewind551072783988540586.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdims___-6627904546511788292.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdims___-6627904546511788292.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdims___-7236496705769878027.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdims___-7236496705769878027.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewi-1035527451504575367.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewi-1035527451504575367.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewi8957927086497228610.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewi8957927086497228610.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___updatewindo-6250034927652667738.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___updatewindo-6250034927652667738.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___updatewindo3872250257123715336.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___updatewindo3872250257123715336.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__up-769885505866663214.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__up-769885505866663214.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__up8042376641814452391.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__up8042376641814452391.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upda2948120356280440177.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upda2948120356280440177.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upda5974274183341077107.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____upda5974274183341077107.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____updateshape_-5296991456639355529.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____updateshape_-5296991456639355529.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____updateshape_4632684866950503328.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____updateshape_4632684866950503328.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_125__scatterindices__0__updateshape__1___updatewindowdim-8698108769819920525.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_125__scatterindices__0__updateshape__1___updatewindowdim-8698108769819920525.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_125__scatterindices__0__updateshape__1___updatewindowdim8087846058922533087.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_125__scatterindices__0__updateshape__1___updatewindowdim8087846058922533087.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_1_1__scatterindices__0__updateshape__1_1__updatewindowdi1276220733139075642.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_1_1__scatterindices__0__updateshape__1_1__updatewindowdi1276220733139075642.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_1_1__scatterindices__0__updateshape__1_1__updatewindowdi4078443036999630362.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_1_1__scatterindices__0__updateshape__1_1__updatewindowdi4078443036999630362.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_1__scatterindices__0__updateshape__1___updatewindowdims_-3629977247342632200.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_1__scatterindices__0__updateshape__1___updatewindowdims_-3629977247342632200.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_1__scatterindices__0__updateshape__1___updatewindowdims_-4115071638028730798.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_1__scatterindices__0__updateshape__1___updatewindowdims_-4115071638028730798.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__0__updateshape__2_3__updatewindowdi-3883231357575282014.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__0__updateshape__2_3__updatewindowdi-3883231357575282014.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__0__updateshape__2_3__updatewindowdi1978913595889693225.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__0__updateshape__2_3__updatewindowdi1978913595889693225.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1_2__updateshape__1___updatewindowd-3566369876500629401.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1_2__updateshape__1___updatewindowd-3566369876500629401.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1_2__updateshape__1___updatewindowd4618097380212176823.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1_2__updateshape__1___updatewindowd4618097380212176823.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1__updateshape__1_3__updatewindowdi2436397930943635512.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1__updateshape__1_3__updatewindowdi2436397930943635512.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1__updateshape__1_3__updatewindowdi8827461135262261632.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_2_3__scatterindices__1__updateshape__1_3__updatewindowdi8827461135262261632.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_50_3__scatterindices__32__updateshape__1_3__updatewindow-4109071485922139713.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_50_3__scatterindices__32__updateshape__1_3__updatewindow-4109071485922139713.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_50_3__scatterindices__32__updateshape__1_3__updatewindow960323707474477742.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1_50_3__scatterindices__32__updateshape__1_3__updatewindow960323707474477742.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1__scatterindices__0__updateshape____updatewindowdims____i2590786440408111957.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1__scatterindices__0__updateshape____updatewindowdims____i2590786440408111957.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1__scatterindices__0__updateshape____updatewindowdims____i3309142488687098958.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_1__scatterindices__0__updateshape____updatewindowdims____i3309142488687098958.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewind-2387065130740248241.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewind-2387065130740248241.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewind-6857143018353430914.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewind-6857143018353430914.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_4_2_3__scatterindices__3_2__updateshape__2___updatewindowd-9078145034046701277.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_4_2_3__scatterindices__3_2__updateshape__2___updatewindowd-9078145034046701277.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_4_2_3__scatterindices__3_2__updateshape__2___updatewindowd7657914062383838323.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_4_2_3__scatterindices__3_2__updateshape__2___updatewindowd7657914062383838323.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__upda-5685031293975477435.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__upda-5685031293975477435.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__upda8137745118639757527.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__upda8137745118639757527.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____update-4929832496997222980.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____update-4929832496997222980.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____update-8287342731327426887.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____update-8287342731327426887.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0___1_____2___3____updateshape__5-3903744609433253284.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0___1_____2___3____updateshape__5-3903744609433253284.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0___1_____2___3____updateshape__5-6179391706430955564.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int16_5_6_7__scatterindices____0___1_____2___3____updateshape__5-6179391706430955564.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_125__scatterindices__0__updateshape__1___updatewindowdim-8041961560498277574.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_125__scatterindices__0__updateshape__1___updatewindowdim-8041961560498277574.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_125__scatterindices__0__updateshape__1___updatewindowdim1732450095990130954.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_125__scatterindices__0__updateshape__1___updatewindowdim1732450095990130954.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_1_1__scatterindices__0__updateshape__1_1__updatewindowdi7713226170430967235.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_1_1__scatterindices__0__updateshape__1_1__updatewindowdi7713226170430967235.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_1_1__scatterindices__0__updateshape__1_1__updatewindowdi8543119104200808925.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_1_1__scatterindices__0__updateshape__1_1__updatewindowdi8543119104200808925.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_1__scatterindices__0__updateshape__1___updatewindowdims_3272632314613488541.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_1__scatterindices__0__updateshape__1___updatewindowdims_3272632314613488541.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_1__scatterindices__0__updateshape__1___updatewindowdims_5182742344668572861.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_1__scatterindices__0__updateshape__1___updatewindowdims_5182742344668572861.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__0__updateshape__2_3__updatewindowdi-2517998333183107903.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__0__updateshape__2_3__updatewindowdi-2517998333183107903.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__0__updateshape__2_3__updatewindowdi8478884336016351970.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__0__updateshape__2_3__updatewindowdi8478884336016351970.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1_2__updateshape__1___updatewindowd66591961499526895.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1_2__updateshape__1___updatewindowd66591961499526895.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1_2__updateshape__1___updatewindowd8972423980274079564.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1_2__updateshape__1___updatewindowd8972423980274079564.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1__updateshape__1_3__updatewindowdi-4913757608281705160.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1__updateshape__1_3__updatewindowdi-4913757608281705160.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1__updateshape__1_3__updatewindowdi-6020693450791392005.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_2_3__scatterindices__1__updateshape__1_3__updatewindowdi-6020693450791392005.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_50_3__scatterindices__32__updateshape__1_3__updatewindow-3607337236459034612.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_50_3__scatterindices__32__updateshape__1_3__updatewindow-3607337236459034612.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_50_3__scatterindices__32__updateshape__1_3__updatewindow8217929817648577925.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1_50_3__scatterindices__32__updateshape__1_3__updatewindow8217929817648577925.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1__scatterindices__0__updateshape____updatewindowdims____i-5238184922794335713.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1__scatterindices__0__updateshape____updatewindowdims____i-5238184922794335713.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1__scatterindices__0__updateshape____updatewindowdims____i-8501313456125247071.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_1__scatterindices__0__updateshape____updatewindowdims____i-8501313456125247071.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewind2339814497718031510.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewind2339814497718031510.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewind6454648953224456034.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewind6454648953224456034.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_4_2_3__scatterindices__3_2__updateshape__2___updatewindowd-8777987494929121958.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_4_2_3__scatterindices__3_2__updateshape__2___updatewindowd-8777987494929121958.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_4_2_3__scatterindices__3_2__updateshape__2___updatewindowd757110069171395288.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_4_2_3__scatterindices__3_2__updateshape__2___updatewindowd757110069171395288.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__upda3661825465707905512.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__upda3661825465707905512.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__upda4401317640487384848.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__upda4401317640487384848.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____update-2801117496105208640.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____update-2801117496105208640.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____update3039220554070550341.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____update3039220554070550341.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0___1_____2___3____updateshape__54475812850829447254.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0___1_____2___3____updateshape__54475812850829447254.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0___1_____2___3____updateshape__57345062635922761033.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int32_5_6_7__scatterindices____0___1_____2___3____updateshape__57345062635922761033.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_125__scatterindices__0__updateshape__1___updatewindowdims-128018089031167.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_125__scatterindices__0__updateshape__1___updatewindowdims-128018089031167.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_125__scatterindices__0__updateshape__1___updatewindowdims1150961019743390834.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_125__scatterindices__0__updateshape__1___updatewindowdims1150961019743390834.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_1_1__scatterindices__0__updateshape__1_1__updatewindowdim-3128990905478656943.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_1_1__scatterindices__0__updateshape__1_1__updatewindowdim-3128990905478656943.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_1_1__scatterindices__0__updateshape__1_1__updatewindowdim-5697043038146688684.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_1_1__scatterindices__0__updateshape__1_1__updatewindowdim-5697043038146688684.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_1__scatterindices__0__updateshape__1___updatewindowdims__-1957699880279094704.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_1__scatterindices__0__updateshape__1___updatewindowdims__-1957699880279094704.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_1__scatterindices__0__updateshape__1___updatewindowdims__4463659161859160997.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_1__scatterindices__0__updateshape__1___updatewindowdims__4463659161859160997.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__0__updateshape__2_3__updatewindowdim-7930785710990024243.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__0__updateshape__2_3__updatewindowdim-7930785710990024243.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__0__updateshape__2_3__updatewindowdim-8041675212181463870.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__0__updateshape__2_3__updatewindowdim-8041675212181463870.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1_2__updateshape__1___updatewindowdi-5778987303411786884.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1_2__updateshape__1___updatewindowdi-5778987303411786884.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1_2__updateshape__1___updatewindowdi8444350783812761590.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1_2__updateshape__1___updatewindowdi8444350783812761590.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1__updateshape__1_3__updatewindowdim-3408679425006372114.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1__updateshape__1_3__updatewindowdim-3408679425006372114.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1__updateshape__1_3__updatewindowdim-364356374783506979.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_2_3__scatterindices__1__updateshape__1_3__updatewindowdim-364356374783506979.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_50_3__scatterindices__32__updateshape__1_3__updatewindowd-356627360969227147.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_50_3__scatterindices__32__updateshape__1_3__updatewindowd-356627360969227147.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_50_3__scatterindices__32__updateshape__1_3__updatewindowd-8666680446554792979.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1_50_3__scatterindices__32__updateshape__1_3__updatewindowd-8666680446554792979.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1__scatterindices__0__updateshape____updatewindowdims____in-5906452100205584348.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1__scatterindices__0__updateshape____updatewindowdims____in-5906452100205584348.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1__scatterindices__0__updateshape____updatewindowdims____in1050596572800058400.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_1__scatterindices__0__updateshape____updatewindowdims____in1050596572800058400.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewindo-3571976316732823693.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewindo-3571976316732823693.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewindo-6191603219336322807.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewindo-6191603219336322807.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_4_2_3__scatterindices__3_2__updateshape__2___updatewindowdi-3048175578679534780.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_4_2_3__scatterindices__3_2__updateshape__2___updatewindowdi-3048175578679534780.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_4_2_3__scatterindices__3_2__updateshape__2___updatewindowdi6315664052372191509.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_4_2_3__scatterindices__3_2__updateshape__2___updatewindowdi6315664052372191509.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__updat1387116752558094332.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__updat1387116752558094332.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__updat4589862969700926488.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__updat4589862969700926488.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____updates-5157275558322390602.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____updates-5157275558322390602.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____updates-5895939879477908360.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____updates-5895939879477908360.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0___1_____2___3____updateshape__5_-9119330590615599912.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0___1_____2___3____updateshape__5_-9119330590615599912.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0___1_____2___3____updateshape__5_7518604883535774282.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_int8_5_6_7__scatterindices____0___1_____2___3____updateshape__5_7518604883535774282.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_125__scatterindices__0__updateshape__1___updatewindowdi1709719826830415272.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_125__scatterindices__0__updateshape__1___updatewindowdi1709719826830415272.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_125__scatterindices__0__updateshape__1___updatewindowdi6949094029620369112.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_125__scatterindices__0__updateshape__1___updatewindowdi6949094029620369112.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_1_1__scatterindices__0__updateshape__1_1__updatewindowd-565426276648605539.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_1_1__scatterindices__0__updateshape__1_1__updatewindowd-565426276648605539.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_1_1__scatterindices__0__updateshape__1_1__updatewindowd4334829496169821059.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_1_1__scatterindices__0__updateshape__1_1__updatewindowd4334829496169821059.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_1__scatterindices__0__updateshape__1___updatewindowdims-1853568041871720165.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_1__scatterindices__0__updateshape__1___updatewindowdims-1853568041871720165.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_1__scatterindices__0__updateshape__1___updatewindowdims-2800941818176172076.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_1__scatterindices__0__updateshape__1___updatewindowdims-2800941818176172076.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__0__updateshape__2_3__updatewindowd-1896253718340167045.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__0__updateshape__2_3__updatewindowd-1896253718340167045.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__0__updateshape__2_3__updatewindowd6150403469595319224.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__0__updateshape__2_3__updatewindowd6150403469595319224.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1_2__updateshape__1___updatewindow-1202610202676547172.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1_2__updateshape__1___updatewindow-1202610202676547172.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1_2__updateshape__1___updatewindow8092064714204763665.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1_2__updateshape__1___updatewindow8092064714204763665.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1__updateshape__1_3__updatewindowd-1196552373318079471.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1__updateshape__1_3__updatewindowd-1196552373318079471.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1__updateshape__1_3__updatewindowd-6481532818920122396.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_2_3__scatterindices__1__updateshape__1_3__updatewindowd-6481532818920122396.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_50_3__scatterindices__32__updateshape__1_3__updatewindo-1828674518234095434.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_50_3__scatterindices__32__updateshape__1_3__updatewindo-1828674518234095434.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_50_3__scatterindices__32__updateshape__1_3__updatewindo-7943737821179902950.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1_50_3__scatterindices__32__updateshape__1_3__updatewindo-7943737821179902950.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1__scatterindices__0__updateshape____updatewindowdims____-6957864214876146366.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1__scatterindices__0__updateshape____updatewindowdims____-6957864214876146366.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1__scatterindices__0__updateshape____updatewindowdims____8521511291519361452.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_1__scatterindices__0__updateshape____updatewindowdims____8521511291519361452.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewin-7577335397410040091.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewin-7577335397410040091.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewin420305544559759402.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewin420305544559759402.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_4_2_3__scatterindices__3_2__updateshape__2___updatewindow-4211987635293399389.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_4_2_3__scatterindices__3_2__updateshape__2___updatewindow-4211987635293399389.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_4_2_3__scatterindices__3_2__updateshape__2___updatewindow8431377997243514204.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_4_2_3__scatterindices__3_2__updateshape__2___updatewindow8431377997243514204.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__upd-1763064319475721773.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__upd-1763064319475721773.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__upd7192867830617648292.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__upd7192867830617648292.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____updat-2972694197857005228.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____updat-2972694197857005228.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____updat5898339477728515111.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____updat5898339477728515111.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0___1_____2___3____updateshape__2602811564001695677.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0___1_____2___3____updateshape__2602811564001695677.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0___1_____2___3____updateshape__500166362744140911.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint16_5_6_7__scatterindices____0___1_____2___3____updateshape__500166362744140911.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_125__scatterindices__0__updateshape__1___updatewindowdi-1688302901246251983.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_125__scatterindices__0__updateshape__1___updatewindowdi-1688302901246251983.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_125__scatterindices__0__updateshape__1___updatewindowdi-7403433579795086737.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_125__scatterindices__0__updateshape__1___updatewindowdi-7403433579795086737.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_1_1__scatterindices__0__updateshape__1_1__updatewindowd124765762738191335.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_1_1__scatterindices__0__updateshape__1_1__updatewindowd124765762738191335.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_1_1__scatterindices__0__updateshape__1_1__updatewindowd781473145886613309.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_1_1__scatterindices__0__updateshape__1_1__updatewindowd781473145886613309.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_1__scatterindices__0__updateshape__1___updatewindowdims-8211810013263470528.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_1__scatterindices__0__updateshape__1___updatewindowdims-8211810013263470528.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_1__scatterindices__0__updateshape__1___updatewindowdims7129685623957404554.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_1__scatterindices__0__updateshape__1___updatewindowdims7129685623957404554.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__0__updateshape__2_3__updatewindowd5320211669957695973.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__0__updateshape__2_3__updatewindowd5320211669957695973.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__0__updateshape__2_3__updatewindowd5461774889517582963.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__0__updateshape__2_3__updatewindowd5461774889517582963.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1_2__updateshape__1___updatewindow-163652940973155099.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1_2__updateshape__1___updatewindow-163652940973155099.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1_2__updateshape__1___updatewindow8184019343288996738.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1_2__updateshape__1___updatewindow8184019343288996738.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1__updateshape__1_3__updatewindowd2672684945363288763.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1__updateshape__1_3__updatewindowd2672684945363288763.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1__updateshape__1_3__updatewindowd5354314623131050500.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_2_3__scatterindices__1__updateshape__1_3__updatewindowd5354314623131050500.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_50_3__scatterindices__32__updateshape__1_3__updatewindo1868587186902615224.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_50_3__scatterindices__32__updateshape__1_3__updatewindo1868587186902615224.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_50_3__scatterindices__32__updateshape__1_3__updatewindo6837170408141216480.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1_50_3__scatterindices__32__updateshape__1_3__updatewindo6837170408141216480.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1__scatterindices__0__updateshape____updatewindowdims____-3546209324335573385.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1__scatterindices__0__updateshape____updatewindowdims____-3546209324335573385.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1__scatterindices__0__updateshape____updatewindowdims____-3671700194875203478.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_1__scatterindices__0__updateshape____updatewindowdims____-3671700194875203478.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewin-2522674721507997761.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewin-2522674721507997761.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewin-2758232658412626325.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewin-2758232658412626325.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_4_2_3__scatterindices__3_2__updateshape__2___updatewindow-1940630927273973679.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_4_2_3__scatterindices__3_2__updateshape__2___updatewindow-1940630927273973679.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_4_2_3__scatterindices__3_2__updateshape__2___updatewindow-6965913679939402575.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_4_2_3__scatterindices__3_2__updateshape__2___updatewindow-6965913679939402575.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__upd-8712709380021038962.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__upd-8712709380021038962.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__upd4449301830185425735.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__upd4449301830185425735.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____updat-4293316453503330429.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____updat-4293316453503330429.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____updat7893343186085503986.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____updat7893343186085503986.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0___1_____2___3____updateshape__4842477100420295985.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0___1_____2___3____updateshape__4842477100420295985.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0___1_____2___3____updateshape__8225012549892341281.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint32_5_6_7__scatterindices____0___1_____2___3____updateshape__8225012549892341281.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_125__scatterindices__0__updateshape__1___updatewindowdim4897701391840007208.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_125__scatterindices__0__updateshape__1___updatewindowdim4897701391840007208.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_125__scatterindices__0__updateshape__1___updatewindowdim6232235312107433645.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_125__scatterindices__0__updateshape__1___updatewindowdim6232235312107433645.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_1_1__scatterindices__0__updateshape__1_1__updatewindowdi-36899100055995107.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_1_1__scatterindices__0__updateshape__1_1__updatewindowdi-36899100055995107.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_1_1__scatterindices__0__updateshape__1_1__updatewindowdi1177948157318465368.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_1_1__scatterindices__0__updateshape__1_1__updatewindowdi1177948157318465368.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_1__scatterindices__0__updateshape__1___updatewindowdims_-5834322957039009125.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_1__scatterindices__0__updateshape__1___updatewindowdims_-5834322957039009125.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_1__scatterindices__0__updateshape__1___updatewindowdims_8219644983733290724.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_1__scatterindices__0__updateshape__1___updatewindowdims_8219644983733290724.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__0__updateshape__2_3__updatewindowdi-5861384246211432114.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__0__updateshape__2_3__updatewindowdi-5861384246211432114.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__0__updateshape__2_3__updatewindowdi1584703602367340481.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__0__updateshape__2_3__updatewindowdi1584703602367340481.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1_2__updateshape__1___updatewindowd-1546876755771932966.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1_2__updateshape__1___updatewindowd-1546876755771932966.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1_2__updateshape__1___updatewindowd-4537251676254979075.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1_2__updateshape__1___updatewindowd-4537251676254979075.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1__updateshape__1_3__updatewindowdi-2704631236776867428.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1__updateshape__1_3__updatewindowdi-2704631236776867428.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1__updateshape__1_3__updatewindowdi8717625349561755806.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_2_3__scatterindices__1__updateshape__1_3__updatewindowdi8717625349561755806.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_50_3__scatterindices__32__updateshape__1_3__updatewindow-2069691074413654165.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_50_3__scatterindices__32__updateshape__1_3__updatewindow-2069691074413654165.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_50_3__scatterindices__32__updateshape__1_3__updatewindow-9204662166819519530.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1_50_3__scatterindices__32__updateshape__1_3__updatewindow-9204662166819519530.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1__scatterindices__0__updateshape____updatewindowdims____i4654172382900524664.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1__scatterindices__0__updateshape____updatewindowdims____i4654172382900524664.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1__scatterindices__0__updateshape____updatewindowdims____i805910080804411976.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_1__scatterindices__0__updateshape____updatewindowdims____i805910080804411976.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewind-1528822601276352271.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewind-1528822601276352271.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewind-3037328780648918720.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_4_2_3_5__scatterindices__0_4__updateshape__4_3__updatewind-3037328780648918720.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_4_2_3__scatterindices__3_2__updateshape__2___updatewindowd-6696604613778121788.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_4_2_3__scatterindices__3_2__updateshape__2___updatewindowd-6696604613778121788.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_4_2_3__scatterindices__3_2__updateshape__2___updatewindowd-7788287855338834369.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_4_2_3__scatterindices__3_2__updateshape__2___updatewindowd-7788287855338834369.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__upda6636636746706115426.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__upda6636636746706115426.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__upda7288769158933240945.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices___0_1___2_3___updateshape__2_7__upda7288769158933240945.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____update-5519337277775784500.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____update-5519337277775784500.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____update6802180533867290475.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0_1___2_3_____4_0___1_2____update6802180533867290475.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0___1_____2___3____updateshape__5-4899128541496460728.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0___1_____2___3____updateshape__5-4899128541496460728.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0___1_____2___3____updateshape__5-8281471711907089690.mlir
+++ b/stablehlo/testdata/scatter_no_xla_unique_indices_shape_uint8_5_6_7__scatterindices____0___1_____2___3____updateshape__5-8281471711907089690.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_0_dynamic.mlir
+++ b/stablehlo/testdata/select_0_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x3xf32> {mhlo.sharding = ""}) -> tensor<?x3xf32> {

--- a/stablehlo/testdata/select_1_dynamic.mlir
+++ b/stablehlo/testdata/select_1_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x3xf32> {mhlo.sharding = ""}, %arg2: tensor<3xf32> {mhlo.sharding = ""}) -> tensor<?x3xf32> {

--- a/stablehlo/testdata/select_and_gather_add_dilations_shape_float32_4_6__selectprim_le_windowdimensions__2__2__windowstrid-1234442230378059557.mlir
+++ b/stablehlo/testdata/select_and_gather_add_dilations_shape_float32_4_6__selectprim_le_windowdimensions__2__2__windowstrid-1234442230378059557.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_and_gather_add_dilations_shape_float32_4_6__selectprim_le_windowdimensions__2__2__windowstrid-8339917744334524227.mlir
+++ b/stablehlo/testdata/select_and_gather_add_dilations_shape_float32_4_6__selectprim_le_windowdimensions__2__2__windowstrid-8339917744334524227.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_and_gather_add_dilations_shape_float32_4_6__selectprim_le_windowdimensions__2__2__windowstrid4494141771612406334.mlir
+++ b/stablehlo/testdata/select_and_gather_add_dilations_shape_float32_4_6__selectprim_le_windowdimensions__2__2__windowstrid4494141771612406334.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_and_gather_add_dtypes_shape_bfloat16_4_6__selectprim_ge_windowdimensions__2__2__windowstrides4313362319678633333.mlir
+++ b/stablehlo/testdata/select_and_gather_add_dtypes_shape_bfloat16_4_6__selectprim_ge_windowdimensions__2__2__windowstrides4313362319678633333.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_and_gather_add_dtypes_shape_bfloat16_4_6__selectprim_le_windowdimensions__2__2__windowstrides-1012953229766402479.mlir
+++ b/stablehlo/testdata/select_and_gather_add_dtypes_shape_bfloat16_4_6__selectprim_le_windowdimensions__2__2__windowstrides-1012953229766402479.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_and_gather_add_dtypes_shape_float16_4_6__selectprim_ge_windowdimensions__2__2__windowstrides_7468763519813009785.mlir
+++ b/stablehlo/testdata/select_and_gather_add_dtypes_shape_float16_4_6__selectprim_ge_windowdimensions__2__2__windowstrides_7468763519813009785.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_and_gather_add_dtypes_shape_float16_4_6__selectprim_le_windowdimensions__2__2__windowstrides_-5656666469697250749.mlir
+++ b/stablehlo/testdata/select_and_gather_add_dtypes_shape_float16_4_6__selectprim_le_windowdimensions__2__2__windowstrides_-5656666469697250749.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_and_gather_add_dtypes_shape_float32_4_6__selectprim_ge_windowdimensions__2__2__windowstrides_1049736773648920798.mlir
+++ b/stablehlo/testdata/select_and_gather_add_dtypes_shape_float32_4_6__selectprim_ge_windowdimensions__2__2__windowstrides_1049736773648920798.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_and_gather_add_dtypes_shape_float32_4_6__selectprim_le_windowdimensions__2__2__windowstrides_8180748863193819158.mlir
+++ b/stablehlo/testdata/select_and_gather_add_dtypes_shape_float32_4_6__selectprim_le_windowdimensions__2__2__windowstrides_8180748863193819158.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_and_gather_add_padding_shape_float32_4_6__selectprim_le_windowdimensions__2__2__windowstrides7172513329414880838.mlir
+++ b/stablehlo/testdata/select_and_gather_add_padding_shape_float32_4_6__selectprim_le_windowdimensions__2__2__windowstrides7172513329414880838.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_and_gather_add_select_prim_shape_float32_4_6__selectprim_ge_windowdimensions__2__2__windowstr-2717710683935812517.mlir
+++ b/stablehlo/testdata/select_and_gather_add_select_prim_shape_float32_4_6__selectprim_ge_windowdimensions__2__2__windowstr-2717710683935812517.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_and_gather_add_window_dimensions_shape_float32_4_6__selectprim_le_windowdimensions__2__3__win-2005780783284749355.mlir
+++ b/stablehlo/testdata/select_and_gather_add_window_dimensions_shape_float32_4_6__selectprim_le_windowdimensions__2__3__win-2005780783284749355.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_and_gather_add_window_strides_shape_float32_4_6__selectprim_le_windowdimensions__2__2__window1194065983982281707.mlir
+++ b/stablehlo/testdata/select_and_gather_add_window_strides_shape_float32_4_6__selectprim_le_windowdimensions__2__2__window1194065983982281707.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_and_scatter_add_dtypes_shape_bfloat16_2_4_6__selectprim_ge_windowdimensions__2__2__2__windows5498388055904314537.mlir
+++ b/stablehlo/testdata/select_and_scatter_add_dtypes_shape_bfloat16_2_4_6__selectprim_ge_windowdimensions__2__2__2__windows5498388055904314537.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_and_scatter_add_dtypes_shape_bool_2_4_6__selectprim_ge_windowdimensions__2__2__2__windowstrid3953935332736217868.mlir
+++ b/stablehlo/testdata/select_and_scatter_add_dtypes_shape_bool_2_4_6__selectprim_ge_windowdimensions__2__2__2__windowstrid3953935332736217868.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_and_scatter_add_dtypes_shape_float16_2_4_6__selectprim_ge_windowdimensions__2__2__2__windowst645862737998720881.mlir
+++ b/stablehlo/testdata/select_and_scatter_add_dtypes_shape_float16_2_4_6__selectprim_ge_windowdimensions__2__2__2__windowst645862737998720881.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_and_scatter_add_dtypes_shape_float32_2_4_6__selectprim_ge_windowdimensions__2__2__2__windowst6350781848831556769.mlir
+++ b/stablehlo/testdata/select_and_scatter_add_dtypes_shape_float32_2_4_6__selectprim_ge_windowdimensions__2__2__2__windowst6350781848831556769.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_and_scatter_add_dtypes_shape_int16_2_4_6__selectprim_ge_windowdimensions__2__2__2__windowstri1180273328702244000.mlir
+++ b/stablehlo/testdata/select_and_scatter_add_dtypes_shape_int16_2_4_6__selectprim_ge_windowdimensions__2__2__2__windowstri1180273328702244000.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_and_scatter_add_dtypes_shape_int32_2_4_6__selectprim_ge_windowdimensions__2__2__2__windowstri-799453658564734982.mlir
+++ b/stablehlo/testdata/select_and_scatter_add_dtypes_shape_int32_2_4_6__selectprim_ge_windowdimensions__2__2__2__windowstri-799453658564734982.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_and_scatter_add_dtypes_shape_int8_2_4_6__selectprim_ge_windowdimensions__2__2__2__windowstrid-1158927479391781377.mlir
+++ b/stablehlo/testdata/select_and_scatter_add_dtypes_shape_int8_2_4_6__selectprim_ge_windowdimensions__2__2__2__windowstrid-1158927479391781377.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_and_scatter_add_dtypes_shape_uint16_2_4_6__selectprim_ge_windowdimensions__2__2__2__windowstr2639417885255268371.mlir
+++ b/stablehlo/testdata/select_and_scatter_add_dtypes_shape_uint16_2_4_6__selectprim_ge_windowdimensions__2__2__2__windowstr2639417885255268371.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_and_scatter_add_dtypes_shape_uint32_2_4_6__selectprim_ge_windowdimensions__2__2__2__windowstr4996434443108277595.mlir
+++ b/stablehlo/testdata/select_and_scatter_add_dtypes_shape_uint32_2_4_6__selectprim_ge_windowdimensions__2__2__2__windowstr4996434443108277595.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_and_scatter_add_dtypes_shape_uint8_2_4_6__selectprim_ge_windowdimensions__2__2__2__windowstri3918878843829093576.mlir
+++ b/stablehlo/testdata/select_and_scatter_add_dtypes_shape_uint8_2_4_6__selectprim_ge_windowdimensions__2__2__2__windowstri3918878843829093576.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_and_scatter_add_padding_shape_float32_2_4_6__selectprim_ge_windowdimensions__2__2__2__windows7745011263169515186.mlir
+++ b/stablehlo/testdata/select_and_scatter_add_padding_shape_float32_2_4_6__selectprim_ge_windowdimensions__2__2__2__windows7745011263169515186.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_and_scatter_add_select_prim_shape_float32_2_4_6__selectprim_le_windowdimensions__2__2__2__win3195252304676505603.mlir
+++ b/stablehlo/testdata/select_and_scatter_add_select_prim_shape_float32_2_4_6__selectprim_le_windowdimensions__2__2__2__win3195252304676505603.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_and_scatter_add_tpu_dtypes_shape_bfloat16_2_4_6__selectprim_ge_windowdimensions__1__3__1__win7138983918417685208.mlir
+++ b/stablehlo/testdata/select_and_scatter_add_tpu_dtypes_shape_bfloat16_2_4_6__selectprim_ge_windowdimensions__1__3__1__win7138983918417685208.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_and_scatter_add_tpu_dtypes_shape_float16_2_4_6__selectprim_ge_windowdimensions__1__3__1__wind7040864175077487301.mlir
+++ b/stablehlo/testdata/select_and_scatter_add_tpu_dtypes_shape_float16_2_4_6__selectprim_ge_windowdimensions__1__3__1__wind7040864175077487301.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_and_scatter_add_tpu_dtypes_shape_float32_2_4_6__selectprim_ge_windowdimensions__1__3__1__wind-6867541439412093951.mlir
+++ b/stablehlo/testdata/select_and_scatter_add_tpu_dtypes_shape_float32_2_4_6__selectprim_ge_windowdimensions__1__3__1__wind-6867541439412093951.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_and_scatter_add_tpu_dtypes_shape_int16_2_4_6__selectprim_ge_windowdimensions__1__3__1__window-1515521222491375303.mlir
+++ b/stablehlo/testdata/select_and_scatter_add_tpu_dtypes_shape_int16_2_4_6__selectprim_ge_windowdimensions__1__3__1__window-1515521222491375303.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_and_scatter_add_tpu_dtypes_shape_int32_2_4_6__selectprim_ge_windowdimensions__1__3__1__window-8827730052770528042.mlir
+++ b/stablehlo/testdata/select_and_scatter_add_tpu_dtypes_shape_int32_2_4_6__selectprim_ge_windowdimensions__1__3__1__window-8827730052770528042.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_and_scatter_add_tpu_dtypes_shape_uint16_2_4_6__selectprim_ge_windowdimensions__1__3__1__windo2756544409025303514.mlir
+++ b/stablehlo/testdata/select_and_scatter_add_tpu_dtypes_shape_uint16_2_4_6__selectprim_ge_windowdimensions__1__3__1__windo2756544409025303514.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_and_scatter_add_tpu_dtypes_shape_uint32_2_4_6__selectprim_ge_windowdimensions__1__3__1__windo-6304561722695857269.mlir
+++ b/stablehlo/testdata/select_and_scatter_add_tpu_dtypes_shape_uint32_2_4_6__selectprim_ge_windowdimensions__1__3__1__windo-6304561722695857269.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_and_scatter_add_window_dimensions_shape_float32_2_4_6__selectprim_ge_windowdimensions__1__2__2730457018571670567.mlir
+++ b/stablehlo/testdata/select_and_scatter_add_window_dimensions_shape_float32_2_4_6__selectprim_ge_windowdimensions__1__2__2730457018571670567.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_and_scatter_add_window_strides_shape_float32_2_4_6__selectprim_ge_windowdimensions__2__2__2__-3819633790000483811.mlir
+++ b/stablehlo/testdata/select_and_scatter_add_window_strides_shape_float32_2_4_6__selectprim_ge_windowdimensions__2__2__2__-3819633790000483811.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_n_dtypes_shapepred_bool_2_3__shapeargs_bfloat16_2_3.mlir
+++ b/stablehlo/testdata/select_n_dtypes_shapepred_bool_2_3__shapeargs_bfloat16_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_n_dtypes_shapepred_bool_2_3__shapeargs_bool_2_3.mlir
+++ b/stablehlo/testdata/select_n_dtypes_shapepred_bool_2_3__shapeargs_bool_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_n_dtypes_shapepred_bool_2_3__shapeargs_complex64_2_3.mlir
+++ b/stablehlo/testdata/select_n_dtypes_shapepred_bool_2_3__shapeargs_complex64_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_n_dtypes_shapepred_bool_2_3__shapeargs_float16_2_3.mlir
+++ b/stablehlo/testdata/select_n_dtypes_shapepred_bool_2_3__shapeargs_float16_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_n_dtypes_shapepred_bool_2_3__shapeargs_float32_2_3.mlir
+++ b/stablehlo/testdata/select_n_dtypes_shapepred_bool_2_3__shapeargs_float32_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_n_dtypes_shapepred_bool_2_3__shapeargs_int16_2_3.mlir
+++ b/stablehlo/testdata/select_n_dtypes_shapepred_bool_2_3__shapeargs_int16_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_n_dtypes_shapepred_bool_2_3__shapeargs_int32_2_3.mlir
+++ b/stablehlo/testdata/select_n_dtypes_shapepred_bool_2_3__shapeargs_int32_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_n_dtypes_shapepred_bool_2_3__shapeargs_int8_2_3.mlir
+++ b/stablehlo/testdata/select_n_dtypes_shapepred_bool_2_3__shapeargs_int8_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_n_dtypes_shapepred_bool_2_3__shapeargs_uint16_2_3.mlir
+++ b/stablehlo/testdata/select_n_dtypes_shapepred_bool_2_3__shapeargs_uint16_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_n_dtypes_shapepred_bool_2_3__shapeargs_uint32_2_3.mlir
+++ b/stablehlo/testdata/select_n_dtypes_shapepred_bool_2_3__shapeargs_uint32_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_n_dtypes_shapepred_bool_2_3__shapeargs_uint8_2_3.mlir
+++ b/stablehlo/testdata/select_n_dtypes_shapepred_bool_2_3__shapeargs_uint8_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_n_dtypes_shapepred_int32_2_3__shapeargs_bfloat16_2_3.mlir
+++ b/stablehlo/testdata/select_n_dtypes_shapepred_int32_2_3__shapeargs_bfloat16_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_n_dtypes_shapepred_int32_2_3__shapeargs_bool_2_3.mlir
+++ b/stablehlo/testdata/select_n_dtypes_shapepred_int32_2_3__shapeargs_bool_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_n_dtypes_shapepred_int32_2_3__shapeargs_complex64_2_3.mlir
+++ b/stablehlo/testdata/select_n_dtypes_shapepred_int32_2_3__shapeargs_complex64_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_n_dtypes_shapepred_int32_2_3__shapeargs_float16_2_3.mlir
+++ b/stablehlo/testdata/select_n_dtypes_shapepred_int32_2_3__shapeargs_float16_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_n_dtypes_shapepred_int32_2_3__shapeargs_float32_2_3.mlir
+++ b/stablehlo/testdata/select_n_dtypes_shapepred_int32_2_3__shapeargs_float32_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_n_dtypes_shapepred_int32_2_3__shapeargs_int16_2_3.mlir
+++ b/stablehlo/testdata/select_n_dtypes_shapepred_int32_2_3__shapeargs_int16_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_n_dtypes_shapepred_int32_2_3__shapeargs_int32_2_3.mlir
+++ b/stablehlo/testdata/select_n_dtypes_shapepred_int32_2_3__shapeargs_int32_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_n_dtypes_shapepred_int32_2_3__shapeargs_int8_2_3.mlir
+++ b/stablehlo/testdata/select_n_dtypes_shapepred_int32_2_3__shapeargs_int8_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_n_dtypes_shapepred_int32_2_3__shapeargs_uint16_2_3.mlir
+++ b/stablehlo/testdata/select_n_dtypes_shapepred_int32_2_3__shapeargs_uint16_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_n_dtypes_shapepred_int32_2_3__shapeargs_uint32_2_3.mlir
+++ b/stablehlo/testdata/select_n_dtypes_shapepred_int32_2_3__shapeargs_uint32_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_n_dtypes_shapepred_int32_2_3__shapeargs_uint8_2_3.mlir
+++ b/stablehlo/testdata/select_n_dtypes_shapepred_int32_2_3__shapeargs_uint8_2_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_n_shapes_shapepred_bool___shapeargs_float32_18.mlir
+++ b/stablehlo/testdata/select_n_shapes_shapepred_bool___shapeargs_float32_18.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/select_n_shapes_shapepred_int32___shapeargs_float32_18.mlir
+++ b/stablehlo/testdata/select_n_shapes_shapepred_int32___shapeargs_float32_18.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/shift_left_broadcasting_lhs_int32_1_20__rhs_int32_20_20.mlir
+++ b/stablehlo/testdata/shift_left_broadcasting_lhs_int32_1_20__rhs_int32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/shift_left_broadcasting_lhs_int32_20_20__rhs_int32_1_20.mlir
+++ b/stablehlo/testdata/shift_left_broadcasting_lhs_int32_20_20__rhs_int32_1_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/shift_left_dtypes_lhs_int16_20_20__rhs_int16_20_20.mlir
+++ b/stablehlo/testdata/shift_left_dtypes_lhs_int16_20_20__rhs_int16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/shift_left_dtypes_lhs_int32_20_20__rhs_int32_20_20.mlir
+++ b/stablehlo/testdata/shift_left_dtypes_lhs_int32_20_20__rhs_int32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/shift_left_dtypes_lhs_int8_20_20__rhs_int8_20_20.mlir
+++ b/stablehlo/testdata/shift_left_dtypes_lhs_int8_20_20__rhs_int8_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/shift_left_dtypes_lhs_uint16_20_20__rhs_uint16_20_20.mlir
+++ b/stablehlo/testdata/shift_left_dtypes_lhs_uint16_20_20__rhs_uint16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/shift_left_dtypes_lhs_uint32_20_20__rhs_uint32_20_20.mlir
+++ b/stablehlo/testdata/shift_left_dtypes_lhs_uint32_20_20__rhs_uint32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/shift_left_dtypes_lhs_uint8_20_20__rhs_uint8_20_20.mlir
+++ b/stablehlo/testdata/shift_left_dtypes_lhs_uint8_20_20__rhs_uint8_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/shift_right_arithmetic_broadcasting_lhs_int32_1_20__rhs_int32_20_20.mlir
+++ b/stablehlo/testdata/shift_right_arithmetic_broadcasting_lhs_int32_1_20__rhs_int32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/shift_right_arithmetic_broadcasting_lhs_int32_20_20__rhs_int32_1_20.mlir
+++ b/stablehlo/testdata/shift_right_arithmetic_broadcasting_lhs_int32_20_20__rhs_int32_1_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/shift_right_arithmetic_dtypes_lhs_int16_20_20__rhs_int16_20_20.mlir
+++ b/stablehlo/testdata/shift_right_arithmetic_dtypes_lhs_int16_20_20__rhs_int16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/shift_right_arithmetic_dtypes_lhs_int32_20_20__rhs_int32_20_20.mlir
+++ b/stablehlo/testdata/shift_right_arithmetic_dtypes_lhs_int32_20_20__rhs_int32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/shift_right_arithmetic_dtypes_lhs_int8_20_20__rhs_int8_20_20.mlir
+++ b/stablehlo/testdata/shift_right_arithmetic_dtypes_lhs_int8_20_20__rhs_int8_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/shift_right_arithmetic_dtypes_lhs_uint16_20_20__rhs_uint16_20_20.mlir
+++ b/stablehlo/testdata/shift_right_arithmetic_dtypes_lhs_uint16_20_20__rhs_uint16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/shift_right_arithmetic_dtypes_lhs_uint32_20_20__rhs_uint32_20_20.mlir
+++ b/stablehlo/testdata/shift_right_arithmetic_dtypes_lhs_uint32_20_20__rhs_uint32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/shift_right_arithmetic_dtypes_lhs_uint8_20_20__rhs_uint8_20_20.mlir
+++ b/stablehlo/testdata/shift_right_arithmetic_dtypes_lhs_uint8_20_20__rhs_uint8_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/shift_right_logical_broadcasting_lhs_int32_1_20__rhs_int32_20_20.mlir
+++ b/stablehlo/testdata/shift_right_logical_broadcasting_lhs_int32_1_20__rhs_int32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/shift_right_logical_broadcasting_lhs_int32_20_20__rhs_int32_1_20.mlir
+++ b/stablehlo/testdata/shift_right_logical_broadcasting_lhs_int32_20_20__rhs_int32_1_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/shift_right_logical_dtypes_lhs_int16_20_20__rhs_int16_20_20.mlir
+++ b/stablehlo/testdata/shift_right_logical_dtypes_lhs_int16_20_20__rhs_int16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/shift_right_logical_dtypes_lhs_int32_20_20__rhs_int32_20_20.mlir
+++ b/stablehlo/testdata/shift_right_logical_dtypes_lhs_int32_20_20__rhs_int32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/shift_right_logical_dtypes_lhs_int8_20_20__rhs_int8_20_20.mlir
+++ b/stablehlo/testdata/shift_right_logical_dtypes_lhs_int8_20_20__rhs_int8_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/shift_right_logical_dtypes_lhs_uint16_20_20__rhs_uint16_20_20.mlir
+++ b/stablehlo/testdata/shift_right_logical_dtypes_lhs_uint16_20_20__rhs_uint16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/shift_right_logical_dtypes_lhs_uint32_20_20__rhs_uint32_20_20.mlir
+++ b/stablehlo/testdata/shift_right_logical_dtypes_lhs_uint32_20_20__rhs_uint32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/shift_right_logical_dtypes_lhs_uint8_20_20__rhs_uint8_20_20.mlir
+++ b/stablehlo/testdata/shift_right_logical_dtypes_lhs_uint8_20_20__rhs_uint8_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sign_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/sign_shape_bfloat16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sign_shape_complex64_20_20.mlir
+++ b/stablehlo/testdata/sign_shape_complex64_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sign_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/sign_shape_float16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sign_shape_float32_20_20.mlir
+++ b/stablehlo/testdata/sign_shape_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sign_shape_int16_20_20.mlir
+++ b/stablehlo/testdata/sign_shape_int16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sign_shape_int32_20_20.mlir
+++ b/stablehlo/testdata/sign_shape_int32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sign_shape_int8_20_20.mlir
+++ b/stablehlo/testdata/sign_shape_int8_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sign_shape_uint16_20_20.mlir
+++ b/stablehlo/testdata/sign_shape_uint16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sign_shape_uint32_20_20.mlir
+++ b/stablehlo/testdata/sign_shape_uint32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sign_shape_uint8_20_20.mlir
+++ b/stablehlo/testdata/sign_shape_uint8_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sign_special_0_dtype_bfloat16.mlir
+++ b/stablehlo/testdata/sign_special_0_dtype_bfloat16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sign_special_0_dtype_complex64.mlir
+++ b/stablehlo/testdata/sign_special_0_dtype_complex64.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sign_special_0_dtype_float16.mlir
+++ b/stablehlo/testdata/sign_special_0_dtype_float16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sign_special_0_dtype_float32.mlir
+++ b/stablehlo/testdata/sign_special_0_dtype_float32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sign_special_0_dtype_int16.mlir
+++ b/stablehlo/testdata/sign_special_0_dtype_int16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sign_special_0_dtype_int32.mlir
+++ b/stablehlo/testdata/sign_special_0_dtype_int32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sign_special_0_dtype_int8.mlir
+++ b/stablehlo/testdata/sign_special_0_dtype_int8.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sign_special_0_dtype_uint16.mlir
+++ b/stablehlo/testdata/sign_special_0_dtype_uint16.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sign_special_0_dtype_uint32.mlir
+++ b/stablehlo/testdata/sign_special_0_dtype_uint32.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sign_special_0_dtype_uint8.mlir
+++ b/stablehlo/testdata/sign_special_0_dtype_uint8.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sin_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/sin_shape_bfloat16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sin_shape_complex64_20_20.mlir
+++ b/stablehlo/testdata/sin_shape_complex64_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sin_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/sin_shape_float16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sin_shape_float32_20_20.mlir
+++ b/stablehlo/testdata/sin_shape_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sinh_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/sinh_shape_bfloat16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sinh_shape_complex64_20_20.mlir
+++ b/stablehlo/testdata/sinh_shape_complex64_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED(#1278): stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sinh_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/sinh_shape_float16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sinh_shape_float32_20_20.mlir
+++ b/stablehlo/testdata/sinh_shape_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/slice_dtypes_a_bfloat16_3__start_indices__1___limit_indices__2___strides_None.mlir
+++ b/stablehlo/testdata/slice_dtypes_a_bfloat16_3__start_indices__1___limit_indices__2___strides_None.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/slice_dtypes_a_bool_3__start_indices__1___limit_indices__2___strides_None.mlir
+++ b/stablehlo/testdata/slice_dtypes_a_bool_3__start_indices__1___limit_indices__2___strides_None.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/slice_dtypes_a_complex64_3__start_indices__1___limit_indices__2___strides_None.mlir
+++ b/stablehlo/testdata/slice_dtypes_a_complex64_3__start_indices__1___limit_indices__2___strides_None.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/slice_dtypes_a_float16_3__start_indices__1___limit_indices__2___strides_None.mlir
+++ b/stablehlo/testdata/slice_dtypes_a_float16_3__start_indices__1___limit_indices__2___strides_None.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/slice_dtypes_a_float32_3__start_indices__1___limit_indices__2___strides_None.mlir
+++ b/stablehlo/testdata/slice_dtypes_a_float32_3__start_indices__1___limit_indices__2___strides_None.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/slice_dtypes_a_int16_3__start_indices__1___limit_indices__2___strides_None.mlir
+++ b/stablehlo/testdata/slice_dtypes_a_int16_3__start_indices__1___limit_indices__2___strides_None.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/slice_dtypes_a_int32_3__start_indices__1___limit_indices__2___strides_None.mlir
+++ b/stablehlo/testdata/slice_dtypes_a_int32_3__start_indices__1___limit_indices__2___strides_None.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/slice_dtypes_a_int8_3__start_indices__1___limit_indices__2___strides_None.mlir
+++ b/stablehlo/testdata/slice_dtypes_a_int8_3__start_indices__1___limit_indices__2___strides_None.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/slice_dtypes_a_uint16_3__start_indices__1___limit_indices__2___strides_None.mlir
+++ b/stablehlo/testdata/slice_dtypes_a_uint16_3__start_indices__1___limit_indices__2___strides_None.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/slice_dtypes_a_uint32_3__start_indices__1___limit_indices__2___strides_None.mlir
+++ b/stablehlo/testdata/slice_dtypes_a_uint32_3__start_indices__1___limit_indices__2___strides_None.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/slice_dtypes_a_uint8_3__start_indices__1___limit_indices__2___strides_None.mlir
+++ b/stablehlo/testdata/slice_dtypes_a_uint8_3__start_indices__1___limit_indices__2___strides_None.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/slice_entire_axis_dynamic.mlir
+++ b/stablehlo/testdata/slice_entire_axis_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x3xf32> {mhlo.sharding = ""}) -> tensor<?x2xf32> {

--- a/stablehlo/testdata/slice_in_dim_entire_axis_dynamic.mlir
+++ b/stablehlo/testdata/slice_in_dim_entire_axis_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}) -> tensor<?x4xf32> {

--- a/stablehlo/testdata/slice_in_dim_limit_neg_dynamic.mlir
+++ b/stablehlo/testdata/slice_in_dim_limit_neg_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}) -> tensor<?x4xf32> {

--- a/stablehlo/testdata/slice_in_dim_start_neg_dynamic.mlir
+++ b/stablehlo/testdata/slice_in_dim_start_neg_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}) -> tensor<1x4xf32> {

--- a/stablehlo/testdata/slice_in_dim_stride_2_even_dynamic.mlir
+++ b/stablehlo/testdata/slice_in_dim_stride_2_even_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}) -> tensor<?x4xf32> {

--- a/stablehlo/testdata/slice_in_dim_stride_2_odd_dynamic.mlir
+++ b/stablehlo/testdata/slice_in_dim_stride_2_odd_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}) -> tensor<?x4xf32> {

--- a/stablehlo/testdata/slice_shapes_a_float32_3__start_indices__1___limit_indices__2___strides_None.mlir
+++ b/stablehlo/testdata/slice_shapes_a_float32_3__start_indices__1___limit_indices__2___strides_None.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/slice_shapes_a_float32_5_3__start_indices__1__1__limit_indices__2__1__strides__1__1.mlir
+++ b/stablehlo/testdata/slice_shapes_a_float32_5_3__start_indices__1__1__limit_indices__2__1__strides__1__1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/slice_shapes_a_float32_5_3__start_indices__1__1__limit_indices__3__1__strides_None.mlir
+++ b/stablehlo/testdata/slice_shapes_a_float32_5_3__start_indices__1__1__limit_indices__3__1__strides_None.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/slice_shapes_a_float32_5_3__start_indices__1__1__limit_indices__3__2__strides_None.mlir
+++ b/stablehlo/testdata/slice_shapes_a_float32_5_3__start_indices__1__1__limit_indices__3__2__strides_None.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/slice_shapes_a_float32_5_3__start_indices__1__1__limit_indices__5__3__strides__2__1.mlir
+++ b/stablehlo/testdata/slice_shapes_a_float32_5_3__start_indices__1__1__limit_indices__5__3__strides__2__1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/slice_shapes_a_float32_5__start_indices__1___limit_indices__5___strides__2.mlir
+++ b/stablehlo/testdata/slice_shapes_a_float32_5__start_indices__1___limit_indices__5___strides__2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/slice_shapes_a_float32_7_5_3__start_indices__4__0__1__limit_indices__7__1__3__strides_None.mlir
+++ b/stablehlo/testdata/slice_shapes_a_float32_7_5_3__start_indices__4__0__1__limit_indices__7__1__3__strides_None.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/slice_shapes_a_float32_7__start_indices__4___limit_indices__7___strides_None.mlir
+++ b/stablehlo/testdata/slice_shapes_a_float32_7__start_indices__4___limit_indices__7___strides_None.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/slice_shapes_a_float32_8__start_indices__1___limit_indices__6___strides__2.mlir
+++ b/stablehlo/testdata/slice_shapes_a_float32_8__start_indices__1___limit_indices__6___strides__2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sqrt_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/sqrt_shape_bfloat16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sqrt_shape_complex64_20_20.mlir
+++ b/stablehlo/testdata/sqrt_shape_complex64_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sqrt_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/sqrt_shape_float16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sqrt_shape_float32_20_20.mlir
+++ b/stablehlo/testdata/sqrt_shape_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/squeeze_axis_1_2_dynamic.mlir
+++ b/stablehlo/testdata/squeeze_axis_1_2_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x1xf32> {mhlo.sharding = ""}) -> tensor<?xf32> {

--- a/stablehlo/testdata/squeeze_axis_1_dynamic.mlir
+++ b/stablehlo/testdata/squeeze_axis_1_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1xf32> {mhlo.sharding = ""}) -> tensor<?xf32> {

--- a/stablehlo/testdata/squeeze_axis_empty_dynamic.mlir
+++ b/stablehlo/testdata/squeeze_axis_empty_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?xf32> {mhlo.sharding = ""}) -> tensor<?xf32> {

--- a/stablehlo/testdata/squeeze_dtypes_inshape_bfloat16_1_2__dimensions__0.mlir
+++ b/stablehlo/testdata/squeeze_dtypes_inshape_bfloat16_1_2__dimensions__0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/squeeze_dtypes_inshape_bool_1_2__dimensions__0.mlir
+++ b/stablehlo/testdata/squeeze_dtypes_inshape_bool_1_2__dimensions__0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/squeeze_dtypes_inshape_complex64_1_2__dimensions__0.mlir
+++ b/stablehlo/testdata/squeeze_dtypes_inshape_complex64_1_2__dimensions__0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/squeeze_dtypes_inshape_float16_1_2__dimensions__0.mlir
+++ b/stablehlo/testdata/squeeze_dtypes_inshape_float16_1_2__dimensions__0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/squeeze_dtypes_inshape_float32_1_2__dimensions__0.mlir
+++ b/stablehlo/testdata/squeeze_dtypes_inshape_float32_1_2__dimensions__0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/squeeze_dtypes_inshape_int16_1_2__dimensions__0.mlir
+++ b/stablehlo/testdata/squeeze_dtypes_inshape_int16_1_2__dimensions__0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/squeeze_dtypes_inshape_int32_1_2__dimensions__0.mlir
+++ b/stablehlo/testdata/squeeze_dtypes_inshape_int32_1_2__dimensions__0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/squeeze_dtypes_inshape_int8_1_2__dimensions__0.mlir
+++ b/stablehlo/testdata/squeeze_dtypes_inshape_int8_1_2__dimensions__0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/squeeze_dtypes_inshape_uint16_1_2__dimensions__0.mlir
+++ b/stablehlo/testdata/squeeze_dtypes_inshape_uint16_1_2__dimensions__0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/squeeze_dtypes_inshape_uint32_1_2__dimensions__0.mlir
+++ b/stablehlo/testdata/squeeze_dtypes_inshape_uint32_1_2__dimensions__0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/squeeze_dtypes_inshape_uint8_1_2__dimensions__0.mlir
+++ b/stablehlo/testdata/squeeze_dtypes_inshape_uint8_1_2__dimensions__0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/squeeze_shapes_inshape_float32_1__dimensions__-1.mlir
+++ b/stablehlo/testdata/squeeze_shapes_inshape_float32_1__dimensions__-1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/squeeze_shapes_inshape_float32_1__dimensions__0.mlir
+++ b/stablehlo/testdata/squeeze_shapes_inshape_float32_1__dimensions__0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/squeeze_shapes_inshape_float32_2_1_3_1__dimensions__1.mlir
+++ b/stablehlo/testdata/squeeze_shapes_inshape_float32_2_1_3_1__dimensions__1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/squeeze_shapes_inshape_float32_2_1_3_1__dimensions__1__-1.mlir
+++ b/stablehlo/testdata/squeeze_shapes_inshape_float32_2_1_3_1__dimensions__1__-1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/squeeze_shapes_inshape_float32_2_1_3_1__dimensions__1__3.mlir
+++ b/stablehlo/testdata/squeeze_shapes_inshape_float32_2_1_3_1__dimensions__1__3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/squeeze_shapes_inshape_float32_2_1_3_1__dimensions__3.mlir
+++ b/stablehlo/testdata/squeeze_shapes_inshape_float32_2_1_3_1__dimensions__3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/squeeze_shapes_inshape_float32_2_1_4__dimensions__-2.mlir
+++ b/stablehlo/testdata/squeeze_shapes_inshape_float32_2_1_4__dimensions__-2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/squeeze_shapes_inshape_float32_2_1_4__dimensions__1.mlir
+++ b/stablehlo/testdata/squeeze_shapes_inshape_float32_2_1_4__dimensions__1.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/stop_gradient_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/stop_gradient_bfloat16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/stop_gradient_bool_20_20.mlir
+++ b/stablehlo/testdata/stop_gradient_bool_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/stop_gradient_complex64_20_20.mlir
+++ b/stablehlo/testdata/stop_gradient_complex64_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/stop_gradient_float16_20_20.mlir
+++ b/stablehlo/testdata/stop_gradient_float16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/stop_gradient_float32_20_20.mlir
+++ b/stablehlo/testdata/stop_gradient_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/stop_gradient_int16_20_20.mlir
+++ b/stablehlo/testdata/stop_gradient_int16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/stop_gradient_int32_20_20.mlir
+++ b/stablehlo/testdata/stop_gradient_int32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/stop_gradient_int8_20_20.mlir
+++ b/stablehlo/testdata/stop_gradient_int8_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/stop_gradient_uint16_20_20.mlir
+++ b/stablehlo/testdata/stop_gradient_uint16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/stop_gradient_uint32_20_20.mlir
+++ b/stablehlo/testdata/stop_gradient_uint32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/stop_gradient_uint8_20_20.mlir
+++ b/stablehlo/testdata/stop_gradient_uint8_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sub_broadcasting_lhs_float32_1_20__rhs_float32_20_20.mlir
+++ b/stablehlo/testdata/sub_broadcasting_lhs_float32_1_20__rhs_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sub_broadcasting_lhs_float32_20_20__rhs_float32_1_20.mlir
+++ b/stablehlo/testdata/sub_broadcasting_lhs_float32_20_20__rhs_float32_1_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sub_dtypes_lhs_bfloat16_20_20__rhs_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/sub_dtypes_lhs_bfloat16_20_20__rhs_bfloat16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sub_dtypes_lhs_complex64_20_20__rhs_complex64_20_20.mlir
+++ b/stablehlo/testdata/sub_dtypes_lhs_complex64_20_20__rhs_complex64_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sub_dtypes_lhs_float16_20_20__rhs_float16_20_20.mlir
+++ b/stablehlo/testdata/sub_dtypes_lhs_float16_20_20__rhs_float16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sub_dtypes_lhs_float32_20_20__rhs_float32_20_20.mlir
+++ b/stablehlo/testdata/sub_dtypes_lhs_float32_20_20__rhs_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sub_dtypes_lhs_int16_20_20__rhs_int16_20_20.mlir
+++ b/stablehlo/testdata/sub_dtypes_lhs_int16_20_20__rhs_int16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sub_dtypes_lhs_int32_20_20__rhs_int32_20_20.mlir
+++ b/stablehlo/testdata/sub_dtypes_lhs_int32_20_20__rhs_int32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sub_dtypes_lhs_int8_20_20__rhs_int8_20_20.mlir
+++ b/stablehlo/testdata/sub_dtypes_lhs_int8_20_20__rhs_int8_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sub_dtypes_lhs_uint16_20_20__rhs_uint16_20_20.mlir
+++ b/stablehlo/testdata/sub_dtypes_lhs_uint16_20_20__rhs_uint16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sub_dtypes_lhs_uint32_20_20__rhs_uint32_20_20.mlir
+++ b/stablehlo/testdata/sub_dtypes_lhs_uint32_20_20__rhs_uint32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/sub_dtypes_lhs_uint8_20_20__rhs_uint8_20_20.mlir
+++ b/stablehlo/testdata/sub_dtypes_lhs_uint8_20_20__rhs_uint8_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/take__enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/take__enable_xla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x5xf32> {mhlo.sharding = ""}, %arg2: tensor<2xi32> {mhlo.sharding = ""}) -> tensor<?x2x5xf32> {

--- a/stablehlo/testdata/take_along_axis_0_dynamic.mlir
+++ b/stablehlo/testdata/take_along_axis_0_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1xi32> {mhlo.sharding = ""}) -> tensor<?x2xf32> {

--- a/stablehlo/testdata/take_along_axis_1_dynamic.mlir
+++ b/stablehlo/testdata/take_along_axis_1_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1xi32> {mhlo.sharding = ""}) -> tensor<?x1xf32> {

--- a/stablehlo/testdata/tanh_shape_bfloat16_20_20.mlir
+++ b/stablehlo/testdata/tanh_shape_bfloat16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/tanh_shape_complex64_20_20.mlir
+++ b/stablehlo/testdata/tanh_shape_complex64_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/tanh_shape_float16_20_20.mlir
+++ b/stablehlo/testdata/tanh_shape_float16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/tanh_shape_float32_20_20.mlir
+++ b/stablehlo/testdata/tanh_shape_float32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/tile_0_dynamic.mlir
+++ b/stablehlo/testdata/tile_0_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x3xf32> {mhlo.sharding = ""}) -> tensor<?x6xf32> {

--- a/stablehlo/testdata/tile_1_dynamic.mlir
+++ b/stablehlo/testdata/tile_1_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2xf32> {mhlo.sharding = ""}) -> tensor<?x?xf32> {

--- a/stablehlo/testdata/transpose_dtypes_shape_bfloat16_2_3__permutation__1_0.mlir
+++ b/stablehlo/testdata/transpose_dtypes_shape_bfloat16_2_3__permutation__1_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/transpose_dtypes_shape_bool_2_3__permutation__1_0.mlir
+++ b/stablehlo/testdata/transpose_dtypes_shape_bool_2_3__permutation__1_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/transpose_dtypes_shape_complex64_2_3__permutation__1_0.mlir
+++ b/stablehlo/testdata/transpose_dtypes_shape_complex64_2_3__permutation__1_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/transpose_dtypes_shape_float16_2_3__permutation__1_0.mlir
+++ b/stablehlo/testdata/transpose_dtypes_shape_float16_2_3__permutation__1_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/transpose_dtypes_shape_float32_2_3__permutation__1_0.mlir
+++ b/stablehlo/testdata/transpose_dtypes_shape_float32_2_3__permutation__1_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/transpose_dtypes_shape_int16_2_3__permutation__1_0.mlir
+++ b/stablehlo/testdata/transpose_dtypes_shape_int16_2_3__permutation__1_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/transpose_dtypes_shape_int32_2_3__permutation__1_0.mlir
+++ b/stablehlo/testdata/transpose_dtypes_shape_int32_2_3__permutation__1_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/transpose_dtypes_shape_int8_2_3__permutation__1_0.mlir
+++ b/stablehlo/testdata/transpose_dtypes_shape_int8_2_3__permutation__1_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/transpose_dtypes_shape_uint16_2_3__permutation__1_0.mlir
+++ b/stablehlo/testdata/transpose_dtypes_shape_uint16_2_3__permutation__1_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/transpose_dtypes_shape_uint32_2_3__permutation__1_0.mlir
+++ b/stablehlo/testdata/transpose_dtypes_shape_uint32_2_3__permutation__1_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/transpose_dtypes_shape_uint8_2_3__permutation__1_0.mlir
+++ b/stablehlo/testdata/transpose_dtypes_shape_uint8_2_3__permutation__1_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/transpose_permutations_shape_float32_2_3_4__permutation__0_1_2.mlir
+++ b/stablehlo/testdata/transpose_permutations_shape_float32_2_3_4__permutation__0_1_2.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/transpose_permutations_shape_float32_2_3_4__permutation__1_2_0.mlir
+++ b/stablehlo/testdata/transpose_permutations_shape_float32_2_3_4__permutation__1_2_0.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/tri_N_poly_M_None_dynamic.mlir
+++ b/stablehlo/testdata/tri_N_poly_M_None_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1xf32> {mhlo.sharding = ""}) -> tensor<?x?xf32> {

--- a/stablehlo/testdata/tri_N_poly_M_poly_dynamic.mlir
+++ b/stablehlo/testdata/tri_N_poly_M_poly_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1xf32> {mhlo.sharding = ""}) -> tensor<?x?xf32> {

--- a/stablehlo/testdata/triangular_solve_dtypes_a_bfloat16_4_4__b_bfloat16_4_1__leftside_True_lower_False_transposea_False_c-1891405975874908666.mlir
+++ b/stablehlo/testdata/triangular_solve_dtypes_a_bfloat16_4_4__b_bfloat16_4_1__leftside_True_lower_False_transposea_False_c-1891405975874908666.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/triangular_solve_dtypes_a_bfloat16_4_4__b_bfloat16_4_1__leftside_True_lower_False_transposea_False_c-2703463759911232690.mlir
+++ b/stablehlo/testdata/triangular_solve_dtypes_a_bfloat16_4_4__b_bfloat16_4_1__leftside_True_lower_False_transposea_False_c-2703463759911232690.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/triangular_solve_dtypes_a_float16_4_4__b_float16_4_1__leftside_True_lower_False_transposea_False_con-390360442512084026.mlir
+++ b/stablehlo/testdata/triangular_solve_dtypes_a_float16_4_4__b_float16_4_1__leftside_True_lower_False_transposea_False_con-390360442512084026.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/triangular_solve_dtypes_a_float16_4_4__b_float16_4_1__leftside_True_lower_False_transposea_False_con7082299047671998699.mlir
+++ b/stablehlo/testdata/triangular_solve_dtypes_a_float16_4_4__b_float16_4_1__leftside_True_lower_False_transposea_False_con7082299047671998699.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/triangular_solve_shapes_right_a_float32_2_8_8__b_float32_2_10_8__leftside_False_lower_False_transpos6895233476980041755.mlir
+++ b/stablehlo/testdata/triangular_solve_shapes_right_a_float32_2_8_8__b_float32_2_10_8__leftside_False_lower_False_transpos6895233476980041755.mlir
@@ -1,5 +1,7 @@
 // RUN-DISABLED: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/tridiagonal_solve_shape_float32_3.mlir
+++ b/stablehlo/testdata/tridiagonal_solve_shape_float32_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/tridiagonal_solve_shape_float64_3.mlir
+++ b/stablehlo/testdata/tridiagonal_solve_shape_float64_3.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/var_axis_None_keepdims_False_where_None_dynamic.mlir
+++ b/stablehlo/testdata/var_axis_None_keepdims_False_where_None_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8x4xf32> {mhlo.sharding = ""}) -> tensor<f32> {

--- a/stablehlo/testdata/var_axis_None_keepdims_False_where_Some_dynamic.mlir
+++ b/stablehlo/testdata/var_axis_None_keepdims_False_where_Some_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8x4xf32> {mhlo.sharding = ""}, %arg2: tensor<?x8x4xi1> {mhlo.sharding = ""}) -> tensor<f32> {

--- a/stablehlo/testdata/var_axis_None_keepdims_True_where_None_dynamic.mlir
+++ b/stablehlo/testdata/var_axis_None_keepdims_True_where_None_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8x4xf32> {mhlo.sharding = ""}) -> tensor<1x1x1xf32> {

--- a/stablehlo/testdata/var_axis_None_keepdims_True_where_Some_dynamic.mlir
+++ b/stablehlo/testdata/var_axis_None_keepdims_True_where_Some_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8x4xf32> {mhlo.sharding = ""}, %arg2: tensor<?x8x4xi1> {mhlo.sharding = ""}) -> tensor<1x1x1xf32> {

--- a/stablehlo/testdata/var_axis__0__1__keepdims_False_where_None_dynamic.mlir
+++ b/stablehlo/testdata/var_axis__0__1__keepdims_False_where_None_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8x4xf32> {mhlo.sharding = ""}) -> tensor<4xf32> {

--- a/stablehlo/testdata/var_axis__0__1__keepdims_False_where_Some_dynamic.mlir
+++ b/stablehlo/testdata/var_axis__0__1__keepdims_False_where_Some_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8x4xf32> {mhlo.sharding = ""}, %arg2: tensor<?x8x4xi1> {mhlo.sharding = ""}) -> tensor<4xf32> {

--- a/stablehlo/testdata/var_axis__0__1__keepdims_True_where_None_dynamic.mlir
+++ b/stablehlo/testdata/var_axis__0__1__keepdims_True_where_None_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8x4xf32> {mhlo.sharding = ""}) -> tensor<1x1x4xf32> {

--- a/stablehlo/testdata/var_axis__0__1__keepdims_True_where_Some_dynamic.mlir
+++ b/stablehlo/testdata/var_axis__0__1__keepdims_True_where_Some_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8x4xf32> {mhlo.sharding = ""}, %arg2: tensor<?x8x4xi1> {mhlo.sharding = ""}) -> tensor<1x1x4xf32> {

--- a/stablehlo/testdata/var_axis__0___keepdims_False_where_None_dynamic.mlir
+++ b/stablehlo/testdata/var_axis__0___keepdims_False_where_None_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8x4xf32> {mhlo.sharding = ""}) -> tensor<8x4xf32> {

--- a/stablehlo/testdata/var_axis__0___keepdims_False_where_Some_dynamic.mlir
+++ b/stablehlo/testdata/var_axis__0___keepdims_False_where_Some_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8x4xf32> {mhlo.sharding = ""}, %arg2: tensor<?x8x4xi1> {mhlo.sharding = ""}) -> tensor<8x4xf32> {

--- a/stablehlo/testdata/var_axis__0___keepdims_True_where_None_dynamic.mlir
+++ b/stablehlo/testdata/var_axis__0___keepdims_True_where_None_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8x4xf32> {mhlo.sharding = ""}) -> tensor<1x8x4xf32> {

--- a/stablehlo/testdata/var_axis__0___keepdims_True_where_Some_dynamic.mlir
+++ b/stablehlo/testdata/var_axis__0___keepdims_True_where_Some_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8x4xf32> {mhlo.sharding = ""}, %arg2: tensor<?x8x4xi1> {mhlo.sharding = ""}) -> tensor<1x8x4xf32> {

--- a/stablehlo/testdata/var_axis__1___keepdims_False_where_None_dynamic.mlir
+++ b/stablehlo/testdata/var_axis__1___keepdims_False_where_None_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8x4xf32> {mhlo.sharding = ""}) -> tensor<?x4xf32> {

--- a/stablehlo/testdata/var_axis__1___keepdims_False_where_Some_dynamic.mlir
+++ b/stablehlo/testdata/var_axis__1___keepdims_False_where_Some_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8x4xf32> {mhlo.sharding = ""}, %arg2: tensor<?x8x4xi1> {mhlo.sharding = ""}) -> tensor<?x4xf32> {

--- a/stablehlo/testdata/var_axis__1___keepdims_True_where_None_dynamic.mlir
+++ b/stablehlo/testdata/var_axis__1___keepdims_True_where_None_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8x4xf32> {mhlo.sharding = ""}) -> tensor<?x1x4xf32> {

--- a/stablehlo/testdata/var_axis__1___keepdims_True_where_Some_dynamic.mlir
+++ b/stablehlo/testdata/var_axis__1___keepdims_True_where_Some_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8x4xf32> {mhlo.sharding = ""}, %arg2: tensor<?x8x4xi1> {mhlo.sharding = ""}) -> tensor<?x1x4xf32> {

--- a/stablehlo/testdata/vmap_abs_shape_int64_20_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_abs_shape_int64_20_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x20xi64> {mhlo.sharding = ""}) -> tensor<?x20x20xi64> {

--- a/stablehlo/testdata/vmap_acos_shape_bfloat16_20_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_acos_shape_bfloat16_20_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x20xbf16> {mhlo.sharding = ""}) -> tensor<?x20x20xbf16> {

--- a/stablehlo/testdata/vmap_acosh_shape_bfloat16_20_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_acosh_shape_bfloat16_20_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x20xbf16> {mhlo.sharding = ""}) -> tensor<?x20x20xbf16> {

--- a/stablehlo/testdata/vmap_add_any_dtypes_lhs_uint64_2__rhs_uint64_2_dynamic.mlir
+++ b/stablehlo/testdata/vmap_add_any_dtypes_lhs_uint64_2__rhs_uint64_2_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2xui64> {mhlo.sharding = ""}, %arg2: tensor<?x2xui64> {mhlo.sharding = ""}) -> tensor<?x2xui64> {

--- a/stablehlo/testdata/vmap_add_broadcasting_lhs_float32_1_20__rhs_float32_20_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_add_broadcasting_lhs_float32_1_20__rhs_float32_20_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x20xf32> {mhlo.sharding = ""}, %arg2: tensor<?x20x20xf32> {mhlo.sharding = ""}) -> tensor<?x20x20xf32> {

--- a/stablehlo/testdata/vmap_add_broadcasting_lhs_float32_20_20__rhs_float32_1_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_add_broadcasting_lhs_float32_20_20__rhs_float32_1_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x20xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1x20xf32> {mhlo.sharding = ""}) -> tensor<?x20x20xf32> {

--- a/stablehlo/testdata/vmap_add_dtypes_lhs_float32_20_20__rhs_float32_20_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_add_dtypes_lhs_float32_20_20__rhs_float32_20_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x20xf32> {mhlo.sharding = ""}, %arg2: tensor<?x20x20xf32> {mhlo.sharding = ""}) -> tensor<?x20x20xf32> {

--- a/stablehlo/testdata/vmap_and_broadcasting_lhs_int32_1_20__rhs_int32_20_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_and_broadcasting_lhs_int32_1_20__rhs_int32_20_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x20xi32> {mhlo.sharding = ""}, %arg2: tensor<?x20x20xi32> {mhlo.sharding = ""}) -> tensor<?x20x20xi32> {

--- a/stablehlo/testdata/vmap_and_broadcasting_lhs_int32_20_20__rhs_int32_1_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_and_broadcasting_lhs_int32_20_20__rhs_int32_1_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x20xi32> {mhlo.sharding = ""}, %arg2: tensor<?x1x20xi32> {mhlo.sharding = ""}) -> tensor<?x20x20xi32> {

--- a/stablehlo/testdata/vmap_and_dtypes_lhs_int32_20_20__rhs_int32_20_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_and_dtypes_lhs_int32_20_20__rhs_int32_20_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x20xi32> {mhlo.sharding = ""}, %arg2: tensor<?x20x20xi32> {mhlo.sharding = ""}) -> tensor<?x20x20xi32> {

--- a/stablehlo/testdata/vmap_argmax_axes_shape_float32_18_12__axes__1___indexdtype_int32_enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_argmax_axes_shape_float32_18_12__axes__1___indexdtype_int32_enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x18x12xf32> {mhlo.sharding = ""}) -> tensor<?x18xi32> {

--- a/stablehlo/testdata/vmap_argmax_dtypes_shape_float32_15__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_argmax_dtypes_shape_float32_15__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x15xf32> {mhlo.sharding = ""}) -> tensor<?xi32> {

--- a/stablehlo/testdata/vmap_argmax_index_dtype_shape_float32_15__axes__0___indexdtype_int16_enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_argmax_index_dtype_shape_float32_15__axes__0___indexdtype_int16_enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x15xf32> {mhlo.sharding = ""}) -> tensor<?xi16> {

--- a/stablehlo/testdata/vmap_argmax_index_dtype_shape_float32_15__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_argmax_index_dtype_shape_float32_15__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x15xf32> {mhlo.sharding = ""}) -> tensor<?xi32> {

--- a/stablehlo/testdata/vmap_argmax_index_dtype_shape_float32_15__axes__0___indexdtype_int64_enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_argmax_index_dtype_shape_float32_15__axes__0___indexdtype_int64_enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x15xf32> {mhlo.sharding = ""}) -> tensor<?xi64> {

--- a/stablehlo/testdata/vmap_argmax_index_dtype_shape_float32_15__axes__0___indexdtype_int8_enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_argmax_index_dtype_shape_float32_15__axes__0___indexdtype_int8_enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x15xf32> {mhlo.sharding = ""}) -> tensor<?xi8> {

--- a/stablehlo/testdata/vmap_argmax_index_dtype_shape_float32_15__axes__0___indexdtype_uint16_enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_argmax_index_dtype_shape_float32_15__axes__0___indexdtype_uint16_enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x15xf32> {mhlo.sharding = ""}) -> tensor<?xui16> {

--- a/stablehlo/testdata/vmap_argmax_index_dtype_shape_float32_15__axes__0___indexdtype_uint32_enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_argmax_index_dtype_shape_float32_15__axes__0___indexdtype_uint32_enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x15xf32> {mhlo.sharding = ""}) -> tensor<?xui32> {

--- a/stablehlo/testdata/vmap_argmax_index_dtype_shape_float32_15__axes__0___indexdtype_uint64_enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_argmax_index_dtype_shape_float32_15__axes__0___indexdtype_uint64_enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x15xf32> {mhlo.sharding = ""}) -> tensor<?xui64> {

--- a/stablehlo/testdata/vmap_argmax_index_dtype_shape_float32_15__axes__0___indexdtype_uint8_enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_argmax_index_dtype_shape_float32_15__axes__0___indexdtype_uint8_enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x15xf32> {mhlo.sharding = ""}) -> tensor<?xui8> {

--- a/stablehlo/testdata/vmap_argmax_special_inf_0_shape_float32_4__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_argmax_special_inf_0_shape_float32_4__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}) -> tensor<?xi32> {

--- a/stablehlo/testdata/vmap_argmax_special_inf_1_shape_float32_4__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_argmax_special_inf_1_shape_float32_4__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}) -> tensor<?xi32> {

--- a/stablehlo/testdata/vmap_argmax_special_inf_2_shape_float32_4__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_argmax_special_inf_2_shape_float32_4__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}) -> tensor<?xi32> {

--- a/stablehlo/testdata/vmap_argmax_special_inf_3_shape_float32_4__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_argmax_special_inf_3_shape_float32_4__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}) -> tensor<?xi32> {

--- a/stablehlo/testdata/vmap_argmax_special_nan_0_shape_float32_6__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_argmax_special_nan_0_shape_float32_6__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x6xf32> {mhlo.sharding = ""}) -> tensor<?xi32> {

--- a/stablehlo/testdata/vmap_argmax_special_nan_1_shape_float32_4__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_argmax_special_nan_1_shape_float32_4__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}) -> tensor<?xi32> {

--- a/stablehlo/testdata/vmap_argmax_special_nan_inf_0_shape_float32_4__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_argmax_special_nan_inf_0_shape_float32_4__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}) -> tensor<?xi32> {

--- a/stablehlo/testdata/vmap_argmax_special_nan_inf_1_shape_float32_4__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_argmax_special_nan_inf_1_shape_float32_4__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}) -> tensor<?xi32> {

--- a/stablehlo/testdata/vmap_argmax_special_singleton_shape_float32_1__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_argmax_special_singleton_shape_float32_1__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1xf32> {mhlo.sharding = ""}) -> tensor<?xi32> {

--- a/stablehlo/testdata/vmap_argmin_axes_shape_float32_18_12__axes__1___indexdtype_int32_enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_argmin_axes_shape_float32_18_12__axes__1___indexdtype_int32_enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x18x12xf32> {mhlo.sharding = ""}) -> tensor<?x18xi32> {

--- a/stablehlo/testdata/vmap_argmin_dtypes_shape_float32_15__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_argmin_dtypes_shape_float32_15__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x15xf32> {mhlo.sharding = ""}) -> tensor<?xi32> {

--- a/stablehlo/testdata/vmap_argmin_index_dtype_shape_float32_15__axes__0___indexdtype_int16_enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_argmin_index_dtype_shape_float32_15__axes__0___indexdtype_int16_enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x15xf32> {mhlo.sharding = ""}) -> tensor<?xi16> {

--- a/stablehlo/testdata/vmap_argmin_index_dtype_shape_float32_15__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_argmin_index_dtype_shape_float32_15__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x15xf32> {mhlo.sharding = ""}) -> tensor<?xi32> {

--- a/stablehlo/testdata/vmap_argmin_index_dtype_shape_float32_15__axes__0___indexdtype_int64_enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_argmin_index_dtype_shape_float32_15__axes__0___indexdtype_int64_enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x15xf32> {mhlo.sharding = ""}) -> tensor<?xi64> {

--- a/stablehlo/testdata/vmap_argmin_index_dtype_shape_float32_15__axes__0___indexdtype_int8_enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_argmin_index_dtype_shape_float32_15__axes__0___indexdtype_int8_enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x15xf32> {mhlo.sharding = ""}) -> tensor<?xi8> {

--- a/stablehlo/testdata/vmap_argmin_index_dtype_shape_float32_15__axes__0___indexdtype_uint16_enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_argmin_index_dtype_shape_float32_15__axes__0___indexdtype_uint16_enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x15xf32> {mhlo.sharding = ""}) -> tensor<?xui16> {

--- a/stablehlo/testdata/vmap_argmin_index_dtype_shape_float32_15__axes__0___indexdtype_uint32_enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_argmin_index_dtype_shape_float32_15__axes__0___indexdtype_uint32_enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x15xf32> {mhlo.sharding = ""}) -> tensor<?xui32> {

--- a/stablehlo/testdata/vmap_argmin_index_dtype_shape_float32_15__axes__0___indexdtype_uint64_enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_argmin_index_dtype_shape_float32_15__axes__0___indexdtype_uint64_enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x15xf32> {mhlo.sharding = ""}) -> tensor<?xui64> {

--- a/stablehlo/testdata/vmap_argmin_index_dtype_shape_float32_15__axes__0___indexdtype_uint8_enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_argmin_index_dtype_shape_float32_15__axes__0___indexdtype_uint8_enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x15xf32> {mhlo.sharding = ""}) -> tensor<?xui8> {

--- a/stablehlo/testdata/vmap_argmin_special_inf_0_shape_float32_4__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_argmin_special_inf_0_shape_float32_4__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}) -> tensor<?xi32> {

--- a/stablehlo/testdata/vmap_argmin_special_inf_1_shape_float32_4__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_argmin_special_inf_1_shape_float32_4__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}) -> tensor<?xi32> {

--- a/stablehlo/testdata/vmap_argmin_special_inf_2_shape_float32_4__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_argmin_special_inf_2_shape_float32_4__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}) -> tensor<?xi32> {

--- a/stablehlo/testdata/vmap_argmin_special_inf_3_shape_float32_4__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_argmin_special_inf_3_shape_float32_4__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}) -> tensor<?xi32> {

--- a/stablehlo/testdata/vmap_argmin_special_nan_0_shape_float32_6__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_argmin_special_nan_0_shape_float32_6__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x6xf32> {mhlo.sharding = ""}) -> tensor<?xi32> {

--- a/stablehlo/testdata/vmap_argmin_special_nan_1_shape_float32_4__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_argmin_special_nan_1_shape_float32_4__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}) -> tensor<?xi32> {

--- a/stablehlo/testdata/vmap_argmin_special_nan_inf_0_shape_float32_4__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_argmin_special_nan_inf_0_shape_float32_4__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}) -> tensor<?xi32> {

--- a/stablehlo/testdata/vmap_argmin_special_nan_inf_1_shape_float32_4__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_argmin_special_nan_inf_1_shape_float32_4__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}) -> tensor<?xi32> {

--- a/stablehlo/testdata/vmap_argmin_special_singleton_shape_float32_1__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_argmin_special_singleton_shape_float32_1__axes__0___indexdtype_int32_enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1xf32> {mhlo.sharding = ""}) -> tensor<?xi32> {

--- a/stablehlo/testdata/vmap_asin_shape_bfloat16_20_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_asin_shape_bfloat16_20_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x20xbf16> {mhlo.sharding = ""}) -> tensor<?x20x20xbf16> {

--- a/stablehlo/testdata/vmap_asinh_shape_bfloat16_20_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_asinh_shape_bfloat16_20_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x20xbf16> {mhlo.sharding = ""}) -> tensor<?x20x20xbf16> {

--- a/stablehlo/testdata/vmap_atan2_broadcasting_lhs_float32_1_20__rhs_float32_20_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_atan2_broadcasting_lhs_float32_1_20__rhs_float32_20_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x20xf32> {mhlo.sharding = ""}, %arg2: tensor<?x20x20xf32> {mhlo.sharding = ""}) -> tensor<?x20x20xf32> {

--- a/stablehlo/testdata/vmap_atan2_broadcasting_lhs_float32_20_20__rhs_float32_1_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_atan2_broadcasting_lhs_float32_20_20__rhs_float32_1_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x20xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1x20xf32> {mhlo.sharding = ""}) -> tensor<?x20x20xf32> {

--- a/stablehlo/testdata/vmap_atan2_dtypes_lhs_float32_20_20__rhs_float32_20_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_atan2_dtypes_lhs_float32_20_20__rhs_float32_20_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x20xf32> {mhlo.sharding = ""}, %arg2: tensor<?x20x20xf32> {mhlo.sharding = ""}) -> tensor<?x20x20xf32> {

--- a/stablehlo/testdata/vmap_atan_shape_bfloat16_20_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_atan_shape_bfloat16_20_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x20xbf16> {mhlo.sharding = ""}) -> tensor<?x20x20xbf16> {

--- a/stablehlo/testdata/vmap_atanh_shape_bfloat16_20_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_atanh_shape_bfloat16_20_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x20xbf16> {mhlo.sharding = ""}) -> tensor<?x20x20xbf16> {

--- a/stablehlo/testdata/vmap_bessel_i1e_shape_bfloat16_20_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_bessel_i1e_shape_bfloat16_20_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x20xbf16> {mhlo.sharding = ""}) -> tensor<?x20x20xbf16> {

--- a/stablehlo/testdata/vmap_bitcast_convert_type_dtypes_to_new_dtypes_shape_bfloat16_2_3__newdtype_bfloat16_dynamic.mlir
+++ b/stablehlo/testdata/vmap_bitcast_convert_type_dtypes_to_new_dtypes_shape_bfloat16_2_3__newdtype_bfloat16_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2x3xbf16> {mhlo.sharding = ""}) -> tensor<?x2x3xbf16> {

--- a/stablehlo/testdata/vmap_bitcast_convert_type_dtypes_to_new_dtypes_shape_bfloat16_2_3__newdtype_float16_dynamic.mlir
+++ b/stablehlo/testdata/vmap_bitcast_convert_type_dtypes_to_new_dtypes_shape_bfloat16_2_3__newdtype_float16_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2x3xbf16> {mhlo.sharding = ""}) -> tensor<?x2x3xf16> {

--- a/stablehlo/testdata/vmap_bitcast_convert_type_dtypes_to_new_dtypes_shape_bfloat16_2_3__newdtype_int16_dynamic.mlir
+++ b/stablehlo/testdata/vmap_bitcast_convert_type_dtypes_to_new_dtypes_shape_bfloat16_2_3__newdtype_int16_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2x3xbf16> {mhlo.sharding = ""}) -> tensor<?x2x3xi16> {

--- a/stablehlo/testdata/vmap_bitcast_convert_type_dtypes_to_new_dtypes_shape_bfloat16_2_3__newdtype_uint16_dynamic.mlir
+++ b/stablehlo/testdata/vmap_bitcast_convert_type_dtypes_to_new_dtypes_shape_bfloat16_2_3__newdtype_uint16_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2x3xbf16> {mhlo.sharding = ""}) -> tensor<?x2x3xui16> {

--- a/stablehlo/testdata/vmap_broadcast_in_dim_dtypes_shape_float32_2__outshape__2___broadcastdimensions__0_dynamic.mlir
+++ b/stablehlo/testdata/vmap_broadcast_in_dim_dtypes_shape_float32_2__outshape__2___broadcastdimensions__0_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2xf32> {mhlo.sharding = ""}) -> tensor<?x2xf32> {

--- a/stablehlo/testdata/vmap_broadcast_in_dim_parameter_combinations_shape_float32_1_2__outshape__4__3__2__broadcastdimensions__0__2_dynamic.mlir
+++ b/stablehlo/testdata/vmap_broadcast_in_dim_parameter_combinations_shape_float32_1_2__outshape__4__3__2__broadcastdimensions__0__2_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x2xf32> {mhlo.sharding = ""}) -> tensor<?x4x3x2xf32> {

--- a/stablehlo/testdata/vmap_broadcast_in_dim_parameter_combinations_shape_float32_2__outshape__2__3__broadcastdimensions__0_dynamic.mlir
+++ b/stablehlo/testdata/vmap_broadcast_in_dim_parameter_combinations_shape_float32_2__outshape__2__3__broadcastdimensions__0_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2xf32> {mhlo.sharding = ""}) -> tensor<?x2x3xf32> {

--- a/stablehlo/testdata/vmap_broadcast_in_dim_parameter_combinations_shape_float32_2__outshape__3__2__broadcastdimensions__1_dynamic.mlir
+++ b/stablehlo/testdata/vmap_broadcast_in_dim_parameter_combinations_shape_float32_2__outshape__3__2__broadcastdimensions__1_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2xf32> {mhlo.sharding = ""}) -> tensor<?x3x2xf32> {

--- a/stablehlo/testdata/vmap_broadcast_in_dim_parameter_combinations_shape_float32___outshape__2__3__broadcastdimensions_dynamic.mlir
+++ b/stablehlo/testdata/vmap_broadcast_in_dim_parameter_combinations_shape_float32___outshape__2__3__broadcastdimensions_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?xf32> {mhlo.sharding = ""}) -> tensor<?x2x3xf32> {

--- a/stablehlo/testdata/vmap_cbrt_shape_bfloat16_20_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_cbrt_shape_bfloat16_20_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x20xbf16> {mhlo.sharding = ""}) -> tensor<?x20x20xbf16> {

--- a/stablehlo/testdata/vmap_ceil_shape_bfloat16_20_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_ceil_shape_bfloat16_20_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x20xbf16> {mhlo.sharding = ""}) -> tensor<?x20x20xbf16> {

--- a/stablehlo/testdata/vmap_clamp_broadcasting_min_float32_2_3__operand_float32_2_3__max_float32_2_3_dynamic.mlir
+++ b/stablehlo/testdata/vmap_clamp_broadcasting_min_float32_2_3__operand_float32_2_3__max_float32_2_3_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2x3xf32> {mhlo.sharding = ""}, %arg3: tensor<?x2x3xf32> {mhlo.sharding = ""}) -> tensor<?x2x3xf32> {

--- a/stablehlo/testdata/vmap_clamp_broadcasting_min_float32_2_3__operand_float32_2_3__max_float32_dynamic.mlir
+++ b/stablehlo/testdata/vmap_clamp_broadcasting_min_float32_2_3__operand_float32_2_3__max_float32_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2x3xf32> {mhlo.sharding = ""}, %arg3: tensor<?xf32> {mhlo.sharding = ""}) -> tensor<?x2x3xf32> {

--- a/stablehlo/testdata/vmap_clamp_broadcasting_min_float32___operand_float32_2_3__max_float32_2_3_dynamic.mlir
+++ b/stablehlo/testdata/vmap_clamp_broadcasting_min_float32___operand_float32_2_3__max_float32_2_3_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2x3xf32> {mhlo.sharding = ""}, %arg3: tensor<?x2x3xf32> {mhlo.sharding = ""}) -> tensor<?x2x3xf32> {

--- a/stablehlo/testdata/vmap_clamp_dtypes_min_float32___operand_float32_2_3__max_float32_dynamic.mlir
+++ b/stablehlo/testdata/vmap_clamp_dtypes_min_float32___operand_float32_2_3__max_float32_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2x3xf32> {mhlo.sharding = ""}, %arg3: tensor<?xf32> {mhlo.sharding = ""}) -> tensor<?x2x3xf32> {

--- a/stablehlo/testdata/vmap_clamp_order_False_min_float32___operand_float32_2_3__max_float32_dynamic.mlir
+++ b/stablehlo/testdata/vmap_clamp_order_False_min_float32___operand_float32_2_3__max_float32_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2x3xf32> {mhlo.sharding = ""}, %arg3: tensor<?xf32> {mhlo.sharding = ""}) -> tensor<?x2x3xf32> {

--- a/stablehlo/testdata/vmap_clamp_order_True_min_float32___operand_float32_2_3__max_float32_dynamic.mlir
+++ b/stablehlo/testdata/vmap_clamp_order_True_min_float32___operand_float32_2_3__max_float32_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2x3xf32> {mhlo.sharding = ""}, %arg3: tensor<?xf32> {mhlo.sharding = ""}) -> tensor<?x2x3xf32> {

--- a/stablehlo/testdata/vmap_complex_broadcast_lhs_float32_3_1__rhs_float32_3_2_dynamic.mlir
+++ b/stablehlo/testdata/vmap_complex_broadcast_lhs_float32_3_1__rhs_float32_3_2_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x3x1xf32> {mhlo.sharding = ""}, %arg2: tensor<?x3x2xf32> {mhlo.sharding = ""}) -> tensor<?x3x2xcomplex<f32>> {

--- a/stablehlo/testdata/vmap_complex_broadcast_lhs_float32_3_2__rhs_float32_3_1_dynamic.mlir
+++ b/stablehlo/testdata/vmap_complex_broadcast_lhs_float32_3_2__rhs_float32_3_1_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x3x2xf32> {mhlo.sharding = ""}, %arg2: tensor<?x3x1xf32> {mhlo.sharding = ""}) -> tensor<?x3x2xcomplex<f32>> {

--- a/stablehlo/testdata/vmap_complex_dtypes_lhs_float32_3_4__rhs_float32_3_4_dynamic.mlir
+++ b/stablehlo/testdata/vmap_complex_dtypes_lhs_float32_3_4__rhs_float32_3_4_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x3x4xf32> {mhlo.sharding = ""}, %arg2: tensor<?x3x4xf32> {mhlo.sharding = ""}) -> tensor<?x3x4xcomplex<f32>> {

--- a/stablehlo/testdata/vmap_concatenate_dimension_shapes_float32_2_3__float32_2_3__dimension_1_dynamic.mlir
+++ b/stablehlo/testdata/vmap_concatenate_dimension_shapes_float32_2_3__float32_2_3__dimension_1_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2x3xf32> {mhlo.sharding = ""}) -> tensor<?x2x6xf32> {

--- a/stablehlo/testdata/vmap_concatenate_dtypes_shapes_float32_2_3__float32_2_3__dimension_0_dynamic.mlir
+++ b/stablehlo/testdata/vmap_concatenate_dtypes_shapes_float32_2_3__float32_2_3__dimension_0_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2x3xf32> {mhlo.sharding = ""}) -> tensor<?x4x3xf32> {

--- a/stablehlo/testdata/vmap_concatenate_nb_operands_shapes_float32_2_3_4__float32_3_3_4__float32_4_3_4__dimension_0_dynamic.mlir
+++ b/stablehlo/testdata/vmap_concatenate_nb_operands_shapes_float32_2_3_4__float32_3_3_4__float32_4_3_4__dimension_0_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2x3x4xf32> {mhlo.sharding = ""}, %arg2: tensor<?x3x3x4xf32> {mhlo.sharding = ""}, %arg3: tensor<?x4x3x4xf32> {mhlo.sharding = ""}) -> tensor<?x9x3x4xf32> {

--- a/stablehlo/testdata/vmap_conj_dtypes_operand_float32_3_4__kwargs_dynamic.mlir
+++ b/stablehlo/testdata/vmap_conj_dtypes_operand_float32_3_4__kwargs_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x3x4xf32> {mhlo.sharding = ""}) -> tensor<?x3x4xcomplex<f32>> {

--- a/stablehlo/testdata/vmap_conj_kwargs_operand_float32_3_4__kwargs____input_dtype___class_numpy_float32_dynamic.mlir
+++ b/stablehlo/testdata/vmap_conj_kwargs_operand_float32_3_4__kwargs____input_dtype___class_numpy_float32_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x3x4xf32> {mhlo.sharding = ""}) -> tensor<?x3x4xcomplex<f32>> {

--- a/stablehlo/testdata/vmap_convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_bfloat16_dynamic.mlir
+++ b/stablehlo/testdata/vmap_convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_bfloat16_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x100x100xi8> {mhlo.sharding = ""}) -> tensor<?x100x100xbf16> {

--- a/stablehlo/testdata/vmap_convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_bool_dynamic.mlir
+++ b/stablehlo/testdata/vmap_convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_bool_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x100x100xi8> {mhlo.sharding = ""}) -> tensor<?x100x100xi1> {

--- a/stablehlo/testdata/vmap_convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_complex128_dynamic.mlir
+++ b/stablehlo/testdata/vmap_convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_complex128_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x100x100xi8> {mhlo.sharding = ""}) -> tensor<?x100x100xcomplex<f64>> {

--- a/stablehlo/testdata/vmap_convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_complex64_dynamic.mlir
+++ b/stablehlo/testdata/vmap_convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_complex64_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x100x100xi8> {mhlo.sharding = ""}) -> tensor<?x100x100xcomplex<f32>> {

--- a/stablehlo/testdata/vmap_convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_float16_dynamic.mlir
+++ b/stablehlo/testdata/vmap_convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_float16_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x100x100xi8> {mhlo.sharding = ""}) -> tensor<?x100x100xf16> {

--- a/stablehlo/testdata/vmap_convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_float32_dynamic.mlir
+++ b/stablehlo/testdata/vmap_convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_float32_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x100x100xi8> {mhlo.sharding = ""}) -> tensor<?x100x100xf32> {

--- a/stablehlo/testdata/vmap_convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_int32_dynamic.mlir
+++ b/stablehlo/testdata/vmap_convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_int32_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x100x100xi8> {mhlo.sharding = ""}) -> tensor<?x100x100xi32> {

--- a/stablehlo/testdata/vmap_convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_int64_dynamic.mlir
+++ b/stablehlo/testdata/vmap_convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_int64_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x100x100xi8> {mhlo.sharding = ""}) -> tensor<?x100x100xi64> {

--- a/stablehlo/testdata/vmap_convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_uint32_dynamic.mlir
+++ b/stablehlo/testdata/vmap_convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_uint32_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x100x100xi8> {mhlo.sharding = ""}) -> tensor<?x100x100xui32> {

--- a/stablehlo/testdata/vmap_convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_uint64_dynamic.mlir
+++ b/stablehlo/testdata/vmap_convert_element_type_dtypes_to_dtypes_shape_int8_100_100__olddtype_int8_newdtype_uint64_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x100x100xi8> {mhlo.sharding = ""}) -> tensor<?x100x100xui64> {

--- a/stablehlo/testdata/vmap_cosh_shape_bfloat16_20_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_cosh_shape_bfloat16_20_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x20xbf16> {mhlo.sharding = ""}) -> tensor<?x20x20xbf16> {

--- a/stablehlo/testdata/vmap_cumlogsumexp_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False_dynamic.mlir
+++ b/stablehlo/testdata/vmap_cumlogsumexp_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/vmap_cumlogsumexp_axis_by_fun_shape_float32_8_9__axis_1_reverse_False_dynamic.mlir
+++ b/stablehlo/testdata/vmap_cumlogsumexp_axis_by_fun_shape_float32_8_9__axis_1_reverse_False_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/vmap_cumlogsumexp_dtype_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False_dynamic.mlir
+++ b/stablehlo/testdata/vmap_cumlogsumexp_dtype_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/vmap_cumlogsumexp_reverse_shape_float32_8_9__axis_0_reverse_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_cumlogsumexp_reverse_shape_float32_8_9__axis_0_reverse_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/vmap_cummax_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False_dynamic.mlir
+++ b/stablehlo/testdata/vmap_cummax_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/vmap_cummax_axis_by_fun_shape_float32_8_9__axis_1_reverse_False_dynamic.mlir
+++ b/stablehlo/testdata/vmap_cummax_axis_by_fun_shape_float32_8_9__axis_1_reverse_False_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/vmap_cummax_dtype_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False_dynamic.mlir
+++ b/stablehlo/testdata/vmap_cummax_dtype_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/vmap_cummax_reverse_shape_float32_8_9__axis_0_reverse_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_cummax_reverse_shape_float32_8_9__axis_0_reverse_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/vmap_cummin_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False_dynamic.mlir
+++ b/stablehlo/testdata/vmap_cummin_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/vmap_cummin_axis_by_fun_shape_float32_8_9__axis_1_reverse_False_dynamic.mlir
+++ b/stablehlo/testdata/vmap_cummin_axis_by_fun_shape_float32_8_9__axis_1_reverse_False_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/vmap_cummin_dtype_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False_dynamic.mlir
+++ b/stablehlo/testdata/vmap_cummin_dtype_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/vmap_cummin_reverse_shape_float32_8_9__axis_0_reverse_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_cummin_reverse_shape_float32_8_9__axis_0_reverse_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/vmap_cumprod_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False_dynamic.mlir
+++ b/stablehlo/testdata/vmap_cumprod_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/vmap_cumprod_axis_by_fun_shape_float32_8_9__axis_1_reverse_False_dynamic.mlir
+++ b/stablehlo/testdata/vmap_cumprod_axis_by_fun_shape_float32_8_9__axis_1_reverse_False_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/vmap_cumprod_dtype_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False_dynamic.mlir
+++ b/stablehlo/testdata/vmap_cumprod_dtype_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/vmap_cumprod_reverse_shape_float32_8_9__axis_0_reverse_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_cumprod_reverse_shape_float32_8_9__axis_0_reverse_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/vmap_cumsum_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False_dynamic.mlir
+++ b/stablehlo/testdata/vmap_cumsum_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/vmap_cumsum_axis_by_fun_shape_float32_8_9__axis_1_reverse_False_dynamic.mlir
+++ b/stablehlo/testdata/vmap_cumsum_axis_by_fun_shape_float32_8_9__axis_1_reverse_False_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/vmap_cumsum_dtype_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False_dynamic.mlir
+++ b/stablehlo/testdata/vmap_cumsum_dtype_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/vmap_cumsum_reverse_shape_float32_8_9__axis_0_reverse_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_cumsum_reverse_shape_float32_8_9__axis_0_reverse_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/vmap_device_put_devices_shape_float32_3_4__device__cpu_dynamic.mlir
+++ b/stablehlo/testdata/vmap_device_put_devices_shape_float32_3_4__device__cpu_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x3x4xf32> {mhlo.sharding = ""}) -> tensor<?x3x4xf32> {

--- a/stablehlo/testdata/vmap_div_broadcast_lhs_float32_2_1_3__rhs_float32_2_4_3_dynamic.mlir
+++ b/stablehlo/testdata/vmap_div_broadcast_lhs_float32_2_1_3__rhs_float32_2_4_3_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2x1x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2x4x3xf32> {mhlo.sharding = ""}) -> tensor<?x2x4x3xf32> {

--- a/stablehlo/testdata/vmap_div_broadcast_lhs_float32_2_4_3__rhs_float32_2_1_3_dynamic.mlir
+++ b/stablehlo/testdata/vmap_div_broadcast_lhs_float32_2_4_3__rhs_float32_2_1_3_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2x4x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2x1x3xf32> {mhlo.sharding = ""}) -> tensor<?x2x4x3xf32> {

--- a/stablehlo/testdata/vmap_div_singularity_inf_by_inf_lhs_float32_1__rhs_float32_1_dynamic.mlir
+++ b/stablehlo/testdata/vmap_div_singularity_inf_by_inf_lhs_float32_1__rhs_float32_1_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1xf32> {mhlo.sharding = ""}) -> tensor<?x1xf32> {

--- a/stablehlo/testdata/vmap_div_singularity_negative_by_0_lhs_float32_2__rhs_float32_2_dynamic.mlir
+++ b/stablehlo/testdata/vmap_div_singularity_negative_by_0_lhs_float32_2__rhs_float32_2_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2xf32> {mhlo.sharding = ""}) -> tensor<?x2xf32> {

--- a/stablehlo/testdata/vmap_dot_general_batch_dimensions_lhs_float32_8_4_3_3_4__rhs_float32_4_8_3_4_2__dimensionnumbers____4_3___3_2_____0_1___1_0_dynamic.mlir
+++ b/stablehlo/testdata/vmap_dot_general_batch_dimensions_lhs_float32_8_4_3_3_4__rhs_float32_4_8_3_4_2__dimensionnumbers____4_3___3_2_____0_1___1_0_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8x4x3x3x4xf32> {mhlo.sharding = ""}, %arg2: tensor<?x4x8x3x4x2xf32> {mhlo.sharding = ""}) -> tensor<?x8x4x3x2xf32> {

--- a/stablehlo/testdata/vmap_dot_general_dtypes_and_precision_lhs_float32_1_3_4__rhs_float32_1_4_3__dimensionnumbers____2_1_-6362698473521588318_dynamic.mlir
+++ b/stablehlo/testdata/vmap_dot_general_dtypes_and_precision_lhs_float32_1_3_4__rhs_float32_1_4_3__dimensionnumbers____2_1_-6362698473521588318_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x3x4xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1x4x3xf32> {mhlo.sharding = ""}) -> tensor<?x1xf32> {

--- a/stablehlo/testdata/vmap_dot_general_dtypes_and_precision_lhs_float32_1_3_4__rhs_float32_1_4_3__dimensionnumbers____2_1___1_2_____0____0_dynamic.mlir
+++ b/stablehlo/testdata/vmap_dot_general_dtypes_and_precision_lhs_float32_1_3_4__rhs_float32_1_4_3__dimensionnumbers____2_1___1_2_____0____0_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x3x4xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1x4x3xf32> {mhlo.sharding = ""}) -> tensor<?x1xf32> {

--- a/stablehlo/testdata/vmap_dot_general_dtypes_and_precision_lhs_float32_3_4__rhs_float32_4_2__dimensionnumbers____1____0__4570748673492980165_dynamic.mlir
+++ b/stablehlo/testdata/vmap_dot_general_dtypes_and_precision_lhs_float32_3_4__rhs_float32_4_2__dimensionnumbers____1____0__4570748673492980165_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x3x4xf32> {mhlo.sharding = ""}, %arg2: tensor<?x4x2xf32> {mhlo.sharding = ""}) -> tensor<?x3x2xf32> {

--- a/stablehlo/testdata/vmap_dot_general_dtypes_and_precision_lhs_float32_3_4__rhs_float32_4_2__dimensionnumbers____1____0_dynamic.mlir
+++ b/stablehlo/testdata/vmap_dot_general_dtypes_and_precision_lhs_float32_3_4__rhs_float32_4_2__dimensionnumbers____1____0_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x3x4xf32> {mhlo.sharding = ""}, %arg2: tensor<?x4x2xf32> {mhlo.sharding = ""}) -> tensor<?x3x2xf32> {

--- a/stablehlo/testdata/vmap_dot_general_dtypes_and_precision_lhs_float32_7_3_4__rhs_float32_7_4__dimensionnumbers____2____1-18078742790955980_dynamic.mlir
+++ b/stablehlo/testdata/vmap_dot_general_dtypes_and_precision_lhs_float32_7_3_4__rhs_float32_7_4__dimensionnumbers____2____1-18078742790955980_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x7x3x4xf32> {mhlo.sharding = ""}, %arg2: tensor<?x7x4xf32> {mhlo.sharding = ""}) -> tensor<?x7x3xf32> {

--- a/stablehlo/testdata/vmap_dot_general_dtypes_and_precision_lhs_float32_7_3_4__rhs_float32_7_4__dimensionnumbers____2____1______0____0_dynamic.mlir
+++ b/stablehlo/testdata/vmap_dot_general_dtypes_and_precision_lhs_float32_7_3_4__rhs_float32_7_4__dimensionnumbers____2____1______0____0_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x7x3x4xf32> {mhlo.sharding = ""}, %arg2: tensor<?x7x4xf32> {mhlo.sharding = ""}) -> tensor<?x7x3xf32> {

--- a/stablehlo/testdata/vmap_dot_general_preferred_lhs_float32_3__rhs_float32_3_6__dimensionnumbers____0____0_____________preferred_float32_dynamic.mlir
+++ b/stablehlo/testdata/vmap_dot_general_preferred_lhs_float32_3__rhs_float32_3_6__dimensionnumbers____0____0_____________preferred_float32_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x3x6xf32> {mhlo.sharding = ""}) -> tensor<?x6xf32> {

--- a/stablehlo/testdata/vmap_dot_general_preferred_lhs_float32_3__rhs_float32_3__dimensionnumbers____0____0_____________preferred_float64_dynamic.mlir
+++ b/stablehlo/testdata/vmap_dot_general_preferred_lhs_float32_3__rhs_float32_3__dimensionnumbers____0____0_____________preferred_float64_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x3xf32> {mhlo.sharding = ""}) -> tensor<?xf64> {

--- a/stablehlo/testdata/vmap_dot_general_preferred_lhs_float32_4_3__rhs_float32_3_6__dimensionnumbers____1____0_____________preferred_float32_dynamic.mlir
+++ b/stablehlo/testdata/vmap_dot_general_preferred_lhs_float32_4_3__rhs_float32_3_6__dimensionnumbers____1____0_____________preferred_float32_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x3x6xf32> {mhlo.sharding = ""}) -> tensor<?x4x6xf32> {

--- a/stablehlo/testdata/vmap_dot_general_preferred_lhs_float32_4_3__rhs_float32_3__dimensionnumbers____1____0_____________preferred_float64_dynamic.mlir
+++ b/stablehlo/testdata/vmap_dot_general_preferred_lhs_float32_4_3__rhs_float32_3__dimensionnumbers____1____0_____________preferred_float64_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x3xf32> {mhlo.sharding = ""}) -> tensor<?x4xf64> {

--- a/stablehlo/testdata/vmap_dot_general_squeeze_lhs_float32_4_4__rhs_float32_4__dimensionnumbers____1____0_dynamic.mlir
+++ b/stablehlo/testdata/vmap_dot_general_squeeze_lhs_float32_4_4__rhs_float32_4__dimensionnumbers____1____0_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x4xf32> {mhlo.sharding = ""}, %arg2: tensor<?x4xf32> {mhlo.sharding = ""}) -> tensor<?x4xf32> {

--- a/stablehlo/testdata/vmap_dynamic_slice_dtypes_a_float32_3__start_indices__1___limit_indices__2___enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_dynamic_slice_dtypes_a_float32_3__start_indices__1___limit_indices__2___enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1xi64> {mhlo.sharding = ""}) -> tensor<?x1xf32> {

--- a/stablehlo/testdata/vmap_dynamic_slice_shapes_a_float32_3__start_indices__1___limit_indices__2___enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_dynamic_slice_shapes_a_float32_3__start_indices__1___limit_indices__2___enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1xi64> {mhlo.sharding = ""}) -> tensor<?x1xf32> {

--- a/stablehlo/testdata/vmap_dynamic_slice_shapes_a_float32_5_3__start_indices__1__1__limit_indices__2__1__enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_dynamic_slice_shapes_a_float32_5_3__start_indices__1__1__limit_indices__2__1__enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2xi64> {mhlo.sharding = ""}) -> tensor<?x1x0xf32> {

--- a/stablehlo/testdata/vmap_dynamic_slice_shapes_a_float32_5_3__start_indices__1__1__limit_indices__3__2__enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_dynamic_slice_shapes_a_float32_5_3__start_indices__1__1__limit_indices__3__2__enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2xi64> {mhlo.sharding = ""}) -> tensor<?x2x1xf32> {

--- a/stablehlo/testdata/vmap_dynamic_slice_shapes_a_float32_5__start_indices__-100___limit_indices__-99___enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_dynamic_slice_shapes_a_float32_5__start_indices__-100___limit_indices__-99___enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1xi64> {mhlo.sharding = ""}) -> tensor<?x1xf32> {

--- a/stablehlo/testdata/vmap_dynamic_slice_shapes_a_float32_5__start_indices__-10___limit_indices__-9___enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_dynamic_slice_shapes_a_float32_5__start_indices__-10___limit_indices__-9___enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1xi64> {mhlo.sharding = ""}) -> tensor<?x1xf32> {

--- a/stablehlo/testdata/vmap_dynamic_slice_shapes_a_float32_5__start_indices__-6___limit_indices__-5___enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_dynamic_slice_shapes_a_float32_5__start_indices__-6___limit_indices__-5___enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1xi64> {mhlo.sharding = ""}) -> tensor<?x1xf32> {

--- a/stablehlo/testdata/vmap_dynamic_slice_shapes_a_float32_5__start_indices__1___limit_indices__5___enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_dynamic_slice_shapes_a_float32_5__start_indices__1___limit_indices__5___enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1xi64> {mhlo.sharding = ""}) -> tensor<?x4xf32> {

--- a/stablehlo/testdata/vmap_dynamic_slice_shapes_a_float32_5__start_indices__5___limit_indices__6___enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_dynamic_slice_shapes_a_float32_5__start_indices__5___limit_indices__6___enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1xi64> {mhlo.sharding = ""}) -> tensor<?x1xf32> {

--- a/stablehlo/testdata/vmap_dynamic_slice_shapes_a_float32_7_5_3__start_indices__4__0__1__limit_indices__7__1__3__enablexla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_dynamic_slice_shapes_a_float32_7_5_3__start_indices__4__0__1__limit_indices__7__1__3__enablexla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x7x5x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x3xi64> {mhlo.sharding = ""}) -> tensor<?x3x1x2xf32> {

--- a/stablehlo/testdata/vmap_dynamic_update_slice_dtypes_operand_float32_3__update_float32_1__start_indices__1___enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_dynamic_update_slice_dtypes_operand_float32_3__update_float32_1__start_indices__1___enable_xla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1xf32> {mhlo.sharding = ""}, %arg3: tensor<?x1xi64> {mhlo.sharding = ""}) -> tensor<?x3xf32> {

--- a/stablehlo/testdata/vmap_dynamic_update_slice_shapes_operand_float32_3__update_float32_1__start_indices__-1___enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_dynamic_update_slice_shapes_operand_float32_3__update_float32_1__start_indices__-1___enable_xla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1xf32> {mhlo.sharding = ""}, %arg3: tensor<?x1xi64> {mhlo.sharding = ""}) -> tensor<?x3xf32> {

--- a/stablehlo/testdata/vmap_dynamic_update_slice_shapes_operand_float32_3__update_float32_1__start_indices__array_1__dtype_uint32____enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_dynamic_update_slice_shapes_operand_float32_3__update_float32_1__start_indices__array_1__dtype_uint32____enable_xla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1xf32> {mhlo.sharding = ""}, %arg3: tensor<?x1xui32> {mhlo.sharding = ""}) -> tensor<?x3xf32> {

--- a/stablehlo/testdata/vmap_dynamic_update_slice_shapes_operand_float32_3__update_float32_1__start_indices__array_1__dtype_uint8____enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_dynamic_update_slice_shapes_operand_float32_3__update_float32_1__start_indices__array_1__dtype_uint8____enable_xla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1xf32> {mhlo.sharding = ""}, %arg3: tensor<?x1xui8> {mhlo.sharding = ""}) -> tensor<?x3xf32> {

--- a/stablehlo/testdata/vmap_dynamic_update_slice_shapes_operand_float32_7_5_3__update_float32_2_0_1__start_indices__4__1__0__enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_dynamic_update_slice_shapes_operand_float32_7_5_3__update_float32_2_0_1__start_indices__4__1__0__enable_xla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x7x5x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2x0x1xf32> {mhlo.sharding = ""}, %arg3: tensor<?x3xi64> {mhlo.sharding = ""}) -> tensor<?x7x5x3xf32> {

--- a/stablehlo/testdata/vmap_eq_broadcasting_lhs_float32___rhs_float32_2_3_dynamic.mlir
+++ b/stablehlo/testdata/vmap_eq_broadcasting_lhs_float32___rhs_float32_2_3_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2x3xf32> {mhlo.sharding = ""}) -> tensor<?x2x3xi1> {

--- a/stablehlo/testdata/vmap_eq_dtypes_lhs_float32___rhs_float32_dynamic.mlir
+++ b/stablehlo/testdata/vmap_eq_dtypes_lhs_float32___rhs_float32_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?xf32> {mhlo.sharding = ""}, %arg2: tensor<?xf32> {mhlo.sharding = ""}) -> tensor<?xi1> {

--- a/stablehlo/testdata/vmap_erfc_shape_bfloat16_20_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_erfc_shape_bfloat16_20_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x20xbf16> {mhlo.sharding = ""}) -> tensor<?x20x20xbf16> {

--- a/stablehlo/testdata/vmap_exp_shape_bfloat16_20_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_exp_shape_bfloat16_20_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x20xbf16> {mhlo.sharding = ""}) -> tensor<?x20x20xbf16> {

--- a/stablehlo/testdata/vmap_gather_batchdims_shape__1__2__start_indices_shape__1__2__slice_sizes__1__1__enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_gather_batchdims_shape__1__2__start_indices_shape__1__2__slice_sizes__1__1__enable_xla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x2xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1x2xi64> {mhlo.sharding = ""}) -> tensor<?x1xf32> {

--- a/stablehlo/testdata/vmap_gather_batchdims_shape__2__3__3__start_indices_shape__2__3__slice_sizes__1__3__2__enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_gather_batchdims_shape__2__3__3__start_indices_shape__2__3__slice_sizes__1__3__2__enable_xla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2x3x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2x3xi64> {mhlo.sharding = ""}) -> tensor<?x2x3x2xf32> {

--- a/stablehlo/testdata/vmap_gather_batchdims_shape__4__6__start_indices_shape__4__2__slice_sizes__1__3__enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_gather_batchdims_shape__4__6__start_indices_shape__4__2__slice_sizes__1__3__enable_xla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x6xf32> {mhlo.sharding = ""}, %arg2: tensor<?x4x2xi64> {mhlo.sharding = ""}) -> tensor<?x4x3xf32> {

--- a/stablehlo/testdata/vmap_gather_dtypes_shape_float32_10__axis_0_enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_gather_dtypes_shape_float32_10__axis_0_enable_xla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x10xf32> {mhlo.sharding = ""}, %arg2: tensor<?xi32> {mhlo.sharding = ""}) -> tensor<?xf32> {

--- a/stablehlo/testdata/vmap_gather_from_slicing_name___0___enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_gather_from_slicing_name___0___enable_xla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x10x10x10xf32> {mhlo.sharding = ""}) -> tensor<?x10x10xf32> {

--- a/stablehlo/testdata/vmap_gather_from_slicing_name___2_5_5___enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_gather_from_slicing_name___2_5_5___enable_xla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x10x10x10xf32> {mhlo.sharding = ""}) -> tensor<?x3x10xf32> {

--- a/stablehlo/testdata/vmap_gather_from_take_indices_name__1__axis_0_enable_xla_True_mode_clip_dynamic.mlir
+++ b/stablehlo/testdata/vmap_gather_from_take_indices_name__1__axis_0_enable_xla_True_mode_clip_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x10x10x10xf32> {mhlo.sharding = ""}, %arg2: tensor<?xi32> {mhlo.sharding = ""}) -> tensor<?x10x10xf32> {

--- a/stablehlo/testdata/vmap_gather_from_take_indices_name__1__axis_0_enable_xla_True_mode_fill_dynamic.mlir
+++ b/stablehlo/testdata/vmap_gather_from_take_indices_name__1__axis_0_enable_xla_True_mode_fill_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x10x10x10xf32> {mhlo.sharding = ""}, %arg2: tensor<?xi32> {mhlo.sharding = ""}) -> tensor<?x10x10xf32> {

--- a/stablehlo/testdata/vmap_gather_from_take_indices_name__1__axis_2_enable_xla_True_mode_clip_dynamic.mlir
+++ b/stablehlo/testdata/vmap_gather_from_take_indices_name__1__axis_2_enable_xla_True_mode_clip_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x10x10x10xf32> {mhlo.sharding = ""}, %arg2: tensor<?xi32> {mhlo.sharding = ""}) -> tensor<?x10x10xf32> {

--- a/stablehlo/testdata/vmap_gather_from_take_indices_name__1__axis_2_enable_xla_True_mode_fill_dynamic.mlir
+++ b/stablehlo/testdata/vmap_gather_from_take_indices_name__1__axis_2_enable_xla_True_mode_fill_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x10x10x10xf32> {mhlo.sharding = ""}, %arg2: tensor<?xi32> {mhlo.sharding = ""}) -> tensor<?x10x10xf32> {

--- a/stablehlo/testdata/vmap_gather_from_take_indices_name__2__axis_1_enable_xla_True_mode_clip_dynamic.mlir
+++ b/stablehlo/testdata/vmap_gather_from_take_indices_name__2__axis_1_enable_xla_True_mode_clip_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x10x10x10xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1xi32> {mhlo.sharding = ""}) -> tensor<?x10x1x10xf32> {

--- a/stablehlo/testdata/vmap_gather_from_take_indices_name__2__axis_1_enable_xla_True_mode_fill_dynamic.mlir
+++ b/stablehlo/testdata/vmap_gather_from_take_indices_name__2__axis_1_enable_xla_True_mode_fill_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/vmap_gather_from_take_indices_name__3__axis_0_enable_xla_True_mode_clip_dynamic.mlir
+++ b/stablehlo/testdata/vmap_gather_from_take_indices_name__3__axis_0_enable_xla_True_mode_clip_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x10x10x10xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2xi32> {mhlo.sharding = ""}) -> tensor<?x2x10x10xf32> {

--- a/stablehlo/testdata/vmap_gather_from_take_indices_name__3__axis_0_enable_xla_True_mode_fill_dynamic.mlir
+++ b/stablehlo/testdata/vmap_gather_from_take_indices_name__3__axis_0_enable_xla_True_mode_fill_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/vmap_gather_from_take_indices_name__3__axis_2_enable_xla_True_mode_clip_dynamic.mlir
+++ b/stablehlo/testdata/vmap_gather_from_take_indices_name__3__axis_2_enable_xla_True_mode_clip_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x10x10x10xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2xi32> {mhlo.sharding = ""}) -> tensor<?x10x10x2xf32> {

--- a/stablehlo/testdata/vmap_gather_from_take_indices_name__3__axis_2_enable_xla_True_mode_fill_dynamic.mlir
+++ b/stablehlo/testdata/vmap_gather_from_take_indices_name__3__axis_2_enable_xla_True_mode_fill_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/vmap_gather_from_take_indices_name__3_uint32__axis_1_enable_xla_True_mode_clip_dynamic.mlir
+++ b/stablehlo/testdata/vmap_gather_from_take_indices_name__3_uint32__axis_1_enable_xla_True_mode_clip_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x10x10x10xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2xui32> {mhlo.sharding = ""}) -> tensor<?x10x2x10xf32> {

--- a/stablehlo/testdata/vmap_gather_from_take_indices_name__3_uint32__axis_1_enable_xla_True_mode_fill_dynamic.mlir
+++ b/stablehlo/testdata/vmap_gather_from_take_indices_name__3_uint32__axis_1_enable_xla_True_mode_fill_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/vmap_gather_from_take_indices_name__4__axis_0_enable_xla_True_mode_clip_dynamic.mlir
+++ b/stablehlo/testdata/vmap_gather_from_take_indices_name__4__axis_0_enable_xla_True_mode_clip_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x10x10x10xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2x2xi32> {mhlo.sharding = ""}) -> tensor<?x2x2x10x10xf32> {

--- a/stablehlo/testdata/vmap_gather_from_take_indices_name__4__axis_0_enable_xla_True_mode_fill_dynamic.mlir
+++ b/stablehlo/testdata/vmap_gather_from_take_indices_name__4__axis_0_enable_xla_True_mode_fill_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/vmap_gather_from_take_indices_name__4__axis_2_enable_xla_True_mode_clip_dynamic.mlir
+++ b/stablehlo/testdata/vmap_gather_from_take_indices_name__4__axis_2_enable_xla_True_mode_clip_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x10x10x10xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2x2xi32> {mhlo.sharding = ""}) -> tensor<?x10x10x2x2xf32> {

--- a/stablehlo/testdata/vmap_gather_from_take_indices_name__4__axis_2_enable_xla_True_mode_fill_dynamic.mlir
+++ b/stablehlo/testdata/vmap_gather_from_take_indices_name__4__axis_2_enable_xla_True_mode_fill_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/vmap_gather_from_take_indices_name__5_oob__axis_1_enable_xla_True_mode_clip_dynamic.mlir
+++ b/stablehlo/testdata/vmap_gather_from_take_indices_name__5_oob__axis_1_enable_xla_True_mode_clip_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x10x10x10xf32> {mhlo.sharding = ""}, %arg2: tensor<?x3x1xi32> {mhlo.sharding = ""}) -> tensor<?x10x3x1x10xf32> {

--- a/stablehlo/testdata/vmap_gather_from_take_indices_name__5_oob__axis_1_enable_xla_True_mode_fill_dynamic.mlir
+++ b/stablehlo/testdata/vmap_gather_from_take_indices_name__5_oob__axis_1_enable_xla_True_mode_fill_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/vmap_gather_from_take_indices_name__6_neg__axis_0_enable_xla_True_mode_clip_dynamic.mlir
+++ b/stablehlo/testdata/vmap_gather_from_take_indices_name__6_neg__axis_0_enable_xla_True_mode_clip_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x10x10x10xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2x2xi32> {mhlo.sharding = ""}) -> tensor<?x2x2x10x10xf32> {

--- a/stablehlo/testdata/vmap_gather_from_take_indices_name__6_neg__axis_0_enable_xla_True_mode_fill_dynamic.mlir
+++ b/stablehlo/testdata/vmap_gather_from_take_indices_name__6_neg__axis_0_enable_xla_True_mode_fill_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/vmap_gather_from_take_indices_name__6_neg__axis_2_enable_xla_True_mode_clip_dynamic.mlir
+++ b/stablehlo/testdata/vmap_gather_from_take_indices_name__6_neg__axis_2_enable_xla_True_mode_clip_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x10x10x10xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2x2xi32> {mhlo.sharding = ""}) -> tensor<?x10x10x2x2xf32> {

--- a/stablehlo/testdata/vmap_gather_from_take_indices_name__6_neg__axis_2_enable_xla_True_mode_fill_dynamic.mlir
+++ b/stablehlo/testdata/vmap_gather_from_take_indices_name__6_neg__axis_2_enable_xla_True_mode_fill_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/vmap_gather_from_take_indices_name__7_neg__axis_1_enable_xla_True_mode_clip_dynamic.mlir
+++ b/stablehlo/testdata/vmap_gather_from_take_indices_name__7_neg__axis_1_enable_xla_True_mode_clip_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x10x10x10xf32> {mhlo.sharding = ""}, %arg2: tensor<?x5xi32> {mhlo.sharding = ""}) -> tensor<?x10x5x10xf32> {

--- a/stablehlo/testdata/vmap_gather_from_take_indices_name__7_neg__axis_1_enable_xla_True_mode_fill_dynamic.mlir
+++ b/stablehlo/testdata/vmap_gather_from_take_indices_name__7_neg__axis_1_enable_xla_True_mode_fill_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/vmap_gather_from_take_indices_name__8_neg_oob__axis_0_enable_xla_True_mode_clip_dynamic.mlir
+++ b/stablehlo/testdata/vmap_gather_from_take_indices_name__8_neg_oob__axis_0_enable_xla_True_mode_clip_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x10x10x10xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2x2x1xi32> {mhlo.sharding = ""}) -> tensor<?x2x2x1x10x10xf32> {

--- a/stablehlo/testdata/vmap_gather_from_take_indices_name__8_neg_oob__axis_0_enable_xla_True_mode_fill_dynamic.mlir
+++ b/stablehlo/testdata/vmap_gather_from_take_indices_name__8_neg_oob__axis_0_enable_xla_True_mode_fill_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/vmap_gather_from_take_indices_name__8_neg_oob__axis_2_enable_xla_True_mode_clip_dynamic.mlir
+++ b/stablehlo/testdata/vmap_gather_from_take_indices_name__8_neg_oob__axis_2_enable_xla_True_mode_clip_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x10x10x10xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2x2x1xi32> {mhlo.sharding = ""}) -> tensor<?x10x10x2x2x1xf32> {

--- a/stablehlo/testdata/vmap_gather_from_take_indices_name__8_neg_oob__axis_2_enable_xla_True_mode_fill_dynamic.mlir
+++ b/stablehlo/testdata/vmap_gather_from_take_indices_name__8_neg_oob__axis_2_enable_xla_True_mode_fill_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/vmap_gather_shape__10___idxs_shape__3__1__dnums_GatherDimensionNumbers_offset_dims__1____collapsed_s-3138458249020037857_dynamic.mlir
+++ b/stablehlo/testdata/vmap_gather_shape__10___idxs_shape__3__1__dnums_GatherDimensionNumbers_offset_dims__1____collapsed_s-3138458249020037857_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x10xf32> {mhlo.sharding = ""}, %arg2: tensor<?x3x1xi64> {mhlo.sharding = ""}) -> tensor<?x3x2xf32> {

--- a/stablehlo/testdata/vmap_gather_shape__5___idxs_shape__2__1__dnums_GatherDimensionNumbers_offset_dims_____collapsed_slic-4256662786843852688_dynamic.mlir
+++ b/stablehlo/testdata/vmap_gather_shape__5___idxs_shape__2__1__dnums_GatherDimensionNumbers_offset_dims_____collapsed_slic-4256662786843852688_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2x1xi64> {mhlo.sharding = ""}) -> tensor<?x2xf32> {

--- a/stablehlo/testdata/vmap_ge_dtypes_lhs_float32___rhs_float32_dynamic.mlir
+++ b/stablehlo/testdata/vmap_ge_dtypes_lhs_float32___rhs_float32_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?xf32> {mhlo.sharding = ""}, %arg2: tensor<?xf32> {mhlo.sharding = ""}) -> tensor<?xi1> {

--- a/stablehlo/testdata/vmap_gt_broadcasting_lhs_float32_1_2__rhs_float32_3_2_dynamic.mlir
+++ b/stablehlo/testdata/vmap_gt_broadcasting_lhs_float32_1_2__rhs_float32_3_2_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x2xf32> {mhlo.sharding = ""}, %arg2: tensor<?x3x2xf32> {mhlo.sharding = ""}) -> tensor<?x3x2xi1> {

--- a/stablehlo/testdata/vmap_integer_pow_dtypes_shape_bfloat16_20_30__y_-2_dynamic.mlir
+++ b/stablehlo/testdata/vmap_integer_pow_dtypes_shape_bfloat16_20_30__y_-2_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x30xbf16> {mhlo.sharding = ""}) -> tensor<?x20x30xbf16> {

--- a/stablehlo/testdata/vmap_integer_pow_dtypes_shape_bfloat16_20_30__y_-3_dynamic.mlir
+++ b/stablehlo/testdata/vmap_integer_pow_dtypes_shape_bfloat16_20_30__y_-3_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x30xbf16> {mhlo.sharding = ""}) -> tensor<?x20x30xbf16> {

--- a/stablehlo/testdata/vmap_integer_pow_dtypes_shape_bfloat16_20_30__y_2_dynamic.mlir
+++ b/stablehlo/testdata/vmap_integer_pow_dtypes_shape_bfloat16_20_30__y_2_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x30xbf16> {mhlo.sharding = ""}) -> tensor<?x20x30xbf16> {

--- a/stablehlo/testdata/vmap_integer_pow_dtypes_shape_bfloat16_20_30__y_3_dynamic.mlir
+++ b/stablehlo/testdata/vmap_integer_pow_dtypes_shape_bfloat16_20_30__y_3_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x30xbf16> {mhlo.sharding = ""}) -> tensor<?x20x30xbf16> {

--- a/stablehlo/testdata/vmap_integer_pow_overflow_shape_bfloat16_20_30__y_127_dynamic.mlir
+++ b/stablehlo/testdata/vmap_integer_pow_overflow_shape_bfloat16_20_30__y_127_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x30xbf16> {mhlo.sharding = ""}) -> tensor<?x20x30xbf16> {

--- a/stablehlo/testdata/vmap_is_finite_shape_bfloat16_20_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_is_finite_shape_bfloat16_20_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x20xbf16> {mhlo.sharding = ""}) -> tensor<?x20x20xi1> {

--- a/stablehlo/testdata/vmap_le_dtypes_lhs_float32___rhs_float32_dynamic.mlir
+++ b/stablehlo/testdata/vmap_le_dtypes_lhs_float32___rhs_float32_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?xf32> {mhlo.sharding = ""}, %arg2: tensor<?xf32> {mhlo.sharding = ""}) -> tensor<?xi1> {

--- a/stablehlo/testdata/vmap_lgamma_shape_bfloat16_20_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_lgamma_shape_bfloat16_20_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x20xbf16> {mhlo.sharding = ""}) -> tensor<?x20x20xbf16> {

--- a/stablehlo/testdata/vmap_logistic_shape_bfloat16_20_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_logistic_shape_bfloat16_20_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x20xbf16> {mhlo.sharding = ""}) -> tensor<?x20x20xbf16> {

--- a/stablehlo/testdata/vmap_lt_broadcasting_lhs_float32_1_2__rhs_float32_3_2_dynamic.mlir
+++ b/stablehlo/testdata/vmap_lt_broadcasting_lhs_float32_1_2__rhs_float32_3_2_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x2xf32> {mhlo.sharding = ""}, %arg2: tensor<?x3x2xf32> {mhlo.sharding = ""}) -> tensor<?x3x2xi1> {

--- a/stablehlo/testdata/vmap_max_broadcasting_lhs_float32_1_20__rhs_float32_20_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_max_broadcasting_lhs_float32_1_20__rhs_float32_20_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x20xf32> {mhlo.sharding = ""}, %arg2: tensor<?x20x20xf32> {mhlo.sharding = ""}) -> tensor<?x20x20xf32> {

--- a/stablehlo/testdata/vmap_max_broadcasting_lhs_float32_20_20__rhs_float32_1_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_max_broadcasting_lhs_float32_20_20__rhs_float32_1_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x20xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1x20xf32> {mhlo.sharding = ""}) -> tensor<?x20x20xf32> {

--- a/stablehlo/testdata/vmap_min_broadcasting_lhs_float32_1_20__rhs_float32_20_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_min_broadcasting_lhs_float32_1_20__rhs_float32_20_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x20xf32> {mhlo.sharding = ""}, %arg2: tensor<?x20x20xf32> {mhlo.sharding = ""}) -> tensor<?x20x20xf32> {

--- a/stablehlo/testdata/vmap_min_broadcasting_lhs_float32_20_20__rhs_float32_1_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_min_broadcasting_lhs_float32_20_20__rhs_float32_1_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x20xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1x20xf32> {mhlo.sharding = ""}) -> tensor<?x20x20xf32> {

--- a/stablehlo/testdata/vmap_mul_broadcasting_lhs_float32_1_20__rhs_float32_20_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_mul_broadcasting_lhs_float32_1_20__rhs_float32_20_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x20xf32> {mhlo.sharding = ""}, %arg2: tensor<?x20x20xf32> {mhlo.sharding = ""}) -> tensor<?x20x20xf32> {

--- a/stablehlo/testdata/vmap_mul_broadcasting_lhs_float32_20_20__rhs_float32_1_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_mul_broadcasting_lhs_float32_20_20__rhs_float32_1_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x20xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1x20xf32> {mhlo.sharding = ""}) -> tensor<?x20x20xf32> {

--- a/stablehlo/testdata/vmap_ne_broadcasting_lhs_float32___rhs_float32_2_3_dynamic.mlir
+++ b/stablehlo/testdata/vmap_ne_broadcasting_lhs_float32___rhs_float32_2_3_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2x3xf32> {mhlo.sharding = ""}) -> tensor<?x2x3xi1> {

--- a/stablehlo/testdata/vmap_ne_dtypes_lhs_float32___rhs_float32_dynamic.mlir
+++ b/stablehlo/testdata/vmap_ne_dtypes_lhs_float32___rhs_float32_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?xf32> {mhlo.sharding = ""}, %arg2: tensor<?xf32> {mhlo.sharding = ""}) -> tensor<?xi1> {

--- a/stablehlo/testdata/vmap_nextafter_broadcasting_lhs_float32_20_20__rhs_float32_1_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_nextafter_broadcasting_lhs_float32_20_20__rhs_float32_1_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x20xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1x20xf32> {mhlo.sharding = ""}) -> tensor<?x20x20xf32> {

--- a/stablehlo/testdata/vmap_nextafter_dtypes_lhs_float32_20_20__rhs_float32_20_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_nextafter_dtypes_lhs_float32_20_20__rhs_float32_20_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x20xf32> {mhlo.sharding = ""}, %arg2: tensor<?x20x20xf32> {mhlo.sharding = ""}) -> tensor<?x20x20xf32> {

--- a/stablehlo/testdata/vmap_or_dtypes_lhs_int32_20_20__rhs_int32_20_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_or_dtypes_lhs_int32_20_20__rhs_int32_20_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x20xi32> {mhlo.sharding = ""}, %arg2: tensor<?x20x20xi32> {mhlo.sharding = ""}) -> tensor<?x20x20xi32> {

--- a/stablehlo/testdata/vmap_pad_inshape_bfloat16_2_3__pads___0__0__0____-1__-1__0___enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_pad_inshape_bfloat16_2_3__pads___0__0__0____-1__-1__0___enable_xla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2x3xbf16> {mhlo.sharding = ""}, %arg2: tensor<?xbf16> {mhlo.sharding = ""}) -> tensor<?x2x1xbf16> {

--- a/stablehlo/testdata/vmap_pad_inshape_bfloat16_2_3__pads___0__0__0____0__0__0___enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_pad_inshape_bfloat16_2_3__pads___0__0__0____0__0__0___enable_xla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2x3xbf16> {mhlo.sharding = ""}, %arg2: tensor<?xbf16> {mhlo.sharding = ""}) -> tensor<?x2x3xbf16> {

--- a/stablehlo/testdata/vmap_pad_inshape_bfloat16_2_3__pads___1__1__0____2__2__0___enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/vmap_pad_inshape_bfloat16_2_3__pads___1__1__0____2__2__0___enable_xla_True_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2x3xbf16> {mhlo.sharding = ""}, %arg2: tensor<?xbf16> {mhlo.sharding = ""}) -> tensor<?x4x7xbf16> {

--- a/stablehlo/testdata/vmap_pow_broadcast_lhs_float32_4_1_6__rhs_float32_4_5_6_dynamic.mlir
+++ b/stablehlo/testdata/vmap_pow_broadcast_lhs_float32_4_1_6__rhs_float32_4_5_6_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x1x6xf32> {mhlo.sharding = ""}, %arg2: tensor<?x4x5x6xf32> {mhlo.sharding = ""}) -> tensor<?x4x5x6xf32> {

--- a/stablehlo/testdata/vmap_pow_broadcast_lhs_float32_4_5_6__rhs_float32_4_1_6_dynamic.mlir
+++ b/stablehlo/testdata/vmap_pow_broadcast_lhs_float32_4_5_6__rhs_float32_4_1_6_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x5x6xf32> {mhlo.sharding = ""}, %arg2: tensor<?x4x1x6xf32> {mhlo.sharding = ""}) -> tensor<?x4x5x6xf32> {

--- a/stablehlo/testdata/vmap_pow_dtypes_lhs_float32_20_30__rhs_float32_20_30_dynamic.mlir
+++ b/stablehlo/testdata/vmap_pow_dtypes_lhs_float32_20_30__rhs_float32_20_30_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x30xf32> {mhlo.sharding = ""}, %arg2: tensor<?x20x30xf32> {mhlo.sharding = ""}) -> tensor<?x20x30xf32> {

--- a/stablehlo/testdata/vmap_random_categorical_shape_bfloat16_5_4__axis_1_dynamic.mlir
+++ b/stablehlo/testdata/vmap_random_categorical_shape_bfloat16_5_4__axis_1_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/vmap_random_categorical_shape_bfloat16_8__axis_0_dynamic.mlir
+++ b/stablehlo/testdata/vmap_random_categorical_shape_bfloat16_8__axis_0_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/vmap_random_randint_shape_int8_32_dynamic.mlir
+++ b/stablehlo/testdata/vmap_random_randint_shape_int8_32_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/vmap_random_randint_shape_int8_5_4_dynamic.mlir
+++ b/stablehlo/testdata/vmap_random_randint_shape_int8_5_4_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/vmap_random_split_i_1_dynamic.mlir
+++ b/stablehlo/testdata/vmap_random_split_i_1_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/vmap_random_split_i_2_dynamic.mlir
+++ b/stablehlo/testdata/vmap_random_split_i_2_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/vmap_random_uniform_shape_bfloat16_32_dynamic.mlir
+++ b/stablehlo/testdata/vmap_random_uniform_shape_bfloat16_32_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/vmap_random_uniform_shape_bfloat16_5_4_dynamic.mlir
+++ b/stablehlo/testdata/vmap_random_uniform_shape_bfloat16_5_4_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module {
 }

--- a/stablehlo/testdata/vmap_reduce_and_dtypes_shape_bool_2_3_dynamic.mlir
+++ b/stablehlo/testdata/vmap_reduce_and_dtypes_shape_bool_2_3_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2x3xi1> {mhlo.sharding = ""}) -> tensor<?x3xi1> {

--- a/stablehlo/testdata/vmap_reduce_gen_add_scalar_shape_int32_4_6__initvalue_3_nr_operands_1_dimensions__0_dynamic.mlir
+++ b/stablehlo/testdata/vmap_reduce_gen_add_scalar_shape_int32_4_6__initvalue_3_nr_operands_1_dimensions__0_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x6xi32> {mhlo.sharding = ""}) -> tensor<?x6xi32> {

--- a/stablehlo/testdata/vmap_reduce_gen_max_min_shape_int32_4_6__initvalue_3_nr_operands_2_dimensions__0_1_dynamic.mlir
+++ b/stablehlo/testdata/vmap_reduce_gen_max_min_shape_int32_4_6__initvalue_3_nr_operands_2_dimensions__0_1_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x6xi32> {mhlo.sharding = ""}, %arg2: tensor<?x4x6xi32> {mhlo.sharding = ""}) -> (tensor<?xi32>, tensor<?xi32>) {

--- a/stablehlo/testdata/vmap_reduce_gen_max_min_shape_int32_4_6__initvalue_3_nr_operands_2_dimensions__0_dynamic.mlir
+++ b/stablehlo/testdata/vmap_reduce_gen_max_min_shape_int32_4_6__initvalue_3_nr_operands_2_dimensions__0_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x6xi32> {mhlo.sharding = ""}, %arg2: tensor<?x4x6xi32> {mhlo.sharding = ""}) -> (tensor<?x6xi32>, tensor<?x6xi32>) {

--- a/stablehlo/testdata/vmap_reduce_min_dtypes_shape_bfloat16_2_3_dynamic.mlir
+++ b/stablehlo/testdata/vmap_reduce_min_dtypes_shape_bfloat16_2_3_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2x3xbf16> {mhlo.sharding = ""}) -> tensor<?x3xbf16> {

--- a/stablehlo/testdata/vmap_reduce_or_dtypes_shape_bool_2_3_dynamic.mlir
+++ b/stablehlo/testdata/vmap_reduce_or_dtypes_shape_bool_2_3_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2x3xi1> {mhlo.sharding = ""}) -> tensor<?x3xi1> {

--- a/stablehlo/testdata/vmap_reduce_precision_in_bfloat16_5_7__out_float32_5_7_dynamic.mlir
+++ b/stablehlo/testdata/vmap_reduce_precision_in_bfloat16_5_7__out_float32_5_7_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5x7xbf16> {mhlo.sharding = ""}) -> tensor<?x5x7xbf16> {

--- a/stablehlo/testdata/vmap_reduce_precision_in_bfloat16_5_7__out_float64_5_7_dynamic.mlir
+++ b/stablehlo/testdata/vmap_reduce_precision_in_bfloat16_5_7__out_float64_5_7_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5x7xbf16> {mhlo.sharding = ""}) -> tensor<?x5x7xbf16> {

--- a/stablehlo/testdata/vmap_reduce_precision_in_bfloat16___out_float32_dynamic.mlir
+++ b/stablehlo/testdata/vmap_reduce_precision_in_bfloat16___out_float32_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?xbf16> {mhlo.sharding = ""}) -> tensor<?xbf16> {

--- a/stablehlo/testdata/vmap_reduce_precision_in_bfloat16___out_float64_dynamic.mlir
+++ b/stablehlo/testdata/vmap_reduce_precision_in_bfloat16___out_float64_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?xbf16> {mhlo.sharding = ""}) -> tensor<?xbf16> {

--- a/stablehlo/testdata/vmap_reduce_window_add_base_dilation_shape_float32_4_6__initvalue_0_windowdimensions__2_2__windowstr-763947363108393640_dynamic.mlir
+++ b/stablehlo/testdata/vmap_reduce_window_add_base_dilation_shape_float32_4_6__initvalue_0_windowdimensions__2_2__windowstr-763947363108393640_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x6xf32> {mhlo.sharding = ""}) -> tensor<?x3x10xf32> {

--- a/stablehlo/testdata/vmap_reduce_window_add_dtypes_shape_float32_4_6__initvalue_0_windowdimensions__2_2__windowstrides__13341440039283118536_dynamic.mlir
+++ b/stablehlo/testdata/vmap_reduce_window_add_dtypes_shape_float32_4_6__initvalue_0_windowdimensions__2_2__windowstrides__13341440039283118536_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x6xf32> {mhlo.sharding = ""}) -> tensor<?x3x5xf32> {

--- a/stablehlo/testdata/vmap_reduce_window_add_manual_padding_shape_float32_12_12__initvalue_0_0_windowdimensions__2_2__wind3919194238712771376_dynamic.mlir
+++ b/stablehlo/testdata/vmap_reduce_window_add_manual_padding_shape_float32_12_12__initvalue_0_0_windowdimensions__2_2__wind3919194238712771376_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x12x12xf32> {mhlo.sharding = ""}) -> tensor<?x12x12xf32> {

--- a/stablehlo/testdata/vmap_reduce_window_add_manual_padding_shape_float32_12_12__initvalue_0_0_windowdimensions__3_3__wind-1621514835767157889_dynamic.mlir
+++ b/stablehlo/testdata/vmap_reduce_window_add_manual_padding_shape_float32_12_12__initvalue_0_0_windowdimensions__3_3__wind-1621514835767157889_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x12x12xf32> {mhlo.sharding = ""}) -> tensor<?x6x6xf32> {

--- a/stablehlo/testdata/vmap_reduce_window_add_window_dilation_shape_float32_4_6__initvalue_0_windowdimensions__2_2__windows-6742770852540702874_dynamic.mlir
+++ b/stablehlo/testdata/vmap_reduce_window_add_window_dilation_shape_float32_4_6__initvalue_0_windowdimensions__2_2__windows-6742770852540702874_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x6xf32> {mhlo.sharding = ""}) -> tensor<?x3x4xf32> {

--- a/stablehlo/testdata/vmap_reduce_window_add_window_dimensions_shape_float32_4_6__initvalue_0_windowdimensions__1_1__windo3189028916486005793_dynamic.mlir
+++ b/stablehlo/testdata/vmap_reduce_window_add_window_dimensions_shape_float32_4_6__initvalue_0_windowdimensions__1_1__windo3189028916486005793_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x6xf32> {mhlo.sharding = ""}) -> tensor<?x4x6xf32> {

--- a/stablehlo/testdata/vmap_reduce_window_max_batch_channel_dims_shape_float32_1_2_4_1__initvalue_-inf_windowdimensions__1_2184160813763330522_dynamic.mlir
+++ b/stablehlo/testdata/vmap_reduce_window_max_batch_channel_dims_shape_float32_1_2_4_1__initvalue_-inf_windowdimensions__1_2184160813763330522_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x2x4x1xf32> {mhlo.sharding = ""}) -> tensor<?x1x1x3x1xf32> {

--- a/stablehlo/testdata/vmap_reduce_window_max_batch_channel_dims_shape_float32_1_2__initvalue_-inf_windowdimensions__1_2__w3223090226801945110_dynamic.mlir
+++ b/stablehlo/testdata/vmap_reduce_window_max_batch_channel_dims_shape_float32_1_2__initvalue_-inf_windowdimensions__1_2__w3223090226801945110_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x2xf32> {mhlo.sharding = ""}) -> tensor<?x1x1xf32> {

--- a/stablehlo/testdata/vmap_reduce_window_max_batch_channel_dims_shape_float32_2_4_3__initvalue_-inf_windowdimensions__2_2_5486644682491296121_dynamic.mlir
+++ b/stablehlo/testdata/vmap_reduce_window_max_batch_channel_dims_shape_float32_2_4_3__initvalue_-inf_windowdimensions__2_2_5486644682491296121_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2x4x3xf32> {mhlo.sharding = ""}) -> tensor<?x1x3x2xf32> {

--- a/stablehlo/testdata/vmap_reduce_window_max_batch_channel_dims_shape_float32_2_4__initvalue_-inf_windowdimensions__2_2__w-6307575688664696782_dynamic.mlir
+++ b/stablehlo/testdata/vmap_reduce_window_max_batch_channel_dims_shape_float32_2_4__initvalue_-inf_windowdimensions__2_2__w-6307575688664696782_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2x4xf32> {mhlo.sharding = ""}) -> tensor<?x1x3xf32> {

--- a/stablehlo/testdata/vmap_reduce_window_max_dtypes_shape_float32_4_6__initvalue_1_windowdimensions__2_2__windowstrides__11940131758519929992_dynamic.mlir
+++ b/stablehlo/testdata/vmap_reduce_window_max_dtypes_shape_float32_4_6__initvalue_1_windowdimensions__2_2__windowstrides__11940131758519929992_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x6xf32> {mhlo.sharding = ""}) -> tensor<?x3x5xf32> {

--- a/stablehlo/testdata/vmap_reduce_window_max_same_padding_shape_float32_112_112__initvalue_-inf_windowdimensions__3_3__win2956379201356537115_dynamic.mlir
+++ b/stablehlo/testdata/vmap_reduce_window_max_same_padding_shape_float32_112_112__initvalue_-inf_windowdimensions__3_3__win2956379201356537115_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x112x112xf32> {mhlo.sharding = ""}) -> tensor<?x56x56xf32> {

--- a/stablehlo/testdata/vmap_reduce_window_min_same_padding_shape_float32_112_112__initvalue_inf_windowdimensions__3_3__wind-2185529473609255265_dynamic.mlir
+++ b/stablehlo/testdata/vmap_reduce_window_min_same_padding_shape_float32_112_112__initvalue_inf_windowdimensions__3_3__wind-2185529473609255265_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x112x112xf32> {mhlo.sharding = ""}) -> tensor<?x56x56xf32> {

--- a/stablehlo/testdata/vmap_reduce_window_mul_dtypes_shape_bfloat16_4_6__initvalue_0_windowdimensions__2_2__windowstrides__-7573250183158637827_dynamic.mlir
+++ b/stablehlo/testdata/vmap_reduce_window_mul_dtypes_shape_bfloat16_4_6__initvalue_0_windowdimensions__2_2__windowstrides__-7573250183158637827_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x6xbf16> {mhlo.sharding = ""}) -> tensor<?x3x5xbf16> {

--- a/stablehlo/testdata/vmap_rem_broadcast_lhs_float32_2_1_3__rhs_float32_2_4_3_dynamic.mlir
+++ b/stablehlo/testdata/vmap_rem_broadcast_lhs_float32_2_1_3__rhs_float32_2_4_3_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2x1x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2x4x3xf32> {mhlo.sharding = ""}) -> tensor<?x2x4x3xf32> {

--- a/stablehlo/testdata/vmap_rem_singularity_0_by_0_lhs_float32_2__rhs_float32_2_dynamic.mlir
+++ b/stablehlo/testdata/vmap_rem_singularity_0_by_0_lhs_float32_2__rhs_float32_2_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2xf32> {mhlo.sharding = ""}) -> tensor<?x2xf32> {

--- a/stablehlo/testdata/vmap_rem_singularity_inf_by_inf_lhs_float32_1__rhs_float32_1_dynamic.mlir
+++ b/stablehlo/testdata/vmap_rem_singularity_inf_by_inf_lhs_float32_1__rhs_float32_1_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1xf32> {mhlo.sharding = ""}) -> tensor<?x1xf32> {

--- a/stablehlo/testdata/vmap_reshape_dimensions_shape_float32_3_4_5__newsizes__3__20__dimensions__2__0__1_dynamic.mlir
+++ b/stablehlo/testdata/vmap_reshape_dimensions_shape_float32_3_4_5__newsizes__3__20__dimensions__2__0__1_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x3x4x5xf32> {mhlo.sharding = ""}) -> tensor<?x3x20xf32> {

--- a/stablehlo/testdata/vmap_reshape_dimensions_shape_float32_3_4_5__newsizes__3__20__dimensions__2__1__0_dynamic.mlir
+++ b/stablehlo/testdata/vmap_reshape_dimensions_shape_float32_3_4_5__newsizes__3__20__dimensions__2__1__0_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x3x4x5xf32> {mhlo.sharding = ""}) -> tensor<?x3x20xf32> {

--- a/stablehlo/testdata/vmap_reshape_new_sizes_shape_float32_3_4_5__newsizes__4__15__dimensions__0__1__2_dynamic.mlir
+++ b/stablehlo/testdata/vmap_reshape_new_sizes_shape_float32_3_4_5__newsizes__4__15__dimensions__0__1__2_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x3x4x5xf32> {mhlo.sharding = ""}) -> tensor<?x4x15xf32> {

--- a/stablehlo/testdata/vmap_rev_dimensions_shape_float32_3_4_5__dimensions__2__0__1_dynamic.mlir
+++ b/stablehlo/testdata/vmap_rev_dimensions_shape_float32_3_4_5__dimensions__2__0__1_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x3x4x5xf32> {mhlo.sharding = ""}) -> tensor<?x3x4x5xf32> {

--- a/stablehlo/testdata/vmap_rev_dimensions_shape_float32_3_4_5__dimensions_dynamic.mlir
+++ b/stablehlo/testdata/vmap_rev_dimensions_shape_float32_3_4_5__dimensions_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x3x4x5xf32> {mhlo.sharding = ""}) -> tensor<?x3x4x5xf32> {

--- a/stablehlo/testdata/vmap_rev_dtypes_shape_float32_4_5__dimensions__0_dynamic.mlir
+++ b/stablehlo/testdata/vmap_rev_dtypes_shape_float32_4_5__dimensions__0_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x5xf32> {mhlo.sharding = ""}) -> tensor<?x4x5xf32> {

--- a/stablehlo/testdata/vmap_round_rounding_methods_shape_float32_2_5__roundingmethod_1_dynamic.mlir
+++ b/stablehlo/testdata/vmap_round_rounding_methods_shape_float32_2_5__roundingmethod_1_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2x5xf32> {mhlo.sharding = ""}) -> tensor<?x2x5xf32> {

--- a/stablehlo/testdata/vmap_rsqrt_shape_bfloat16_20_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_rsqrt_shape_bfloat16_20_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x20xbf16> {mhlo.sharding = ""}) -> tensor<?x20x20xbf16> {

--- a/stablehlo/testdata/vmap_scatter_add_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewi6055534360455013861_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_add_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewi6055534360455013861_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2xf32> {mhlo.sharding = ""}) -> tensor<?x5xf32> {

--- a/stablehlo/testdata/vmap_scatter_add_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatew8336162695313694512_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_add_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatew8336162695313694512_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x5xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1xf32> {mhlo.sharding = ""}) -> tensor<?x1x5xf32> {

--- a/stablehlo/testdata/vmap_scatter_add_no_xla_non_unique_indices_shape_float32_1__scatterindices___0___0___updateshape__2_2904581232417667225_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_add_no_xla_non_unique_indices_shape_float32_1__scatterindices___0___0___updateshape__2_2904581232417667225_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2xf32> {mhlo.sharding = ""}) -> tensor<?x1xf32> {

--- a/stablehlo/testdata/vmap_scatter_add_no_xla_non_unique_indices_shape_float32_2_3__scatterindices____2___2___2____updates5328663953079728064_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_add_no_xla_non_unique_indices_shape_float32_2_3__scatterindices____2___2___2____updates5328663953079728064_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2x1x3xf32> {mhlo.sharding = ""}) -> tensor<?x2x3xf32> {

--- a/stablehlo/testdata/vmap_scatter_add_no_xla_non_unique_indices_shape_float32_3_5_40__scatterindices___1___1___updateshap5547654251253727501_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_add_no_xla_non_unique_indices_shape_float32_3_5_40__scatterindices___1___1___updateshap5547654251253727501_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x3x5x40xf32> {mhlo.sharding = ""}, %arg2: tensor<?x3x5x2xf32> {mhlo.sharding = ""}) -> tensor<?x3x5x40xf32> {

--- a/stablehlo/testdata/vmap_scatter_add_no_xla_non_unique_indices_shape_float32_3_5_4__scatterindices___1___1___updateshape-6257995102305470621_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_add_no_xla_non_unique_indices_shape_float32_3_5_4__scatterindices___1___1___updateshape-6257995102305470621_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x3x5x4xf32> {mhlo.sharding = ""}, %arg2: tensor<?x3x2x4xf32> {mhlo.sharding = ""}) -> tensor<?x3x5x4xf32> {

--- a/stablehlo/testdata/vmap_scatter_add_no_xla_non_unique_indices_shape_float32_3__scatterindices___1___0___1___updateshape-1961608562385891379_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_add_no_xla_non_unique_indices_shape_float32_3__scatterindices___1___0___1___updateshape-1961608562385891379_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x3xf32> {mhlo.sharding = ""}) -> tensor<?x3xf32> {

--- a/stablehlo/testdata/vmap_scatter_add_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___upda-4330096553829385661_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_add_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___upda-4330096553829385661_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x125xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1xf32> {mhlo.sharding = ""}) -> tensor<?x1x125xf32> {

--- a/stablehlo/testdata/vmap_scatter_add_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__upd-8267141602015230832_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_add_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__upd-8267141602015230832_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x1x1xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1x1xf32> {mhlo.sharding = ""}) -> tensor<?x1x1x1xf32> {

--- a/stablehlo/testdata/vmap_scatter_add_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___update-2467157960622839264_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_add_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___update-2467157960622839264_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x1xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1xf32> {mhlo.sharding = ""}) -> tensor<?x1x1xf32> {

--- a/stablehlo/testdata/vmap_scatter_add_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__upd-2797041986951806934_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_add_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__upd-2797041986951806934_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x2x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2x3xf32> {mhlo.sharding = ""}) -> tensor<?x1x2x3xf32> {

--- a/stablehlo/testdata/vmap_scatter_add_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___up-1652632706581328052_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_add_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___up-1652632706581328052_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x2x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1xf32> {mhlo.sharding = ""}) -> tensor<?x1x2x3xf32> {

--- a/stablehlo/testdata/vmap_scatter_add_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__upd2780770384140473730_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_add_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__upd2780770384140473730_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x2x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1x3xf32> {mhlo.sharding = ""}) -> tensor<?x1x2x3xf32> {

--- a/stablehlo/testdata/vmap_scatter_add_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__u8823418707287762610_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_add_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__u8823418707287762610_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x50x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1x3xf32> {mhlo.sharding = ""}) -> tensor<?x1x50x3xf32> {

--- a/stablehlo/testdata/vmap_scatter_add_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewind-2000079015758051254_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_add_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewind-2000079015758051254_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1xf32> {mhlo.sharding = ""}, %arg2: tensor<?xf32> {mhlo.sharding = ""}) -> tensor<?x1xf32> {

--- a/stablehlo/testdata/vmap_scatter_add_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3_-4803298729015274218_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_add_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3_-4803298729015274218_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x2x3x5xf32> {mhlo.sharding = ""}, %arg2: tensor<?x4x3xf32> {mhlo.sharding = ""}) -> tensor<?x4x2x3x5xf32> {

--- a/stablehlo/testdata/vmap_scatter_add_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___up-8054327789287843393_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_add_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___up-8054327789287843393_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x2x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2xf32> {mhlo.sharding = ""}) -> tensor<?x4x2x3xf32> {

--- a/stablehlo/testdata/vmap_scatter_add_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape-1540256330237966560_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_add_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape-1540256330237966560_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5x6x7xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2x7xf32> {mhlo.sharding = ""}) -> tensor<?x5x6x7xf32> {

--- a/stablehlo/testdata/vmap_scatter_add_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_7771025020828126250_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_add_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_7771025020828126250_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5x6x7xf32> {mhlo.sharding = ""}, %arg2: tensor<?x5x2x2xf32> {mhlo.sharding = ""}) -> tensor<?x5x6x7xf32> {

--- a/stablehlo/testdata/vmap_scatter_add_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____upd-6581826086918124189_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_add_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____upd-6581826086918124189_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5x6x7xf32> {mhlo.sharding = ""}, %arg2: tensor<?x5x2x2x7xf32> {mhlo.sharding = ""}) -> tensor<?x5x6x7xf32> {

--- a/stablehlo/testdata/vmap_scatter_max_dtypes_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowdims_-5764261824898117411_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_max_dtypes_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowdims_-5764261824898117411_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2xf32> {mhlo.sharding = ""}) -> tensor<?x5xf32> {

--- a/stablehlo/testdata/vmap_scatter_max_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewi1940709225654426465_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_max_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewi1940709225654426465_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2xf32> {mhlo.sharding = ""}) -> tensor<?x5xf32> {

--- a/stablehlo/testdata/vmap_scatter_max_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatew-2496154919222465140_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_max_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatew-2496154919222465140_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x5xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1xf32> {mhlo.sharding = ""}) -> tensor<?x1x5xf32> {

--- a/stablehlo/testdata/vmap_scatter_max_no_xla_non_unique_indices_shape_float32_1__scatterindices___0___0___updateshape__2_-8124105407724313165_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_max_no_xla_non_unique_indices_shape_float32_1__scatterindices___0___0___updateshape__2_-8124105407724313165_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2xf32> {mhlo.sharding = ""}) -> tensor<?x1xf32> {

--- a/stablehlo/testdata/vmap_scatter_max_no_xla_non_unique_indices_shape_float32_2_3__scatterindices____2___2___2____updates-4089314200016504731_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_max_no_xla_non_unique_indices_shape_float32_2_3__scatterindices____2___2___2____updates-4089314200016504731_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2x1x3xf32> {mhlo.sharding = ""}) -> tensor<?x2x3xf32> {

--- a/stablehlo/testdata/vmap_scatter_max_no_xla_non_unique_indices_shape_float32_3_5_40__scatterindices___1___1___updateshap748823117728060152_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_max_no_xla_non_unique_indices_shape_float32_3_5_40__scatterindices___1___1___updateshap748823117728060152_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x3x5x40xf32> {mhlo.sharding = ""}, %arg2: tensor<?x3x5x2xf32> {mhlo.sharding = ""}) -> tensor<?x3x5x40xf32> {

--- a/stablehlo/testdata/vmap_scatter_max_no_xla_non_unique_indices_shape_float32_3_5_4__scatterindices___1___1___updateshape3695601425617809628_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_max_no_xla_non_unique_indices_shape_float32_3_5_4__scatterindices___1___1___updateshape3695601425617809628_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x3x5x4xf32> {mhlo.sharding = ""}, %arg2: tensor<?x3x2x4xf32> {mhlo.sharding = ""}) -> tensor<?x3x5x4xf32> {

--- a/stablehlo/testdata/vmap_scatter_max_no_xla_non_unique_indices_shape_float32_3__scatterindices___1___0___1___updateshape5068345218212197349_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_max_no_xla_non_unique_indices_shape_float32_3__scatterindices___1___0___1___updateshape5068345218212197349_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x3xf32> {mhlo.sharding = ""}) -> tensor<?x3xf32> {

--- a/stablehlo/testdata/vmap_scatter_max_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___upda6081469298736608919_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_max_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___upda6081469298736608919_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x125xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1xf32> {mhlo.sharding = ""}) -> tensor<?x1x125xf32> {

--- a/stablehlo/testdata/vmap_scatter_max_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__upd2840657680228772140_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_max_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__upd2840657680228772140_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x1x1xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1x1xf32> {mhlo.sharding = ""}) -> tensor<?x1x1x1xf32> {

--- a/stablehlo/testdata/vmap_scatter_max_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___update-2126490207939343017_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_max_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___update-2126490207939343017_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x1xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1xf32> {mhlo.sharding = ""}) -> tensor<?x1x1xf32> {

--- a/stablehlo/testdata/vmap_scatter_max_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__upd7413427446020982882_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_max_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__upd7413427446020982882_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x2x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2x3xf32> {mhlo.sharding = ""}) -> tensor<?x1x2x3xf32> {

--- a/stablehlo/testdata/vmap_scatter_max_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___up6526843050774032423_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_max_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___up6526843050774032423_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x2x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1xf32> {mhlo.sharding = ""}) -> tensor<?x1x2x3xf32> {

--- a/stablehlo/testdata/vmap_scatter_max_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__upd7211601265419522997_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_max_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__upd7211601265419522997_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x2x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1x3xf32> {mhlo.sharding = ""}) -> tensor<?x1x2x3xf32> {

--- a/stablehlo/testdata/vmap_scatter_max_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__u-4953536905526144488_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_max_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__u-4953536905526144488_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x50x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1x3xf32> {mhlo.sharding = ""}) -> tensor<?x1x50x3xf32> {

--- a/stablehlo/testdata/vmap_scatter_max_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewind-8341673587435356516_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_max_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewind-8341673587435356516_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1xf32> {mhlo.sharding = ""}, %arg2: tensor<?xf32> {mhlo.sharding = ""}) -> tensor<?x1xf32> {

--- a/stablehlo/testdata/vmap_scatter_max_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3_5462424620676021445_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_max_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3_5462424620676021445_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x2x3x5xf32> {mhlo.sharding = ""}, %arg2: tensor<?x4x3xf32> {mhlo.sharding = ""}) -> tensor<?x4x2x3x5xf32> {

--- a/stablehlo/testdata/vmap_scatter_max_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___up3779125690534766698_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_max_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___up3779125690534766698_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x2x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2xf32> {mhlo.sharding = ""}) -> tensor<?x4x2x3xf32> {

--- a/stablehlo/testdata/vmap_scatter_max_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape2765412634573769407_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_max_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape2765412634573769407_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5x6x7xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2x7xf32> {mhlo.sharding = ""}) -> tensor<?x5x6x7xf32> {

--- a/stablehlo/testdata/vmap_scatter_max_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_-774078194914362582_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_max_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_-774078194914362582_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5x6x7xf32> {mhlo.sharding = ""}, %arg2: tensor<?x5x2x2xf32> {mhlo.sharding = ""}) -> tensor<?x5x6x7xf32> {

--- a/stablehlo/testdata/vmap_scatter_max_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____upd6720937502996211960_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_max_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____upd6720937502996211960_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5x6x7xf32> {mhlo.sharding = ""}, %arg2: tensor<?x5x2x2x7xf32> {mhlo.sharding = ""}) -> tensor<?x5x6x7xf32> {

--- a/stablehlo/testdata/vmap_scatter_min_dtypes_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowdims_-5027041476475588234_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_min_dtypes_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowdims_-5027041476475588234_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2xf32> {mhlo.sharding = ""}) -> tensor<?x5xf32> {

--- a/stablehlo/testdata/vmap_scatter_min_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewi2179977339871965947_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_min_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewi2179977339871965947_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2xf32> {mhlo.sharding = ""}) -> tensor<?x5xf32> {

--- a/stablehlo/testdata/vmap_scatter_min_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatew-7974443862451953591_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_min_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatew-7974443862451953591_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x5xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1xf32> {mhlo.sharding = ""}) -> tensor<?x1x5xf32> {

--- a/stablehlo/testdata/vmap_scatter_min_no_xla_non_unique_indices_shape_float32_1__scatterindices___0___0___updateshape__2_8756238129880751792_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_min_no_xla_non_unique_indices_shape_float32_1__scatterindices___0___0___updateshape__2_8756238129880751792_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2xf32> {mhlo.sharding = ""}) -> tensor<?x1xf32> {

--- a/stablehlo/testdata/vmap_scatter_min_no_xla_non_unique_indices_shape_float32_2_3__scatterindices____2___2___2____updates8575588623839251988_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_min_no_xla_non_unique_indices_shape_float32_2_3__scatterindices____2___2___2____updates8575588623839251988_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2x1x3xf32> {mhlo.sharding = ""}) -> tensor<?x2x3xf32> {

--- a/stablehlo/testdata/vmap_scatter_min_no_xla_non_unique_indices_shape_float32_3_5_40__scatterindices___1___1___updateshap-6253513119505551455_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_min_no_xla_non_unique_indices_shape_float32_3_5_40__scatterindices___1___1___updateshap-6253513119505551455_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x3x5x40xf32> {mhlo.sharding = ""}, %arg2: tensor<?x3x5x2xf32> {mhlo.sharding = ""}) -> tensor<?x3x5x40xf32> {

--- a/stablehlo/testdata/vmap_scatter_min_no_xla_non_unique_indices_shape_float32_3_5_4__scatterindices___1___1___updateshape983927181620686545_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_min_no_xla_non_unique_indices_shape_float32_3_5_4__scatterindices___1___1___updateshape983927181620686545_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x3x5x4xf32> {mhlo.sharding = ""}, %arg2: tensor<?x3x2x4xf32> {mhlo.sharding = ""}) -> tensor<?x3x5x4xf32> {

--- a/stablehlo/testdata/vmap_scatter_min_no_xla_non_unique_indices_shape_float32_3__scatterindices___1___0___1___updateshape5258521423700182968_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_min_no_xla_non_unique_indices_shape_float32_3__scatterindices___1___0___1___updateshape5258521423700182968_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x3xf32> {mhlo.sharding = ""}) -> tensor<?x3xf32> {

--- a/stablehlo/testdata/vmap_scatter_min_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___upda-5993012582365005497_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_min_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___upda-5993012582365005497_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x125xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1xf32> {mhlo.sharding = ""}) -> tensor<?x1x125xf32> {

--- a/stablehlo/testdata/vmap_scatter_min_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__upd-284263931634471795_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_min_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__upd-284263931634471795_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x1x1xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1x1xf32> {mhlo.sharding = ""}) -> tensor<?x1x1x1xf32> {

--- a/stablehlo/testdata/vmap_scatter_min_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___update862610184073650022_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_min_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___update862610184073650022_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x1xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1xf32> {mhlo.sharding = ""}) -> tensor<?x1x1xf32> {

--- a/stablehlo/testdata/vmap_scatter_min_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__upd-7168182379288847478_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_min_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__upd-7168182379288847478_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x2x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2x3xf32> {mhlo.sharding = ""}) -> tensor<?x1x2x3xf32> {

--- a/stablehlo/testdata/vmap_scatter_min_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___up-2763278004312431473_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_min_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___up-2763278004312431473_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x2x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1xf32> {mhlo.sharding = ""}) -> tensor<?x1x2x3xf32> {

--- a/stablehlo/testdata/vmap_scatter_min_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__upd1413038545080597239_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_min_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__upd1413038545080597239_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x2x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1x3xf32> {mhlo.sharding = ""}) -> tensor<?x1x2x3xf32> {

--- a/stablehlo/testdata/vmap_scatter_min_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__u4438022560484915299_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_min_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__u4438022560484915299_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x50x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1x3xf32> {mhlo.sharding = ""}) -> tensor<?x1x50x3xf32> {

--- a/stablehlo/testdata/vmap_scatter_min_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewind-2726930287266588652_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_min_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewind-2726930287266588652_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1xf32> {mhlo.sharding = ""}, %arg2: tensor<?xf32> {mhlo.sharding = ""}) -> tensor<?x1xf32> {

--- a/stablehlo/testdata/vmap_scatter_min_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3_2943820756044635176_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_min_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3_2943820756044635176_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x2x3x5xf32> {mhlo.sharding = ""}, %arg2: tensor<?x4x3xf32> {mhlo.sharding = ""}) -> tensor<?x4x2x3x5xf32> {

--- a/stablehlo/testdata/vmap_scatter_min_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___up-5421831615157965320_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_min_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___up-5421831615157965320_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x2x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2xf32> {mhlo.sharding = ""}) -> tensor<?x4x2x3xf32> {

--- a/stablehlo/testdata/vmap_scatter_min_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape7947812391394670364_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_min_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape7947812391394670364_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5x6x7xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2x7xf32> {mhlo.sharding = ""}) -> tensor<?x5x6x7xf32> {

--- a/stablehlo/testdata/vmap_scatter_min_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_-6164647317530533214_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_min_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_-6164647317530533214_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5x6x7xf32> {mhlo.sharding = ""}, %arg2: tensor<?x5x2x2xf32> {mhlo.sharding = ""}) -> tensor<?x5x6x7xf32> {

--- a/stablehlo/testdata/vmap_scatter_min_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____upd-3246275247647653360_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_min_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____upd-3246275247647653360_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5x6x7xf32> {mhlo.sharding = ""}, %arg2: tensor<?x5x2x2x7xf32> {mhlo.sharding = ""}) -> tensor<?x5x6x7xf32> {

--- a/stablehlo/testdata/vmap_scatter_min_shapes_and_dimension_numbers_shape_float32_10__scatterindices___0___0___0___updates-2934847509326040653_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_min_shapes_and_dimension_numbers_shape_float32_10__scatterindices___0___0___0___updates-2934847509326040653_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x10xf32> {mhlo.sharding = ""}, %arg2: tensor<?x3x2xf32> {mhlo.sharding = ""}) -> tensor<?x10xf32> {

--- a/stablehlo/testdata/vmap_scatter_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindow8074080200253653116_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_modes_in_bounds_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindow8074080200253653116_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2xf32> {mhlo.sharding = ""}) -> tensor<?x5xf32> {

--- a/stablehlo/testdata/vmap_scatter_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatewindo-1700064001509558237_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatewindo-1700064001509558237_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x5xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1xf32> {mhlo.sharding = ""}) -> tensor<?x1x5xf32> {

--- a/stablehlo/testdata/vmap_scatter_mul_dtypes_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowdims_-9090468133288724986_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_mul_dtypes_shape_float32_5__scatterindices___0___2___updateshape__2___updatewindowdims_-9090468133288724986_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2xf32> {mhlo.sharding = ""}) -> tensor<?x5xf32> {

--- a/stablehlo/testdata/vmap_scatter_mul_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatew-3502229084909032327_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_mul_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatew-3502229084909032327_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x5xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1xf32> {mhlo.sharding = ""}) -> tensor<?x1x5xf32> {

--- a/stablehlo/testdata/vmap_scatter_mul_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatew-6746082005718701413_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_mul_modes_out_of_bounds_shape_float32_1_5__scatterindices__10__updateshape__1___updatew-6746082005718701413_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x5xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1xf32> {mhlo.sharding = ""}) -> tensor<?x1x5xf32> {

--- a/stablehlo/testdata/vmap_scatter_mul_no_xla_non_unique_indices_shape_float32_2_3__scatterindices____2___2___2____updates-1471740899374361872_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_mul_no_xla_non_unique_indices_shape_float32_2_3__scatterindices____2___2___2____updates-1471740899374361872_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2x1x3xf32> {mhlo.sharding = ""}) -> tensor<?x2x3xf32> {

--- a/stablehlo/testdata/vmap_scatter_mul_no_xla_non_unique_indices_shape_float32_2_3__scatterindices____2___2___2____updates-166607048202314636_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_mul_no_xla_non_unique_indices_shape_float32_2_3__scatterindices____2___2___2____updates-166607048202314636_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2x1x3xf32> {mhlo.sharding = ""}) -> tensor<?x2x3xf32> {

--- a/stablehlo/testdata/vmap_scatter_mul_no_xla_non_unique_indices_shape_float32_3_5_4__scatterindices___1___1___updateshape-5528120507439039350_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_mul_no_xla_non_unique_indices_shape_float32_3_5_4__scatterindices___1___1___updateshape-5528120507439039350_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x3x5x4xf32> {mhlo.sharding = ""}, %arg2: tensor<?x3x2x4xf32> {mhlo.sharding = ""}) -> tensor<?x3x5x4xf32> {

--- a/stablehlo/testdata/vmap_scatter_mul_no_xla_non_unique_indices_shape_float32_3_5_4__scatterindices___1___1___updateshape6042003342843751070_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_mul_no_xla_non_unique_indices_shape_float32_3_5_4__scatterindices___1___1___updateshape6042003342843751070_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x3x5x4xf32> {mhlo.sharding = ""}, %arg2: tensor<?x3x2x4xf32> {mhlo.sharding = ""}) -> tensor<?x3x5x4xf32> {

--- a/stablehlo/testdata/vmap_scatter_mul_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__upd-2808913388735808657_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_mul_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__upd-2808913388735808657_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x1x1xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1x1xf32> {mhlo.sharding = ""}) -> tensor<?x1x1x1xf32> {

--- a/stablehlo/testdata/vmap_scatter_mul_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__upd1543060650071439564_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_mul_no_xla_unique_indices_shape_float32_1_1_1__scatterindices__0__updateshape__1_1__upd1543060650071439564_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x1x1xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1x1xf32> {mhlo.sharding = ""}) -> tensor<?x1x1x1xf32> {

--- a/stablehlo/testdata/vmap_scatter_mul_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___update-7200391604101536509_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_mul_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___update-7200391604101536509_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x1xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1xf32> {mhlo.sharding = ""}) -> tensor<?x1x1xf32> {

--- a/stablehlo/testdata/vmap_scatter_mul_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___update4296095924018700173_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_mul_no_xla_unique_indices_shape_float32_1_1__scatterindices__0__updateshape__1___update4296095924018700173_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x1xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1xf32> {mhlo.sharding = ""}) -> tensor<?x1x1xf32> {

--- a/stablehlo/testdata/vmap_scatter_mul_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___up3701943997459931967_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_mul_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___up3701943997459931967_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x2x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1xf32> {mhlo.sharding = ""}) -> tensor<?x1x2x3xf32> {

--- a/stablehlo/testdata/vmap_scatter_mul_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___up8234042590534764496_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_mul_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1_2__updateshape__1___up8234042590534764496_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x2x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1xf32> {mhlo.sharding = ""}) -> tensor<?x1x2x3xf32> {

--- a/stablehlo/testdata/vmap_scatter_mul_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__u-828580220061074222_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_mul_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__u-828580220061074222_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x50x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1x3xf32> {mhlo.sharding = ""}) -> tensor<?x1x50x3xf32> {

--- a/stablehlo/testdata/vmap_scatter_mul_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__u1460129047472043590_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_mul_no_xla_unique_indices_shape_float32_1_50_3__scatterindices__32__updateshape__1_3__u1460129047472043590_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x50x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1x3xf32> {mhlo.sharding = ""}) -> tensor<?x1x50x3xf32> {

--- a/stablehlo/testdata/vmap_scatter_mul_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3_154718790450234540_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_mul_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3_154718790450234540_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x2x3x5xf32> {mhlo.sharding = ""}, %arg2: tensor<?x4x3xf32> {mhlo.sharding = ""}) -> tensor<?x4x2x3x5xf32> {

--- a/stablehlo/testdata/vmap_scatter_mul_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3_3532548525002744769_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_mul_no_xla_unique_indices_shape_float32_4_2_3_5__scatterindices__0_4__updateshape__4_3_3532548525002744769_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x2x3x5xf32> {mhlo.sharding = ""}, %arg2: tensor<?x4x3xf32> {mhlo.sharding = ""}) -> tensor<?x4x2x3x5xf32> {

--- a/stablehlo/testdata/vmap_scatter_mul_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape-6446502383339081893_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_mul_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape-6446502383339081893_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5x6x7xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2x7xf32> {mhlo.sharding = ""}) -> tensor<?x5x6x7xf32> {

--- a/stablehlo/testdata/vmap_scatter_mul_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape9204356222771337884_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_mul_no_xla_unique_indices_shape_float32_5_6_7__scatterindices___0_1___2_3___updateshape9204356222771337884_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5x6x7xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2x7xf32> {mhlo.sharding = ""}) -> tensor<?x5x6x7xf32> {

--- a/stablehlo/testdata/vmap_scatter_mul_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____upd-4040885839949540746_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_mul_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____upd-4040885839949540746_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5x6x7xf32> {mhlo.sharding = ""}, %arg2: tensor<?x5x2x2x7xf32> {mhlo.sharding = ""}) -> tensor<?x5x6x7xf32> {

--- a/stablehlo/testdata/vmap_scatter_mul_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____upd2900578795717779480_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_mul_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0___1_____2___3____upd2900578795717779480_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5x6x7xf32> {mhlo.sharding = ""}, %arg2: tensor<?x5x2x2x7xf32> {mhlo.sharding = ""}) -> tensor<?x5x6x7xf32> {

--- a/stablehlo/testdata/vmap_scatter_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewi-1570647707463590786_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewi-1570647707463590786_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x125xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1xf32> {mhlo.sharding = ""}) -> tensor<?x1x125xf32> {

--- a/stablehlo/testdata/vmap_scatter_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewi-8186768156843759319_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_no_xla_unique_indices_shape_float32_1_125__scatterindices__0__updateshape__1___updatewi-8186768156843759319_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x125xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1xf32> {mhlo.sharding = ""}) -> tensor<?x1x125xf32> {

--- a/stablehlo/testdata/vmap_scatter_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatew245264988849197991_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatew245264988849197991_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x2x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2x3xf32> {mhlo.sharding = ""}) -> tensor<?x1x2x3xf32> {

--- a/stablehlo/testdata/vmap_scatter_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatew831233141664921477_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__0__updateshape__2_3__updatew831233141664921477_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x2x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2x3xf32> {mhlo.sharding = ""}) -> tensor<?x1x2x3xf32> {

--- a/stablehlo/testdata/vmap_scatter_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatew-1277425684929024229_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatew-1277425684929024229_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x2x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1x3xf32> {mhlo.sharding = ""}) -> tensor<?x1x2x3xf32> {

--- a/stablehlo/testdata/vmap_scatter_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatew2602171638526244391_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_no_xla_unique_indices_shape_float32_1_2_3__scatterindices__1__updateshape__1_3__updatew2602171638526244391_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x2x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1x3xf32> {mhlo.sharding = ""}) -> tensor<?x1x2x3xf32> {

--- a/stablehlo/testdata/vmap_scatter_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdi-1255899477592758987_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdi-1255899477592758987_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1xf32> {mhlo.sharding = ""}, %arg2: tensor<?xf32> {mhlo.sharding = ""}) -> tensor<?x1xf32> {

--- a/stablehlo/testdata/vmap_scatter_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdi6084885026424677862_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_no_xla_unique_indices_shape_float32_1__scatterindices__0__updateshape____updatewindowdi6084885026424677862_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1xf32> {mhlo.sharding = ""}, %arg2: tensor<?xf32> {mhlo.sharding = ""}) -> tensor<?x1xf32> {

--- a/stablehlo/testdata/vmap_scatter_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___update3921191246235772981_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___update3921191246235772981_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x2x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2xf32> {mhlo.sharding = ""}) -> tensor<?x4x2x3xf32> {

--- a/stablehlo/testdata/vmap_scatter_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___update4395019629286861827_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_no_xla_unique_indices_shape_float32_4_2_3__scatterindices__3_2__updateshape__2___update4395019629286861827_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x2x3xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2xf32> {mhlo.sharding = ""}) -> tensor<?x4x2x3xf32> {

--- a/stablehlo/testdata/vmap_scatter_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2___386593041464503998_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2___386593041464503998_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5x6x7xf32> {mhlo.sharding = ""}, %arg2: tensor<?x5x2x2xf32> {mhlo.sharding = ""}) -> tensor<?x5x6x7xf32> {

--- a/stablehlo/testdata/vmap_scatter_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2___6757099439771819196_dynamic.mlir
+++ b/stablehlo/testdata/vmap_scatter_no_xla_unique_indices_shape_float32_5_6_7__scatterindices____0_1___2_3_____4_0___1_2___6757099439771819196_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5x6x7xf32> {mhlo.sharding = ""}, %arg2: tensor<?x5x2x2xf32> {mhlo.sharding = ""}) -> tensor<?x5x6x7xf32> {

--- a/stablehlo/testdata/vmap_select_and_gather_add_dilations_shape_float32_4_6__selectprim_le_windowdimensions__2__2__window-3668408315562044057_dynamic.mlir
+++ b/stablehlo/testdata/vmap_select_and_gather_add_dilations_shape_float32_4_6__selectprim_le_windowdimensions__2__2__window-3668408315562044057_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x6xf32> {mhlo.sharding = ""}, %arg2: tensor<?x4x6xf32> {mhlo.sharding = ""}) -> tensor<?x6x15xf32> {

--- a/stablehlo/testdata/vmap_select_and_gather_add_dilations_shape_float32_4_6__selectprim_le_windowdimensions__2__2__window5641367141920285965_dynamic.mlir
+++ b/stablehlo/testdata/vmap_select_and_gather_add_dilations_shape_float32_4_6__selectprim_le_windowdimensions__2__2__window5641367141920285965_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x6xf32> {mhlo.sharding = ""}, %arg2: tensor<?x4x6xf32> {mhlo.sharding = ""}) -> tensor<?x2x3xf32> {

--- a/stablehlo/testdata/vmap_select_and_gather_add_dtypes_shape_float32_4_6__selectprim_le_windowdimensions__2__2__windowstr9035867587788163605_dynamic.mlir
+++ b/stablehlo/testdata/vmap_select_and_gather_add_dtypes_shape_float32_4_6__selectprim_le_windowdimensions__2__2__windowstr9035867587788163605_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x6xf32> {mhlo.sharding = ""}, %arg2: tensor<?x4x6xf32> {mhlo.sharding = ""}) -> tensor<?x3x5xf32> {

--- a/stablehlo/testdata/vmap_select_and_gather_add_padding_shape_float32_4_6__selectprim_le_windowdimensions__2__2__windowst-1651705789938795959_dynamic.mlir
+++ b/stablehlo/testdata/vmap_select_and_gather_add_padding_shape_float32_4_6__selectprim_le_windowdimensions__2__2__windowst-1651705789938795959_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x6xf32> {mhlo.sharding = ""}, %arg2: tensor<?x4x6xf32> {mhlo.sharding = ""}) -> tensor<?x4x6xf32> {

--- a/stablehlo/testdata/vmap_select_and_gather_add_window_strides_shape_float32_4_6__selectprim_le_windowdimensions__2__2__w-7130227668472867832_dynamic.mlir
+++ b/stablehlo/testdata/vmap_select_and_gather_add_window_strides_shape_float32_4_6__selectprim_le_windowdimensions__2__2__w-7130227668472867832_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x6xf32> {mhlo.sharding = ""}, %arg2: tensor<?x4x6xf32> {mhlo.sharding = ""}) -> tensor<?x2x2xf32> {

--- a/stablehlo/testdata/vmap_select_and_scatter_add_dtypes_shape_float32_2_4_6__selectprim_ge_windowdimensions__2__2__2__win-6232315144219558965_dynamic.mlir
+++ b/stablehlo/testdata/vmap_select_and_scatter_add_dtypes_shape_float32_2_4_6__selectprim_ge_windowdimensions__2__2__2__win-6232315144219558965_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x3x5xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2x4x6xf32> {mhlo.sharding = ""}) -> tensor<?x2x4x6xf32> {

--- a/stablehlo/testdata/vmap_select_and_scatter_add_tpu_dtypes_shape_float32_2_4_6__selectprim_ge_windowdimensions__1__3__1_7476758622011829286_dynamic.mlir
+++ b/stablehlo/testdata/vmap_select_and_scatter_add_tpu_dtypes_shape_float32_2_4_6__selectprim_ge_windowdimensions__1__3__1_7476758622011829286_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2x1x6xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2x4x6xf32> {mhlo.sharding = ""}) -> tensor<?x2x4x6xf32> {

--- a/stablehlo/testdata/vmap_select_and_scatter_add_window_dimensions_shape_float32_2_4_6__selectprim_ge_windowdimensions__13419466118969880708_dynamic.mlir
+++ b/stablehlo/testdata/vmap_select_and_scatter_add_window_dimensions_shape_float32_2_4_6__selectprim_ge_windowdimensions__13419466118969880708_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2x3x4xf32> {mhlo.sharding = ""}, %arg2: tensor<?x2x4x6xf32> {mhlo.sharding = ""}) -> tensor<?x2x4x6xf32> {

--- a/stablehlo/testdata/vmap_select_n_dtypes_shapepred_int32_2_3__shapeargs_float32_2_3_dynamic.mlir
+++ b/stablehlo/testdata/vmap_select_n_dtypes_shapepred_int32_2_3__shapeargs_float32_2_3_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2x3xi32> {mhlo.sharding = ""}, %arg2: tensor<?x2x3xf32> {mhlo.sharding = ""}, %arg3: tensor<?x2x3xf32> {mhlo.sharding = ""}, %arg4: tensor<?x2x3xf32> {mhlo.sharding = ""}) -> tensor<?x2x3xf32> {

--- a/stablehlo/testdata/vmap_select_n_shapes_shapepred_bool___shapeargs_float32_18_dynamic.mlir
+++ b/stablehlo/testdata/vmap_select_n_shapes_shapepred_bool___shapeargs_float32_18_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?xi1> {mhlo.sharding = ""}, %arg2: tensor<?x18xf32> {mhlo.sharding = ""}, %arg3: tensor<?x18xf32> {mhlo.sharding = ""}) -> tensor<?x18xf32> {

--- a/stablehlo/testdata/vmap_shift_left_broadcasting_lhs_int32_20_20__rhs_int32_1_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_shift_left_broadcasting_lhs_int32_20_20__rhs_int32_1_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x20xi32> {mhlo.sharding = ""}, %arg2: tensor<?x1x20xi32> {mhlo.sharding = ""}) -> tensor<?x20x20xi32> {

--- a/stablehlo/testdata/vmap_shift_left_dtypes_lhs_int32_20_20__rhs_int32_20_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_shift_left_dtypes_lhs_int32_20_20__rhs_int32_20_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x20xi32> {mhlo.sharding = ""}, %arg2: tensor<?x20x20xi32> {mhlo.sharding = ""}) -> tensor<?x20x20xi32> {

--- a/stablehlo/testdata/vmap_shift_right_arithmetic_dtypes_lhs_int32_20_20__rhs_int32_20_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_shift_right_arithmetic_dtypes_lhs_int32_20_20__rhs_int32_20_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x20xi32> {mhlo.sharding = ""}, %arg2: tensor<?x20x20xi32> {mhlo.sharding = ""}) -> tensor<?x20x20xi32> {

--- a/stablehlo/testdata/vmap_shift_right_logical_broadcasting_lhs_int32_1_20__rhs_int32_20_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_shift_right_logical_broadcasting_lhs_int32_1_20__rhs_int32_20_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x20xi32> {mhlo.sharding = ""}, %arg2: tensor<?x20x20xi32> {mhlo.sharding = ""}) -> tensor<?x20x20xi32> {

--- a/stablehlo/testdata/vmap_sign_shape_uint64_20_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_sign_shape_uint64_20_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x20xui64> {mhlo.sharding = ""}) -> tensor<?x20x20xui64> {

--- a/stablehlo/testdata/vmap_sin_shape_bfloat16_20_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_sin_shape_bfloat16_20_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x20xbf16> {mhlo.sharding = ""}) -> tensor<?x20x20xbf16> {

--- a/stablehlo/testdata/vmap_slice_shapes_a_float32_3__start_indices__1___limit_indices__2___strides_None_dynamic.mlir
+++ b/stablehlo/testdata/vmap_slice_shapes_a_float32_3__start_indices__1___limit_indices__2___strides_None_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x3xf32> {mhlo.sharding = ""}) -> tensor<?x1xf32> {

--- a/stablehlo/testdata/vmap_slice_shapes_a_float32_5_3__start_indices__1__1__limit_indices__2__1__strides__1__1_dynamic.mlir
+++ b/stablehlo/testdata/vmap_slice_shapes_a_float32_5_3__start_indices__1__1__limit_indices__2__1__strides__1__1_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5x3xf32> {mhlo.sharding = ""}) -> tensor<?x1x0xf32> {

--- a/stablehlo/testdata/vmap_slice_shapes_a_float32_5_3__start_indices__1__1__limit_indices__5__3__strides__2__1_dynamic.mlir
+++ b/stablehlo/testdata/vmap_slice_shapes_a_float32_5_3__start_indices__1__1__limit_indices__5__3__strides__2__1_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5x3xf32> {mhlo.sharding = ""}) -> tensor<?x2x2xf32> {

--- a/stablehlo/testdata/vmap_slice_shapes_a_float32_5__start_indices__1___limit_indices__5___strides__2_dynamic.mlir
+++ b/stablehlo/testdata/vmap_slice_shapes_a_float32_5__start_indices__1___limit_indices__5___strides__2_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5xf32> {mhlo.sharding = ""}) -> tensor<?x2xf32> {

--- a/stablehlo/testdata/vmap_slice_shapes_a_float32_8__start_indices__1___limit_indices__6___strides__2_dynamic.mlir
+++ b/stablehlo/testdata/vmap_slice_shapes_a_float32_8__start_indices__1___limit_indices__6___strides__2_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x8xf32> {mhlo.sharding = ""}) -> tensor<?x3xf32> {

--- a/stablehlo/testdata/vmap_sort_dtypes_num_arrays_1_shape_int32_5_7__axis_0_isstable_False_num_keys_1_dynamic.mlir
+++ b/stablehlo/testdata/vmap_sort_dtypes_num_arrays_1_shape_int32_5_7__axis_0_isstable_False_num_keys_1_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x5x7xi32> {mhlo.sharding = ""}) -> tensor<?x5x7xi32> {

--- a/stablehlo/testdata/vmap_sort_multiple_arrays_num_arrays_2_shape_int32_100__axis_0_isstable_True_num_keys_1_dynamic.mlir
+++ b/stablehlo/testdata/vmap_sort_multiple_arrays_num_arrays_2_shape_int32_100__axis_0_isstable_True_num_keys_1_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x100xi32> {mhlo.sharding = ""}, %arg2: tensor<?x100xi32> {mhlo.sharding = ""}) -> (tensor<?x100xi32>, tensor<?x100xi32>) {

--- a/stablehlo/testdata/vmap_sort_multiple_arrays_num_arrays_2_shape_int32_100__axis_0_isstable_True_num_keys_2_dynamic.mlir
+++ b/stablehlo/testdata/vmap_sort_multiple_arrays_num_arrays_2_shape_int32_100__axis_0_isstable_True_num_keys_2_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x100xi32> {mhlo.sharding = ""}, %arg2: tensor<?x100xi32> {mhlo.sharding = ""}) -> (tensor<?x100xi32>, tensor<?x100xi32>) {

--- a/stablehlo/testdata/vmap_sort_multiple_arrays_num_arrays_3_shape_int32_100__axis_0_isstable_False_num_keys_3_dynamic.mlir
+++ b/stablehlo/testdata/vmap_sort_multiple_arrays_num_arrays_3_shape_int32_100__axis_0_isstable_False_num_keys_3_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x100xi32> {mhlo.sharding = ""}, %arg2: tensor<?x100xi32> {mhlo.sharding = ""}, %arg3: tensor<?x100xf32> {mhlo.sharding = ""}) -> (tensor<?x100xi32>, tensor<?x100xi32>, tensor<?x100xf32>) {

--- a/stablehlo/testdata/vmap_sort_multiple_arrays_num_arrays_3_shape_int32_100__axis_0_isstable_True_num_keys_1_dynamic.mlir
+++ b/stablehlo/testdata/vmap_sort_multiple_arrays_num_arrays_3_shape_int32_100__axis_0_isstable_True_num_keys_1_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x100xi32> {mhlo.sharding = ""}, %arg2: tensor<?x100xi32> {mhlo.sharding = ""}, %arg3: tensor<?x100xf32> {mhlo.sharding = ""}) -> (tensor<?x100xi32>, tensor<?x100xi32>, tensor<?x100xf32>) {

--- a/stablehlo/testdata/vmap_sqrt_shape_bfloat16_20_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_sqrt_shape_bfloat16_20_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x20xbf16> {mhlo.sharding = ""}) -> tensor<?x20x20xbf16> {

--- a/stablehlo/testdata/vmap_squeeze_dtypes_inshape_float32_1_2__dimensions__0_dynamic.mlir
+++ b/stablehlo/testdata/vmap_squeeze_dtypes_inshape_float32_1_2__dimensions__0_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x1x2xf32> {mhlo.sharding = ""}) -> tensor<?x2xf32> {

--- a/stablehlo/testdata/vmap_squeeze_shapes_inshape_float32_2_1_3_1__dimensions__1__-1_dynamic.mlir
+++ b/stablehlo/testdata/vmap_squeeze_shapes_inshape_float32_2_1_3_1__dimensions__1__-1_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2x1x3x1xf32> {mhlo.sharding = ""}) -> tensor<?x2x3xf32> {

--- a/stablehlo/testdata/vmap_squeeze_shapes_inshape_float32_2_1_3_1__dimensions__1__3_dynamic.mlir
+++ b/stablehlo/testdata/vmap_squeeze_shapes_inshape_float32_2_1_3_1__dimensions__1__3_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2x1x3x1xf32> {mhlo.sharding = ""}) -> tensor<?x2x3xf32> {

--- a/stablehlo/testdata/vmap_squeeze_shapes_inshape_float32_2_1_4__dimensions__-2_dynamic.mlir
+++ b/stablehlo/testdata/vmap_squeeze_shapes_inshape_float32_2_1_4__dimensions__-2_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2x1x4xf32> {mhlo.sharding = ""}) -> tensor<?x2x4xf32> {

--- a/stablehlo/testdata/vmap_squeeze_shapes_inshape_float32_2_1_4__dimensions__1_dynamic.mlir
+++ b/stablehlo/testdata/vmap_squeeze_shapes_inshape_float32_2_1_4__dimensions__1_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2x1x4xf32> {mhlo.sharding = ""}) -> tensor<?x2x4xf32> {

--- a/stablehlo/testdata/vmap_sub_broadcasting_lhs_float32_20_20__rhs_float32_1_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_sub_broadcasting_lhs_float32_20_20__rhs_float32_1_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x20xf32> {mhlo.sharding = ""}, %arg2: tensor<?x1x20xf32> {mhlo.sharding = ""}) -> tensor<?x20x20xf32> {

--- a/stablehlo/testdata/vmap_sub_dtypes_lhs_float32_20_20__rhs_float32_20_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_sub_dtypes_lhs_float32_20_20__rhs_float32_20_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x20xf32> {mhlo.sharding = ""}, %arg2: tensor<?x20x20xf32> {mhlo.sharding = ""}) -> tensor<?x20x20xf32> {

--- a/stablehlo/testdata/vmap_transpose_dtypes_shape_float32_2_3__permutation__1_0_dynamic.mlir
+++ b/stablehlo/testdata/vmap_transpose_dtypes_shape_float32_2_3__permutation__1_0_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x2x3xf32> {mhlo.sharding = ""}) -> tensor<?x3x2xf32> {

--- a/stablehlo/testdata/vmap_triangular_solve_complex_transformations_a_complex64_4_4__b_complex64_4_1__leftside_True_lower_-5512541391217876637_dynamic.mlir
+++ b/stablehlo/testdata/vmap_triangular_solve_complex_transformations_a_complex64_4_4__b_complex64_4_1__leftside_True_lower_-5512541391217876637_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x4xcomplex<f32>> {mhlo.sharding = ""}, %arg2: tensor<?x4x1xcomplex<f32>> {mhlo.sharding = ""}) -> tensor<?x4x1xcomplex<f32>> {

--- a/stablehlo/testdata/vmap_triangular_solve_complex_transformations_a_complex64_4_4__b_complex64_4_1__leftside_True_lower_2513125903252013383_dynamic.mlir
+++ b/stablehlo/testdata/vmap_triangular_solve_complex_transformations_a_complex64_4_4__b_complex64_4_1__leftside_True_lower_2513125903252013383_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x4xcomplex<f32>> {mhlo.sharding = ""}, %arg2: tensor<?x4x1xcomplex<f32>> {mhlo.sharding = ""}) -> tensor<?x4x1xcomplex<f32>> {

--- a/stablehlo/testdata/vmap_triangular_solve_complex_transformations_a_complex64_4_4__b_complex64_4_1__leftside_True_lower_4450370616207869016_dynamic.mlir
+++ b/stablehlo/testdata/vmap_triangular_solve_complex_transformations_a_complex64_4_4__b_complex64_4_1__leftside_True_lower_4450370616207869016_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x4xcomplex<f32>> {mhlo.sharding = ""}, %arg2: tensor<?x4x1xcomplex<f32>> {mhlo.sharding = ""}) -> tensor<?x4x1xcomplex<f32>> {

--- a/stablehlo/testdata/vmap_triangular_solve_complex_transformations_a_complex64_4_4__b_complex64_4_1__leftside_True_lower_9074177395320084759_dynamic.mlir
+++ b/stablehlo/testdata/vmap_triangular_solve_complex_transformations_a_complex64_4_4__b_complex64_4_1__leftside_True_lower_9074177395320084759_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x4xcomplex<f32>> {mhlo.sharding = ""}, %arg2: tensor<?x4x1xcomplex<f32>> {mhlo.sharding = ""}) -> tensor<?x4x1xcomplex<f32>> {

--- a/stablehlo/testdata/vmap_triangular_solve_dtypes_a_complex64_4_4__b_complex64_4_1__leftside_True_lower_False_transposea_2093477155835941317_dynamic.mlir
+++ b/stablehlo/testdata/vmap_triangular_solve_dtypes_a_complex64_4_4__b_complex64_4_1__leftside_True_lower_False_transposea_2093477155835941317_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x4xcomplex<f32>> {mhlo.sharding = ""}, %arg2: tensor<?x4x1xcomplex<f32>> {mhlo.sharding = ""}) -> tensor<?x4x1xcomplex<f32>> {

--- a/stablehlo/testdata/vmap_triangular_solve_dtypes_a_complex64_4_4__b_complex64_4_1__leftside_True_lower_False_transposea_2697072896316745326_dynamic.mlir
+++ b/stablehlo/testdata/vmap_triangular_solve_dtypes_a_complex64_4_4__b_complex64_4_1__leftside_True_lower_False_transposea_2697072896316745326_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4x4xcomplex<f32>> {mhlo.sharding = ""}, %arg2: tensor<?x4x1xcomplex<f32>> {mhlo.sharding = ""}) -> tensor<?x4x1xcomplex<f32>> {

--- a/stablehlo/testdata/vmap_xor_dtypes_lhs_int32_20_20__rhs_int32_20_20_dynamic.mlir
+++ b/stablehlo/testdata/vmap_xor_dtypes_lhs_int32_20_20__rhs_int32_20_20_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x20x20xi32> {mhlo.sharding = ""}, %arg2: tensor<?x20x20xi32> {mhlo.sharding = ""}) -> tensor<?x20x20xi32> {

--- a/stablehlo/testdata/vmap_zeros_like_shape_bfloat16_3_4_5_dynamic.mlir
+++ b/stablehlo/testdata/vmap_zeros_like_shape_bfloat16_3_4_5_dynamic.mlir
@@ -1,4 +1,6 @@
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x3x4x5xbf16> {mhlo.sharding = ""}) -> tensor<?x3x4x5xbf16> {

--- a/stablehlo/testdata/xor_broadcasting_lhs_int32_1_20__rhs_int32_20_20.mlir
+++ b/stablehlo/testdata/xor_broadcasting_lhs_int32_1_20__rhs_int32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/xor_broadcasting_lhs_int32_20_20__rhs_int32_1_20.mlir
+++ b/stablehlo/testdata/xor_broadcasting_lhs_int32_20_20__rhs_int32_1_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/xor_dtypes_lhs_bool_20_20__rhs_bool_20_20.mlir
+++ b/stablehlo/testdata/xor_dtypes_lhs_bool_20_20__rhs_bool_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/xor_dtypes_lhs_int16_20_20__rhs_int16_20_20.mlir
+++ b/stablehlo/testdata/xor_dtypes_lhs_int16_20_20__rhs_int16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/xor_dtypes_lhs_int32_20_20__rhs_int32_20_20.mlir
+++ b/stablehlo/testdata/xor_dtypes_lhs_int32_20_20__rhs_int32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/xor_dtypes_lhs_int8_20_20__rhs_int8_20_20.mlir
+++ b/stablehlo/testdata/xor_dtypes_lhs_int8_20_20__rhs_int8_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/xor_dtypes_lhs_uint16_20_20__rhs_uint16_20_20.mlir
+++ b/stablehlo/testdata/xor_dtypes_lhs_uint16_20_20__rhs_uint16_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/xor_dtypes_lhs_uint32_20_20__rhs_uint32_20_20.mlir
+++ b/stablehlo/testdata/xor_dtypes_lhs_uint32_20_20__rhs_uint32_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/xor_dtypes_lhs_uint8_20_20__rhs_uint8_20_20.mlir
+++ b/stablehlo/testdata/xor_dtypes_lhs_uint8_20_20__rhs_uint8_20_20.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/zeros_like_shape_bfloat16_3_4_5.mlir
+++ b/stablehlo/testdata/zeros_like_shape_bfloat16_3_4_5.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/zeros_like_shape_bool_3_4_5.mlir
+++ b/stablehlo/testdata/zeros_like_shape_bool_3_4_5.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/zeros_like_shape_complex64_3_4_5.mlir
+++ b/stablehlo/testdata/zeros_like_shape_complex64_3_4_5.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/zeros_like_shape_float16_3_4_5.mlir
+++ b/stablehlo/testdata/zeros_like_shape_float16_3_4_5.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/zeros_like_shape_float32_3_4_5.mlir
+++ b/stablehlo/testdata/zeros_like_shape_float32_3_4_5.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/zeros_like_shape_int16_3_4_5.mlir
+++ b/stablehlo/testdata/zeros_like_shape_int16_3_4_5.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/zeros_like_shape_int32_3_4_5.mlir
+++ b/stablehlo/testdata/zeros_like_shape_int32_3_4_5.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/zeros_like_shape_int8_3_4_5.mlir
+++ b/stablehlo/testdata/zeros_like_shape_int8_3_4_5.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/zeros_like_shape_uint16_3_4_5.mlir
+++ b/stablehlo/testdata/zeros_like_shape_uint16_3_4_5.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/zeros_like_shape_uint32_3_4_5.mlir
+++ b/stablehlo/testdata/zeros_like_shape_uint32_3_4_5.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/testdata/zeros_like_shape_uint8_3_4_5.mlir
+++ b/stablehlo/testdata/zeros_like_shape_uint8_3_4_5.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt -inline %s | stablehlo-translate --interpret
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 
 module @jit_testcase {
   func.func public @main() -> tensor<i1> {

--- a/stablehlo/tests/ops_stablehlo_roundtrip.mlir
+++ b/stablehlo/tests/ops_stablehlo_roundtrip.mlir
@@ -1,5 +1,7 @@
 // RUN: stablehlo-opt %s | stablehlo-opt
-// RUN: diff <(stablehlo-opt %s) <(stablehlo-opt -emit-bytecode %s | stablehlo-opt)
+// RUN: stablehlo-opt %s > %t.0
+// RUN: stablehlo-opt -emit-bytecode %s | stablehlo-opt > %t.1
+// RUN: diff %t.0 %t.1
 // RUN: stablehlo-opt -emit-bytecode -debug-only=stablehlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s
 // RUN: stablehlo-opt -emit-bytecode %s | stablehlo-opt -debug-only=stablehlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s
 

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_10_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_10_0.mlir
@@ -1,7 +1,10 @@
 // RUN: stablehlo-opt --mlir-print-op-generic %s.bc | FileCheck %s
 // RUN: stablehlo-translate --deserialize %s.bc | stablehlo-translate --serialize --target=0.10.0 | stablehlo-opt --mlir-print-op-generic | FileCheck %s
-// RUN: diff <(stablehlo-translate --deserialize %s.bc | stablehlo-opt) <(stablehlo-opt --strip-debuginfo %s)
-// RUN: diff %s.bc <(stablehlo-translate --serialize --target=0.10.0 --strip-debuginfo %s)
+// RUN: stablehlo-translate --deserialize %s.bc | stablehlo-opt > %t.0
+// RUN: stablehlo-opt --strip-debuginfo %s > %t.1
+// RUN: diff %t.0 %t.1
+// RUN: stablehlo-translate --serialize --target=0.10.0 --strip-debuginfo %s > %t.2
+// RUN: diff %s.bc %t.2
 
 // ============ ATTRIBUTES ============
 

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_11_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_11_0.mlir
@@ -1,7 +1,10 @@
 // RUN: stablehlo-opt --mlir-print-op-generic %s.bc | FileCheck %s
 // RUN: stablehlo-translate --deserialize %s.bc | stablehlo-translate --serialize --target=0.11.0 | stablehlo-opt --mlir-print-op-generic | FileCheck %s
-// RUN: diff <(stablehlo-translate --deserialize %s.bc | stablehlo-opt) <(stablehlo-opt --strip-debuginfo %s)
-// RUN: diff %s.bc <(stablehlo-translate --serialize --target=0.11.0 --strip-debuginfo %s)
+// RUN: stablehlo-translate --deserialize %s.bc | stablehlo-opt > %t.0
+// RUN: stablehlo-opt --strip-debuginfo %s > %t.1
+// RUN: diff %t.0 %t.1
+// RUN: stablehlo-translate --serialize --target=0.11.0 --strip-debuginfo %s > %t.2
+// RUN: diff %s.bc %t.2
 
 // ============ ATTRIBUTES ============
 

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_12_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_12_0.mlir
@@ -1,7 +1,12 @@
 // RUN: stablehlo-opt --mlir-print-op-generic %s.bc | FileCheck %s
 // RUN: stablehlo-translate --deserialize %s.bc | stablehlo-translate --serialize --target=0.12.0 | stablehlo-opt --mlir-print-op-generic | FileCheck %s
-// RUN: diff <(stablehlo-translate --deserialize %s.bc | stablehlo-opt) <(stablehlo-opt --strip-debuginfo %s)
-// RUN: diff %s.bc <(stablehlo-translate --serialize --target=0.12.0 --strip-debuginfo %s)
+
+// RUN: stablehlo-translate --deserialize %s.bc | stablehlo-opt > %t.0
+// RUN: stablehlo-opt --strip-debuginfo %s > %t.1
+// RUN: diff %t.0 %t.1
+
+// RUN: stablehlo-translate --serialize --target=0.12.0 --strip-debuginfo %s > %t.3
+// RUN: diff %s.bc %t.3
 
 // ============ ATTRIBUTES ============
 

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_13_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_13_0.mlir
@@ -1,7 +1,10 @@
 // RUN: stablehlo-opt --mlir-print-op-generic %s.bc | FileCheck %s
 // RUN: stablehlo-translate --deserialize %s.bc | stablehlo-translate --serialize --target=0.13.0 | stablehlo-opt --mlir-print-op-generic | FileCheck %s
-// RUN: diff <(stablehlo-translate --deserialize %s.bc | stablehlo-opt) <(stablehlo-opt --strip-debuginfo %s)
-// RUN: diff %s.bc <(stablehlo-translate --serialize --target=0.13.0 --strip-debuginfo %s)
+// RUN: stablehlo-translate --deserialize %s.bc | stablehlo-opt > %t.0
+// RUN: stablehlo-opt --strip-debuginfo %s > %t.1
+// RUN: diff %t.0 %t.1
+// RUN: stablehlo-translate --serialize --target=0.13.0 --strip-debuginfo %s > %t.2
+// RUN: diff %s.bc %t.2
 
 // ============ ATTRIBUTES ============
 

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_14_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_14_0.mlir
@@ -1,7 +1,10 @@
 // RUN: stablehlo-opt --mlir-print-op-generic %s.bc | FileCheck %s
 // RUN: stablehlo-translate --deserialize %s.bc | stablehlo-translate --serialize --target=0.14.0 | stablehlo-opt --mlir-print-op-generic | FileCheck %s
-// RUN: diff <(stablehlo-translate --deserialize %s.bc | stablehlo-opt) <(stablehlo-opt --strip-debuginfo %s)
-// RUN: diff %s.bc <(stablehlo-translate --serialize --target=0.14.0 --strip-debuginfo %s)
+// RUN: stablehlo-translate --deserialize %s.bc | stablehlo-opt > %t.0
+// RUN: stablehlo-opt --strip-debuginfo %s > %t.1
+// RUN: diff %t.0 %t.1
+// RUN: stablehlo-translate --serialize --target=0.14.0 --strip-debuginfo %s > %t.2
+// RUN: diff %s.bc %t.2
 
 // ============ ATTRIBUTES ============
 

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_9_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_9_0.mlir
@@ -1,7 +1,10 @@
 // RUN: stablehlo-opt --mlir-print-op-generic %s.bc | FileCheck %s
 // RUN: stablehlo-translate --deserialize %s.bc | stablehlo-translate --serialize --target=0.9.0 | stablehlo-opt --mlir-print-op-generic | FileCheck %s
-// RUN: diff <(stablehlo-translate --deserialize %s.bc | stablehlo-opt) <(stablehlo-opt --strip-debuginfo %s)
-// RUN: diff %s.bc <(stablehlo-translate --serialize --target=0.9.0 --strip-debuginfo %s)
+// RUN: stablehlo-translate --deserialize %s.bc | stablehlo-opt > %t.0
+// RUN: stablehlo-opt --strip-debuginfo %s > %t.1
+// RUN: diff %t.0 %t.1
+// RUN: stablehlo-translate --serialize --target=0.9.0 --strip-debuginfo %s > %t.2
+// RUN: diff %s.bc %t.2
 
 // ============ ATTRIBUTES ============
 

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.mlir
@@ -1,6 +1,10 @@
 // RUN: stablehlo-opt --stablehlo-legalize-to-vhlo --mlir-print-op-generic --split-input-file %s | FileCheck %s
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt) <(stablehlo-opt %s)
-// RUN: diff <(stablehlo-translate --serialize --target=current %s | stablehlo-opt --pass-pipeline='builtin.module(stablehlo-deserialize)') <(stablehlo-opt %s)
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
+// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-opt --pass-pipeline='builtin.module(stablehlo-deserialize)' > %t.0
+// RUN: stablehlo-opt %s > %t.1
+// RUN: diff %t.0 %t.1
 // RUN: stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s
 // RUN: stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s
 


### PR DESCRIPTION
On Windows, command substitution fails when the `RUN` command uses
sub-shells, which are often used when the lit test needs to use the
output of commands, for example, `diff <(cmd1 arg1 arg2) <(cmd2 arg1)`.
To avoid such incorrect substitution, it seems the canonical way to use
the output of one command as an input for the subsequent command is to
save the output of each sub-command into a temporary file before running
the original (`diff`) command on the temporary files (see clang lit
tests for examples).

This patch applies this pattern to all tests in the "tests" and
"testdata" directories.  Although this patch is massive, it was generated
using the following sed command:

```bash
sed 's/\/\/ RUN: diff <(\(.*\)) <(\(.*\))/\/\/ RUN: \1 > %t.0\n\/\/ RUN: \2 > %t.1\n\/\/ RUN: diff %t.0 %t.1/' -i stablehlo/tests/*.mlir

sed 's/\/\/ RUN: diff <(\(.*\)) <(\(.*\))/\/\/ RUN: \1 > %t.0\n\/\/ RUN: \2 > %t.1\n\/\/ RUN: diff %t.0 %t.1/' -i stablehlo/testdata/*.mlir
```

As a result of this and previous two patches (#1760 and #1761), the
StableHlo code builds and runs all lit tests successfully on Windows.