### PR TITLE
Fix issues found during the recent downstream integrate

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -289,10 +289,10 @@ cc_library(
     strip_include_prefix = ".",
     deps = [
         ":interpreter_ops_inc_gen",
-        ":reference_value",
         ":reference_numpy",
         ":reference_ops",
         ":reference_process_grid",
+        ":reference_value",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:IR",
@@ -465,10 +465,10 @@ cc_library(
     strip_include_prefix = ".",
     deps = [
         ":reference_axes",
+        ":reference_configuration",
         ":reference_element",
         ":reference_errors",
         ":reference_index",
-        ":reference_configuration",
         ":reference_process",
         ":reference_process_grid",
         ":reference_scope",
@@ -965,8 +965,8 @@ cc_binary(
     ],
     deps = [
         ":interpreter_ops",
-        ":reference_errors",
         ":reference_api",
+        ":reference_errors",
         ":reference_ops",
         ":reference_process_grid",
         ":reference_scope",

--- a/stablehlo/dialect/Base.h
+++ b/stablehlo/dialect/Base.h
@@ -371,4 +371,4 @@ class CompatibleOperandsAndResultType
 }  // namespace hlo
 }  // namespace mlir
 
-#endif
+#endif  // STABLEHLO_DIALECT_BASE_H

--- a/stablehlo/tests/BUILD.bazel
+++ b/stablehlo/tests/BUILD.bazel
@@ -40,6 +40,7 @@ cc_library(
 
 gentbl_cc_library(
     name = "check_ops_inc_gen",
+    strip_include_prefix = ".",
     tbl_outs = [
         (
             ["-gen-op-decls"],
@@ -52,7 +53,6 @@ gentbl_cc_library(
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "CheckOps.td",
-    strip_include_prefix = ".",
     deps = [
         ":check_ops_td_files",
     ],
@@ -140,6 +140,7 @@ expand_template(
 [
     lit_test(
         name = "%s.test" % src,
+        size = "small",
         srcs = [src],
         data = [
             "lit.cfg.py",
@@ -149,7 +150,6 @@ expand_template(
             "@llvm-project//llvm:FileCheck",
             "@llvm-project//llvm:not",
         ] + glob(["%s.bc" % src]),
-        size = "small",
         tags = ["stablehlo_tests"],
     )
     for src in glob(["**/*.mlir"])


### PR DESCRIPTION
  * Add a comment next to #endif in Base.h.
  * Sort dependencies alphabetically in BUILD.bazel.