### PR TITLE
Migrate InterpreterDialect and CheckDialect to use properties

### DIFF
--- a/stablehlo/reference/InterpreterOps.td
+++ b/stablehlo/reference/InterpreterOps.td
@@ -32,7 +32,7 @@ def Interpreter_Dialect : Dialect {
     StableHLO spec.
   }];
 
-  let usePropertiesForAttributes = 0;
+  let usePropertiesForAttributes = 1;
 }
 
 def Interpreter_ArrayOfFlatSymbolRefArrayAttr :

--- a/stablehlo/tests/CheckOps.td
+++ b/stablehlo/tests/CheckOps.td
@@ -32,7 +32,7 @@ def CHECK_Dialect : Dialect {
 
   let useDefaultAttributePrinterParser = 0;
   let useDefaultTypePrinterParser = 0;
-  let usePropertiesForAttributes = 0;
+  let usePropertiesForAttributes = 1;
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
[MLIR Properties](https://mlir.llvm.org/OpenMeetings/2023-02-09-Properties.pdf) are the new standard for non-discardable attributes. In the near future, all dialects must migrate to use properties by default. This PR migrates InterpreterDialect and CheckDialect, which turned out to be trivial.

VHLO changes are approved, the changes for StableHLO and CHLO will be slightly more involved.

Part of #1584.