### PR TITLE
Sort dependencies of the stablehlo_ci_tests target

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1362,8 +1362,8 @@ gentbl_cc_library(
 test_suite(
     name = "stablehlo_ci_tests",
     tests = [
-        "//stablehlo/tests:stablehlo_tests",
+        "//stablehlo/conversions/tosa/tests:stablehlo_tosa_tests",
         "//stablehlo/testdata:stablehlo_testdata_tests",
-        "//stablehlo/conversions/tosa/tests:stablehlo_tosa_tests"
+        "//stablehlo/tests:stablehlo_tests",
     ],
 )


### PR DESCRIPTION
Previously, these dependencies were not sorted which triggered a lint check during a downstream integrate. Looks like a useful thing to fix.