### PR TITLE
Remove sign-based floating-point comparison

### DIFF
--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -170,7 +170,6 @@ bool areApproximatelyEqual(APFloat f, APFloat g) {
   }
 
   // Both f and g are finite (zero, subnormal, or normal) values.
-  if (f.isNegative() != g.isNegative()) return false;
   return std::fabs(f.convertToDouble() - g.convertToDouble()) <= 0.0001;
 }
 


### PR DESCRIPTION
If there are two finite values such that the absolute difference is less than zero but their sign is different, I think it should compare approximately true. I.e. `areApproximatelyEqual(0.0, -0.00001)` should evaluate to true.