### PR TITLE
Allow unsafe probe_id values to be serialized properly to disk

### DIFF
--- a/stablehlo/reference/Api.cpp
+++ b/stablehlo/reference/Api.cpp
@@ -97,7 +97,7 @@ class DefaultInterpreterFallback : public InterpreterFallback {
   const InterpreterConfiguration &config;
 
   /// Probe instrumentation counter for uniquely identifying instrumented tensor
-  /// serialized filenames.
+  /// filenames.
   int64_t serializedProbeFileId = 0;
 };
 

--- a/stablehlo/reference/Api.cpp
+++ b/stablehlo/reference/Api.cpp
@@ -60,7 +60,8 @@ class DefaultInterpreterFallback : public InterpreterFallback {
       auto input =
           stablehlo::InterpreterValue(scope.findTensor(probeOp.getOperand()));
       auto status = stablehlo::interpreter::evalProbeOp(
-          input, probeOp.getProbeId(), config.probeInstrumentationDir);
+          input, probeOp.getProbeId(), config.probeInstrumentationDir,
+          ++serializedProbeFileId);
       scope.add(probeOp.getResult(), input);
       return wrapFallbackStatus(std::move(status), funcName,
                                 "interpreter.probe");
@@ -94,6 +95,10 @@ class DefaultInterpreterFallback : public InterpreterFallback {
  private:
   /// Interpreter configuration.
   const InterpreterConfiguration &config;
+
+  /// Probe instrumentation counter for uniquely identifying instrumented tensor
+  /// serialized filenames.
+  int64_t serializedProbeFileId = 0;
 };
 
 }  // namespace

--- a/stablehlo/reference/Api.cpp
+++ b/stablehlo/reference/Api.cpp
@@ -60,8 +60,7 @@ class DefaultInterpreterFallback : public InterpreterFallback {
       auto input =
           stablehlo::InterpreterValue(scope.findTensor(probeOp.getOperand()));
       auto status = stablehlo::interpreter::evalProbeOp(
-          input, probeOp.getProbeId(), config.probeInstrumentationDir,
-          instrumentedTensors);
+          input, probeOp.getProbeId(), config.probeInstrumentationDir);
       scope.add(probeOp.getResult(), input);
       return wrapFallbackStatus(std::move(status), funcName,
                                 "interpreter.probe");
@@ -95,10 +94,6 @@ class DefaultInterpreterFallback : public InterpreterFallback {
  private:
   /// Interpreter configuration.
   const InterpreterConfiguration &config;
-
-  /// If the input StableHLO program has been instrumented, keep track of how
-  /// many times a given operation has been executed.
-  llvm::StringMap<int32_t> instrumentedTensors;
 };
 
 }  // namespace

--- a/stablehlo/reference/InterpreterOps.h
+++ b/stablehlo/reference/InterpreterOps.h
@@ -40,7 +40,8 @@ SmallVector<InterpreterValue> evalRunParallelOp(
     SmallVector<SmallVector<StringAttr>> programs, SymbolTable &symbolTable);
 
 llvm::Error evalProbeOp(InterpreterValue input, StringRef probeId,
-                        StringRef probeOutputDir);
+                        StringRef probeOutputDir,
+                        int64_t serializedProbeFileId);
 
 }  // namespace interpreter
 }  // namespace stablehlo

--- a/stablehlo/reference/InterpreterOps.h
+++ b/stablehlo/reference/InterpreterOps.h
@@ -40,8 +40,7 @@ SmallVector<InterpreterValue> evalRunParallelOp(
     SmallVector<SmallVector<StringAttr>> programs, SymbolTable &symbolTable);
 
 llvm::Error evalProbeOp(InterpreterValue input, StringRef probeId,
-                        StringRef probeOutputDir,
-                        llvm::StringMap<int32_t> &probeIterations);
+                        StringRef probeOutputDir);
 
 }  // namespace interpreter
 }  // namespace stablehlo

--- a/stablehlo/tests/interpret_probe.mlir
+++ b/stablehlo/tests/interpret_probe.mlir
@@ -55,6 +55,17 @@ func.func @probe_c32() {
 
 // -----
 
+func.func @probe_sanitized_probe_id() {
+  %0 = stablehlo.constant dense<[[1], [2], [3]]> : tensor<3x1xi64>
+  %1 = stablehlo.constant dense<[[4], [5], [6]]> : tensor<3x1xi64>
+  %2 = stablehlo.add %0, %1 : tensor<3x1xi64>
+  %3 = interpreter.probe %2, probe_id = "probe/0" : tensor<3x1xi64>
+  check.expect_serialized_eq %3, probe_id = "probe/0" : tensor<3x1xi64>
+  func.return
+}
+
+// -----
+
 func.func @probe_iterations() {
   // int i = 0;
   // int sum = 0;


### PR DESCRIPTION
This PR builds off of the recently submitted changes in #1784. Prior to this change, the value of `probe_id` and an internal execution counter is used to derive the filename for serializing probed tensor values (i.e. `<probe_output_dir>/<probe_id>_<execution_count>.npy`). This current design has the following disadvantage:

1. This can be unsafe as no filename sanitation is performed, relying on the compiler (or other tooling) to produce friendly `probe_id` values. Instead of having this implicit assumption on the instrumented StableHLO program, this change uses internally generated serialization filenames by using a strictly increasing counter.

This change proposes that the serialization filename now be derived as follows:
```
<probe_output_dir>/probe<i>.npy
```

Where `i` is a uniquely increasing positive `int64_t`.
