### PR TITLE
Add reference interpreter probe instrumentation

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -290,6 +290,7 @@ cc_library(
     deps = [
         ":interpreter_ops_inc_gen",
         ":reference_interpretervalue",
+        ":reference_numpy",
         ":reference_ops",
         ":reference_process_grid",
         "@llvm-project//llvm:Support",
@@ -406,6 +407,24 @@ cc_library(
         ":reference_token",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
+    ],
+)
+
+cc_library(
+    name = "reference_numpy",
+    srcs = [
+        "stablehlo/reference/NumPy.cpp",
+    ],
+    hdrs = [
+        "stablehlo/reference/NumPy.h",
+    ],
+    strip_include_prefix = ".",
+    deps = [
+        ":reference_index",
+        ":reference_tensor",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Support",
     ],
 )
 

--- a/stablehlo/reference/CMakeLists.txt
+++ b/stablehlo/reference/CMakeLists.txt
@@ -54,6 +54,7 @@ add_mlir_dialect_library(InterpreterOps
 
   LINK_LIBS PUBLIC
   StablehloReferenceInterpreterValue
+  StablehloReferenceNumPy
   StablehloReferenceOps
   StablehloReferenceProcessGrid
   MLIRIR
@@ -68,6 +69,17 @@ add_mlir_library(StablehloReferenceInterpreterValue
   MLIRIR
   StablehloReferenceTensor
   StablehloReferenceToken
+)
+
+add_mlir_dialect_library(StablehloReferenceNumPy
+  PARTIAL_SOURCES_INTENDED
+  NumPy.cpp
+
+  LINK_LIBS PUBLIC
+  StablehloReferenceIndex
+  StablehloReferenceTensor
+  MLIRIR
+  MLIRSupport
 )
 
 add_mlir_library(StablehloReferenceOps

--- a/stablehlo/reference/InterpreterOps.h
+++ b/stablehlo/reference/InterpreterOps.h
@@ -18,6 +18,8 @@ limitations under the License.
 
 #include <queue>
 
+#include "llvm/Support/Error.h"
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/Support/LLVM.h"
@@ -36,6 +38,10 @@ class InterpreterDialect : public Dialect {
 SmallVector<InterpreterValue> evalRunParallelOp(
     ArrayRef<InterpreterValue> inputs, std::queue<StringAttr> &infeed,
     SmallVector<SmallVector<StringAttr>> programs, SymbolTable &symbolTable);
+
+llvm::Error evalProbeOp(InterpreterValue input, StringRef probeId,
+                        StringRef serializationDir,
+                        llvm::StringMap<int32_t> &probeIterations);
 
 }  // namespace interpreter
 }  // namespace stablehlo

--- a/stablehlo/reference/InterpreterOps.td
+++ b/stablehlo/reference/InterpreterOps.td
@@ -80,4 +80,38 @@ def Interpreter_RunParallelOp : Op<Interpreter_Dialect, "run_parallel", []> {
   let hasVerifier = 1;
 }
 
+def Interpreter_ProbeOp : Op<Interpreter_Dialect, "probe",
+    [SameOperandsAndResultType]> {
+  let arguments = (ins
+    HLO_Tensor:$operand,
+    StrAttr:$probe_id
+  );
+  let results = (outs HLO_Tensor:$result);
+
+  let description = [{
+    Probe and store the values of the input tensor at runtime, using the NumPy
+    file format. Writes tensor input value to
+    `<output-dir>/<probe_id>_<iteration>.npy` (where output-dir is specified by
+    the `--probe_output_dir` flag). Additionally, adds an entry to
+    <output-dir>/index.csv metadata file which maps probe IDs and iterations to
+    filenames with their tensor values.
+
+    The `probe` operation will not modify its input in any way. Probe
+    instrumentation may however slow down the interpretation of a module as
+    there will be increased file I/O.
+
+    Note that `probe_id` should be unique for each `probe` instruction in a
+    StableHLO module. A `probe` may run more than once, in which case it will
+    produce separate serialized data for each iteration in the form
+    `probe_id_#` where # is a 1-based counter.
+
+    Example:
+    ```mlir
+    %result = interpreter.probe %operand, probe_id = "probe0" : tensor<3xi32>
+    ```
+  }];
+
+  let assemblyFormat = "$operand `,` `probe_id` `=` $probe_id attr-dict `:` type($result)";
+}
+
 #endif  // STABLEHLO_REFERENCE_INTERPRETER_OPS

--- a/stablehlo/reference/NumPy.cpp
+++ b/stablehlo/reference/NumPy.cpp
@@ -1,0 +1,346 @@
+/* Copyright 2023 The StableHLO Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "stablehlo/reference/NumPy.h"
+
+#include <cctype>
+#include <fstream>
+#include <regex>
+
+#include "llvm/Support/Endian.h"
+#include "llvm/Support/Errc.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/raw_ostream.h"
+#include "mlir/IR/BuiltinTypeInterfaces.h"
+#include "mlir/IR/Types.h"
+
+namespace mlir {
+namespace stablehlo {
+namespace numpy {
+namespace {
+
+constexpr char kMagicString[] = "\x93NUMPY";
+constexpr int kMagicStringSize = 6;
+constexpr char kMajorVersion = 0x01;
+constexpr char kMinorVersion = 0x00;
+
+template <typename T>
+struct IsComplexT : public std::false_type {};
+template <typename T>
+struct IsComplexT<std::complex<T>> : public std::true_type {};
+
+}  // namespace
+
+// Determine the NumPy type abbreviation for the given underlying data type T.
+template <typename T>
+static constexpr char getNumPyType() {
+  if constexpr (std::is_same_v<T, bool>) return 'b';
+  if constexpr (IsComplexT<T>::value) return 'c';
+  if constexpr (std::is_floating_point_v<T>) return 'f';
+  if constexpr (std::is_integral_v<T>) {
+    if constexpr (std::is_signed_v<T>)
+      return 'i';
+    else
+      return 'u';
+  }
+
+  llvm::report_fatal_error("Unknown type");
+}
+
+// Creates the NumPy dict header. This will serialize the `descr`,
+// `fortran_order` and `shape` keys after the NumPy magic string. See
+// `parseDescrHeader` for additional information on how the `descr` key is
+// structured.
+template <typename T>
+static void buildNumpyHeaderDict(llvm::raw_fd_ostream& out,
+                                 ArrayRef<int64_t> shape) {
+  // For now, only little endian machines are supported.
+  const auto descr = std::string(1, /*endianness=*/'<') +
+                     std::string(1, getNumPyType<T>()) +
+                     std::to_string(sizeof(T));
+  const auto shapeString =
+      std::accumulate(shape.begin(), shape.end(), std::string(""),
+                      [](const std::string& dest, size_t dim) {
+                        return dest + std::to_string(dim) + ",";
+                      });
+  std::string dict;
+  std::stringstream outDict(dict);
+
+  outDict << "{'descr': '" << descr << "', ";
+  outDict << "'fortran_order': False, ";
+  outDict << "'shape' : (" << shapeString << "), }";
+
+  // The NumPy header is padded with spaces for proper alignment.
+  // Account for newline and the magic string length.
+  const auto headerSize = static_cast<int>(out.tell());
+  const auto padding = 16 - (headerSize + 1) % 16;
+  outDict << std::string(padding - 1, ' ') << '\n';
+
+  const auto dictLength = static_cast<uint16_t>(outDict.str().size());
+  out << (char)(dictLength & 0xff) << (char)((dictLength >> 8) & 0xff)
+      << outDict.str();
+}
+
+template <typename T>
+static void buildNumpyHeader(llvm::raw_fd_ostream& out,
+                             ArrayRef<int64_t> shape) {
+  out.write(kMagicString, kMagicStringSize);
+  out.write(kMajorVersion);
+  out.write(kMinorVersion);
+  buildNumpyHeaderDict<T>(out, shape);
+}
+
+static llvm::Error parseFortranOrderKey(const std::string& header) {
+  const std::size_t fortranOrderOffset = header.find("'fortran_order':");
+  if (fortranOrderOffset == std::string::npos)
+    return llvm::createStringError(llvm::errc::invalid_argument,
+                                   "Failed to find fortran_order header.");
+
+  if (header.find("False", fortranOrderOffset) == std::string::npos)
+    return llvm::createStringError(llvm::errc::invalid_argument,
+                                   "Only fortran_order: False is supported.");
+
+  return llvm::Error::success();
+}
+
+// Parses the NumPy `descr` header, which is in the following format:
+// 'descr': '<i4'
+// Where the first character determines the endianness of the data (< for little
+// endian, > for big endian), the next character determines the data type (i.e.
+// unsigned int, float, bool, etc) and the last number(s) determine the data
+// type size (8, 16, 32, etc). For now, we only support little endian values.
+// Returns the size of the underlying type in bytes (i.e. for '<i4', this will
+// return 4).
+template <typename T>
+static llvm::ErrorOr<int> parseDescrHeader(const std::string& header) {
+  constexpr char kDescr[] = "'descr':";
+  constexpr int kDescrSize = 8;
+
+  const std::size_t descrOffset = header.find(kDescr);
+  if (descrOffset == std::string::npos) return llvm::errc::invalid_argument;
+
+  const std::size_t needleSize = header.find(',', descrOffset + kDescrSize + 1);
+  std::string typeString = header.substr(
+      descrOffset + kDescrSize, needleSize - (descrOffset + kDescrSize));
+
+  if (typeString.front() != '\'' || typeString.back() != '\'')
+    return llvm::errc::invalid_argument;
+
+  // Strip quotes from type string (i.e. '<i8' to <i8).
+  typeString = typeString.substr(1, typeString.size() - 2);
+
+  if (typeString.size() < 3) return llvm::errc::invalid_argument;
+
+  // Check that the serialized type string matches the expected type string.
+  if (getNumPyType<T>() != typeString[1]) return llvm::errc::invalid_argument;
+
+  return std::stoi(typeString.substr(2));
+}
+
+// Parses the `shape` key of the NumPy file format dictionary. Returns a vector
+// representing the parsed shape or errors otherwise.
+static llvm::ErrorOr<ArrayRef<int64_t>> parseShapeHeader(
+    const std::string& header) {
+  const std::size_t shapeOffset = header.find("'shape':");
+  const std::size_t dimEnd = header.find(')', shapeOffset);
+  if (shapeOffset == std::string::npos || dimEnd == std::string::npos)
+    return llvm::errc::invalid_argument;
+
+  // By convention, NumPy writers should include the shape key last (preserving
+  // alphabetical ordering relative to other header keys), however we cannot
+  // assume this to be unilaterally true. Therefore, apply a tight bound on the
+  // regex matching for dimension integrals.
+  std::regex dimRegex("[0-9]+");
+  std::smatch dimMatch;
+  std::string shapeString = header.substr(shapeOffset, shapeOffset - dimEnd);
+  std::vector<int64_t> shape(4);
+
+  while (std::regex_search(shapeString, dimMatch, dimRegex)) {
+    shape.push_back(std::stoi(dimMatch[0]));
+    shapeString = dimMatch.suffix();
+  }
+
+  return shape;
+}
+
+template <typename T>
+static llvm::Error readNumpyHeader(std::ifstream& in, size_t& wordSize,
+                                   ArrayRef<int64_t> shape) {
+  char magicString[kMagicStringSize];
+  if (!in.read(magicString, kMagicStringSize))
+    return llvm::createStringError(llvm::errc::io_error,
+                                   "Failed to read NumPy magic string.");
+
+  if (strncmp(magicString, kMagicString, kMagicStringSize))
+    return llvm::createStringError(llvm::errc::invalid_argument,
+                                   "Invalid NumPy file format detected.");
+
+  // Currently, only supports NumPy v1.0 format
+  char majorVersion, minorVersion;
+  in.read(&majorVersion, 1);
+  in.read(&minorVersion, 1);
+
+  if (majorVersion != kMajorVersion || minorVersion != kMinorVersion)
+    return llvm::createStringError(
+        llvm::errc::invalid_argument,
+        "Invalid NumPy version: %c.%c. Expected version to be %c.%c.",
+        majorVersion, minorVersion, kMajorVersion, kMinorVersion);
+
+  char headerSizeBuffer[2];
+  if (!in.read(headerSizeBuffer, 2))
+    return llvm::createStringError(llvm::errc::io_error,
+                                   "Failed to read NumPy header size.");
+
+  const int headerSize = (headerSizeBuffer[0]) | (headerSizeBuffer[1] << 8);
+  std::string header(headerSize, '\0');
+  if (!in.read(header.data(), headerSize) || header.back() != '\n')
+    return llvm::createStringError(llvm::errc::invalid_argument,
+                                   "Invalid NumPy header.");
+
+  header.erase(std::remove_if(header.begin(), header.end(),
+                              [](char c) { return std::isspace(c); }),
+               header.end());
+
+  auto wordSizeOrError = parseDescrHeader<T>(header);
+  if (!wordSizeOrError)
+    return llvm::createStringError(llvm::errc::invalid_argument,
+                                   "Failed to parse descr header.");
+
+  auto fortranOrderKeyOrError = parseFortranOrderKey(header);
+  if (fortranOrderKeyOrError)
+    return llvm::createStringError(llvm::errc::invalid_argument,
+                                   "Failed to parse fortran_order header.");
+
+  auto shapeOrError = parseShapeHeader(header);
+  if (!shapeOrError)
+    return llvm::createStringError(llvm::errc::invalid_argument,
+                                   "Failed to parse shape header.");
+
+  shape = *shapeOrError;
+  wordSize = *wordSizeOrError;
+
+  return llvm::Error::success();
+}
+
+namespace {
+template <typename T>
+class ToNumpy {
+ public:
+  llvm::Error operator()(StringRef filename, ShapedType type,
+                         const char* data) {
+    int fd;
+    if (llvm::sys::fs::openFileForWrite(filename, fd,
+                                        llvm::sys::fs::CD_CreateAlways))
+      return llvm::createStringError(llvm::errc::io_error,
+                                     "Failed to open NumPy file.");
+
+    llvm::raw_fd_ostream out(fd, /*shouldClose=*/true);
+
+    buildNumpyHeader<T>(out, type.getShape());
+    out.write(data, sizeof(T) * type.getNumElements());
+
+    return llvm::Error::success();
+  }
+};
+
+template <typename T>
+class FromNumpy {
+ public:
+  llvm::ErrorOr<Tensor> operator()(StringRef filename, ShapedType type) {
+    std::ifstream in(filename.str(), std::ifstream::binary);
+    size_t wordSize = 0;
+
+    if (readNumpyHeader<T>(in, wordSize, type.getShape()))
+      return llvm::errc::invalid_argument;
+
+    const int64_t numLoadedElements = std::accumulate(
+        type.getShape().begin(), type.getShape().end(), 1, std::multiplies<>());
+
+    if (numLoadedElements != type.getNumElements() || wordSize != sizeof(T))
+      return llvm::errc::invalid_argument;
+
+    const size_t dataBytesToRead = wordSize * numLoadedElements;
+    std::vector<T> data(dataBytesToRead);
+    in.read(reinterpret_cast<char*>(data.data()), dataBytesToRead);
+
+    return Tensor(type,
+                  HeapAsmResourceBlob::allocateAndCopyInferAlign<T>(data));
+  }
+};
+
+template <template <typename Type> class Functor, typename... Args>
+static decltype(auto) dispatchType(Type type, Args&&... args) {
+  if (type.isSignlessInteger(1))
+    return Functor<char>()(std::forward<Args>(args)...);
+  if (type.isSignlessInteger(8))
+    return Functor<int8_t>()(std::forward<Args>(args)...);
+  if (type.isInteger(8)) return Functor<uint8_t>()(std::forward<Args>(args)...);
+  if (type.isSignlessInteger(16))
+    return Functor<int16_t>()(std::forward<Args>(args)...);
+  if (type.isInteger(16))
+    return Functor<uint16_t>()(std::forward<Args>(args)...);
+  if (type.isSignlessInteger(32))
+    return Functor<int32_t>()(std::forward<Args>(args)...);
+  if (type.isInteger(32))
+    return Functor<uint32_t>()(std::forward<Args>(args)...);
+  if (type.isSignlessInteger(64))
+    return Functor<uint64_t>()(std::forward<Args>(args)...);
+  if (type.isInteger(64))
+    return Functor<int64_t>()(std::forward<Args>(args)...);
+  if (type.isF16()) return Functor<uint16_t>()(std::forward<Args>(args)...);
+  if (type.isF32()) return Functor<float>()(std::forward<Args>(args)...);
+  if (type.isF64()) return Functor<double>()(std::forward<Args>(args)...);
+  if (auto complexTy = type.dyn_cast<ComplexType>()) {
+    auto complexElemTy = complexTy.getElementType();
+
+    // Use a double data type to serialize the real (32bit) and imaginary (32
+    // bit) components of a complex number.
+    if (complexElemTy.isF32())
+      return Functor<double>()(std::forward<Args>(args)...);
+
+#ifdef __SIZEOF_INT128__
+    // Only some platforms support 128bit native data types required to
+    // to serialize f64 complex element types.
+    if (complexElemTy.isF64())
+      return Functor<__int128>()(std::forward<Args>(args)...);
+#endif
+  }
+
+  llvm::report_fatal_error("Unknown type");
+}
+
+}  // namespace
+
+llvm::ErrorOr<Tensor> deserializeTensor(StringRef filename, ShapedType type) {
+  if (llvm::support::endian::system_endianness() ==
+      llvm::support::endianness::big)
+    llvm::report_fatal_error("Only little endian supported.");
+
+  return dispatchType<FromNumpy>(type.getElementType(), filename, type);
+}
+
+llvm::Error serializeTensor(StringRef filename, ShapedType type,
+                            const char* data) {
+  if (llvm::support::endian::system_endianness() ==
+      llvm::support::endianness::big)
+    llvm::report_fatal_error("Only little endian supported.");
+
+  return dispatchType<ToNumpy>(type.getElementType(), filename, type, data);
+}
+
+}  // namespace numpy
+}  // namespace stablehlo
+}  // namespace mlir

