### PR TITLE
[RFC] Add hybrid quantized convolution and dot_general for weight-only quantization

### DIFF
--- a/rfcs/20231005-hybrid-quantization.md
+++ b/rfcs/20231005-hybrid-quantization.md
@@ -149,10 +149,9 @@ rhs)`.
 
 ### Dynamic Range Quantization
 
-Dynamic range quantization(DRQ) is a different quantization scheme, which has
-the same type signature as weight-only quantization. A dynamic range quantized
+Dynamic range quantization(DRQ) is a different quantization scheme, which is represented in comparable MLIR dialects using the same type signature as this proposed weight-only quantization representation. A dynamic range quantized
 graph also accepts input in float and weight in quantized type. Instead of
 dequantizing weights, inputs are quantized on-the-fly based on input range and
-computation is done in quantized type. To represent DRQ, we can consider
+computation is done in quantized type. To represent DRQ in StableHLO, we can consider
 utilizing custom call, but this issue will be considered separately from this
 RFC as more discussion is needed. 

--- a/rfcs/20231005-hybrid-quantization.md
+++ b/rfcs/20231005-hybrid-quantization.md
@@ -149,9 +149,10 @@ rhs)`.
 
 ### Dynamic Range Quantization
 
-Dynamic range quantization(DRQ) is a different quantization scheme, which is represented in comparable MLIR dialects using the same type signature as this proposed weight-only quantization representation. A dynamic range quantized
-graph also accepts input in float and weight in quantized type. Instead of
-dequantizing weights, inputs are quantized on-the-fly based on input range and
-computation is done in quantized type. To represent DRQ in StableHLO, we can consider
-utilizing custom call, but this issue will be considered separately from this
-RFC as more discussion is needed.
+Dynamic range quantization(DRQ) is a different quantization scheme, which is
+represented in comparable MLIR dialects using the same type signature as this proposed
+weight-only quantization representation. A dynamic range quantized graph also accepts
+input in float and weight in quantized type. Instead of dequantizing weights, inputs
+are quantized on-the-fly based on input range and computation is done in quantized
+type. To represent DRQ in StableHLO, we can consider utilizing custom call, but this
+issue will be considered separately from this RFC as more discussion is needed.

--- a/rfcs/20231005-hybrid-quantization.md
+++ b/rfcs/20231005-hybrid-quantization.md
@@ -70,9 +70,9 @@ in float. Element type of float lhs tensor and expressed type of quantized rhs
 tensor should be identical.
 
 ```python
-def hybrid_dequantize_then_op(op, *inputs):
-  float_inputs = map(lambda input: input if is_float(element_type(type(input))) else dequantize(input) , inputs)
-  return op(*float_inputs)
+def hybrid_dequantize_then_op(op, lhs, rhs):
+  assert(is_float(lhs) and is_quantized(rhs) and element_type(lhs) == expressed_type(rhs))
+  return op(lhs, dequantize(rhs))
 ```
 
 ### convolution

--- a/rfcs/20231005-hybrid-quantization.md
+++ b/rfcs/20231005-hybrid-quantization.md
@@ -7,7 +7,7 @@ Last updated: 10/31/2023<br/>
 ## Version log
 
 * 10/05/2023: Initial version.
-* 10/17/2023: Minor fixes and add proposed operation semantics. 
+* 10/17/2023: Minor fixes and add proposed operation semantics.
 
 ## Introduction
 
@@ -61,7 +61,7 @@ op.
 ### hybrid_dequantize_then_op semantics
 
 We propose to define `hybrid_dequantize_then_op` semantics as part of quantization
-computations. 
+computations.
 
 * `hybrid_dequantize_then_op` is used to specify weight-only quantization for
 hybrid op which accepts lhs in floating-point and rhs in quantized types. It
@@ -107,7 +107,7 @@ feature_group_count, batch_group_count, precision_config), lhs, rhs)`.
   * (C28) `is_quantized(lhs) = is_quantized(result) and is_quantized(rhs)`.
   * (C29) If `is_per_axis_quantized(rhs)`,
     then `quantization_dimension(rhs) = kernel_output_feature_dimension`.
-  * (C30) If `is_per_axis_quantized(result)`, then 
+  * (C30) If `is_per_axis_quantized(result)`, then
     `quantization_dimension(result) = output_feature_dimension`.
   * If `is_quantized(lhs)`:
     * (C31) `storage_type(lhs) = storage_type(rhs)`.
@@ -154,4 +154,4 @@ graph also accepts input in float and weight in quantized type. Instead of
 dequantizing weights, inputs are quantized on-the-fly based on input range and
 computation is done in quantized type. To represent DRQ in StableHLO, we can consider
 utilizing custom call, but this issue will be considered separately from this
-RFC as more discussion is needed. 
+RFC as more discussion is needed.

--- a/rfcs/20231005-hybrid-quantization.md
+++ b/rfcs/20231005-hybrid-quantization.md
@@ -35,7 +35,9 @@ requirements on use-cases across various frameworks and hardwares.
 
 ## Examples
 
-Here are examples of hybrid quantized convolution and dot_general.
+Here are examples of hybrid quantized convolution and dot_general. Hybrid
+quantized ops will get float input(or lhs) and quantized weight(or rhs) as
+operands and output float results.
 
 ```mlir
 %conv = "stablehlo.convolution"(%input_f, %weight_q) ... : (tensor<...xf32>, !quant.uniform<i8:f32, scale:zp>) -> tensor<...xf32>>

--- a/rfcs/20231005-hybrid-quantization.md
+++ b/rfcs/20231005-hybrid-quantization.md
@@ -64,10 +64,10 @@ We propose to define `hybrid_dequantize_then_op` semantics as part of quantizati
 computations. 
 
 * `hybrid_dequantize_then_op` is used to specify weight-only quantization for
-hybrid op which accepts lhs in float and rhs in quantized types. It dequantizes
-quantized inputs into their expressed types and performs computation in float.
-Element type of float lhs tensor and expressed type of quantized rhs tensor
-should be identical.
+hybrid op which accepts lhs in floating-point and rhs in quantized types. It
+dequantizes quantized inputs into their expressed types and performs computation
+in float. Element type of float lhs tensor and expressed type of quantized rhs
+tensor should be identical.
 
 ```python
 def hybrid_dequantize_then_op(op, *inputs):


### PR DESCRIPTION
This RFC proposes to add hybrid quantized convolution and dot_general for weight-only quantization.
Please let me know your feedback on this.

The RFC partially address the issue https://github.com/openxla/stablehlo/issues/1575 w.r.t supporting weight only quantization support in StableHLO. The remaining tasks for the above the are highlighted [here](https://github.com/openxla/stablehlo/issues/1575#issuecomment-1819957802). 