### PR TITLE
Add dependency on LLVM's not tool

### DIFF
--- a/stablehlo/tests/CMakeLists.txt
+++ b/stablehlo/tests/CMakeLists.txt
@@ -22,7 +22,7 @@ configure_lit_site_cfg(
 add_lit_testsuite(check-stablehlo-tests "Running the tests/ suite"
   ${CMAKE_CURRENT_BINARY_DIR}
   DEPENDS
-  FileCheck
+  FileCheck not
   stablehlo-opt
   stablehlo-translate
 )


### PR DESCRIPTION
Was working in a corrupt build area and got a "command `not` not found" error. CMake somehow works without it normally, but still better to add it for correctness.

References:

- [StableHLO test using `not`](https://github.com/openxla/stablehlo/blob/654c202babbab3f4bd50cdd276de02dc17ecc358/stablehlo/tests/vhlo_to_version_invalid.mlir#L4)
- [StableHLO bazel dependency on `not`](https://github.com/openxla/stablehlo/blob/654c202babbab3f4bd50cdd276de02dc17ecc358/stablehlo/tests/BUILD.bazel#L150)
- [MHLO example](https://github.com/openxla/xla/blob/fb67091154574430a8fd17b7eae7ceadd79f7139/xla/mlir_hlo/tests/CMakeLists.txt#L24) using not dependency in cmake