### PR TITLE
[build] create initial CMake export configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,3 +169,4 @@ add_custom_target(check-stablehlo-quick)
 add_dependencies(check-stablehlo-ci check-stablehlo-quick)
 
 add_subdirectory(stablehlo)
+add_subdirectory(cmake/modules)

--- a/cmake/modules/CMakeLists.txt
+++ b/cmake/modules/CMakeLists.txt
@@ -1,0 +1,69 @@
+# Since we just use MLIR's cmake functions (add_mlir_library, etc.),
+# MLIR_EXPORTS would have the necessary targets to export.
+get_property(STABLEHLO_EXPORTS GLOBAL PROPERTY MLIR_EXPORTS)
+
+set(STABLEHLO_CONFIG_CMAKE_DIR "${CMAKE_BINARY_DIR}/lib/cmake/stablehlo")
+
+export(TARGETS ${STABLEHLO_EXPORTS}
+  NAMESPACE Stablehlo::
+  FILE "${STABLEHLO_CONFIG_CMAKE_DIR}/StablehloTargets.cmake"
+)
+
+# Set variables and configure StablehloConfig.cmake for the _build_ tree.
+set(STABLEHLO_CONFIG_INCLUDE_DIRS
+  "${STABLEHLO_SOURCE_DIR}"
+  "${STABLEHLO_BINARY_DIR}"
+)
+
+configure_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/StablehloConfig.cmake.in"
+  "${STABLEHLO_CONFIG_CMAKE_DIR}/StablehloConfig.cmake"
+  @ONLY
+)
+
+export(EXPORT MLIRTargets
+  NAMESPACE Stablehlo::
+  FILE "${PROJECT_BINARY_DIR}/StablehloTargets.cmake"
+)
+
+# Set variables and configure StablehloConfig.cmake for the _install_ tree.
+set(STABLEHLO_CONFIG_INCLUDE_DIRS
+  "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}"
+)
+
+set(STABLEHLO_CONFIG_CMAKE_DIR
+  "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/cmake/stablehlo"
+)
+
+configure_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/StablehloConfig.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/StablehloConfig.cmake"
+  @ONLY
+)
+
+# Specify sources and destinations for install files.
+install(EXPORT MLIRTargets
+  NAMESPACE Stablehlo::
+  FILE StablehloTargets.cmake
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/stablehlo"
+)
+
+install(FILES
+  "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/StablehloConfig.cmake"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/stablehlo"
+)
+
+# Copy header files from the source path to the install location.
+install(DIRECTORY "${STABLEHLO_SOURCE_DIR}/stablehlo"
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+  FILES_MATCHING PATTERN "*.h"
+)
+
+# Copy (generated) header files from the build path to the install location.
+install(DIRECTORY "${STABLEHLO_BINARY_DIR}/stablehlo"
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+  FILES_MATCHING
+  PATTERN "*.h"
+  PATTERN "*.inc"
+  PATTERN "CMakeFiles" EXCLUDE
+)

--- a/cmake/modules/StablehloConfig.cmake.in
+++ b/cmake/modules/StablehloConfig.cmake.in
@@ -1,0 +1,8 @@
+# This file allows users to call find_package(Stablehlo) and pick up StableHLO
+# targets.
+
+find_package(MLIR REQUIRED CONFIG)
+
+# Provide all our include files, library targets, and binary targets to users.
+set(STABLEHLO_INCLUDE_DIRS "@STABLEHLO_CONFIG_INCLUDE_DIRS@")
+include("@STABLEHLO_CONFIG_CMAKE_DIR@/StablehloTargets.cmake")


### PR DESCRIPTION
Prior to this patch, it seems that consumers of StableHLO dialects and
passes are required to build StableHLO from source.  More precisely,
such consumers cannot point to a StableHLO build tree or install tree.
This is because StableHLO's build and install trees do not create an
export configuration (StablehloConfig.cmake) that consumers can refer
to, by calling `find_package(StableHLO)`.

This patch adds a CMake script to create a basic export configuration
that lists the library targets of StableHLO, along with their
dependencies.

Since these library targets are created using the `add_mlir_library()`
CMake function, these targets get added to MLIRTargets and MLIR_EXPORTS.
A better alternative is to add the names of these targets to StableHLO's
list of exports that is separate from MLIR's, but doing so requires a
somewhat invasive change of replacing all `add_mlir_library()` with a
wrapper that adds the target names to a StableHLO-specific list of
exports.