--- a/stablehlo/reference/NumPy.cpp
+++ b/stablehlo/reference/NumPy.cpp
@@ -325,8 +325,7 @@ static decltype(auto) dispatchType(Type type, Args&&... args) {
 }  // namespace
 
 llvm::ErrorOr<Tensor> deserializeTensor(StringRef filename, ShapedType type) {
-  if (llvm::support::endian::system_endianness() ==
-      llvm::support::endianness::big)
+  if (llvm::endianness::native == llvm::support::endianness::big)
     llvm::report_fatal_error("Only little endian supported.");
 
   return dispatchType<FromNumpy>(type.getElementType(), filename, type);
@@ -334,8 +333,7 @@ llvm::ErrorOr<Tensor> deserializeTensor(StringRef filename, ShapedType type) {
 
 llvm::Error serializeTensor(StringRef filename, ShapedType type,
                             const char* data) {
-  if (llvm::support::endian::system_endianness() ==
-      llvm::support::endianness::big)
+  if (llvm::endianness::native == llvm::support::endianness::big)
     llvm::report_fatal_error("Only little endian supported.");
 
   return dispatchType<ToNumpy>(type.getElementType(), filename, type, data);

--- a/stablehlo/reference/NumPy.h
+++ b/stablehlo/reference/NumPy.h
@@ -1,0 +1,44 @@
+/* Copyright 2023 The StableHLO Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef STABLEHLO_REFERENCE_NUMPY_H
+#define STABLEHLO_REFERENCE_NUMPY_H
+
+#include "llvm/Support/ErrorOr.h"
+#include "mlir/IR/BuiltinTypeInterfaces.h"
+#include "stablehlo/reference/Tensor.h"
+
+namespace mlir {
+namespace stablehlo {
+namespace numpy {
+
+// Filename to use for the metadata CSV file associating probeId values to
+// serialized NumPy files.
+constexpr char kInstrumentationMetadataFilename[] = "index.csv";
+
+// Read a NumPy serialized tensor from disk stored at `filename` with the given
+// `type`.
+llvm::ErrorOr<Tensor> deserializeTensor(StringRef filename, ShapedType type);
+
+// Store a tensor using the NumPy file format with the given `type` to the given
+// `filename`.
+llvm::Error serializeTensor(StringRef filename, ShapedType type,
+                            const char* data);
+
+}  // namespace numpy
+}  // namespace stablehlo
+}  // namespace mlir
+
+#endif  // STABLEHLO_REFERENCE_NUMPY_H

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -193,9 +193,10 @@ Tensor evalTanhOp(const Tensor &operand, ShapedType resultType);
 Tensor evalTransposeOp(const Tensor &operand, const Axes &permutation,
                        ShapedType resultType);
 Tuple evalTupleOp(ArrayRef<InterpreterValue> val, TupleType resultType);
-SmallVector<InterpreterValue> evalWhileOp(SmallVector<InterpreterValue> operand,
-                                          Region &cond, Region &body,
-                                          Process *process, Scope &scope);
+SmallVector<InterpreterValue> evalWhileOp(
+    SmallVector<InterpreterValue> operand, Region &cond, Region &body,
+    Process *process, Scope &scope,
+    llvm::function_ref<llvm::Error(Operation &, Process *, Scope &)> fallback);
 Tensor evalXorOp(const Tensor &lhs, const Tensor &rhs, ShapedType resultType);
 
 /// Evaluates an mlir::Region `region` using the runtime values `args`

--- a/stablehlo/reference/Tensor.h
+++ b/stablehlo/reference/Tensor.h
@@ -110,6 +110,9 @@ class Tensor {
   /// Provides read access to the tensor element indexed at 'index'.
   Element get(const Index &index) const;
 
+  /// Provides read access to underlying tensor data buffer.
+  const char *getData() const { return impl_->getData().data(); }
+
   /// Provides write access to the tensor element indexed at 'index'.
   ///
   /// \param index The multi-dimensional index to write to.

--- a/stablehlo/tests/BUILD.bazel
+++ b/stablehlo/tests/BUILD.bazel
@@ -33,6 +33,7 @@ cc_library(
         ":check_ops_inc_gen",
         "//:base",
         "//:reference_interpretervalue",
+        "//:reference_numpy",
         "//:reference_tensor",
         "//:reference_token",
     ],

--- a/stablehlo/tests/CMakeLists.txt
+++ b/stablehlo/tests/CMakeLists.txt
@@ -65,6 +65,7 @@ add_mlir_dialect_library(CheckOps
 
   LINK_LIBS PUBLIC
   StablehloBase
+  StablehloReferenceNumPy
   StablehloReferenceTensor
   MLIRIR
   MLIRSupport

--- a/stablehlo/tests/CheckOps.h
+++ b/stablehlo/tests/CheckOps.h
@@ -25,7 +25,6 @@ limitations under the License.
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/OpDefinition.h"
 #include "stablehlo/reference/Tensor.h"
-#include "stablehlo/tests/CheckOps.h"
 
 namespace mlir {
 namespace stablehlo {
@@ -42,6 +41,8 @@ llvm::Error evalExpectAlmostEqConstOp(const Tensor &lhs, ElementsAttr value);
 llvm::Error evalExpectAlmostEqOp(const Tensor &lhs, const Tensor &rhs);
 llvm::Error evalExpectEqConstOp(const Tensor &lhs, ElementsAttr value);
 llvm::Error evalExpectEqOp(const Tensor &lhs, const Tensor &rhs);
+llvm::Error evalExpectSerializedEqOp(const Tensor &expected, StringRef probeId,
+                                     StringRef probeDir, uint32_t iteration);
 
 }  // namespace check
 }  // namespace stablehlo

--- a/stablehlo/tests/CheckOps.td
+++ b/stablehlo/tests/CheckOps.td
@@ -118,4 +118,30 @@ def CHECK_ExpectEqOp : Op<CHECK_Dialect, "expect_eq", [SameTypeOperands]> {
   let assemblyFormat = "$lhs `,` $rhs attr-dict `:` type($lhs)";
 }
 
+def CHECK_ExpectSerializedEqOp : Op<CHECK_Dialect, "expect_serialized_eq", []> {
+  let summary = [{Checks value of serialized tensor value.}];
+  let description = [{
+    Verifies that the value of the serialized tensor `probe_id` matches the
+    optionally specified input tensor at iteration `iteration`, using previously
+    serialized filepaths in `index.csv`.
+
+    ```mlir
+    check.expect_serialized_eq %arg0,
+      probe_id = "probe0",
+      iter = 0 : tensor<2xi32>
+    ```
+  }];
+
+  let arguments = (ins
+      HLO_Tensor:$expected,
+      StrAttr:$probe_id,
+      DefaultValuedOptionalAttr<UI32Attr, "0">:$iteration
+  );
+
+  let assemblyFormat = [{
+    $expected `,` `probe_id` `=` $probe_id (`,` `iter` `=` $iteration^)?
+    attr-dict `:` type($expected)
+  }];
+}
+
 #endif  // STABLEHLO_DIALECT_CHECK_OPS

--- a/stablehlo/tests/interpret_probe.mlir
+++ b/stablehlo/tests/interpret_probe.mlir
@@ -1,0 +1,84 @@
+// RUN: stablehlo-translate --interpret --probe-output-dir=%T -split-input-file %s
+
+func.func @probe_i1() {
+  %0 = stablehlo.constant dense<[[0], [0], [0]]> : tensor<3x1xi1>
+  %1 = stablehlo.constant dense<[[1], [1], [1]]> : tensor<3x1xi1>
+  %2 = stablehlo.add %0, %1 : tensor<3x1xi1>
+  %3 = interpreter.probe %2, probe_id = "probe_i1" : tensor<3x1xi1>
+  check.expect_serialized_eq %3, probe_id = "probe_i1" : tensor<3x1xi1>
+  func.return
+}
+
+// -----
+
+func.func @probe_si64() {
+  %0 = stablehlo.constant dense<[[-127], [126], [0]]> : tensor<3x1xi64>
+  %1 = stablehlo.constant dense<[[-1], [1], [1]]> : tensor<3x1xi64>
+  %2 = stablehlo.add %0, %1 : tensor<3x1xi64>
+  %3 = interpreter.probe %2, probe_id = "probe_si64" : tensor<3x1xi64>
+  check.expect_serialized_eq %3, probe_id = "probe_si64" : tensor<3x1xi64>
+  func.return
+}
+
+// -----
+
+func.func @probe_ui64() {
+  %0 = stablehlo.constant dense<[[32766, 0], [0, 0]]> : tensor<2x2xui64>
+  %1 = stablehlo.constant dense<[[1, 1], [2, 2]]> : tensor<2x2xui64>
+  %2 = stablehlo.add %0, %1 : tensor<2x2xui64>
+  %3 = interpreter.probe %2, probe_id = "probe_ui64" : tensor<2x2xui64>
+  check.expect_serialized_eq %3, probe_id = "probe_ui64" : tensor<2x2xui64>
+  func.return
+}
+
+// -----
+
+func.func @probe_f64() {
+  %0 = stablehlo.constant dense<[3.402e+38, 1.175e-38, 0.0e+00]> : tensor<3xf64>
+  %1 = stablehlo.constant dense<[1.0e+00, -1.0e+00, 1.0e+00]> : tensor<3xf64>
+  %2 = stablehlo.add %0, %1 : tensor<3xf64>
+  %3 = interpreter.probe %2, probe_id = "probe_f64" : tensor<3xf64>
+  check.expect_serialized_eq %3, probe_id = "probe_f64" : tensor<3xf64>
+  func.return
+}
+
+// -----
+
+func.func @probe_c32() {
+  %0 = stablehlo.constant dense<[(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)]> : tensor<3xcomplex<f32>>
+  %1 = stablehlo.constant dense<[(1.0, 1.0), (1.0, 1.0), (1.0, 1.0)]> : tensor<3xcomplex<f32>>
+  %2 = stablehlo.add %0, %1 : tensor<3xcomplex<f32>>
+  %3 = interpreter.probe %2, probe_id = "probe_c32" : tensor<3xcomplex<f32>>
+  check.expect_serialized_eq %3, probe_id = "probe_c32" : tensor<3xcomplex<f32>>
+  func.return
+}
+
+// -----
+
+func.func @probe_iterations() {
+  // int i = 0;
+  // int sum = 0;
+  // while (i < 10) {
+  //   sum += 1;
+  //   i += 1;
+  // }
+  %init_i = stablehlo.constant dense<0> : tensor<i64>
+  %init_sum = stablehlo.constant dense<0> : tensor<i64>
+  %one = stablehlo.constant dense<1> : tensor<i64>
+  %two = stablehlo.constant dense<2> : tensor<i64>
+  %results0, %results1 = stablehlo.while(%arg0 = %init_i, %arg1 = %init_sum) : tensor<i64>, tensor<i64>
+  cond {
+    %cond = stablehlo.compare LT, %arg0, %two : (tensor<i64>, tensor<i64>) -> tensor<i1>
+    stablehlo.return %cond : tensor<i1>
+  } do {
+    %new_sum = stablehlo.add %arg1, %one : tensor<i64>
+    %new_sum_instrumented = interpreter.probe %new_sum, probe_id = "probe_iterations" : tensor<i64>
+    %new_i = stablehlo.add %arg0, %one : tensor<i64>
+    stablehlo.return %new_i, %new_sum_instrumented : tensor<i64>, tensor<i64>
+  }
+
+  check.expect_eq_const %results0, dense<2> : tensor<i64>
+  check.expect_serialized_eq %one, probe_id = "probe_iterations", iter = 0 : tensor<i64>
+  check.expect_serialized_eq %two, probe_id = "probe_iterations", iter = 1 : tensor<i64>
+  func.return
+}


### PR DESCRIPTION
Reopening #1763 due to a branch corruption issue. Original text below:

===

As the number of ML frameworks continues to rapidly grow, it’s becoming increasingly desirable to be able to compare numerical results across different runtimes. This ensures that ML models run equivalently in different environments, and overall helps to instill confidence in ML frameworks. For example, given the recency of the StableHLO representation, it may be desirable to have a way to compare StableHLO interpreter results to other frameworks, such as Tensorflow, or other implementations

This PR proposes the addition of a probe instruction to the new interpreter dialect in StableHLO. The probe instruction will enable us to extract intermediate tensor state from the StableHLO interpreter. Since this new op is intended to initially support debuggability, it will not be added to the StableHLO opset itself, but instead to the new [interpreter dialect](https://github.com/openxla/stablehlo/pull/1703).

The probe instruction will take precisely 1 shaped tensor input, and produce the same shaped tensor output, without modifying it:

```
%1 = "interpreter.probe"(%0) {probe_id="probe0"} : (tensor<*xf32) -> tensor<*xf32>
```

The op will be modeled as having side effects, to prevent it from being moved or removed by the compiler. It will additionally contain a singular, unique string attribute, `probe_id`, which will allow us to later pair this tensor’s data with other runtimes. At compile time, the probe instruction may be inserted after every StableHLO operation (except constants), allowing runtime data to be serialized to disk.

This PR also adds a new StableHLO interpreter configuration flag, `--probe_readout_dir`, which will be used to specify the directory in which to store all probed interpreter values. When executed, the probe instruction will associate the contents of its input tensor with the given probe_id, and serialize the tensor data to disk using the portable [NumPy](https://numpy.org/) format. The filename used will be in the form of `probe_readout_dir/probe_id.npy`. As the interpreter executes `interpreter.probe` operations, in addition to serializing tensor data to NumPy files, it will also append serialized filepaths to a metadata `index.csv` file in the form of:

```
probe_id0,/probe_readout_dir/probe_id0.npy
probe_id1,/probe_readout_dir/probe_id1.npy
…
probe_id0,/probe_readout_dir/probe_id0_1.npy
```

The metadata file can then be used by post processing tools to analyze the instrumented tensor data. Note that a `probe_id` can appear more than once in the metadata file (i.e. if a probe is executed within a loop).

### Validation

To validate the new instruction, we propose extending the existing `stablehlo::check` MLIR dialect with a `expect_serialized_eq` operation, which can be utilized in the following way:

```
// Where `T` is a statically shaped tensor
%0 = …
%1 = interpreter.probe %0 { probe_id = "probe0" } : (tensor<T>) -> tensor<T>
check.expect_serialized_eq %3 { probe_id = "probe0", iteration = 0 : i32 } : tensor<T>
```

The `check.expect_serialized_eq` is expected to appear after the producing `interpreter.probe` instruction with the same `probe_id`. When executed, the instruction will search for an existing `index.csv` metadata file in the same directory as specified by the `--probe_readout_dir` flag, and then attempt to find the serialized filepath for the given `probe_id` and iteration. After which, the interpreter will load the serialized tensor from the NumPy file, and then proceed to compare it with its operand tensor. The operation will assert on an answer mismatch or failure to find/parse the associated NumPy file. The iteration attribute is 0-based and is optional and will default to 0.