### PR TITLE
Do not throw error when executing empty StableHLO modules

### DIFF
--- a/stablehlo/reference/Api.cpp
+++ b/stablehlo/reference/Api.cpp
@@ -106,6 +106,9 @@ class DefaultInterpreterFallback : public InterpreterFallback {
 llvm::ErrorOr<SmallVector<InterpreterValue>> evalModule(
     ModuleOp module, ArrayRef<InterpreterValue> inputs,
     const InterpreterConfiguration &config) {
+  if (module.getOps<func::FuncOp>().empty())
+    return (SmallVector<InterpreterValue>){};
+
   auto mainFunc = getMainFunction(module, config.mainFunction);
   if (!mainFunc) llvm::report_fatal_error("Requested main function not found.");
 

--- a/stablehlo/reference/Api.cpp
+++ b/stablehlo/reference/Api.cpp
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 #include "stablehlo/reference/Api.h"
 
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FileSystem.h"
@@ -107,7 +108,7 @@ llvm::ErrorOr<SmallVector<InterpreterValue>> evalModule(
     ModuleOp module, ArrayRef<InterpreterValue> inputs,
     const InterpreterConfiguration &config) {
   if (module.getOps<func::FuncOp>().empty())
-    return (SmallVector<InterpreterValue>){};
+    return SmallVector<InterpreterValue>();
 
   auto mainFunc = getMainFunction(module, config.mainFunction);
   if (!mainFunc) llvm::report_fatal_error("Requested main function not found.");

--- a/stablehlo/tests/interpret_probe.mlir
+++ b/stablehlo/tests/interpret_probe.mlir
@@ -1,5 +1,9 @@
 // RUN: stablehlo-translate --interpret --probe-output-dir=%T -split-input-file %s
 
+// Test an empty module
+
+// -----
+
 func.func @probe_i1() {
   %0 = stablehlo.constant dense<[[0], [0], [0]]> : tensor<3x1xi1>
   %1 = stablehlo.constant dense<[[1], [1], [1]]> : tensor<3x1xi1>


### PR DESCRIPTION
This PR addresses a bug introduced by PR #1797 where as a result of the new interpreter API, running empty StableHLO modules would result in an error `Requested main function not found.` whereas previously, the `stablehlo-translate` utility would not throw any error.

(Found by @ghpvnist in #1841).