### PR TITLE
Fix clang-tidy error

### DIFF
--- a/stablehlo/conversions/linalg/transforms/MapStablehloToScalarOp.h
+++ b/stablehlo/conversions/linalg/transforms/MapStablehloToScalarOp.h
@@ -910,12 +910,13 @@ struct CompareSelectOpToStdScalarOp<SupportedType, StdCompareOp, Predicate,
 template <>
 inline Value mapStablehloOpToStdScalarOp<stablehlo::ClampOp>(
     Location loc, ArrayRef<Type> resultTypes, ArrayRef<Type> argTypes,
-    stablehlo::ClampOp::Adaptor op, OpBuilder *b) {
+    stablehlo::ClampOp::Adaptor adaptor, OpBuilder *b) {
   // clamp(lb, x, ub) = min(max(lb, x), ub)
   Value maxLbX = mapStablehloOpToStdScalarOp<stablehlo::MaxOp>(
-      loc, resultTypes, argTypes, ValueRange{op.getMin(), op.getOperand()}, b);
+      loc, resultTypes, argTypes,
+      ValueRange{adaptor.getMin(), adaptor.getOperand()}, b);
   return mapStablehloOpToStdScalarOp<stablehlo::MinOp>(
-      loc, resultTypes, argTypes, ValueRange{maxLbX, op.getMax()}, b);
+      loc, resultTypes, argTypes, ValueRange{maxLbX, adaptor.getMax()}, b);
 }
 
 template <typename U, typename S>


### PR DESCRIPTION
The following error is surfaced during the StableHLO integration. 

```
function template specialization 'mlir::stablehlo::impl::mapStablehloOpToStdScalarOp<mlir::stablehlo::ClampOp>' has a primary template declaration with different parameter names
```