### PR TITLE
Fix clang tidy, change constness of rendezvous results

### DIFF
--- a/stablehlo/reference/Process.cpp
+++ b/stablehlo/reference/Process.cpp
@@ -44,7 +44,7 @@ ProcessId Process::getId() { return id_; }
 
 void Process::outfeed(ArrayRef<Tensor> inputs) { grid_->outfeed(inputs); }
 
-const std::shared_ptr<RendezvousResult> Process::rendezvous(
+std::shared_ptr<RendezvousResult const> Process::rendezvous(
     ProcessGroup processGroup, ChannelId channelId, const Tensor &operand) {
   return grid_->rendezvous(processGroup, channelId, getId(), operand);
 }

--- a/stablehlo/reference/Process.h
+++ b/stablehlo/reference/Process.h
@@ -54,7 +54,7 @@ class Process {
   void outfeed(ArrayRef<Tensor> inputs);
 
   /// See `ProcessGrid::rendezvous`.
-  const std::shared_ptr<RendezvousResult> rendezvous(ProcessGroup processGroup,
+  std::shared_ptr<RendezvousResult const> rendezvous(ProcessGroup processGroup,
                                                      ChannelId channelId,
                                                      const Tensor &operand);
 

--- a/stablehlo/reference/ProcessGrid.cpp
+++ b/stablehlo/reference/ProcessGrid.cpp
@@ -59,7 +59,7 @@ std::optional<ProcessGroup> ProcessGroups::findGroup(ProcessId processId) {
 // RendezvousResult.
 //===----------------------------------------------------------------------===//
 
-RendezvousResult::RendezvousResult(std::map<ProcessId, Tensor> result)
+RendezvousResult::RendezvousResult(std::map<ProcessId, Tensor> const &result)
     : result_(result) {}
 
 void RendezvousResult::insert(ProcessId processId, Tensor tensor) {

--- a/stablehlo/reference/ProcessGrid.cpp
+++ b/stablehlo/reference/ProcessGrid.cpp
@@ -66,13 +66,13 @@ void RendezvousResult::insert(ProcessId processId, Tensor tensor) {
   result_[processId] = tensor;
 }
 
-Tensor RendezvousResult::lookup(ProcessId processId) {
+Tensor RendezvousResult::lookup(ProcessId processId) const {
   auto it = result_.find(processId);
   if (it != result_.end()) return it->second;
   return {};
 }
 
-SmallVector<Tensor> RendezvousResult::getSortedTensors() {
+SmallVector<Tensor> RendezvousResult::getSortedTensors() const {
   return llvm::to_vector(
       llvm::map_range(result_, [](const auto &pair) { return pair.second; }));
 }
@@ -162,7 +162,7 @@ ProcessGroups ProcessGrid::flattenedIds(
 
 void ProcessGrid::outfeed(ArrayRef<Tensor> inputs) { outfeed_.push(inputs); }
 
-const std::shared_ptr<RendezvousResult> ProcessGrid::rendezvous(
+std::shared_ptr<RendezvousResult const> ProcessGrid::rendezvous(
     ProcessGroup processGroup, ChannelId channelId, ProcessId processId,
     const Tensor &operand) {
   std::pair<ProcessGroup, ChannelId> channelKey(processGroup, channelId);

--- a/stablehlo/reference/ProcessGrid.h
+++ b/stablehlo/reference/ProcessGrid.h
@@ -70,7 +70,7 @@ class ProcessGroups : public SmallVector<ProcessGroup> {
 /// map-like API.
 class RendezvousResult {
  public:
-  RendezvousResult(std::map<ProcessId, Tensor> result);
+  RendezvousResult(std::map<ProcessId, Tensor> const &result);
 
   /// Iterates through the (ProcessId, Tensor) map entires and returns a vector
   /// of Tensors sorted by ProcessId--(replicaId, partitionId) pair--in

--- a/stablehlo/reference/ProcessGrid.h
+++ b/stablehlo/reference/ProcessGrid.h
@@ -75,14 +75,14 @@ class RendezvousResult {
   /// Iterates through the (ProcessId, Tensor) map entires and returns a vector
   /// of Tensors sorted by ProcessId--(replicaId, partitionId) pair--in
   /// lexicographical order.
-  SmallVector<Tensor> getSortedTensors();
+  SmallVector<Tensor> getSortedTensors() const;
 
   /// Inserts `tensor` into the map using the key `processId`.
   void insert(ProcessId processId, Tensor tensor);
 
   /// Iterates through the map and returns the value associated with the key
   /// `processId`. If key is not found, return an empty `Tensor`.
-  Tensor lookup(ProcessId processId);
+  Tensor lookup(ProcessId processId) const;
 
  private:
   /// Internal map representation of the result of `ProcessGrid::rendezvous`.
@@ -134,7 +134,7 @@ class ProcessGrid {
   /// tensors are accumulated in `RendezvousResult` whose shard pointer is
   /// returned to all callers once the barrier has been reached by all StableHLO
   /// processes.
-  const std::shared_ptr<RendezvousResult> rendezvous(ProcessGroup processGroup,
+  std::shared_ptr<RendezvousResult const> rendezvous(ProcessGroup processGroup,
                                                      ChannelId channelId,
                                                      ProcessId processId,
                                                      const Tensor &operand);


### PR DESCRIPTION
These results should not be modified by threads once returned, thus the pointer can be to const data. Making the shared pointer const doesn't add much, just means that the thing being pointed at cant be changed, which doesn't guarantee much.