### PR TITLE
Allow the specification of a scalar operand for broadcast_in_dim operation

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1358,7 +1358,8 @@ implementation-defined as well.
 
 Expands the dimensions and/or rank of an input tensor by duplicating the data
 in the `operand` tensor and produces a `result` tensor. More formally,
-`result[result_index] = operand[operand_index]` where:
+`result[result_index] = rank(operand) = 0 ? operand : operand[operand_index]`
+where:
 
 * `operand_index[d] = 0` if `dim(operand, d) = 1`.
 * `operand_index[d] = result_index[broadcast_dimensions[d]]` otherwise.


### PR DESCRIPTION
The specification of broadcasting a scalar operand, using broadcast_in_dim, is unclear. The PR attempts to update the semantics for the operation to accommodate the case. 

Also, the update is limited to a spec change as the following program

```
func.func @main() -> (tensor<1x750xi32>) {
  %0 = stablehlo.constant dense<1> : tensor<i32>
  %1 = stablehlo.broadcast_in_dim %0, dims = [] : (tensor<i32>) -> tensor<1x750xi32>
  return %1 : tensor<1x750xi32>
}
```
is currently a valid representation in StableHLO.