### PR TITLE
Fix an accidental modification to TOSA tests

### DIFF
--- a/stablehlo/conversions/tosa/tests/nullary.mlir
+++ b/stablehlo/conversions/tosa/tests/nullary.mlir
@@ -19,6 +19,7 @@ func.func @constant_f64() -> tensor<10xf64> {
 func.func @iota_dimension_0() -> tensor<4x8xf32> {
   // CHECK-DAG: %[[VAR0:.*]] = "tosa.const"()
   // CHECK-SAME{LITERAL}: <{value = dense<[[0.000000e+00], [1.000000e+00], [2.000000e+00], [3.000000e+00]]> : tensor<4x1xf32>}>
+  // CHECK-DAG: %[[VAR1:.*]] = tosa.tile %[[VAR0]] {multiples = array<i64: 1, 8>}
   %0 = "stablehlo.iota"() {iota_dimension = 0 : i64} : () -> (tensor<4x8xf32>)
   return %0 : tensor<4x8xf32>
 }
@@ -27,6 +28,7 @@ func.func @iota_dimension_0() -> tensor<4x8xf32> {
 func.func @iota_dimension_1() -> tensor<4x8xi32> {
   // CHECK-DAG: %[[VAR0:.*]] = "tosa.const"()
   // CHECK-SAME{LITERAL}: <{value = dense<[[0, 1, 2, 3, 4, 5, 6, 7]]> : tensor<1x8xi32>}>
+  // CHECK-DAG: %[[VAR1:.*]] = tosa.tile %[[VAR0]] {multiples = array<i64: 4, 1>}
   %0 = "stablehlo.iota"() {iota_dimension = 1 : i64} : () -> (tensor<4x8xi32>)
   return %0 : tensor<4x8xi32>
 }


### PR DESCRIPTION
In #1822, I accidentally removed a few CHECK lines from a TOSA conversion test. This PR restores them.