### PR TITLE
TableGen Headers Included Before They Are Generated

### DIFF
--- a/stablehlo/conversions/tosa/transforms/CMakeLists.txt
+++ b/stablehlo/conversions/tosa/transforms/CMakeLists.txt
@@ -29,6 +29,7 @@ add_mlir_library(StablehloTOSATransforms
   DEPENDS
   StablehloTOSATransformsPassIncGen
   StablehloTOSAPDLLPatternsIncGen
+  StablehloOpsIncGen
 
   LINK_COMPONENTS
   Core


### PR DESCRIPTION
## TableGen Headers Included Before They Are Generated

**Issue:**

The issue is due to **`StablehloLegalizeToTosa.cpp`** attempting to include a TableGen'd file (**`StablehloEnums.h.inc`**) that hasn't been generated yet, resulting in the following build failure:

```bash
In file included from /stablehlo/stablehlo/conversions/tosa/transforms/StablehloLegalizeToTosa.cpp:25:
/stablehlo/stablehlo/dialect/StablehloOps.h:45:10: fatal error: 'stablehlo/dialect/StablehloEnums.h.inc' file not found
#include "stablehlo/dialect/StablehloEnums.h.inc"
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

**Reproduce:**

To reproduce this issue on Linux or Mac, follow these steps:

```bash
export LLVM_PROJECT_BUILD="/path/to/llvm-project/build"
git clone https://github.com/openxla/stablehlo.git
python3 -m venv stablehlo_venv
source stablehlo_venv/bin/activate
pip install ninja cmake
cd stablehlo
cmake -B build -G "Ninja" \
        -DCMAKE_C_COMPILER=/usr/bin/clang \
        -DCMAKE_CXX_COMPILER=/usr/bin/clang++ \
        -DMLIR_DIR=${LLVM_PROJECT_BUILD}/lib/cmake/mlir \
        -DCMAKE_BUILD_TYPE=Release \
        -DLLVM_ENABLE_ASSERTIONS=ON
cmake --build build -j2
```

**Resolution**:

To resolve this issue, explicitly define the dependency between `StablehloLegalizeToTosa.cpp` and `StablehloEnums.h.inc`. Otherwise it is the luck of the draw which one will compile first.

This fix  defines the StableHLO TableGen'd headers as a dependency to for the for the MLIR library that includes `StablehloLegalizeToTosa.cpp` . This ensures that the stablehlo header files are always generated before the library is compiled.