### PR TITLE
build: miscellaneous CMake fixes

### DIFF
--- a/stablehlo/api/CMakeLists.txt
+++ b/stablehlo/api/CMakeLists.txt
@@ -25,4 +25,5 @@ add_mlir_dialect_library(StablehloPortableApi
   MLIRBytecodeWriter
   MLIRFuncDialect
   MLIRIR
+  MLIRParser
 )

--- a/stablehlo/dialect/CMakeLists.txt
+++ b/stablehlo/dialect/CMakeLists.txt
@@ -114,6 +114,7 @@ add_mlir_dialect_library(StablehloSerialization
   VhloOps
   MLIRBytecodeWriter
   MLIRIR
+  MLIRParser
 )
 
 add_mlir_dialect_library(StablehloTypeInference

--- a/stablehlo/integrations/python/tests/CMakeLists.txt
+++ b/stablehlo/integrations/python/tests/CMakeLists.txt
@@ -16,7 +16,7 @@ add_custom_target(check-stablehlo-python)
 
 function(add_stablehlo_python_test test_name file_name)
 add_custom_target(${test_name}
-  PYTHONPATH=${STABLEHLO_BINARY_DIR}/python_packages/stablehlo:$ENV{PYTHONPATH} ${Python3_EXECUTABLE} ${file_name}
+  ${CMAKE_COMMAND} -E env PYTHONPATH=${STABLEHLO_BINARY_DIR}/python_packages/stablehlo ${Python3_EXECUTABLE} ${file_name}
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   DEPENDS
     StablehloUnifiedPythonModules


### PR DESCRIPTION
This patch makes two small changes.  First, it adds the `MLIRParser`
library as a dependency for the `StablehloPortableApi` and the
`StablehloSerialization` library targets, since both PortableApi.cpp and
Serialization.cpp include calls to `mlir::parseSourceString()`.
Although the code _does_ build without this dependency, it seems like an
accidental result, so this patch makes the dependency explicit.

Second, the Windows shell does not use the same rules as Bash for
setting environment variables, thus causing the `check-stablehlo-python`
target to fail.  This patch uses the (cross-platform) CMake syntax for
setting the `PYTHONPATH` environment variable before running the python
script.