### PR TITLE
Specification of quantized `reduce` and other related ops

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1067,7 +1067,7 @@ For quantized types, performs
 `dequantize_batch_norm_grad_or_training_quantize(lambda operand, scale, mean,
 variance, grad_output: batch_norm_grad(operand, scale, mean, variance,
 grad_output, epsilon, feature_index), operand, scale, mean, variance,
-grad_output, type(result))`.
+grad_output, type(grad_operand), type(grad_scale), type(feature_index))`.
 
 #### Inputs
 
@@ -1252,7 +1252,7 @@ def batch_norm_training(operand, scale, offset, epsilon, feature_index):
 For quantized types, performs
 `dequantize_batch_norm_grad_or_training_quantize(lambda operand, scale, offset:
 batch_norm_training(operand, scale, offset, epsilon, feature_index), operand,
-scale, offset, type(result))`.
+scale, offset, type(output), type(batch_mean), type(batch_var))`.
 
 #### Inputs
 


### PR DESCRIPTION
The PR implements the approved [RFC for reduce op](https://github.com/openxla/stablehlo/pull/1664) by proposing the specification related changes for `reduce`, `reduce_window` and `select_and_scatter` ops.

In https://github.com/openxla/stablehlo/pull/1647, we talked about some  of the other ops which will depend on the quantized specification of reduce op. Initially, I thought about creating separate PRs for them, but for the interest of time and the fact that their handling is going to be very similar to how `reduce` op is handled, I propose to include their PR in the current PR.

Here are the  additional ops (other than `reduce`, `reduce_window`, `select_and_scatter`) whose specification is added
 - Ops with explicit computation regions: `all_reduce`, `reduce_scatter`, `scatter`: They are handled similar to how `reduce` op is handled. 

 - Ops w/o explicit computation region:  `batch_norm_grad`, `batch_norm_training`: For these ops, the semantics of the operation implicitly does reduction with a custom computation function. As there is no explicit computation function in the IR, the proposal in the RFC cannot be applied. I propose (A) to handle these ops similar to how `batch_norm_inference` is handled with `dequant-op-quant` strategy, (B) we can revisit this op later if there is use case to do that implicit reduction using higher accumulation type.  
 
One implementation detail: The fact that  `batch_norm_grad`, `batch_norm_training` ops returns multiple outputs and current `dequantize_op_quantize` returns a single output, is handled using a dedicated meta function for these two ops. 



Next steps: Once the PR is approved the plan is to propose the corresponding changes in the verifier/shape functions for these ops.

**Only support promotion of reduction operands to reduction-block arguments**
The specific question bought up in the discussion is: should we promote demotion as well? It seems that there aren't any use-cases for that. For example, consider the following cases of implicit conversion for reduction operations. The examples are shown using integer type but can be generalized to other types as well.
 
| input element type | accumulator element type  | result element type | use-cases |
|:--:|:--:|:--:|:--|
| i8| i8 |i8| Reduction using min/max|
| i8| i32 |i32| Reduction using average/sum|
| i8| i32| i8 | Demotion from accumulation type to result type. (No use-case)|
| i8| i32| i64 | Extra promotion from accumulation type to result type. (No use-case) |
| i32 | i8 | i8 | Demotion from input value type to accumulation type. (No use case) |

With that in mind, we propose to develop the specification based on the scenario we have the use-case for (just for promotion: _none of the cases of demotion or extra promotion will be supported in the specification_. 